### PR TITLE
Fix Command Invoker pattern link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 | | |
 | ------------- | ------------- |
 |![canon](https://openclipart.org/people/amilo/canon.svg) |[Brighter](https://brightercommand.github.io/Brighter//Brighter.html)|
-||Brighter is a command dispatcher, processor, and task queue. It can be used to implement the [Command Invoker] (http://servicedesignpatterns.com/WebServiceImplementationStyles/CommandInvoker) pattern. It can be used for interoperability in a microservices architecture as well. |
+||Brighter is a command dispatcher, processor, and task queue. It can be used to implement the [Command Invoker](http://servicedesignpatterns.com/WebServiceImplementationStyles/CommandInvoker) pattern. It can be used for interoperability in a microservices architecture as well. |
 | Version  | [![NuGet Version](http://img.shields.io/nuget/v/paramore.brighter.svg)](https://www.nuget.org/packages/paramore.brighter/)  |
 | Download | [![NuGet Downloads](http://img.shields.io/nuget/dt/paramore.brighter.svg)](https://www.nuget.org/packages/Paramore.Brighter/) |
 | Web  |http://brightercommand.github.io/Brighter/  |
@@ -12,7 +12,7 @@
 ## Why a Command Dispatcher, Command Processor, and Task Queue?
 * When implementing a hexagonal architecture, one question is how to implement a port.
 	- Brighter shows how to implement ports using a Command approach (with a Command Dispatcher)
-	- This is the strategy described for services in Service Design Patterns as  [Command Invoker] (http://servicedesignpatterns.com/WebServiceImplementationStyles/CommandInvoker)
+	- This is the strategy described for services in Service Design Patterns as  [Command Invoker](http://servicedesignpatterns.com/WebServiceImplementationStyles/CommandInvoker)
 * A command processor lets you add orthogonal concerns seperately to the processing of commands such as logging, undo, validation, retry, and circuit breaker
  	- Brighter provides a Command Processor, using a 'Russian Doll' model to allow a pipeline of handlers to operate on a command.
 * A task queue allows a one process to send work to be handled asynchronously to another process, using a message queue as the channel, for processing. A common use case is to help a web server scale by handing off a request to another process for back-end processing. This allows both a faster ack and throttling of the request arrival rate to that which can be handled by a back end processing component. For another project with this goal, see [Celery](https://github.com/celery/celery)
@@ -31,7 +31,7 @@
 | [Other]  | A branch for any work that is not ready to go into master (for example would break CI) or is experimental i.e. we don't know if we intend to ever ship, we are just trying out ideas.  |
 
 ## How do I get the NuGet packages for the latest build?
-We release the build artefacts (NuGet packages) to [Nuget](http://nuget.org) on a regular basis and we update the release notes on those drops. We also tag the master code line. If you want to take the packages that represent master at any point you can download the packages for the latest good build from [AppVeyor](https://ci.appveyor.com/nuget/paramore-brighter-m289d49fraww). The easiest approach to using those is to download them into a folder that you add to your NuGet sources. 
+We release the build artefacts (NuGet packages) to [NuGet](http://nuget.org) on a regular basis and we update the release notes on those drops. We also tag the master code line. If you want to take the packages that represent master at any point you can download the packages for the latest good build from [AppVeyor](https://ci.appveyor.com/nuget/paramore-brighter-m289d49fraww). The easiest approach to using those is to download them into a folder that you add to your NuGet sources. 
 
 <a href="https://scan.coverity.com/projects/2900">
   <img alt="Coverity Scan Build Status"


### PR DESCRIPTION
Fix incorrect Markdown syntax for links pointing to the command invoker pattern.

Also: Nuget -> NuGet.