### PR TITLE
upgrade EventStore client to 4.0.0

### DIFF
--- a/samples/DocumentsAndFolders.Sqs.WindowsService/DocumentsAndFolders.Sqs.WindowsService.csproj
+++ b/samples/DocumentsAndFolders.Sqs.WindowsService/DocumentsAndFolders.Sqs.WindowsService.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="2.0.5" />
+    <PackageReference Include="log4net" Version="2.0.8" />
     <PackageReference Include="Topshelf" Version="4.0.3" />
   </ItemGroup>
 

--- a/samples/GenericListener/GenericListener.csproj
+++ b/samples/GenericListener/GenericListener.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net46</TargetFramework>
     <DebugType>portable</DebugType>
     <OutputType>Exe</OutputType>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
@@ -21,13 +21,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="EventStore.Client" Version="3.9.4" />
-    <PackageReference Include="log4net" Version="2.0.5" />
+    <PackageReference Include="EventStore.Client" Version="4.0.0" />
+    <PackageReference Include="log4net" Version="2.0.8" />
     <PackageReference Include="Topshelf" Version="4.0.3" />
     <PackageReference Include="Topshelf.Log4Net" Version="4.0.3" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>

--- a/samples/GreetingsCoreConsole/GreetingsCoreConsole.csproj
+++ b/samples/GreetingsCoreConsole/GreetingsCoreConsole.csproj
@@ -14,8 +14,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog.Sinks.Console" Version="2.1.0" />
     <PackageReference Include="Serilog" Version="2.4.0" />
+    <PackageReference Include="Serilog.Sinks.Literate" Version="2.1.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/GreetingsCoreConsole/Program.cs
+++ b/samples/GreetingsCoreConsole/Program.cs
@@ -19,7 +19,7 @@ namespace GreetingsCoreConsole
         public static void Main(string[] args)
         {
             Log.Logger = new LoggerConfiguration()
-                .WriteTo.Console()
+                .WriteTo.LiterateConsole()
                 .CreateLogger();
 
             var container = new TinyIoCContainer();

--- a/samples/GreetingsWindowsService/GreetingsWindowsService.csproj
+++ b/samples/GreetingsWindowsService/GreetingsWindowsService.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="2.0.5" />
+    <PackageReference Include="log4net" Version="2.0.8" />
     <PackageReference Include="Topshelf" Version="4.0.3" />
   </ItemGroup>
 

--- a/samples/ManagementAndMonitoringCoreConsole/ManagementAndMonitoringCoreConsole.csproj
+++ b/samples/ManagementAndMonitoringCoreConsole/ManagementAndMonitoringCoreConsole.csproj
@@ -20,8 +20,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog.Sinks.Console" Version="2.1.0" />
     <PackageReference Include="Serilog" Version="2.4.0" />
+    <PackageReference Include="Serilog.Sinks.Literate" Version="2.1.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/ManagementAndMonitoringCoreConsole/Program.cs
+++ b/samples/ManagementAndMonitoringCoreConsole/Program.cs
@@ -48,7 +48,7 @@ namespace ManagementAndMonitoringCoreConsole
         public static void Main()
         {
             Log.Logger = new LoggerConfiguration()
-                .WriteTo.Console()
+                .WriteTo.LiterateConsole()
                 .CreateLogger();
 
             var container = new TinyIoCContainer();

--- a/samples/ManagementAndMonitoringWindowsService/ManagementAndMonitoringWindowsService.csproj
+++ b/samples/ManagementAndMonitoringWindowsService/ManagementAndMonitoringWindowsService.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="2.0.5" />
+    <PackageReference Include="log4net" Version="2.0.8" />
     <PackageReference Include="Topshelf" Version="4.0.3" />
   </ItemGroup>
 

--- a/src/Paramore.Brighter.MessageStore.EventStore/EventStoreMessageStore.cs
+++ b/src/Paramore.Brighter.MessageStore.EventStore/EventStoreMessageStore.cs
@@ -181,8 +181,7 @@ namespace Paramore.Brighter.MessageStore.EventStore
             return eventStreamSlice.Events.Select(e => ConvertEventToMessage(e.Event, stream)).ToList();
         }
 
-        private static void AddMetadataToHeader(byte[] metadata, MessageHeader messageHeader, int eventNumber,
-            string stream)
+        private static void AddMetadataToHeader(byte[] metadata, MessageHeader messageHeader, long eventNumber, string stream)
         {
             messageHeader.Bag.Add("streamId", stream);
             messageHeader.Bag.Add("eventNumber", eventNumber);

--- a/src/Paramore.Brighter.MessageStore.EventStore/Paramore.Brighter.MessageStore.EventStore.csproj
+++ b/src/Paramore.Brighter.MessageStore.EventStore/Paramore.Brighter.MessageStore.EventStore.csproj
@@ -5,7 +5,7 @@
     <Description>This is an implementation of the message store used for decoupled invocation of commands by Paramore.Brighter, using Event Store</Description>
     <AssemblyTitle>Paramore.Brighter.MessageStore.EventStore</AssemblyTitle>
     <Authors>George Ayris</Authors>
-    <TargetFrameworks>net452</TargetFrameworks>
+    <TargetFrameworks>net46</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyName>Paramore.Brighter.MessageStore.EventStore</AssemblyName>
     <PackageId>Paramore.Brighter.MessageStore.EventStore</PackageId>
@@ -32,11 +32,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="EventStore.Client" Version="3.9.4" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="EventStore.Client" Version="4.0.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>


### PR DESCRIPTION
Requires targeting net46 in `Paramore.Brighter.MessageStore.EventStore`.

This upgrade may be controversial and we may choose not to do it, but I figured it's probably a good strategy to get all the breaking changes out of the way with version 7.