### PR TITLE
throttle MessagePumpBase.Run() when Channel.Receive circuit is broken

### DIFF
--- a/src/Paramore.Brighter.ServiceActivator/MessagePump.cs
+++ b/src/Paramore.Brighter.ServiceActivator/MessagePump.cs
@@ -49,6 +49,7 @@ namespace Paramore.Brighter.ServiceActivator
 
         public bool IsAsync => false;
 
+        // doesn't have async keyword, so won't actually run asynchronously / generate state machine
         protected override Task DispatchRequest(MessageHeader messageHeader, TRequest request)
         {
             var tcs = new TaskCompletionSource<object>();


### PR DESCRIPTION
This should resolve #218