### PR TITLE
Changing to TargetFramework singular when appropriate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ bld/
 
 # Visual Studio 2015 cache/options directory
 .vs/
+.vscode/
 # Uncomment if you have tasks that create the project's static files in wwwroot
 #wwwroot/
 

--- a/samples/EventSourcing/EventSourcing.csproj
+++ b/samples/EventSourcing/EventSourcing.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1</TargetFrameworks>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
     <DebugType>full</DebugType>
     <OutputType>Exe</OutputType>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>

--- a/samples/HelloAsyncListeners/HelloAsyncListeners.csproj
+++ b/samples/HelloAsyncListeners/HelloAsyncListeners.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1</TargetFrameworks>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
     <DebugType>full</DebugType>
     <OutputType>Exe</OutputType>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>

--- a/samples/HelloWorld/HelloWorld.csproj
+++ b/samples/HelloWorld/HelloWorld.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1</TargetFrameworks>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
     <DebugType>full</DebugType>
     <OutputType>Exe</OutputType>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>

--- a/samples/HelloWorldAsync/HelloWorldAsync.csproj
+++ b/samples/HelloWorldAsync/HelloWorldAsync.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1</TargetFrameworks>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
     <DebugType>full</DebugType>
     <OutputType>Exe</OutputType>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>

--- a/src/Paramore.Brighter.MessageStore.EventStore/Paramore.Brighter.MessageStore.EventStore.csproj
+++ b/src/Paramore.Brighter.MessageStore.EventStore/Paramore.Brighter.MessageStore.EventStore.csproj
@@ -5,7 +5,7 @@
     <Description>This is an implementation of the message store used for decoupled invocation of commands by Paramore.Brighter, using Event Store</Description>
     <AssemblyTitle>Paramore.Brighter.MessageStore.EventStore</AssemblyTitle>
     <Authors>George Ayris</Authors>
-    <TargetFrameworks>net46</TargetFrameworks>
+    <TargetFramework>net46</TargetFramework>
     <DebugType>full</DebugType>
     <AssemblyName>Paramore.Brighter.MessageStore.EventStore</AssemblyName>
     <PackageId>Paramore.Brighter.MessageStore.EventStore</PackageId>


### PR DESCRIPTION
Closes #231 by changing "TargetFrameworks" to "TargetFramework" only when there is just a single framework specified like "netcoreapp11." This will allow samples to run with "dotnet run" without specifying a --framework option. 