### PR TITLE
Remove unnecessary parameter.

### DIFF
--- a/samples/DocumentsAndFolders.Sqs.WindowsService/Adapters/ServiceHost/DocumentService.cs
+++ b/samples/DocumentsAndFolders.Sqs.WindowsService/Adapters/ServiceHost/DocumentService.cs
@@ -98,7 +98,7 @@ namespace DocumentsAndFolders.Sqs.Adapters.ServiceHost
                     .RequestContextFactory(new InMemoryRequestContextFactory())
                     .Build())
                 .MessageMappers(messageMapperRegistry)
-                .DefaultChannelFactory(new InputChannelFactory(new SqsMessageConsumerFactory(awsCredentials), new SqsMessageProducerFactory(awsCredentials)))
+                .DefaultChannelFactory(new InputChannelFactory(new SqsMessageConsumerFactory(awsCredentials)))
                 .Connections(new Connection[]
                 {
                     new Connection<DocumentCreatedEvent>(

--- a/samples/GenericListener/Adapters/Services/GenericListenerService.cs
+++ b/samples/GenericListener/Adapters/Services/GenericListenerService.cs
@@ -124,7 +124,7 @@ namespace GenericListener.Adapters.Services
             //<add connectionName="Task.Edited" channelName="Task.Edited" routingKey="Task.Edited" dataType="GenericListener.Ports.Events.GenericTaskEditedEvent" noOfPerformers="1" timeOutInMilliseconds="200" />
             //<add connectionName="Task.Completed" channelName="Task.Completed" routingKey="Task.Completed" dataType="GenericListener.Ports.Events.GenericTaskCompletedEvent" noOfPerformers="1" timeOutInMilliseconds="200" />
 
-            var inputChannelFactory = new InputChannelFactory(new RmqMessageConsumerFactory(rmqConnnection), new RmqMessageProducerFactory(rmqConnnection));
+            var inputChannelFactory = new InputChannelFactory(new RmqMessageConsumerFactory(rmqConnnection));
 
             var connections = new List<Connection>
             {

--- a/samples/GreetingsCoreConsole/Program.cs
+++ b/samples/GreetingsCoreConsole/Program.cs
@@ -65,7 +65,6 @@ namespace GreetingsCoreConsole
             };
 
             var rmqMessageConsumerFactory = new RmqMessageConsumerFactory(rmqConnnection);
-            var rmqMessageProducerFactory = new RmqMessageProducerFactory(rmqConnnection);
 
             var dispatcher = DispatchBuilder.With()
                 .CommandProcessor(CommandProcessorBuilder.With()
@@ -75,7 +74,7 @@ namespace GreetingsCoreConsole
                     .RequestContextFactory(new InMemoryRequestContextFactory())
                     .Build())
                 .MessageMappers(messageMapperRegistry)
-                .DefaultChannelFactory(new InputChannelFactory(rmqMessageConsumerFactory, rmqMessageProducerFactory))
+                .DefaultChannelFactory(new InputChannelFactory(rmqMessageConsumerFactory))
                 .Connections(new Connection[]
                 {
                     new Connection<GreetingEvent>(

--- a/samples/GreetingsWindowsService/GreetingService.cs
+++ b/samples/GreetingsWindowsService/GreetingService.cs
@@ -89,7 +89,6 @@ namespace GreetingsWindowsService
             };
 
             var rmqMessageConsumerFactory = new RmqMessageConsumerFactory(rmqConnnection);
-            var rmqMessageProducerFactory = new RmqMessageProducerFactory(rmqConnnection);
 
             _dispatcher = DispatchBuilder.With()
                 .CommandProcessor(CommandProcessorBuilder.With()
@@ -99,7 +98,7 @@ namespace GreetingsWindowsService
                     .RequestContextFactory(new InMemoryRequestContextFactory())
                     .Build())
                 .MessageMappers(messageMapperRegistry)
-                .DefaultChannelFactory(new InputChannelFactory(rmqMessageConsumerFactory, rmqMessageProducerFactory))
+                .DefaultChannelFactory(new InputChannelFactory(rmqMessageConsumerFactory))
                 .Connections(new []
                 {
                     new Connection<GreetingEvent>(

--- a/samples/ManagementAndMonitoringCoreConsole/Program.cs
+++ b/samples/ManagementAndMonitoringCoreConsole/Program.cs
@@ -90,9 +90,7 @@ namespace ManagementAndMonitoringCoreConsole
                 .Exchange("paramore.brighter.exchange")
                 .DefaultQueues();
 
-            var rmqMessageProducerFactory = new RmqMessageProducerFactory(rmqGatewayMessages);
-
-            var inputChannelFactory = new InputChannelFactory(new RmqMessageConsumerFactory(rmqGatewayMessages), rmqMessageProducerFactory);
+            var inputChannelFactory = new InputChannelFactory(new RmqMessageConsumerFactory(rmqGatewayMessages));
             var builder = DispatchBuilder
                 .With()
                 .CommandProcessor(CommandProcessorBuilder.With()
@@ -117,6 +115,7 @@ namespace ManagementAndMonitoringCoreConsole
                  });
             _dispatcher = builder.Build();
 
+            var rmqMessageProducerFactory = new RmqMessageProducerFactory(rmqGatewayMessages);
             var controlBusBuilder = ControlBusReceiverBuilder
                 .With()
                 .Dispatcher(_dispatcher)

--- a/samples/ManagementAndMonitoringWindowsService/ServiceHost/ManagementAndMonitoringService.cs
+++ b/samples/ManagementAndMonitoringWindowsService/ServiceHost/ManagementAndMonitoringService.cs
@@ -117,7 +117,7 @@ namespace ManagementAndMonitoringWindowsService.ServiceHost
                     .Build()
                  )
                  .MessageMappers(messageMapperRegistry)
-                 .DefaultChannelFactory(new InputChannelFactory(rmqMessageConsumerFactory, rmqMessageProducerFactory))
+                 .DefaultChannelFactory(new InputChannelFactory(rmqMessageConsumerFactory))
                  .Connections(connections);
             _dispatcher = builder.Build();
 
@@ -125,7 +125,7 @@ namespace ManagementAndMonitoringWindowsService.ServiceHost
                 .With()
                 .Dispatcher(_dispatcher)
                 .ProducerFactory(rmqMessageProducerFactory)
-                .ChannelFactory(new InputChannelFactory(rmqMessageConsumerFactory, rmqMessageProducerFactory)) as ControlBusReceiverBuilder;
+                .ChannelFactory(new InputChannelFactory(rmqMessageConsumerFactory)) as ControlBusReceiverBuilder;
             _controlDispatcher = controlBusBuilder.Build(Environment.MachineName + "." + "ManagementAndMonitoring");
 
             container.Register<IAmAControlBusSender>(new ControlBusSenderFactory().Create(

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS/InputChannelFactory.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS/InputChannelFactory.cs
@@ -3,17 +3,14 @@ namespace Paramore.Brighter.MessagingGateway.AWSSQS
     public class InputChannelFactory : IAmAChannelFactory
     {
         private readonly SqsMessageConsumerFactory _messageConsumerFactory;
-        private readonly SqsMessageProducerFactory _messageProducerFactory;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="InputChannelFactory"/> class.
         /// </summary>
         /// <param name="messageConsumerFactory">The messageConsumerFactory.</param>
-        /// <param name="messageProducerFactory">The messageProducerFactory.</param>
-        public InputChannelFactory(SqsMessageConsumerFactory messageConsumerFactory, SqsMessageProducerFactory messageProducerFactory)
+        public InputChannelFactory(SqsMessageConsumerFactory messageConsumerFactory)
         {
             _messageConsumerFactory = messageConsumerFactory;
-            _messageProducerFactory = messageProducerFactory;
         }
 
         ///  <summary>

--- a/src/Paramore.Brighter.MessagingGateway.RMQ/InputChannelfactory.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ/InputChannelfactory.cs
@@ -33,16 +33,14 @@ namespace Paramore.Brighter.MessagingGateway.RMQ
     public class InputChannelFactory : IAmAChannelFactory
     {
         private readonly RmqMessageConsumerFactory _messageConsumerFactory;
-        private readonly RmqMessageProducerFactory _messageProducerFactory;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="InputChannelFactory"/> class.
         /// </summary>
         /// <param name="messageConsumerFactory">The messageConsumerFactory.</param>
-        public InputChannelFactory(RmqMessageConsumerFactory messageConsumerFactory, RmqMessageProducerFactory messageProducerFactory)
+        public InputChannelFactory(RmqMessageConsumerFactory messageConsumerFactory)
         {
             _messageConsumerFactory = messageConsumerFactory;
-            _messageProducerFactory = messageProducerFactory;
         }
 
         /// <summary>

--- a/tests/Paramore.Brighter.Tests/MessageDispatch/When_building_a_dispatcher.cs
+++ b/tests/Paramore.Brighter.Tests/MessageDispatch/When_building_a_dispatcher.cs
@@ -67,7 +67,6 @@ namespace Paramore.Brighter.Tests.MessageDispatch
             };
 
             var rmqMessageConsumerFactory = new RmqMessageConsumerFactory(rmqConnection);
-            var rmqMessageProducerFactory = new RmqMessageProducerFactory(rmqConnection);
 
             var commandProcessor = CommandProcessorBuilder.With()
                 .Handlers(new HandlerConfiguration(new SubscriberRegistry(), new TinyIocHandlerFactory(new TinyIoCContainer())))
@@ -83,7 +82,7 @@ namespace Paramore.Brighter.Tests.MessageDispatch
             _builder = DispatchBuilder.With()
                 .CommandProcessor(commandProcessor)
                 .MessageMappers(messageMapperRegistry)
-                .DefaultChannelFactory(new InputChannelFactory(rmqMessageConsumerFactory, rmqMessageProducerFactory))
+                .DefaultChannelFactory(new InputChannelFactory(rmqMessageConsumerFactory))
                 .Connections(new []
                 {
                     new Connection<MyEvent>(

--- a/tests/Paramore.Brighter.Tests/MessageDispatch/When_building_a_dispatcher_with_named_gateway.cs
+++ b/tests/Paramore.Brighter.Tests/MessageDispatch/When_building_a_dispatcher_with_named_gateway.cs
@@ -66,7 +66,6 @@ namespace Paramore.Brighter.Tests.MessageDispatch
             };
 
             var rmqMessageConsumerFactory = new RmqMessageConsumerFactory(connection);
-            var rmqMessageProducerFactory = new RmqMessageProducerFactory(connection);
 
             var commandProcessor = CommandProcessorBuilder.With()
                 .Handlers(new HandlerConfiguration(new SubscriberRegistry(), new TinyIocHandlerFactory(new TinyIoCContainer())))
@@ -78,7 +77,7 @@ namespace Paramore.Brighter.Tests.MessageDispatch
             _builder = DispatchBuilder.With()
                 .CommandProcessor(commandProcessor)
                 .MessageMappers(messageMapperRegistry)
-                .DefaultChannelFactory(new InputChannelFactory(rmqMessageConsumerFactory, rmqMessageProducerFactory))
+                .DefaultChannelFactory(new InputChannelFactory(rmqMessageConsumerFactory))
                 .Connections(new []
                 {
                     new Connection<MyEvent>(


### PR DESCRIPTION
The input channel factories were receiving a message producer factory parameter that was not used. This PR eliminates the parameter and fixes all the references.