### PR TITLE
Add Exists() method to CommandStore, use that in the CommandSourcingH…

### DIFF
--- a/src/Paramore.Brighter.CommandStore.MySql/MySqlCommandStore.cs
+++ b/src/Paramore.Brighter.CommandStore.MySql/MySqlCommandStore.cs
@@ -116,7 +116,7 @@ namespace Paramore.Brighter.CommandStore.MySql
         /// <returns>True if it exists, False otherwise</returns>
         public bool Exists<T>(Guid id, int timeoutInMilliseconds = -1) where T : class, IRequest
         {
-            var sql = $"SELECT TOP 1 CommandId FROM {_configuration.CommandStoreTableName} WHERE CommandId = @commandId";
+            var sql = $"SELECT CommandId FROM {_configuration.CommandStoreTableName} WHERE CommandId = @commandId LIMIT 1";
             var parameters = new[]
             {
                 CreateSqlParameter("CommandId", id)
@@ -135,7 +135,7 @@ namespace Paramore.Brighter.CommandStore.MySql
         /// <returns>True if it exists, False otherwise</returns>
         public async Task<bool> ExistsAsync<T>(Guid id, int timeoutInMilliseconds = -1, CancellationToken cancellationToken = default(CancellationToken)) where T : class, IRequest
         {
-            var sql = $"SELECT TOP 1 CommandId FROM {_configuration.CommandStoreTableName} WHERE CommandId = @commandId";
+            var sql = $"SELECT CommandId FROM {_configuration.CommandStoreTableName} WHERE CommandId = @commandId LIMIT 1";
             var parameters = new[]
             {
                 CreateSqlParameter("CommandId", id)

--- a/src/Paramore.Brighter.CommandStore.MySql/MySqlCommandStore.cs
+++ b/src/Paramore.Brighter.CommandStore.MySql/MySqlCommandStore.cs
@@ -1,4 +1,4 @@
-#region Licence
+﻿#region Licence
 
 /* The MIT License (MIT)
 Copyright © 2014 Francesco Pighi <francesco.pighi@gmail.com>
@@ -97,8 +97,7 @@ namespace Paramore.Brighter.CommandStore.MySql
         /// <returns>T.</returns>
         public T Get<T>(Guid id, int timeoutInMilliseconds = -1) where T : class, IRequest, new()
         {
-            var sql = string.Format("select * from {0} where CommandId = @commandId",
-                _configuration.CommandStoreTableName);
+            var sql = $"select * from {_configuration.CommandStoreTableName} where CommandId = @commandId";
             var parameters = new[]
             {
                 CreateSqlParameter("CommandId", id)
@@ -106,6 +105,53 @@ namespace Paramore.Brighter.CommandStore.MySql
 
             return ExecuteCommand(command => ReadCommand<T>(command.ExecuteReader()), sql, timeoutInMilliseconds,
                 parameters);
+        }
+
+        /// <summary>
+        /// Checks whether a command with the specified identifier exists in the store
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="id">The identifier.</param>
+        /// <param name="timeoutInMilliseconds"></param>
+        /// <returns>True if it exists, False otherwise</returns>
+        public bool Exists<T>(Guid id, int timeoutInMilliseconds = -1) where T : class, IRequest
+        {
+            var sql = $"SELECT TOP 1 CommandId FROM {_configuration.CommandStoreTableName} WHERE CommandId = @commandId";
+            var parameters = new[]
+            {
+                CreateSqlParameter("CommandId", id)
+            };
+
+            return ExecuteCommand(command => command.ExecuteReader().HasRows, sql, timeoutInMilliseconds,
+                parameters);
+        }
+
+        /// <summary>
+        /// Checks whether a command with the specified identifier exists in the store
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="id">The identifier.</param>
+        /// <param name="timeoutInMilliseconds"></param>
+        /// <returns>True if it exists, False otherwise</returns>
+        public async Task<bool> ExistsAsync<T>(Guid id, int timeoutInMilliseconds = -1, CancellationToken cancellationToken = default(CancellationToken)) where T : class, IRequest
+        {
+            var sql = $"SELECT TOP 1 CommandId FROM {_configuration.CommandStoreTableName} WHERE CommandId = @commandId";
+            var parameters = new[]
+            {
+                CreateSqlParameter("CommandId", id)
+            };
+
+            return await ExecuteCommandAsync<bool>(
+                    async command =>
+                    {
+                        var reader = await command.ExecuteReaderAsync(cancellationToken);
+                        return reader.HasRows;
+                    },
+                    sql,
+                    timeoutInMilliseconds,
+                    cancellationToken,
+                    parameters)
+                .ConfigureAwait(ContinueOnCapturedContext);
         }
 
         /// <summary>
@@ -165,7 +211,7 @@ namespace Paramore.Brighter.CommandStore.MySql
         public async Task<T> GetAsync<T>(Guid id, int timeoutInMilliseconds = -1, CancellationToken cancellationToken = default(CancellationToken))
             where T : class, IRequest, new()
         {
-            var sql = string.Format("select * from {0} where CommandId = @commandId", _configuration.CommandStoreTableName);
+            var sql = $"select * from {_configuration.CommandStoreTableName} where CommandId = @commandId";
 
             var parameters = new[]
             {
@@ -234,9 +280,7 @@ namespace Paramore.Brighter.CommandStore.MySql
         private DbCommand InitAddDbCommand(int timeoutInMilliseconds, DbConnection connection, DbParameter[] parameters)
         {
             var sqlAdd =
-                string.Format(
-                    "insert into {0} (CommandID, CommandType, CommandBody, Timestamp) values (@CommandID, @CommandType, @CommandBody, @Timestamp)",
-                    _configuration.CommandStoreTableName);
+                $"insert into {_configuration.CommandStoreTableName} (CommandID, CommandType, CommandBody, Timestamp) values (@CommandID, @CommandType, @CommandBody, @Timestamp)";
 
             var sqlcmd = connection.CreateCommand();
             if (timeoutInMilliseconds != -1) sqlcmd.CommandTimeout = timeoutInMilliseconds;

--- a/src/Paramore.Brighter.CommandStore.Sqlite/SqliteCommandStore.cs
+++ b/src/Paramore.Brighter.CommandStore.Sqlite/SqliteCommandStore.cs
@@ -108,7 +108,7 @@ namespace Paramore.Brighter.CommandStore.Sqlite
         /// <returns>True if it exists, False otherwise</returns>
         public bool Exists<T>(Guid id, int timeoutInMilliseconds = -1) where T : class, IRequest
         {
-            var sql = $"SELECT TOP 1 CommandId FROM {MessageStoreTableName} WHERE CommandId = @commandId";
+            var sql = $"SELECT CommandId FROM {MessageStoreTableName} WHERE CommandId = @CommandId LIMIT 1";
             var parameters = new[]
             {
                 CreateSqlParameter("CommandId", id)
@@ -127,7 +127,7 @@ namespace Paramore.Brighter.CommandStore.Sqlite
         /// <returns>True if it exists, False otherwise</returns>
         public async Task<bool> ExistsAsync<T>(Guid id, int timeoutInMilliseconds = -1, CancellationToken cancellationToken = default(CancellationToken)) where T : class, IRequest
         {
-            var sql = $"SELECT TOP 1 CommandId FROM {MessageStoreTableName} WHERE CommandId = @commandId";
+            var sql = $"SELECT CommandId FROM {MessageStoreTableName} WHERE CommandId = @CommandId LIMIT 1";
             var parameters = new[]
             {
                 CreateSqlParameter("CommandId", id)

--- a/src/Paramore.Brighter.CommandStore.Sqlite/SqliteCommandStore.cs
+++ b/src/Paramore.Brighter.CommandStore.Sqlite/SqliteCommandStore.cs
@@ -1,4 +1,4 @@
-#region Licence
+﻿#region Licence
 
 /* The MIT License (MIT)
 Copyright © 2014 Francesco Pighi <francesco.pighi@gmail.com>
@@ -90,13 +90,60 @@ namespace Paramore.Brighter.CommandStore.Sqlite
 
         public T Get<T>(Guid id, int timeoutInMilliseconds = -1) where T : class, IRequest, new()
         {
-            var sql = string.Format("select * from {0} where CommandId = @CommandId", this.MessageStoreTableName);
+            var sql = $"select * from {this.MessageStoreTableName} where CommandId = @CommandId";
             var parameters = new[]
             {
                 this.CreateSqlParameter("CommandId", id)
             };
 
             return ExecuteCommand(command => ReadCommand<T>(command.ExecuteReader()), sql, timeoutInMilliseconds, parameters);
+        }
+
+        /// <summary>
+        /// Checks whether a command with the specified identifier exists in the store
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="id">The identifier.</param>
+        /// <param name="timeoutInMilliseconds"></param>
+        /// <returns>True if it exists, False otherwise</returns>
+        public bool Exists<T>(Guid id, int timeoutInMilliseconds = -1) where T : class, IRequest
+        {
+            var sql = $"SELECT TOP 1 CommandId FROM {MessageStoreTableName} WHERE CommandId = @commandId";
+            var parameters = new[]
+            {
+                CreateSqlParameter("CommandId", id)
+            };
+
+            return ExecuteCommand(command => command.ExecuteReader().HasRows, sql, timeoutInMilliseconds,
+                parameters);
+        }
+
+        /// <summary>
+        /// Checks whether a command with the specified identifier exists in the store
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="id">The identifier.</param>
+        /// <param name="timeoutInMilliseconds"></param>
+        /// <returns>True if it exists, False otherwise</returns>
+        public async Task<bool> ExistsAsync<T>(Guid id, int timeoutInMilliseconds = -1, CancellationToken cancellationToken = default(CancellationToken)) where T : class, IRequest
+        {
+            var sql = $"SELECT TOP 1 CommandId FROM {MessageStoreTableName} WHERE CommandId = @commandId";
+            var parameters = new[]
+            {
+                CreateSqlParameter("CommandId", id)
+            };
+
+            return await ExecuteCommandAsync<bool>(
+                    async command =>
+                    {
+                        var reader = await command.ExecuteReaderAsync(cancellationToken);
+                        return reader.HasRows;
+                    },
+                    sql,
+                    timeoutInMilliseconds,
+                    parameters,
+                    cancellationToken)
+                .ConfigureAwait(ContinueOnCapturedContext);
         }
 
         public async Task AddAsync<T>(T command, int timeoutInMilliseconds = -1, CancellationToken cancellationToken = default(CancellationToken)) where T : class, IRequest
@@ -127,7 +174,7 @@ namespace Paramore.Brighter.CommandStore.Sqlite
 
         public async Task<T> GetAsync<T>(Guid id, int timeoutInMilliseconds = -1, CancellationToken cancellationToken = default(CancellationToken)) where T : class, IRequest, new()
         {
-            var sql = string.Format("select * from {0} where CommandId = @CommandId", MessageStoreTableName);
+            var sql = $"select * from {MessageStoreTableName} where CommandId = @CommandId";
             var parameters = new[]
             {
                 CreateSqlParameter("@CommandId", id)
@@ -211,9 +258,7 @@ namespace Paramore.Brighter.CommandStore.Sqlite
 
         private string GetAddSql()
         {
-            var sqlAdd = string.Format(
-                "insert into {0} (CommandID, CommandType, CommandBody, Timestamp) values (@CommandID, @CommandType, @CommandBody, @Timestamp)",
-                MessageStoreTableName);
+            var sqlAdd = $"insert into {MessageStoreTableName} (CommandID, CommandType, CommandBody, Timestamp) values (@CommandID, @CommandType, @CommandBody, @Timestamp)";
             return sqlAdd;
         }
 

--- a/src/Paramore.Brighter/Eventsourcing/Handlers/CommandSourcingHandler.cs
+++ b/src/Paramore.Brighter/Eventsourcing/Handlers/CommandSourcingHandler.cs
@@ -1,4 +1,4 @@
-#region Licence
+﻿#region Licence
 /* The MIT License (MIT)
 Copyright © 2015 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
 
@@ -38,7 +38,7 @@ namespace Paramore.Brighter.Eventsourcing.Handlers
     /// approach is typically called Command Sourcing.
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    public class CommandSourcingHandler<T> : RequestHandler<T> where T: class, IRequest, new()
+    public class CommandSourcingHandler<T> : RequestHandler<T> where T: class, IRequest
     {
         private static readonly Lazy<ILog> _logger = new Lazy<ILog>(LogProvider.For<CommandSourcingHandler<T>>);
 
@@ -72,8 +72,7 @@ namespace Paramore.Brighter.Eventsourcing.Handlers
             if (_onceOnly)
             {
                  _logger.Value.DebugFormat("Checking if command {0} has already been seen", command.Id);
-                var existingCommand = _commandStore.Get<T>(command.Id);
-                if (existingCommand.Id != Guid.Empty)
+                if (_commandStore.Exists<T>(command.Id))
                 {
                     _logger.Value.DebugFormat("Command {0} has already been seen", command.Id);
                     throw new OnceOnlyException($"A command with id {command.Id} has already been handled");

--- a/src/Paramore.Brighter/Eventsourcing/Handlers/CommandSourcingHandlerAsync.cs
+++ b/src/Paramore.Brighter/Eventsourcing/Handlers/CommandSourcingHandlerAsync.cs
@@ -1,4 +1,4 @@
-#region Licence
+﻿#region Licence
 /* The MIT License (MIT)
 Copyright © 2016 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
 
@@ -39,7 +39,7 @@ namespace Paramore.Brighter.Eventsourcing.Handlers
     /// approach is typically called Command Sourcing.
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    public class CommandSourcingHandlerAsync<T> : RequestHandlerAsync<T> where T : class, IRequest, new()
+    public class CommandSourcingHandlerAsync<T> : RequestHandlerAsync<T> where T : class, IRequest
     {
         private static readonly Lazy<ILog> _logger = new Lazy<ILog>(LogProvider.For<CommandSourcingHandlerAsync<T>>);
 
@@ -62,8 +62,6 @@ namespace Paramore.Brighter.Eventsourcing.Handlers
             base.InitializeFromAttributeParams(initializerList);
         }
 
-  
-
         /// <summary>
         /// Awaitably logs the command we received to the command store.
         /// </summary>
@@ -77,8 +75,8 @@ namespace Paramore.Brighter.Eventsourcing.Handlers
             {
                 _logger.Value.DebugFormat("Checking if command {0} has already been seen", command.Id);
                 //TODO: We should not use an infinite timeout here - how to configure
-                var existingCommand = await _commandStore.GetAsync<T>(command.Id, -1, cancellationToken).ConfigureAwait(ContinueOnCapturedContext);
-                if (existingCommand.Id != Guid.Empty)
+                var exists = await _commandStore.ExistsAsync<T>(command.Id, -1, cancellationToken).ConfigureAwait(ContinueOnCapturedContext);
+                if (exists)
                 {
                     _logger.Value.DebugFormat("Command {0} has already been seen", command.Id);
                     throw new OnceOnlyException($"A command with id {command.Id} has already been handled");

--- a/src/Paramore.Brighter/IAmACommandStore.cs
+++ b/src/Paramore.Brighter/IAmACommandStore.cs
@@ -1,4 +1,4 @@
-#region Licence
+﻿#region Licence
 /* The MIT License (MIT)
 Copyright © 2015 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
 
@@ -48,5 +48,14 @@ namespace Paramore.Brighter
         /// <param name="timeoutInMilliseconds"></param>
         /// <returns>T.</returns>
         T Get<T>(Guid id, int timeoutInMilliseconds = -1) where T : class, IRequest, new();
+
+        /// <summary>
+        /// Checks whether a command with the specified identifier exists in the store
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="id">The identifier.</param>
+        /// <param name="timeoutInMilliseconds"></param>
+        /// <returns>True if it exists, False otherwise</returns>
+        bool Exists<T>(Guid id, int timeoutInMilliseconds = -1) where T : class, IRequest;
     }
 }

--- a/src/Paramore.Brighter/IAmACommandStoreAsync.cs
+++ b/src/Paramore.Brighter/IAmACommandStoreAsync.cs
@@ -1,4 +1,4 @@
-#region Licence
+﻿#region Licence
 /* The MIT License (MIT)
 Copyright © 2015 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
 
@@ -53,7 +53,17 @@ namespace Paramore.Brighter
         /// <param name="cancellationToken">Allow the sender to cancel the operation, if the parameter is supplied</param>
         /// <returns><see cref="Task{T}"/>.</returns>
         Task<T> GetAsync<T>(Guid id, int timeoutInMilliseconds = -1, CancellationToken cancellationToken = default(CancellationToken)) where T : class, IRequest, new();
-        
+
+        /// <summary>
+        /// Checks whether a command with the specified identifier exists in the store
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="id">The identifier.</param>
+        /// <param name="timeoutInMilliseconds"></param>
+        /// <param name="cancellationToken">Allow the sender to cancel the operation, if the parameter is supplied</param>
+        /// <returns>True if it exists, False otherwise</returns>
+        Task<bool> ExistsAsync<T>(Guid id, int timeoutInMilliseconds = -1, CancellationToken cancellationToken = default(CancellationToken)) where T : class, IRequest;
+
         /// <summary>
         /// If false we the default thread synchronization context to run any continuation, if true we re-use the original synchronization context.
         /// Default to false unless you know that you need true, as you risk deadlocks with the originating thread if you Wait 

--- a/src/Paramore.Brighter/InMemoryCommandStore.cs
+++ b/src/Paramore.Brighter/InMemoryCommandStore.cs
@@ -1,4 +1,4 @@
-#region Licence
+﻿#region Licence
 
 /* The MIT License (MIT)
 Copyright © 2014 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
@@ -108,6 +108,34 @@ namespace Paramore.Brighter
                     commandStoreItem.CommandType.Name, typeof (T).Name));
 
             return JsonConvert.DeserializeObject<T>(commandStoreItem.CommandBody);
+        }
+
+        public bool Exists<T>(Guid id, int timeoutInMilliseconds = -1) where T : class, IRequest
+        {
+            return _commands.ContainsKey(id);
+        }
+
+        /// <summary>
+        /// Checks whether a command with the specified identifier exists in the store
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="id">The identifier.</param>
+        /// <param name="timeoutInMilliseconds"></param>
+        /// <returns>True if it exists, False otherwise</returns>
+        public Task<bool> ExistsAsync<T>(Guid id, int timeoutInMilliseconds = -1, CancellationToken cancellationToken = default(CancellationToken)) where T : class, IRequest
+        {
+            var tcs = new TaskCompletionSource<bool>();
+
+            if (cancellationToken.IsCancellationRequested)
+            {
+                tcs.SetCanceled();
+                return tcs.Task;
+            }
+
+            var command = Exists<T>(id, timeoutInMilliseconds);
+
+            tcs.SetResult(command);
+            return tcs.Task;
         }
 
         /// <summary>

--- a/tests/Paramore.Brighter.Tests/CommandStore/MsSsql/When_The_Message_Is_Already_In_The_Command_Store_Async.cs
+++ b/tests/Paramore.Brighter.Tests/CommandStore/MsSsql/When_The_Message_Is_Already_In_The_Command_Store_Async.cs
@@ -1,4 +1,4 @@
-#region Licence
+﻿#region Licence
 /* The MIT License (MIT)
 Copyright © 2015 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
 
@@ -58,6 +58,8 @@ namespace Paramore.Brighter.Tests.CommandStore.MsSsql
 
            //_should_succeed_even_if_the_message_is_a_duplicate
             _exception.Should().BeNull();
+            var exists = await _sqlCommandStore.ExistsAsync<MyCommand>(_raisedCommand.Id);
+            exists.Should().BeTrue();
         }
 
         public void Dispose()

--- a/tests/Paramore.Brighter.Tests/CommandStore/MsSsql/When_There_Is_No_Message_In_The_Sql_Command_Store_Async.cs
+++ b/tests/Paramore.Brighter.Tests/CommandStore/MsSsql/When_There_Is_No_Message_In_The_Sql_Command_Store_Async.cs
@@ -1,4 +1,4 @@
-#region Licence
+﻿#region Licence
 /* The MIT License (MIT)
 Copyright © 2015 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
 
@@ -50,10 +50,14 @@ namespace Paramore.Brighter.Tests.CommandStore.MsSsql
         [Fact]
         public async Task When_There_Is_No_Message_In_The_Sql_Command_Store_Async()
         {
-            _storedCommand = await _sqlCommandStore.GetAsync<MyCommand>(Guid.NewGuid());
+            Guid commandId = Guid.NewGuid();
+            _storedCommand = await _sqlCommandStore.GetAsync<MyCommand>(commandId);
 
             //_should_return_an_empty_command_on_a_missing_command
             _storedCommand.Id.Should().Be(Guid.Empty);
+
+            bool exists = await _sqlCommandStore.ExistsAsync<MyCommand>(commandId);
+            exists.Should().BeFalse();
         }
 
         public void Dispose()

--- a/tests/Paramore.Brighter.Tests/CommandStore/MsSsql/When_the_message_is_already_in_the_command_store.cs
+++ b/tests/Paramore.Brighter.Tests/CommandStore/MsSsql/When_the_message_is_already_in_the_command_store.cs
@@ -1,4 +1,4 @@
-#region Licence
+﻿#region Licence
 /* The MIT License (MIT)
 Copyright © 2014 Francesco Pighi <francesco.pighi@gmail.com>
 
@@ -56,6 +56,7 @@ namespace Paramore.Brighter.Tests.CommandStore.MsSsql
 
             //_should_succeed_even_if_the_message_is_a_duplicate
             _exception.Should().BeNull();
+            _sqlCommandStore.Exists<MyCommand>(_raisedCommand.Id).Should().BeTrue();
         }
 
         public void Dispose()

--- a/tests/Paramore.Brighter.Tests/CommandStore/MsSsql/When_there_is_no_message_in_the_sql_command_store.cs
+++ b/tests/Paramore.Brighter.Tests/CommandStore/MsSsql/When_there_is_no_message_in_the_sql_command_store.cs
@@ -1,4 +1,4 @@
-#region Licence
+﻿#region Licence
 /* The MIT License (MIT)
 Copyright © 2014 Francesco Pighi <francesco.pighi@gmail.com>
 
@@ -49,10 +49,12 @@ namespace Paramore.Brighter.Tests.CommandStore.MsSsql
         [Fact]
         public void When_There_Is_No_Message_In_The_Sql_Command_Store()
         {
-            _storedCommand = _sqlCommandStore.Get<MyCommand>(Guid.NewGuid());
+            Guid commandId = Guid.NewGuid();
+            _storedCommand = _sqlCommandStore.Get<MyCommand>(commandId);
 
            //_should_return_an_empty_command_on_a_missing_command
             _storedCommand.Id.Should().Be(Guid.Empty);
+            _sqlCommandStore.Exists<MyCommand>(commandId).Should().BeFalse();
         }
 
         public void Dispose()

--- a/tests/Paramore.Brighter.Tests/CommandStore/MySql/When_The_Message_Is_Already_In_The_Command_Store_Async.cs
+++ b/tests/Paramore.Brighter.Tests/CommandStore/MySql/When_The_Message_Is_Already_In_The_Command_Store_Async.cs
@@ -1,4 +1,4 @@
-#region Licence
+﻿#region Licence
 /* The MIT License (MIT)
 Copyright © 2015 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
 
@@ -59,6 +59,8 @@ namespace Paramore.Brighter.Tests.CommandStore.MySql
 
            //_should_succeed_even_if_the_message_is_a_duplicate
             _exception.Should().BeNull();
+            var exists = await _mysqlCommandStore.ExistsAsync<MyCommand>(_raisedCommand.Id);
+            exists.Should().BeTrue();
         }
 
         public void Dispose()

--- a/tests/Paramore.Brighter.Tests/CommandStore/MySql/When_There_Is_No_Message_In_The_Sql_Command_Store_Async.cs
+++ b/tests/Paramore.Brighter.Tests/CommandStore/MySql/When_There_Is_No_Message_In_The_Sql_Command_Store_Async.cs
@@ -1,4 +1,4 @@
-#region Licence
+﻿#region Licence
 /* The MIT License (MIT)
 Copyright © 2015 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
 
@@ -50,10 +50,14 @@ namespace Paramore.Brighter.Tests.CommandStore.MySql
         [Fact]
         public async Task When_There_Is_No_Message_In_The_Sql_Command_Store_Async()
         {
-            _storedCommand = await _mysqlCommandStore.GetAsync<MyCommand>(Guid.NewGuid());
+            Guid commandId = Guid.NewGuid();
+            _storedCommand = await _mysqlCommandStore.GetAsync<MyCommand>(commandId);
 
             //_should_return_an_empty_command_on_a_missing_command
             _storedCommand.Id.Should().Be(Guid.Empty);
+
+            bool exists = await _mysqlCommandStore.ExistsAsync<MyCommand>(commandId);
+            exists.Should().BeFalse();
         }
 
         public void Dispose()

--- a/tests/Paramore.Brighter.Tests/CommandStore/MySql/When_the_message_is_already_in_the_command_store.cs
+++ b/tests/Paramore.Brighter.Tests/CommandStore/MySql/When_the_message_is_already_in_the_command_store.cs
@@ -1,4 +1,4 @@
-#region Licence
+﻿#region Licence
 /* The MIT License (MIT)
 Copyright © 2014 Francesco Pighi <francesco.pighi@gmail.com>
 
@@ -56,6 +56,7 @@ namespace Paramore.Brighter.Tests.CommandStore.MySql
 
             //_should_succeed_even_if_the_message_is_a_duplicate
             _exception.Should().BeNull();
+            _mysqlCommandStore.Exists<MyCommand>(_raisedCommand.Id).Should().BeTrue();
         }
 
         public void Dispose()

--- a/tests/Paramore.Brighter.Tests/CommandStore/MySql/When_there_is_no_message_in_the_sql_command_store.cs
+++ b/tests/Paramore.Brighter.Tests/CommandStore/MySql/When_there_is_no_message_in_the_sql_command_store.cs
@@ -1,4 +1,4 @@
-#region Licence
+﻿#region Licence
 /* The MIT License (MIT)
 Copyright © 2014 Francesco Pighi <francesco.pighi@gmail.com>
 
@@ -49,10 +49,12 @@ namespace Paramore.Brighter.Tests.CommandStore.MySql
         [Fact]
         public void When_There_Is_No_Message_In_The_Sql_Command_Store()
         {
-            _storedCommand = _mysqlCommandStore.Get<MyCommand>(Guid.NewGuid());
+            Guid commandId = Guid.NewGuid();
+            _storedCommand = _mysqlCommandStore.Get<MyCommand>(commandId);
 
            //_should_return_an_empty_command_on_a_missing_command
             _storedCommand.Id.Should().Be(Guid.Empty);
+            _mysqlCommandStore.Exists<MyCommand>(commandId).Should().BeFalse();
         }
 
         public void Dispose()

--- a/tests/Paramore.Brighter.Tests/CommandStore/Sqlite/When_The_Message_Is_Already_In_The_Command_Store_Async.cs
+++ b/tests/Paramore.Brighter.Tests/CommandStore/Sqlite/When_The_Message_Is_Already_In_The_Command_Store_Async.cs
@@ -1,4 +1,4 @@
-#region Licence
+﻿#region Licence
 /* The MIT License (MIT)
 Copyright © 2015 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
 
@@ -58,6 +58,8 @@ namespace Paramore.Brighter.Tests.CommandStore.Sqlite
 
             //_should_succeed_even_if_the_message_is_a_duplicate
             _exception.Should().BeNull();
+            var exists = await _sqlCommandStore.ExistsAsync<MyCommand>(_raisedCommand.Id);
+            exists.Should().BeTrue();
         }
 
         public void Dispose()

--- a/tests/Paramore.Brighter.Tests/CommandStore/Sqlite/When_There_Is_No_Message_In_The_Sql_Command_Store_Async.cs
+++ b/tests/Paramore.Brighter.Tests/CommandStore/Sqlite/When_There_Is_No_Message_In_The_Sql_Command_Store_Async.cs
@@ -1,4 +1,4 @@
-#region Licence
+﻿#region Licence
 /* The MIT License (MIT)
 Copyright © 2015 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
 
@@ -50,10 +50,14 @@ namespace Paramore.Brighter.Tests.CommandStore.Sqlite
         [Fact]
         public async Task When_There_Is_No_Message_In_The_Sql_Command_Store_Async()
         {
-            _storedCommand = await _sqlCommandStore.GetAsync<MyCommand>(Guid.NewGuid());
+            Guid commandId = Guid.NewGuid();
+            _storedCommand = await _sqlCommandStore.GetAsync<MyCommand>(commandId);
 
             //_should_return_an_empty_command_on_a_missing_command
             _storedCommand.Id.Should().Be(Guid.Empty);
+
+            bool exists = await _sqlCommandStore.ExistsAsync<MyCommand>(commandId);
+            exists.Should().BeFalse();
         }
 
         public void Dispose()

--- a/tests/Paramore.Brighter.Tests/CommandStore/Sqlite/When_the_message_is_already_in_the_command_store.cs
+++ b/tests/Paramore.Brighter.Tests/CommandStore/Sqlite/When_the_message_is_already_in_the_command_store.cs
@@ -1,4 +1,4 @@
-#region Licence
+﻿#region Licence
 /* The MIT License (MIT)
 Copyright © 2014 Francesco Pighi <francesco.pighi@gmail.com>
 
@@ -55,6 +55,7 @@ namespace Paramore.Brighter.Tests.CommandStore.Sqlite
 
             //_should_succeed_even_if_the_message_is_a_duplicate
             _exception.Should().BeNull();
+            _sqlCommandStore.Exists<MyCommand>(_raisedCommand.Id).Should().BeTrue();
         }
 
         public void Dispose()

--- a/tests/Paramore.Brighter.Tests/CommandStore/Sqlite/When_there_is_no_message_in_the_sql_command_store.cs
+++ b/tests/Paramore.Brighter.Tests/CommandStore/Sqlite/When_there_is_no_message_in_the_sql_command_store.cs
@@ -1,4 +1,4 @@
-#region Licence
+﻿#region Licence
 /* The MIT License (MIT)
 Copyright © 2014 Francesco Pighi <francesco.pighi@gmail.com>
 
@@ -48,10 +48,12 @@ namespace Paramore.Brighter.Tests.CommandStore.Sqlite
         [Fact]
         public void When_There_Is_No_Message_In_The_Sql_Command_Store()
         {
-            _storedCommand = _sqlCommandStore.Get<MyCommand>(Guid.NewGuid());
+            Guid commandId = Guid.NewGuid();
+            _storedCommand = _sqlCommandStore.Get<MyCommand>(commandId);
 
            //_should_return_an_empty_command_on_a_missing_command
             _storedCommand.Id.Should().Be(Guid.Empty);
+            _sqlCommandStore.Exists<MyCommand>(commandId).Should().BeFalse();
         }
 
         public void Dispose()


### PR DESCRIPTION
…andler, meaning no need to load the entity and require the default ctor. (That is still required for reading from the store - I aim to submit another PR that allows the reading/writing to the store to use the registered message mappers).