### PR TITLE
Queue Consumer is created in connect phase

### DIFF
--- a/Brighter/paramore.brighter.commandprocessor.messaginggateway.rmq/RMQMessagingGateway.cs
+++ b/Brighter/paramore.brighter.commandprocessor.messaginggateway.rmq/RMQMessagingGateway.cs
@@ -42,6 +42,7 @@ namespace paramore.brighter.commandprocessor.messaginggateway.rmq
         private readonly ConnectionFactory connectionFactory;
         private IConnection connection;
         private IModel channel;
+        private QueueingBasicConsumer consumer;
         private BrokerUnreachableException connectionFailure;
         const bool autoAck = false;
 
@@ -94,8 +95,6 @@ namespace paramore.brighter.commandprocessor.messaginggateway.rmq
             var message = new Message();
             try
             {
-                var consumer = new QueueingBasicConsumer(channel);
-                channel.BasicConsume(queueName, autoAck, consumer);
                 BasicDeliverEventArgs fromQueue;
                 consumer.Queue.Dequeue(timeoutInMilliseconds, out fromQueue);
                 if (fromQueue != null)
@@ -183,6 +182,9 @@ namespace paramore.brighter.commandprocessor.messaginggateway.rmq
                     logger.Debug(m =>m("RMQMessagingGateway: Declaring queue {0} on connection {1}", queueName, configuration.AMPQUri.Uri.ToString()));
                     channel.QueueDeclare(queueName, false, false, false, null);
                     channel.QueueBind(queueName, configuration.Exchange.Name, queueName);
+
+                    consumer = new QueueingBasicConsumer(channel);
+                    channel.BasicConsume(queueName, autoAck, consumer);
 
                 }
             }


### PR DESCRIPTION
The previous version of the code created a new QueueingBasicConsumer for
every call to Receive().

This had unintended consequences. Specifically:
- The client code called Receive
- The channel received a message and passed it to the consumer.
- The client code dequeued from the consumer and processed the message
- The client code ACKd the message
- The channel pre-fetched a new message and passed it to the consumer
- The client code called Receive, ignoring the pre-fetched message on the
  now forgotten consumer

This led to every second message being ignored, and to messages never
being received if the queue was empty when the service started.

Weirdness has now ceased.
