### PR TITLE
Using comma to specify several kafka brokers

### DIFF
--- a/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaMessagingGatewayConfiguration.cs
+++ b/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaMessagingGatewayConfiguration.cs
@@ -50,7 +50,7 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
             var config = new Dictionary<string, object>()
             {
                 {"client.id", Name },
-                {"bootstrap.servers", string.Join(";", BootStrapServers)}
+                {"bootstrap.servers", string.Join(", ", BootStrapServers)}
             };
 
             if (MaxInFlightRequestsPerConnection.HasValue)


### PR DESCRIPTION
This is so important to specify kafka brokers in "bootstrap.servers" key section using just comma, otherwise neither publishing nor consuming would not work for cluster, for ex.