### PR TITLE
fix missing async support interface

### DIFF
--- a/samples/MsSqlMessagingGatewaySamples/CompetingSender/Program.cs
+++ b/samples/MsSqlMessagingGatewaySamples/CompetingSender/Program.cs
@@ -45,12 +45,12 @@ namespace CompetingSender
             var builder = CommandProcessorBuilder.With()
                 .Handlers(new HandlerConfiguration())
                 .DefaultPolicy()
-                .TaskQueues(new MessagingConfiguration(messageStore, producer, messageMapperRegistry))
+                .TaskQueues(new MessagingConfiguration((IAmAMessageStore<Message>) messageStore, producer, messageMapperRegistry))
                 .RequestContextFactory(new InMemoryRequestContextFactory());
 
             var commandProcessor = builder.Build();
 
-            using (var transaction = new TransactionScope(TransactionScopeOption.RequiresNew,
+            using (new TransactionScope(TransactionScopeOption.RequiresNew,
                 new TransactionOptions {IsolationLevel = IsolationLevel.ReadCommitted},
                 TransactionScopeAsyncFlowOption.Enabled))
             {

--- a/samples/MsSqlMessagingGatewaySamples/GreetingsSender/Program.cs
+++ b/samples/MsSqlMessagingGatewaySamples/GreetingsSender/Program.cs
@@ -9,7 +9,7 @@ namespace GreetingsSender
 {
     class Program
     {
-        static void Main(string[] args)
+        static void Main()
         {
             var container = new TinyIoCContainer();
 
@@ -29,7 +29,7 @@ namespace GreetingsSender
             var builder = CommandProcessorBuilder.With()
                 .Handlers(new HandlerConfiguration())
                 .DefaultPolicy()
-                .TaskQueues(new MessagingConfiguration(messageStore, producer, messageMapperRegistry))
+                .TaskQueues(new MessagingConfiguration((IAmAMessageStore<Message>) messageStore, producer, messageMapperRegistry))
                 .RequestContextFactory(new InMemoryRequestContextFactory());
 
             var commandProcessor = builder.Build();

--- a/src/Paramore.Brighter.MessagingGateway.MsSql/MsSqlMessageProducer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.MsSql/MsSqlMessageProducer.cs
@@ -5,7 +5,7 @@ using Paramore.Brighter.MessagingGateway.MsSql.SqlQueues;
 
 namespace Paramore.Brighter.MessagingGateway.MsSql
 {
-    public class MsSqlMessageProducer : IAmAMessageProducer
+    public class MsSqlMessageProducer : IAmAMessageProducer, IAmAMessageProducerAsync
     {
         private static readonly Lazy<ILog> Logger = new Lazy<ILog>(LogProvider.For<MsSqlMessageProducer>);
         private readonly MsSqlMessageQueue<Message> _sqlQ;


### PR DESCRIPTION
The IAmAMessageProducerAsync was missing from MsSqlMessageProducer
cast added to samples to remove ambiguity from MessageConfiguration constructor