### PR TITLE
Once per handler option for command store

### DIFF
--- a/src/Paramore.Brighter.CommandStore.DynamoDB/DynamoDbCommandStoreBuilder.cs
+++ b/src/Paramore.Brighter.CommandStore.DynamoDB/DynamoDbCommandStoreBuilder.cs
@@ -45,6 +45,11 @@ namespace Paramore.Brighter.CommandStore.DynamoDB
                     {
                         AttributeName = "CommandId",
                         AttributeType = ScalarAttributeType.S
+                    },
+                    new AttributeDefinition
+                    {
+                        AttributeName = "ContextKey",
+                        AttributeType = ScalarAttributeType.S
                     }
                 },
                 KeySchema = new List<KeySchemaElement>
@@ -73,6 +78,23 @@ namespace Paramore.Brighter.CommandStore.DynamoDB
                             new KeySchemaElement
                             {
                                 AttributeName = "CommandId",
+                                KeyType = KeyType.HASH
+                            }
+                        },
+                        Projection = new Projection
+                        {
+                            ProjectionType = ProjectionType.ALL
+                        }
+                    },
+                    new GlobalSecondaryIndex
+                    {
+                        IndexName = "ContextKey",
+                        ProvisionedThroughput = provisionedThroughput,
+                        KeySchema = new List<KeySchemaElement>
+                        {
+                            new KeySchemaElement
+                            {
+                                AttributeName = "ContextKey",
                                 KeyType = KeyType.HASH
                             }
                         },

--- a/src/Paramore.Brighter.CommandStore.DynamoDB/DynamoDbCommandStoreConfiguration.cs
+++ b/src/Paramore.Brighter.CommandStore.DynamoDB/DynamoDbCommandStoreConfiguration.cs
@@ -41,6 +41,7 @@ namespace Paramore.Brighter.CommandStore.DynamoDB
         public bool UseStronglyConsistentRead { get; }
 
         public string CommandIdIndex { get; }
+        public string ContextKeyIndex { get; }
 
         /// <summary>
         /// Initalises a new instance of the <see cref="DynamoDbCommandStoreConfiguration"/> class.
@@ -48,7 +49,7 @@ namespace Paramore.Brighter.CommandStore.DynamoDB
         /// <param name="tableName">The table name.</param>
         /// <param name="useStronglyConsistentRead">Whether to use strongly consistent reads.</param>
         /// <param name="commandIdIndex">Name of Command Id index for Scan operations</param>
-        public DynamoDbCommandStoreConfiguration(string tableName, bool useStronglyConsistentRead, string commandIdIndex)
-            => (TableName, UseStronglyConsistentRead, CommandIdIndex) = (tableName, useStronglyConsistentRead, commandIdIndex);
+        public DynamoDbCommandStoreConfiguration(string tableName, bool useStronglyConsistentRead, string commandIdIndex, string contextKeyIndex)
+            => (TableName, UseStronglyConsistentRead, CommandIdIndex, ContextKeyIndex) = (tableName, useStronglyConsistentRead, commandIdIndex, contextKeyIndex);
     }     
 }

--- a/src/Paramore.Brighter.CommandStore.MsSql/DDL Scripts/MSSQL/CommandStore.sql
+++ b/src/Paramore.Brighter.CommandStore.MsSql/DDL Scripts/MSSQL/CommandStore.sql
@@ -9,6 +9,7 @@ CREATE TABLE [Commands] (
 , [CommandType] nvarchar(256) NULL
 , [CommandBody] ntext NULL
 , [Timestamp] datetime NULL
+, [ContextKey] nvarchar(256) NULL
 , PRIMARY KEY ( [Id] )
 );
 GO

--- a/src/Paramore.Brighter.CommandStore.MsSql/MsSqlCommandStore.cs
+++ b/src/Paramore.Brighter.CommandStore.MsSql/MsSqlCommandStore.cs
@@ -60,11 +60,12 @@ namespace Paramore.Brighter.CommandStore.MsSql
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="command">The command.</param>
+        /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
         /// <param name="timeoutInMilliseconds">Timeout in milliseconds; -1 for default timeout</param>
         /// <returns>Task.</returns>
-        public void Add<T>(T command, int timeoutInMilliseconds = -1) where T : class, IRequest
+        public void Add<T>(T command, string contextKey, int timeoutInMilliseconds = -1) where T : class, IRequest
         {
-            var parameters = InitAddDbParameters(command);
+            var parameters = InitAddDbParameters(command, contextKey);
 
             using (var connection = GetConnection())
             {
@@ -94,14 +95,16 @@ namespace Paramore.Brighter.CommandStore.MsSql
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="id">The identifier.</param>
+        /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
         /// <param name="timeoutInMilliseconds">Timeout in milliseconds; -1 for default timeout</param>
         /// <returns>T.</returns>
-        public T Get<T>(Guid id, int timeoutInMilliseconds = -1) where T : class, IRequest, new()
+        public T Get<T>(Guid id, string contextKey, int timeoutInMilliseconds = -1) where T : class, IRequest, new()
         {
-            var sql = $"select * from {_configuration.CommandStoreTableName} where CommandId = @commandId";
+            var sql = $"select * from {_configuration.CommandStoreTableName} where CommandId = @commandId AND ContextKey = @contextKey";
             var parameters = new[]
             {
-                CreateSqlParameter("CommandId", id)
+                CreateSqlParameter("CommandId", id),
+                CreateSqlParameter("ContextKey", contextKey)
             };
 
             return ExecuteCommand(command => ReadCommand<T>(command.ExecuteReader()), sql, timeoutInMilliseconds,
@@ -113,14 +116,16 @@ namespace Paramore.Brighter.CommandStore.MsSql
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="id">The identifier.</param>
+        /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
         /// <param name="timeoutInMilliseconds"></param>
         /// <returns>True if it exists, False otherwise</returns>
-        public bool Exists<T>(Guid id, int timeoutInMilliseconds = -1) where T : class, IRequest
+        public bool Exists<T>(Guid id, string contextKey, int timeoutInMilliseconds = -1) where T : class, IRequest
         {
-            var sql = $"SELECT TOP 1 CommandId FROM {_configuration.CommandStoreTableName} WHERE CommandId = @commandId";
+            var sql = $"SELECT TOP 1 CommandId FROM {_configuration.CommandStoreTableName} WHERE CommandId = @commandId AND ContextKey = @contextKey";
             var parameters = new[]
             {
-                CreateSqlParameter("CommandId", id)
+                CreateSqlParameter("CommandId", id),
+                CreateSqlParameter("ContextKey", contextKey)
             };
 
             return ExecuteCommand(command => command.ExecuteReader().HasRows, sql, timeoutInMilliseconds,
@@ -132,13 +137,14 @@ namespace Paramore.Brighter.CommandStore.MsSql
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="command">The command.</param>
+        /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
         /// <param name="timeoutInMilliseconds">Timeout in milliseconds; -1 for default timeout</param>
         /// <param name="cancellationToken">Allow the sender to cancel the request, optional</param>
         /// <returns><see cref="Task" />.</returns>
-        public async Task AddAsync<T>(T command, int timeoutInMilliseconds = -1, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task AddAsync<T>(T command, string contextKey, int timeoutInMilliseconds = -1, CancellationToken cancellationToken = default(CancellationToken))
             where T : class, IRequest
         {
-            var parameters = InitAddDbParameters(command);
+            var parameters = InitAddDbParameters(command, contextKey);
 
             using (var connection = GetConnection())
             {
@@ -169,14 +175,16 @@ namespace Paramore.Brighter.CommandStore.MsSql
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="id">The identifier.</param>
+        /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
         /// <param name="timeoutInMilliseconds"></param>
         /// <returns>True if it exists, False otherwise</returns>
-        public async Task<bool> ExistsAsync<T>(Guid id, int timeoutInMilliseconds = -1, CancellationToken cancellationToken = default(CancellationToken)) where T : class, IRequest
+        public async Task<bool> ExistsAsync<T>(Guid id, string contextKey, int timeoutInMilliseconds = -1, CancellationToken cancellationToken = default(CancellationToken)) where T : class, IRequest
         {
-            var sql = $"SELECT TOP 1 CommandId FROM {_configuration.CommandStoreTableName} WHERE CommandId = @commandId";
+            var sql = $"SELECT TOP 1 CommandId FROM {_configuration.CommandStoreTableName} WHERE CommandId = @commandId AND ContextKey = @contextKey";
             var parameters = new[]
             {
-                CreateSqlParameter("CommandId", id)
+                CreateSqlParameter("CommandId", id),
+                CreateSqlParameter("ContextKey", contextKey)
             };
 
             return await ExecuteCommandAsync<bool>(
@@ -207,17 +215,19 @@ namespace Paramore.Brighter.CommandStore.MsSql
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="id">The identifier.</param>
+        /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
         /// <param name="timeoutInMilliseconds">Timeout in milliseconds; -1 for default timeout</param>
         /// <param name="cancellationToken">Allow the sender to cancel the request</param>
         /// <returns><see cref="Task{T}" />.</returns>
-        public async Task<T> GetAsync<T>(Guid id, int timeoutInMilliseconds = -1, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<T> GetAsync<T>(Guid id, string contextKey, int timeoutInMilliseconds = -1, CancellationToken cancellationToken = default(CancellationToken))
             where T : class, IRequest, new()
         {
-            var sql = $"select * from {_configuration.CommandStoreTableName} where CommandId = @commandId";
+            var sql = $"select * from {_configuration.CommandStoreTableName} where CommandId = @commandId AND ContextKey = @contextKey";
 
             var parameters = new[]
             {
-                CreateSqlParameter("CommandId", id)
+                CreateSqlParameter("CommandId", id),
+                CreateSqlParameter("ContextKey", contextKey)
             };
 
             return await ExecuteCommandAsync(
@@ -278,7 +288,7 @@ namespace Paramore.Brighter.CommandStore.MsSql
         private DbCommand InitAddDbCommand(int timeoutInMilliseconds, DbConnection connection, DbParameter[] parameters)
         {
             var sqlAdd =
-                $"insert into {_configuration.CommandStoreTableName} (CommandID, CommandType, CommandBody, Timestamp) values (@CommandID, @CommandType, @CommandBody, @Timestamp)";
+                $"insert into {_configuration.CommandStoreTableName} (CommandID, CommandType, CommandBody, Timestamp, ContextKey) values (@CommandID, @CommandType, @CommandBody, @Timestamp, @ContextKey)";
 
             var sqlcmd = connection.CreateCommand();
             if (timeoutInMilliseconds != -1) sqlcmd.CommandTimeout = timeoutInMilliseconds;
@@ -288,7 +298,7 @@ namespace Paramore.Brighter.CommandStore.MsSql
             return sqlcmd;
         }
 
-        private DbParameter[] InitAddDbParameters<T>(T command) where T : class, IRequest
+        private DbParameter[] InitAddDbParameters<T>(T command, string contextKey) where T : class, IRequest
         {
             var commandJson = JsonConvert.SerializeObject(command);
             var parameters = new[]
@@ -296,7 +306,8 @@ namespace Paramore.Brighter.CommandStore.MsSql
                 CreateSqlParameter("CommandID", command.Id),
                 CreateSqlParameter("CommandType", typeof (T).Name),
                 CreateSqlParameter("CommandBody", commandJson),
-                CreateSqlParameter("Timestamp", DateTime.UtcNow)
+                CreateSqlParameter("Timestamp", DateTime.UtcNow),
+                CreateSqlParameter("ContextKey", contextKey)
             };
             return parameters;
         }

--- a/src/Paramore.Brighter.CommandStore.MsSql/SqlCommandStoreBuilder.cs
+++ b/src/Paramore.Brighter.CommandStore.MsSql/SqlCommandStoreBuilder.cs
@@ -1,4 +1,4 @@
-#region Licence
+﻿#region Licence
 /* The MIT License (MIT)
 Copyright © 2014 Francesco Pighi <francesco.pighi@gmail.com>
 
@@ -34,6 +34,7 @@ namespace Paramore.Brighter.CommandStore.MsSql
                             [CommandType] [NVARCHAR](256) NULL ,
                             [CommandBody] [NTEXT] NULL ,
                             [Timestamp] [DATETIME] NULL ,
+                            [ContextKey] [NVARCHAR](256) NULL,
                             PRIMARY KEY ( [Id] )
                         );";
 

--- a/src/Paramore.Brighter.CommandStore.MySql/MySqlCommandStore.cs
+++ b/src/Paramore.Brighter.CommandStore.MySql/MySqlCommandStore.cs
@@ -59,11 +59,12 @@ namespace Paramore.Brighter.CommandStore.MySql
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="command">The command.</param>
+        /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
         /// <param name="timeoutInMilliseconds">Timeout in milliseconds; -1 for default timeout</param>
         /// <returns>Task.</returns>
-        public void Add<T>(T command, int timeoutInMilliseconds = -1) where T : class, IRequest
+        public void Add<T>(T command, string contextKey, int timeoutInMilliseconds = -1) where T : class, IRequest
         {
-            var parameters = InitAddDbParameters(command);
+            var parameters = InitAddDbParameters(command, contextKey);
 
             using (var connection = GetConnection())
             {
@@ -93,14 +94,16 @@ namespace Paramore.Brighter.CommandStore.MySql
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="id">The identifier.</param>
+        /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
         /// <param name="timeoutInMilliseconds">Timeout in milliseconds; -1 for default timeout</param>
         /// <returns>T.</returns>
-        public T Get<T>(Guid id, int timeoutInMilliseconds = -1) where T : class, IRequest, new()
+        public T Get<T>(Guid id, string contextKey, int timeoutInMilliseconds = -1) where T : class, IRequest, new()
         {
-            var sql = $"select * from {_configuration.CommandStoreTableName} where CommandId = @commandId";
+            var sql = $"select * from {_configuration.CommandStoreTableName} where CommandId = @commandId and ContextKey = @contextKey";
             var parameters = new[]
             {
-                CreateSqlParameter("CommandId", id)
+                CreateSqlParameter("CommandId", id),
+                CreateSqlParameter("ContextKey", contextKey)
             };
 
             return ExecuteCommand(command => ReadCommand<T>(command.ExecuteReader()), sql, timeoutInMilliseconds,
@@ -112,14 +115,16 @@ namespace Paramore.Brighter.CommandStore.MySql
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="id">The identifier.</param>
+        /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
         /// <param name="timeoutInMilliseconds"></param>
         /// <returns>True if it exists, False otherwise</returns>
-        public bool Exists<T>(Guid id, int timeoutInMilliseconds = -1) where T : class, IRequest
+        public bool Exists<T>(Guid id, string contextKey, int timeoutInMilliseconds = -1) where T : class, IRequest
         {
-            var sql = $"SELECT CommandId FROM {_configuration.CommandStoreTableName} WHERE CommandId = @commandId LIMIT 1";
+            var sql = $"SELECT CommandId FROM {_configuration.CommandStoreTableName} WHERE CommandId = @commandId and ContextKey = @contextKey LIMIT 1";
             var parameters = new[]
             {
-                CreateSqlParameter("CommandId", id)
+                CreateSqlParameter("CommandId", id),
+                CreateSqlParameter("ContextKey", contextKey)
             };
 
             return ExecuteCommand(command => command.ExecuteReader().HasRows, sql, timeoutInMilliseconds,
@@ -131,14 +136,16 @@ namespace Paramore.Brighter.CommandStore.MySql
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="id">The identifier.</param>
+        /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
         /// <param name="timeoutInMilliseconds"></param>
         /// <returns>True if it exists, False otherwise</returns>
-        public async Task<bool> ExistsAsync<T>(Guid id, int timeoutInMilliseconds = -1, CancellationToken cancellationToken = default(CancellationToken)) where T : class, IRequest
+        public async Task<bool> ExistsAsync<T>(Guid id, string contextKey, int timeoutInMilliseconds = -1, CancellationToken cancellationToken = default(CancellationToken)) where T : class, IRequest
         {
-            var sql = $"SELECT CommandId FROM {_configuration.CommandStoreTableName} WHERE CommandId = @commandId LIMIT 1";
+            var sql = $"SELECT CommandId FROM {_configuration.CommandStoreTableName} WHERE CommandId = @commandId and ContextKey = @contextKey LIMIT 1";
             var parameters = new[]
             {
-                CreateSqlParameter("CommandId", id)
+                CreateSqlParameter("CommandId", id),
+                CreateSqlParameter("ContextKey", contextKey)
             };
 
             return await ExecuteCommandAsync<bool>(
@@ -159,13 +166,14 @@ namespace Paramore.Brighter.CommandStore.MySql
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="command">The command.</param>
+        /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
         /// <param name="timeoutInMilliseconds">Timeout in milliseconds; -1 for default timeout</param>
         /// <param name="cancellationToken">Allow the sender to cancel the request, optional</param>
         /// <returns><see cref="Task" />.</returns>
-        public async Task AddAsync<T>(T command, int timeoutInMilliseconds = -1, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task AddAsync<T>(T command, string contextKey, int timeoutInMilliseconds = -1, CancellationToken cancellationToken = default(CancellationToken))
             where T : class, IRequest
         {
-            var parameters = InitAddDbParameters(command);
+            var parameters = InitAddDbParameters(command, contextKey);
 
             using (var connection = GetConnection())
             {
@@ -205,17 +213,19 @@ namespace Paramore.Brighter.CommandStore.MySql
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="id">The identifier.</param>
+        /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
         /// <param name="timeoutInMilliseconds">Timeout in milliseconds; -1 for default timeout</param>
         /// <param name="cancellationToken">Allow the sender to cancel the request</param>
         /// <returns><see cref="Task{T}" />.</returns>
-        public async Task<T> GetAsync<T>(Guid id, int timeoutInMilliseconds = -1, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<T> GetAsync<T>(Guid id, string contextKey, int timeoutInMilliseconds = -1, CancellationToken cancellationToken = default(CancellationToken))
             where T : class, IRequest, new()
         {
-            var sql = $"select * from {_configuration.CommandStoreTableName} where CommandId = @commandId";
+            var sql = $"select * from {_configuration.CommandStoreTableName} where CommandId = @commandId and ContextKey = @contextKey";
 
             var parameters = new[]
             {
-                CreateSqlParameter("CommandId", id)
+                CreateSqlParameter("CommandId", id),
+                CreateSqlParameter("ContextKey", contextKey)
             };
 
             return await ExecuteCommandAsync(
@@ -280,7 +290,7 @@ namespace Paramore.Brighter.CommandStore.MySql
         private DbCommand InitAddDbCommand(int timeoutInMilliseconds, DbConnection connection, DbParameter[] parameters)
         {
             var sqlAdd =
-                $"insert into {_configuration.CommandStoreTableName} (CommandID, CommandType, CommandBody, Timestamp) values (@CommandID, @CommandType, @CommandBody, @Timestamp)";
+                $"insert into {_configuration.CommandStoreTableName} (CommandID, CommandType, CommandBody, Timestamp, ContextKey) values (@CommandID, @CommandType, @CommandBody, @Timestamp, @ContextKey)";
 
             var sqlcmd = connection.CreateCommand();
             if (timeoutInMilliseconds != -1) sqlcmd.CommandTimeout = timeoutInMilliseconds;
@@ -290,7 +300,7 @@ namespace Paramore.Brighter.CommandStore.MySql
             return sqlcmd;
         }
 
-        private DbParameter[] InitAddDbParameters<T>(T command) where T : class, IRequest
+        private DbParameter[] InitAddDbParameters<T>(T command, string contextKey) where T : class, IRequest
         {
             var commandJson = JsonConvert.SerializeObject(command);
             var parameters = new[]
@@ -298,7 +308,8 @@ namespace Paramore.Brighter.CommandStore.MySql
                 CreateSqlParameter("CommandID", command.Id),
                 CreateSqlParameter("CommandType", typeof (T).Name),
                 CreateSqlParameter("CommandBody", commandJson),
-                CreateSqlParameter("Timestamp", DateTime.UtcNow)
+                CreateSqlParameter("Timestamp", DateTime.UtcNow),
+                CreateSqlParameter("ContextKey", contextKey),
             };
             return parameters;
         }

--- a/src/Paramore.Brighter.CommandStore.MySql/MySqlCommandStoreBuilder.cs
+++ b/src/Paramore.Brighter.CommandStore.MySql/MySqlCommandStoreBuilder.cs
@@ -1,4 +1,4 @@
-#region Licence
+﻿#region Licence
 /* The MIT License (MIT)
 Copyright © 2014 Francesco Pighi <francesco.pighi@gmail.com>
 
@@ -32,6 +32,7 @@ namespace Paramore.Brighter.CommandStore.MySql
                 `CommandType` VARCHAR(256) NOT NULL , 
                 `CommandBody` TEXT NOT NULL , 
                 `Timestamp` TIMESTAMP(4) NOT NULL , 
+                `ContextKey` VARCHAR(256)  NULL , 
                 PRIMARY KEY (`CommandId`)
             ) ENGINE = InnoDB;";
 

--- a/src/Paramore.Brighter.CommandStore.Sqlite/DDL Scripts/SQLite/CommandStore.sql
+++ b/src/Paramore.Brighter.CommandStore.Sqlite/DDL Scripts/SQLite/CommandStore.sql
@@ -20,6 +20,7 @@ CREATE TABLE [Commands] (
 , [CommandType] nvarchar(256) NULL
 , [CommandBody] ntext NULL
 , [Timestamp] datetime NULL
+, [ContextKey] nvarchar(256) NULL
 , CONSTRAINT [PK_MessageId] PRIMARY KEY ([CommandId])
 );
 COMMIT;

--- a/src/Paramore.Brighter.CommandStore.Sqlite/SqliteCommandStoreBuilder.cs
+++ b/src/Paramore.Brighter.CommandStore.Sqlite/SqliteCommandStoreBuilder.cs
@@ -1,4 +1,4 @@
-#region Licence
+﻿#region Licence
 /* The MIT License (MIT)
 Copyright © 2014 Francesco Pighi <francesco.pighi@gmail.com>
 
@@ -30,7 +30,8 @@ namespace Paramore.Brighter.CommandStore.Sqlite
                 "CommandId uniqueidentifier CONSTRAINT PK_MessageId PRIMARY KEY," +
                 "CommandType nvarchar(256)," +
                 "CommandBody ntext," +
-                "Timestamp dateTime" +
+                "Timestamp dateTime," +
+                "ContextKey nvarchar(256)" +
                 ")";
 
         public static string GetDDL(string tableName)

--- a/src/Paramore.Brighter.MessageStore.Sqlite/SqliteMessageStoreBuilder.cs
+++ b/src/Paramore.Brighter.MessageStore.Sqlite/SqliteMessageStoreBuilder.cs
@@ -1,4 +1,4 @@
-#region Licence
+﻿#region Licence
 /* The MIT License (MIT)
 Copyright © 2014 Francesco Pighi <francesco.pighi@gmail.com>
 
@@ -32,7 +32,7 @@ namespace Paramore.Brighter.MessageStore.Sqlite
                                         , [MessageType] nvarchar(32) NULL
                                         , [Timestamp] datetime NULL
                                         , [HeaderBag] ntext NULL
-                                        , [Body] ntext NULL
+                                        , [Body] ntext NULL,
                                         , CONSTRAINT[PK_MessageId] PRIMARY KEY([MessageId])
                                         );";
 

--- a/src/Paramore.Brighter.MessageStore.Sqlite/SqliteMessageStoreBuilder.cs
+++ b/src/Paramore.Brighter.MessageStore.Sqlite/SqliteMessageStoreBuilder.cs
@@ -32,7 +32,7 @@ namespace Paramore.Brighter.MessageStore.Sqlite
                                         , [MessageType] nvarchar(32) NULL
                                         , [Timestamp] datetime NULL
                                         , [HeaderBag] ntext NULL
-                                        , [Body] ntext NULL,
+                                        , [Body] ntext NULL
                                         , CONSTRAINT[PK_MessageId] PRIMARY KEY([MessageId])
                                         );";
 

--- a/src/Paramore.Brighter/Eventsourcing/Attributes/UseCommandSourcingAsyncAttribute.cs
+++ b/src/Paramore.Brighter/Eventsourcing/Attributes/UseCommandSourcingAsyncAttribute.cs
@@ -1,4 +1,4 @@
-#region Licence
+﻿#region Licence
 /* The MIT License (MIT)
 Copyright © 2016 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
 
@@ -37,23 +37,38 @@ namespace Paramore.Brighter.Eventsourcing.Attributes
     public class UseCommandSourcingAsyncAttribute : RequestHandlerAttribute
     {
         public bool OnceOnly { get; }
+        public string ContextKey { get; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="UseCommandSourcingAsyncAttribute"/> class.
         /// </summary>
         /// <param name="step">The step.</param>
         /// <param name="onceOnly">Should we prevent duplicate messages i.e. seen already</param>
+        /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
         /// <param name="timing">The timing.</param>
-        public UseCommandSourcingAsyncAttribute(int step, bool onceOnly = false, HandlerTiming timing = HandlerTiming.Before)
+        public UseCommandSourcingAsyncAttribute(int step, bool onceOnly = false, string contextKey = null, HandlerTiming timing = HandlerTiming.Before)
             : base(step, timing)
         {
             OnceOnly = onceOnly;
+            ContextKey = contextKey;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UseCommandSourcingAsyncAttribute"/> class.
+        /// </summary>
+        /// <param name="step">The step.</param>
+        /// <param name="onceOnly">Should we prevent duplicate messages i.e. seen already</param>
+        /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
+        /// <param name="timing">The timing.</param>
+        public UseCommandSourcingAsyncAttribute(int step, Type contextKey, bool onceOnly = false, HandlerTiming timing = HandlerTiming.Before)
+            : this(step, onceOnly, contextKey.FullName, timing)
+        {
         }
 
         public override object[] InitializerParams()
         {
             
-            return new object[]{OnceOnly};
+            return new object[]{OnceOnly, ContextKey};
         }
 
         /// <summary>

--- a/src/Paramore.Brighter/Eventsourcing/Attributes/UseCommandSourcingAttribute.cs
+++ b/src/Paramore.Brighter/Eventsourcing/Attributes/UseCommandSourcingAttribute.cs
@@ -1,4 +1,4 @@
-#region Licence
+﻿#region Licence
 /* The MIT License (MIT)
 Copyright © 2015 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
 
@@ -36,22 +36,38 @@ namespace Paramore.Brighter.Eventsourcing.Attributes
     /// </summary>
     public class UseCommandSourcingAttribute : RequestHandlerAttribute
     {
+        public string ContextKey { get; }
         public bool OnceOnly { get; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RequestHandlerAttribute"/> class.
         /// </summary>
         /// <param name="step">The step.</param>
+        /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
         /// <param name="onceOnly">Should we prevent duplicate messages i.e. seen already</param>
         /// <param name="timing">The timing.</param>
-        public UseCommandSourcingAttribute(int step, bool onceOnly=false, HandlerTiming timing = HandlerTiming.Before) : base(step, timing)
+        public UseCommandSourcingAttribute(int step, string contextKey = null, bool onceOnly=false, HandlerTiming timing = HandlerTiming.Before) 
+            : base(step, timing)
         {
+            ContextKey = contextKey;
             OnceOnly = onceOnly;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RequestHandlerAttribute"/> class.
+        /// </summary>
+        /// <param name="step">The step.</param>
+        /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the type of the handler)</param>
+        /// <param name="onceOnly">Should we prevent duplicate messages i.e. seen already</param>
+        /// <param name="timing">The timing.</param>
+        public UseCommandSourcingAttribute(int step, Type contextKey, bool onceOnly = false, HandlerTiming timing = HandlerTiming.Before) 
+            : this(step, contextKey.FullName, onceOnly, timing)
+        {
         }
 
         public override object[] InitializerParams()
         {
-            return new object[] {OnceOnly};
+            return new object[] {OnceOnly, ContextKey};
         }
 
         /// <summary>

--- a/src/Paramore.Brighter/Eventsourcing/Handlers/CommandSourcingHandler.cs
+++ b/src/Paramore.Brighter/Eventsourcing/Handlers/CommandSourcingHandler.cs
@@ -44,6 +44,7 @@ namespace Paramore.Brighter.Eventsourcing.Handlers
 
         private readonly IAmACommandStore _commandStore;
         private bool _onceOnly;
+        private string _contextKey;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RequestHandler{TRequest}" /> class.
@@ -58,6 +59,7 @@ namespace Paramore.Brighter.Eventsourcing.Handlers
         public override void InitializeFromAttributeParams(params object[] initializerList)
         {
             _onceOnly = (bool) initializerList[0];
+            _contextKey = (string)initializerList[1];
             base.InitializeFromAttributeParams(initializerList);
         }
 
@@ -72,7 +74,7 @@ namespace Paramore.Brighter.Eventsourcing.Handlers
             if (_onceOnly)
             {
                  _logger.Value.DebugFormat("Checking if command {0} has already been seen", command.Id);
-                if (_commandStore.Exists<T>(command.Id))
+                if (_commandStore.Exists<T>(command.Id, _contextKey))
                 {
                     _logger.Value.DebugFormat("Command {0} has already been seen", command.Id);
                     throw new OnceOnlyException($"A command with id {command.Id} has already been handled");
@@ -82,7 +84,7 @@ namespace Paramore.Brighter.Eventsourcing.Handlers
             
             _logger.Value.DebugFormat("Writing command {0} to the Command Store", command.Id);
 
-            _commandStore.Add(command);
+            _commandStore.Add(command, _contextKey);
 
             return base.Handle(command);
         }

--- a/src/Paramore.Brighter/Eventsourcing/Handlers/CommandSourcingHandlerAsync.cs
+++ b/src/Paramore.Brighter/Eventsourcing/Handlers/CommandSourcingHandlerAsync.cs
@@ -45,6 +45,7 @@ namespace Paramore.Brighter.Eventsourcing.Handlers
 
         private readonly IAmACommandStoreAsync _commandStore;
         private bool _onceOnly;
+        private string _contextKey;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CommandSourcingHandlerAsync{T}" /> class.
@@ -59,6 +60,7 @@ namespace Paramore.Brighter.Eventsourcing.Handlers
         public override void InitializeFromAttributeParams(params object[] initializerList)
         {
             _onceOnly = (bool) initializerList[0];
+            _contextKey = (string)initializerList[1];
             base.InitializeFromAttributeParams(initializerList);
         }
 
@@ -75,7 +77,7 @@ namespace Paramore.Brighter.Eventsourcing.Handlers
             {
                 _logger.Value.DebugFormat("Checking if command {0} has already been seen", command.Id);
                 //TODO: We should not use an infinite timeout here - how to configure
-                var exists = await _commandStore.ExistsAsync<T>(command.Id, -1, cancellationToken).ConfigureAwait(ContinueOnCapturedContext);
+                var exists = await _commandStore.ExistsAsync<T>(command.Id, _contextKey , - 1, cancellationToken).ConfigureAwait(ContinueOnCapturedContext);
                 if (exists)
                 {
                     _logger.Value.DebugFormat("Command {0} has already been seen", command.Id);
@@ -86,7 +88,7 @@ namespace Paramore.Brighter.Eventsourcing.Handlers
             _logger.Value.DebugFormat("Writing command {0} to the Command Store", command.Id);
 
             //TODO: We should not use an infinite timeout here - how to configure
-            await _commandStore.AddAsync(command, -1, cancellationToken).ConfigureAwait(ContinueOnCapturedContext);
+            await _commandStore.AddAsync(command, _contextKey, - 1, cancellationToken).ConfigureAwait(ContinueOnCapturedContext);
 
             return await base.HandleAsync(command, cancellationToken).ConfigureAwait(ContinueOnCapturedContext);
         }

--- a/src/Paramore.Brighter/HandlerFactory.cs
+++ b/src/Paramore.Brighter/HandlerFactory.cs
@@ -1,4 +1,4 @@
-#region Licence
+﻿#region Licence
 /* The MIT License (MIT)
 Copyright © 2014 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
 
@@ -31,7 +31,7 @@ namespace Paramore.Brighter
         private readonly RequestHandlerAttribute _attribute;
         private readonly IAmAHandlerFactory _factory;
         private readonly Type _messageType;
-        private IRequestContext _requestContext;
+        private readonly IRequestContext _requestContext;
 
         public HandlerFactory(RequestHandlerAttribute attribute, IAmAHandlerFactory factory, IRequestContext requestContext)
         {

--- a/src/Paramore.Brighter/IAmACommandStore.cs
+++ b/src/Paramore.Brighter/IAmACommandStore.cs
@@ -37,25 +37,28 @@ namespace Paramore.Brighter
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="command">The command.</param>
+        /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
         /// <param name="timeoutInMilliseconds"></param>
-        void Add<T>(T command, int timeoutInMilliseconds = -1) where T : class, IRequest;
+        void Add<T>(T command, string contextKey, int timeoutInMilliseconds = -1) where T : class, IRequest;
 
         /// <summary>
         /// Finds the specified identifier.
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="id">The identifier.</param>
+        /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
         /// <param name="timeoutInMilliseconds"></param>
         /// <returns>T.</returns>
-        T Get<T>(Guid id, int timeoutInMilliseconds = -1) where T : class, IRequest, new();
+        T Get<T>(Guid id, string contextKey, int timeoutInMilliseconds = -1) where T : class, IRequest, new();
 
         /// <summary>
         /// Checks whether a command with the specified identifier exists in the store
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="id">The identifier.</param>
+        /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
         /// <param name="timeoutInMilliseconds"></param>
         /// <returns>True if it exists, False otherwise</returns>
-        bool Exists<T>(Guid id, int timeoutInMilliseconds = -1) where T : class, IRequest;
+        bool Exists<T>(Guid id, string contextKey, int timeoutInMilliseconds = -1) where T : class, IRequest;
     }
 }

--- a/src/Paramore.Brighter/IAmACommandStoreAsync.cs
+++ b/src/Paramore.Brighter/IAmACommandStoreAsync.cs
@@ -42,7 +42,7 @@ namespace Paramore.Brighter
         /// <param name="timeoutInMilliseconds"></param>
         /// <param name="cancellationToken">Allow the sender to cancel the operation, if the parameter is supplied</param>
         /// <returns><see cref="Task"/>.</returns>
-        Task AddAsync<T>(T command, int timeoutInMilliseconds = -1, CancellationToken cancellationToken = default(CancellationToken)) where T : class, IRequest;
+        Task AddAsync<T>(T command, string contextKey, int timeoutInMilliseconds = -1, CancellationToken cancellationToken = default(CancellationToken)) where T : class, IRequest;
 
         /// <summary>
         /// Awaitably finds the specified identifier.
@@ -52,7 +52,7 @@ namespace Paramore.Brighter
         /// <param name="timeoutInMilliseconds"></param>
         /// <param name="cancellationToken">Allow the sender to cancel the operation, if the parameter is supplied</param>
         /// <returns><see cref="Task{T}"/>.</returns>
-        Task<T> GetAsync<T>(Guid id, int timeoutInMilliseconds = -1, CancellationToken cancellationToken = default(CancellationToken)) where T : class, IRequest, new();
+        Task<T> GetAsync<T>(Guid id, string contextKey, int timeoutInMilliseconds = -1, CancellationToken cancellationToken = default(CancellationToken)) where T : class, IRequest, new();
 
         /// <summary>
         /// Checks whether a command with the specified identifier exists in the store
@@ -62,7 +62,7 @@ namespace Paramore.Brighter
         /// <param name="timeoutInMilliseconds"></param>
         /// <param name="cancellationToken">Allow the sender to cancel the operation, if the parameter is supplied</param>
         /// <returns>True if it exists, False otherwise</returns>
-        Task<bool> ExistsAsync<T>(Guid id, int timeoutInMilliseconds = -1, CancellationToken cancellationToken = default(CancellationToken)) where T : class, IRequest;
+        Task<bool> ExistsAsync<T>(Guid id, string contextKey, int timeoutInMilliseconds = -1, CancellationToken cancellationToken = default(CancellationToken)) where T : class, IRequest;
 
         /// <summary>
         /// If false we the default thread synchronization context to run any continuation, if true we re-use the original synchronization context.

--- a/tests/Paramore.Brighter.Tests/CommandStore/DynamoDB/BaseCommandStoreDyamoDBBaseTest.cs
+++ b/tests/Paramore.Brighter.Tests/CommandStore/DynamoDB/BaseCommandStoreDyamoDBBaseTest.cs
@@ -13,15 +13,16 @@ namespace Paramore.Brighter.Tests.CommandStore.DynamoDB
             DynamoDbTestHelper = new DynamoDbTestHelper();
         }
         
-        protected DynamoDbCommand<T> ConstructCommand<T>(T command, DateTime timeStamp) where T : class, IRequest
-        {                                               
+        protected DynamoDbCommand<T> ConstructCommand<T>(T command, DateTime timeStamp, string contextKey) where T : class, IRequest
+        {
             return new DynamoDbCommand<T>
             {
                 CommandDate = $"{typeof(T).Name}+{timeStamp:yyyy-MM-dd}",
                 Time = $"{timeStamp.Ticks}",
                 CommandId = command.Id.ToString(),
                 CommandType = typeof(T).Name,
-                CommandBody = JsonConvert.SerializeObject(command),       
+                CommandBody = JsonConvert.SerializeObject(command),
+                ContextKey = contextKey
             };
         }
                 

--- a/tests/Paramore.Brighter.Tests/CommandStore/DynamoDB/When_the_message_is_already_in_the_command_store.cs
+++ b/tests/Paramore.Brighter.Tests/CommandStore/DynamoDB/When_the_message_is_already_in_the_command_store.cs
@@ -37,6 +37,7 @@ namespace Paramore.Brighter.Tests.CommandStore.DynamoDB
     {
         private readonly DynamoDbTestHelper _dynamoDbTestHelper;
         private readonly DynamoDbCommandStore _dynamoDbCommandStore;
+        private readonly string _contextKey;
         private readonly MyCommand _raisedCommand;
 
         private Exception _exception;
@@ -48,16 +49,28 @@ namespace Paramore.Brighter.Tests.CommandStore.DynamoDB
 
             _dynamoDbCommandStore = new DynamoDbCommandStore(_dynamoDbTestHelper.DynamoDbContext, _dynamoDbTestHelper.DynamoDbCommandStoreTestConfiguration);
             _raisedCommand = new MyCommand { Value = "Test" };
-            _dynamoDbCommandStore.Add(_raisedCommand);
+            _contextKey = "context-key";
+            _dynamoDbCommandStore.Add(_raisedCommand, _contextKey);
         }
 
         [Fact]
         public void When_The_Message_Is_Already_In_The_Command_Store()
         {
-            _exception = Catch.Exception(() => _dynamoDbCommandStore.Add(_raisedCommand));
+            _exception = Catch.Exception(() => _dynamoDbCommandStore.Add(_raisedCommand, _contextKey));
 
             //_should_succeed_even_if_the_message_is_a_duplicate
             _exception.Should().BeNull();
+        }
+
+        [Fact]
+        public void When_The_Message_Is_Already_In_The_Command_Store_Different_Context()
+        {
+            _dynamoDbCommandStore.Add(_raisedCommand, "some other key");
+
+            var storedCommand = _dynamoDbCommandStore.Get<MyCommand>(_raisedCommand.Id, "some other key");
+
+            //_should_read_the_command_from_the__dynamo_db_command_store
+            storedCommand.Should().NotBeNull();
         }
 
         public void Dispose()

--- a/tests/Paramore.Brighter.Tests/CommandStore/DynamoDB/When_the_message_is_already_in_the_command_store_async.cs
+++ b/tests/Paramore.Brighter.Tests/CommandStore/DynamoDB/When_the_message_is_already_in_the_command_store_async.cs
@@ -38,6 +38,7 @@ namespace Paramore.Brighter.Tests.CommandStore.DynamoDB
         private readonly DynamoDbTestHelper _dynamoDbTestHelper;
         private readonly DynamoDbCommandStore _dynamoDbCommandStore;
         private readonly MyCommand _raisedCommand;
+        private readonly string _contextKey;
         private Exception _exception;
 
         public DynamoDbCommandStoreDuplicateMessageAsyncTests()
@@ -46,15 +47,16 @@ namespace Paramore.Brighter.Tests.CommandStore.DynamoDB
             _dynamoDbTestHelper.CreateCommandStoreTable(new DynamoDbCommandStoreBuilder(_dynamoDbTestHelper.DynamoDbCommandStoreTestConfiguration.TableName).CreateCommandStoreTableRequest(readCapacityUnits: 2, writeCapacityUnits: 1));
 
             _dynamoDbCommandStore = new DynamoDbCommandStore(_dynamoDbTestHelper.DynamoDbContext, _dynamoDbTestHelper.DynamoDbCommandStoreTestConfiguration);
-            _raisedCommand = new MyCommand {Value = "Test"};            
+            _raisedCommand = new MyCommand {Value = "Test"};
+            _contextKey = "context-key";
         }
 
         [Fact]
         public async Task When_the_message_is_already_in_the_command_store_async()
         {
-            _dynamoDbCommandStore.Add(_raisedCommand);
+            _dynamoDbCommandStore.Add(_raisedCommand, _contextKey);
 
-            _exception = await Catch.ExceptionAsync(() => _dynamoDbCommandStore.AddAsync(_raisedCommand));
+            _exception = await Catch.ExceptionAsync(() => _dynamoDbCommandStore.AddAsync(_raisedCommand, _contextKey));
 
             //_should_succeed_even_if_the_message_is_a_duplicate
             _exception.Should().BeNull();

--- a/tests/Paramore.Brighter.Tests/CommandStore/DynamoDB/When_there_is_no_message_in_the_dynamo_command_store.cs
+++ b/tests/Paramore.Brighter.Tests/CommandStore/DynamoDB/When_there_is_no_message_in_the_dynamo_command_store.cs
@@ -49,7 +49,7 @@ namespace Paramore.Brighter.Tests.CommandStore.DynamoDB
         [Fact]
         public void When_There_Is_No_Message_In_The_Sql_Command_Store()
         {
-            _storedCommand = _dynamoDbCommandStore.Get<MyCommand>(Guid.NewGuid());
+            _storedCommand = _dynamoDbCommandStore.Get<MyCommand>(Guid.NewGuid(), "some key");
 
             //_should_return_an_empty_command_on_a_missing_command
             _storedCommand.Id.Should().Be(Guid.Empty);

--- a/tests/Paramore.Brighter.Tests/CommandStore/DynamoDB/When_there_is_no_message_in_the_dynamo_command_store_async.cs
+++ b/tests/Paramore.Brighter.Tests/CommandStore/DynamoDB/When_there_is_no_message_in_the_dynamo_command_store_async.cs
@@ -49,7 +49,7 @@ namespace Paramore.Brighter.Tests.CommandStore.DynamoDB
         [Fact]
         public async void When_There_Is_No_Message_In_The_Sql_Command_Store()
         {
-            _storedCommand = await _dynamoDbCommandStore.GetAsync<MyCommand>(Guid.NewGuid());
+            _storedCommand = await _dynamoDbCommandStore.GetAsync<MyCommand>(Guid.NewGuid(), "some key");
 
             //_should_return_an_empty_command_on_a_missing_command
             _storedCommand.Id.Should().Be(Guid.Empty);

--- a/tests/Paramore.Brighter.Tests/CommandStore/DynamoDB/When_writing_a_message_to_the_command_store.cs
+++ b/tests/Paramore.Brighter.Tests/CommandStore/DynamoDB/When_writing_a_message_to_the_command_store.cs
@@ -37,6 +37,7 @@ namespace Paramore.Brighter.Tests.CommandStore.DynamoDB
         private readonly DynamoDbTestHelper _dynamoDbTestHelper;
         private readonly DynamoDbCommandStore _dynamoDbCommandStore;
         private readonly MyCommand _raisedCommand;
+        private readonly string _contextKey;
         private MyCommand _storedCommand;
 
         public DynamoDbCommandStoreAddMessageTests()
@@ -46,13 +47,14 @@ namespace Paramore.Brighter.Tests.CommandStore.DynamoDB
 
             _dynamoDbCommandStore = new DynamoDbCommandStore(_dynamoDbTestHelper.DynamoDbContext, _dynamoDbTestHelper.DynamoDbCommandStoreTestConfiguration);
             _raisedCommand = new MyCommand {Value = "Test"};
-            _dynamoDbCommandStore.Add(_raisedCommand);
+            _contextKey = "context-key";
+            _dynamoDbCommandStore.Add(_raisedCommand, _contextKey);
         }
 
         [Fact]
         public void When_writing_a_message_to_the_command_store()
         {
-            _storedCommand = _dynamoDbCommandStore.Get<MyCommand>(_raisedCommand.Id);
+            _storedCommand = _dynamoDbCommandStore.Get<MyCommand>(_raisedCommand.Id, _contextKey);
 
             //_should_read_the_command_from_the__dynamo_db_command_store
             _storedCommand.Should().NotBeNull();

--- a/tests/Paramore.Brighter.Tests/CommandStore/DynamoDB/When_writing_a_message_to_the_command_store_async.cs
+++ b/tests/Paramore.Brighter.Tests/CommandStore/DynamoDB/When_writing_a_message_to_the_command_store_async.cs
@@ -38,6 +38,7 @@ namespace Paramore.Brighter.Tests.CommandStore.DynamoDB
         private readonly DynamoDbTestHelper _dynamoDbTestHelper;
         private readonly DynamoDbCommandStore _dynamoDbCommandStore;
         private readonly MyCommand _raisedCommand;
+        private readonly string _contextKey;
         private MyCommand _storedCommand;
 
         public DynamoDbCommandStoreAddMessageAsyncTests()
@@ -47,13 +48,14 @@ namespace Paramore.Brighter.Tests.CommandStore.DynamoDB
 
             _dynamoDbCommandStore = new DynamoDbCommandStore(_dynamoDbTestHelper.DynamoDbContext, _dynamoDbTestHelper.DynamoDbCommandStoreTestConfiguration);
             _raisedCommand = new MyCommand { Value = "Test" };
-            _dynamoDbCommandStore.Add(_raisedCommand);
+            _contextKey = "context-key";
+            _dynamoDbCommandStore.Add(_raisedCommand, _contextKey);
         }
 
         [Fact]
         public async Task When_writing_a_message_to_the_command_store()
         {
-            _storedCommand = await _dynamoDbCommandStore.GetAsync<MyCommand>(_raisedCommand.Id);
+            _storedCommand = await _dynamoDbCommandStore.GetAsync<MyCommand>(_raisedCommand.Id, _contextKey);
 
             //_should_read_the_command_from_the__dynamo_db_command_store
             _storedCommand.Should().NotBeNull();

--- a/tests/Paramore.Brighter.Tests/CommandStore/MsSsql/When_There_Is_No_Message_In_The_Sql_Command_Store_Async.cs
+++ b/tests/Paramore.Brighter.Tests/CommandStore/MsSsql/When_There_Is_No_Message_In_The_Sql_Command_Store_Async.cs
@@ -51,12 +51,12 @@ namespace Paramore.Brighter.Tests.CommandStore.MsSsql
         public async Task When_There_Is_No_Message_In_The_Sql_Command_Store_Async()
         {
             Guid commandId = Guid.NewGuid();
-            _storedCommand = await _sqlCommandStore.GetAsync<MyCommand>(commandId);
+            _storedCommand = await _sqlCommandStore.GetAsync<MyCommand>(commandId, "some-key");
 
             //_should_return_an_empty_command_on_a_missing_command
             _storedCommand.Id.Should().Be(Guid.Empty);
 
-            bool exists = await _sqlCommandStore.ExistsAsync<MyCommand>(commandId);
+            bool exists = await _sqlCommandStore.ExistsAsync<MyCommand>(commandId, "some-key");
             exists.Should().BeFalse();
         }
 

--- a/tests/Paramore.Brighter.Tests/CommandStore/MsSsql/When_Writing_A_Message_To_The_Command_Store_Async.cs
+++ b/tests/Paramore.Brighter.Tests/CommandStore/MsSsql/When_Writing_A_Message_To_The_Command_Store_Async.cs
@@ -1,4 +1,4 @@
-#region Licence
+﻿#region Licence
 /* The MIT License (MIT)
 Copyright © 2015 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
 
@@ -38,6 +38,7 @@ namespace Paramore.Brighter.Tests.CommandStore.MsSsql
         private readonly MsSqlTestHelper _msSqlTestHelper;
         private readonly MsSqlCommandStore _sqlCommandStore;
         private readonly MyCommand _raisedCommand;
+        private readonly string _contextKey;
         private MyCommand _storedCommand;
 
         public SqlCommandStoreAddMessageAsyncTests()
@@ -47,14 +48,15 @@ namespace Paramore.Brighter.Tests.CommandStore.MsSsql
 
             _sqlCommandStore = new MsSqlCommandStore(_msSqlTestHelper.CommandStoreConfiguration);
             _raisedCommand = new MyCommand { Value = "Test" };
+            _contextKey = "context-key";
         }
 
         [Fact]
         public async Task When_Writing_A_Message_To_The_Command_Store_Async()
         {
-            await _sqlCommandStore.AddAsync(_raisedCommand);
+            await _sqlCommandStore.AddAsync(_raisedCommand, _contextKey);
 
-            _storedCommand = await _sqlCommandStore.GetAsync<MyCommand>(_raisedCommand.Id);
+            _storedCommand = await _sqlCommandStore.GetAsync<MyCommand>(_raisedCommand.Id, _contextKey);
 
             //_should_read_the_command_from_the__sql_command_store
             _storedCommand.Should().NotBeNull();

--- a/tests/Paramore.Brighter.Tests/CommandStore/MsSsql/When_there_is_no_message_in_the_sql_command_store.cs
+++ b/tests/Paramore.Brighter.Tests/CommandStore/MsSsql/When_there_is_no_message_in_the_sql_command_store.cs
@@ -36,6 +36,7 @@ namespace Paramore.Brighter.Tests.CommandStore.MsSsql
     {
         private readonly MsSqlTestHelper _msSqlTestHelper;
         private readonly MsSqlCommandStore _sqlCommandStore;
+        private readonly string _contextKey;
         private MyCommand _storedCommand;
 
         public SqlCommandStoreEmptyWhenSearchedTests()
@@ -44,17 +45,18 @@ namespace Paramore.Brighter.Tests.CommandStore.MsSsql
             _msSqlTestHelper.SetupCommandDb();
 
             _sqlCommandStore = new MsSqlCommandStore(_msSqlTestHelper.CommandStoreConfiguration);
+            _contextKey = "context-key";
         }
 
         [Fact]
         public void When_There_Is_No_Message_In_The_Sql_Command_Store()
         {
             Guid commandId = Guid.NewGuid();
-            _storedCommand = _sqlCommandStore.Get<MyCommand>(commandId);
+            _storedCommand = _sqlCommandStore.Get<MyCommand>(commandId, _contextKey);
 
            //_should_return_an_empty_command_on_a_missing_command
             _storedCommand.Id.Should().Be(Guid.Empty);
-            _sqlCommandStore.Exists<MyCommand>(commandId).Should().BeFalse();
+            _sqlCommandStore.Exists<MyCommand>(commandId, _contextKey).Should().BeFalse();
         }
 
         public void Dispose()

--- a/tests/Paramore.Brighter.Tests/CommandStore/MsSsql/When_writing_a_message_to_the_command_store.cs
+++ b/tests/Paramore.Brighter.Tests/CommandStore/MsSsql/When_writing_a_message_to_the_command_store.cs
@@ -1,4 +1,4 @@
-#region Licence
+﻿#region Licence
 /* The MIT License (MIT)
 Copyright © 2014 Francesco Pighi <francesco.pighi@gmail.com>
 
@@ -37,6 +37,7 @@ namespace Paramore.Brighter.Tests.CommandStore.MsSsql
         private readonly MsSqlTestHelper _msSqlTestHelper;
         private readonly MsSqlCommandStore _sqlCommandStore;
         private readonly MyCommand _raisedCommand;
+        private readonly string _contextKey;
         private MyCommand _storedCommand;
 
         public SqlCommandStoreAddMessageTests()
@@ -46,13 +47,14 @@ namespace Paramore.Brighter.Tests.CommandStore.MsSsql
 
             _sqlCommandStore = new MsSqlCommandStore(_msSqlTestHelper.CommandStoreConfiguration);
             _raisedCommand = new MyCommand { Value = "Test" };
-            _sqlCommandStore.Add(_raisedCommand);
+            _contextKey = "context-key";
+            _sqlCommandStore.Add(_raisedCommand, _contextKey);
         }
 
         [Fact]
         public void When_Writing_A_Message_To_The_Command_Store()
         {
-            _storedCommand = _sqlCommandStore.Get<MyCommand>(_raisedCommand.Id);
+            _storedCommand = _sqlCommandStore.Get<MyCommand>(_raisedCommand.Id, _contextKey);
 
             //_should_read_the_command_from_the__sql_command_store
             _storedCommand.Should().NotBeNull();

--- a/tests/Paramore.Brighter.Tests/CommandStore/MySql/When_There_Is_No_Message_In_The_Sql_Command_Store_Async.cs
+++ b/tests/Paramore.Brighter.Tests/CommandStore/MySql/When_There_Is_No_Message_In_The_Sql_Command_Store_Async.cs
@@ -37,6 +37,7 @@ namespace Paramore.Brighter.Tests.CommandStore.MySql
     {
         private readonly MySqlTestHelper _mysqlTestHelper;
         private readonly MySqlCommandStore _mysqlCommandStore;
+        private readonly string _contextKey;
         private MyCommand _storedCommand;
 
         public SqlCommandStoreEmptyWhenSearchedAsyncTests()
@@ -45,18 +46,19 @@ namespace Paramore.Brighter.Tests.CommandStore.MySql
             _mysqlTestHelper.SetupCommandDb();
 
             _mysqlCommandStore = new MySqlCommandStore(_mysqlTestHelper.CommandStoreConfiguration);
+            _contextKey = "test-context";
         }
 
         [Fact]
         public async Task When_There_Is_No_Message_In_The_Sql_Command_Store_Async()
         {
             Guid commandId = Guid.NewGuid();
-            _storedCommand = await _mysqlCommandStore.GetAsync<MyCommand>(commandId);
+            _storedCommand = await _mysqlCommandStore.GetAsync<MyCommand>(commandId, _contextKey);
 
             //_should_return_an_empty_command_on_a_missing_command
             _storedCommand.Id.Should().Be(Guid.Empty);
 
-            bool exists = await _mysqlCommandStore.ExistsAsync<MyCommand>(commandId);
+            bool exists = await _mysqlCommandStore.ExistsAsync<MyCommand>(commandId, _contextKey);
             exists.Should().BeFalse();
         }
 

--- a/tests/Paramore.Brighter.Tests/CommandStore/MySql/When_Writing_A_Message_To_The_Command_Store_Async.cs
+++ b/tests/Paramore.Brighter.Tests/CommandStore/MySql/When_Writing_A_Message_To_The_Command_Store_Async.cs
@@ -1,4 +1,4 @@
-#region Licence
+﻿#region Licence
 /* The MIT License (MIT)
 Copyright © 2015 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
 
@@ -38,6 +38,7 @@ namespace Paramore.Brighter.Tests.CommandStore.MySql
         private readonly MySqlTestHelper _mysqlTestHelper;
         private readonly MySqlCommandStore _mysqlCommandStore;
         private readonly MyCommand _raisedCommand;
+        private readonly string _contextKey;
         private MyCommand _storedCommand;
 
         public MySqlCommandStoreAddMessageAsyncTests()
@@ -47,14 +48,15 @@ namespace Paramore.Brighter.Tests.CommandStore.MySql
 
             _mysqlCommandStore = new MySqlCommandStore(_mysqlTestHelper.CommandStoreConfiguration);
             _raisedCommand = new MyCommand { Value = "Test" };
+            _contextKey = "test-context";
         }
 
         [Fact]
         public async Task When_Writing_A_Message_To_The_Command_Store_Async()
         {
-            await _mysqlCommandStore.AddAsync(_raisedCommand);
+            await _mysqlCommandStore.AddAsync(_raisedCommand, _contextKey);
 
-            _storedCommand = await _mysqlCommandStore.GetAsync<MyCommand>(_raisedCommand.Id);
+            _storedCommand = await _mysqlCommandStore.GetAsync<MyCommand>(_raisedCommand.Id, _contextKey);
 
             //_should_read_the_command_from_the__sql_command_store
             _storedCommand.Should().NotBeNull();

--- a/tests/Paramore.Brighter.Tests/CommandStore/MySql/When_the_message_is_already_in_the_command_store.cs
+++ b/tests/Paramore.Brighter.Tests/CommandStore/MySql/When_the_message_is_already_in_the_command_store.cs
@@ -37,6 +37,7 @@ namespace Paramore.Brighter.Tests.CommandStore.MySql
         private readonly MySqlTestHelper _mysqlTestHelper;
         private readonly MySqlCommandStore _mysqlCommandStore;
         private readonly MyCommand _raisedCommand;
+        private readonly string _contextKey;
         private Exception _exception;
 
         public MySqlCommandStoreDuplicateMessageTests()
@@ -46,17 +47,29 @@ namespace Paramore.Brighter.Tests.CommandStore.MySql
 
             _mysqlCommandStore = new MySqlCommandStore(_mysqlTestHelper.CommandStoreConfiguration);
             _raisedCommand = new MyCommand { Value = "Test" };
-            _mysqlCommandStore.Add(_raisedCommand);
+            _contextKey = "test-context";
+            _mysqlCommandStore.Add(_raisedCommand, _contextKey);
         }
 
         [Fact]
         public void When_The_Message_Is_Already_In_The_Command_Store()
         {
-            _exception = Catch.Exception(() => _mysqlCommandStore.Add(_raisedCommand));
+            _exception = Catch.Exception(() => _mysqlCommandStore.Add(_raisedCommand, _contextKey));
 
             //_should_succeed_even_if_the_message_is_a_duplicate
             _exception.Should().BeNull();
-            _mysqlCommandStore.Exists<MyCommand>(_raisedCommand.Id).Should().BeTrue();
+            _mysqlCommandStore.Exists<MyCommand>(_raisedCommand.Id, _contextKey).Should().BeTrue();
+        }
+
+        [Fact]
+        public void When_The_Message_Is_Already_In_The_Command_Store_Different_Context()
+        {
+            _mysqlCommandStore.Add(_raisedCommand, "some other key");
+
+            var storedCommand = _mysqlCommandStore.Get<MyCommand>(_raisedCommand.Id, "some other key");
+
+            //_should_read_the_command_from_the__dynamo_db_command_store
+            storedCommand.Should().NotBeNull();
         }
 
         public void Dispose()

--- a/tests/Paramore.Brighter.Tests/CommandStore/MySql/When_there_is_no_message_in_the_sql_command_store.cs
+++ b/tests/Paramore.Brighter.Tests/CommandStore/MySql/When_there_is_no_message_in_the_sql_command_store.cs
@@ -36,6 +36,7 @@ namespace Paramore.Brighter.Tests.CommandStore.MySql
     {
         private readonly MySqlTestHelper _mysqlTestHelper;
         private readonly MySqlCommandStore _mysqlCommandStore;
+        private readonly string _contextKey;
         private MyCommand _storedCommand;
 
         public SqlCommandStoreEmptyWhenSearchedTests()
@@ -44,17 +45,18 @@ namespace Paramore.Brighter.Tests.CommandStore.MySql
             _mysqlTestHelper.SetupCommandDb();
 
             _mysqlCommandStore = new MySqlCommandStore(_mysqlTestHelper.CommandStoreConfiguration);
+            _contextKey = "test-context";
         }
 
         [Fact]
         public void When_There_Is_No_Message_In_The_Sql_Command_Store()
         {
             Guid commandId = Guid.NewGuid();
-            _storedCommand = _mysqlCommandStore.Get<MyCommand>(commandId);
+            _storedCommand = _mysqlCommandStore.Get<MyCommand>(commandId, _contextKey);
 
            //_should_return_an_empty_command_on_a_missing_command
             _storedCommand.Id.Should().Be(Guid.Empty);
-            _mysqlCommandStore.Exists<MyCommand>(commandId).Should().BeFalse();
+            _mysqlCommandStore.Exists<MyCommand>(commandId, _contextKey).Should().BeFalse();
         }
 
         public void Dispose()

--- a/tests/Paramore.Brighter.Tests/CommandStore/MySql/When_writing_a_message_to_the_command_store.cs
+++ b/tests/Paramore.Brighter.Tests/CommandStore/MySql/When_writing_a_message_to_the_command_store.cs
@@ -1,4 +1,4 @@
-#region Licence
+﻿#region Licence
 /* The MIT License (MIT)
 Copyright © 2014 Francesco Pighi <francesco.pighi@gmail.com>
 
@@ -37,6 +37,7 @@ namespace Paramore.Brighter.Tests.CommandStore.MySql
         private readonly MySqlTestHelper _mysqlTestHelper;
         private readonly MySqlCommandStore _mysqlCommandStore;
         private readonly MyCommand _raisedCommand;
+        private readonly string _contextKey;
         private MyCommand _storedCommand;
 
         public SqlCommandStoreAddMessageTests()
@@ -46,13 +47,14 @@ namespace Paramore.Brighter.Tests.CommandStore.MySql
 
             _mysqlCommandStore = new MySqlCommandStore(_mysqlTestHelper.CommandStoreConfiguration);
             _raisedCommand = new MyCommand { Value = "Test" };
-            _mysqlCommandStore.Add(_raisedCommand);
+            _contextKey = "test-context";
+            _mysqlCommandStore.Add(_raisedCommand, _contextKey);
         }
 
         [Fact]
         public void When_Writing_A_Message_To_The_Command_Store()
         {
-            _storedCommand = _mysqlCommandStore.Get<MyCommand>(_raisedCommand.Id);
+            _storedCommand = _mysqlCommandStore.Get<MyCommand>(_raisedCommand.Id, _contextKey);
 
             //_should_read_the_command_from_the__sql_command_store
             _storedCommand.Should().NotBeNull();

--- a/tests/Paramore.Brighter.Tests/CommandStore/Sqlite/When_The_Message_Is_Already_In_The_Command_Store_Async.cs
+++ b/tests/Paramore.Brighter.Tests/CommandStore/Sqlite/When_The_Message_Is_Already_In_The_Command_Store_Async.cs
@@ -38,6 +38,7 @@ namespace Paramore.Brighter.Tests.CommandStore.Sqlite
         private readonly SqliteTestHelper _sqliteTestHelper;
         private readonly SqliteCommandStore _sqlCommandStore;
         private readonly MyCommand _raisedCommand;
+        private readonly string _contextKey;
         private Exception _exception;
 
         public SqliteCommandStoreDuplicateMessageAsyncTests()
@@ -47,18 +48,19 @@ namespace Paramore.Brighter.Tests.CommandStore.Sqlite
 
             _sqlCommandStore = new SqliteCommandStore(new SqliteCommandStoreConfiguration(_sqliteTestHelper.ConnectionString, _sqliteTestHelper.TableName));
             _raisedCommand = new MyCommand {Value = "Test"};
+            _contextKey = "context-key";
         }
 
         [Fact]
         public async Task When_The_Message_Is_Already_In_The_Command_Store_Async()
         {
-            await _sqlCommandStore.AddAsync(_raisedCommand);
+            await _sqlCommandStore.AddAsync(_raisedCommand, _contextKey);
 
-            _exception = await Catch.ExceptionAsync(() => _sqlCommandStore.AddAsync(_raisedCommand));
+            _exception = await Catch.ExceptionAsync(() => _sqlCommandStore.AddAsync(_raisedCommand, _contextKey));
 
             //_should_succeed_even_if_the_message_is_a_duplicate
             _exception.Should().BeNull();
-            var exists = await _sqlCommandStore.ExistsAsync<MyCommand>(_raisedCommand.Id);
+            var exists = await _sqlCommandStore.ExistsAsync<MyCommand>(_raisedCommand.Id, _contextKey);
             exists.Should().BeTrue();
         }
 

--- a/tests/Paramore.Brighter.Tests/CommandStore/Sqlite/When_There_Is_No_Message_In_The_Sql_Command_Store_Async.cs
+++ b/tests/Paramore.Brighter.Tests/CommandStore/Sqlite/When_There_Is_No_Message_In_The_Sql_Command_Store_Async.cs
@@ -37,6 +37,7 @@ namespace Paramore.Brighter.Tests.CommandStore.Sqlite
     {
         private readonly SqliteTestHelper _sqliteTestHelper;
         private readonly SqliteCommandStore _sqlCommandStore;
+        private readonly string _contextKey;
         private MyCommand _storedCommand;
 
         public SqliteCommandStoreEmptyWhenSearchedAsyncTests()
@@ -45,18 +46,19 @@ namespace Paramore.Brighter.Tests.CommandStore.Sqlite
             _sqliteTestHelper.SetupCommandDb();
 
             _sqlCommandStore = new SqliteCommandStore(new SqliteCommandStoreConfiguration(_sqliteTestHelper.ConnectionString, _sqliteTestHelper.TableName));
+            _contextKey = "context-key";
         }
 
         [Fact]
         public async Task When_There_Is_No_Message_In_The_Sql_Command_Store_Async()
         {
             Guid commandId = Guid.NewGuid();
-            _storedCommand = await _sqlCommandStore.GetAsync<MyCommand>(commandId);
+            _storedCommand = await _sqlCommandStore.GetAsync<MyCommand>(commandId, _contextKey);
 
             //_should_return_an_empty_command_on_a_missing_command
             _storedCommand.Id.Should().Be(Guid.Empty);
 
-            bool exists = await _sqlCommandStore.ExistsAsync<MyCommand>(commandId);
+            bool exists = await _sqlCommandStore.ExistsAsync<MyCommand>(commandId, _contextKey);
             exists.Should().BeFalse();
         }
 

--- a/tests/Paramore.Brighter.Tests/CommandStore/Sqlite/When_Writing_A_Message_To_The_Command_Store_Async.cs
+++ b/tests/Paramore.Brighter.Tests/CommandStore/Sqlite/When_Writing_A_Message_To_The_Command_Store_Async.cs
@@ -1,4 +1,4 @@
-#region Licence
+﻿#region Licence
 /* The MIT License (MIT)
 Copyright © 2015 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
 
@@ -38,6 +38,7 @@ namespace Paramore.Brighter.Tests.CommandStore.Sqlite
         private readonly SqliteTestHelper _sqliteTestHelper;
         private readonly SqliteCommandStore _sqlCommandStore;
         private readonly MyCommand _raisedCommand;
+        private readonly string _contextKey;
         private MyCommand _storedCommand;
 
         public SqliteCommandStoreAddMessageAsyncTests()
@@ -47,14 +48,15 @@ namespace Paramore.Brighter.Tests.CommandStore.Sqlite
 
             _sqlCommandStore = new SqliteCommandStore(new SqliteCommandStoreConfiguration(_sqliteTestHelper.ConnectionString, _sqliteTestHelper.TableName));
             _raisedCommand = new MyCommand {Value = "Test"};
+            _contextKey = "context-key";
         }
 
         [Fact]
         public async Task When_Writing_A_Message_To_The_Command_Store_Async()
         {
-            await _sqlCommandStore.AddAsync(_raisedCommand);
+            await _sqlCommandStore.AddAsync(_raisedCommand, _contextKey);
 
-            _storedCommand = await _sqlCommandStore.GetAsync<MyCommand>(_raisedCommand.Id);
+            _storedCommand = await _sqlCommandStore.GetAsync<MyCommand>(_raisedCommand.Id, _contextKey);
 
             //_should_read_the_command_from_the__sql_command_store
             _storedCommand.Should().NotBeNull();

--- a/tests/Paramore.Brighter.Tests/CommandStore/Sqlite/When_the_message_is_already_in_the_command_store.cs
+++ b/tests/Paramore.Brighter.Tests/CommandStore/Sqlite/When_the_message_is_already_in_the_command_store.cs
@@ -37,6 +37,7 @@ namespace Paramore.Brighter.Tests.CommandStore.Sqlite
         private readonly SqliteTestHelper _sqliteTestHelper;
         private readonly SqliteCommandStore _sqlCommandStore;
         private readonly MyCommand _raisedCommand;
+        private readonly string _contextKey;
         private Exception _exception;
 
         public SqliteCommandStoreDuplicateMessageTests()
@@ -45,17 +46,18 @@ namespace Paramore.Brighter.Tests.CommandStore.Sqlite
             _sqliteTestHelper.SetupCommandDb();
             _sqlCommandStore = new SqliteCommandStore(new SqliteCommandStoreConfiguration(_sqliteTestHelper.ConnectionString, _sqliteTestHelper.TableName));
             _raisedCommand = new MyCommand { Value = "Test" };
-            _sqlCommandStore.Add(_raisedCommand);
+            _contextKey = "context-key";
+            _sqlCommandStore.Add(_raisedCommand, _contextKey);
         }
 
         [Fact]
         public void When_The_Message_Is_Already_In_The_Command_Store()
         {
-            _exception = Catch.Exception(() => _sqlCommandStore.Add(_raisedCommand));
+            _exception = Catch.Exception(() => _sqlCommandStore.Add(_raisedCommand, _contextKey));
 
             //_should_succeed_even_if_the_message_is_a_duplicate
             _exception.Should().BeNull();
-            _sqlCommandStore.Exists<MyCommand>(_raisedCommand.Id).Should().BeTrue();
+            _sqlCommandStore.Exists<MyCommand>(_raisedCommand.Id, _contextKey).Should().BeTrue();
         }
 
         public void Dispose()

--- a/tests/Paramore.Brighter.Tests/CommandStore/Sqlite/When_there_is_no_message_in_the_sql_command_store.cs
+++ b/tests/Paramore.Brighter.Tests/CommandStore/Sqlite/When_there_is_no_message_in_the_sql_command_store.cs
@@ -36,6 +36,7 @@ namespace Paramore.Brighter.Tests.CommandStore.Sqlite
     {
         private readonly SqliteTestHelper _sqliteTestHelper;
         private readonly SqliteCommandStore _sqlCommandStore;
+        private readonly string _contextKey;
         private MyCommand _storedCommand;
 
         public SqliteCommandStoreEmptyWhenSearchedTests()
@@ -43,17 +44,18 @@ namespace Paramore.Brighter.Tests.CommandStore.Sqlite
             _sqliteTestHelper = new SqliteTestHelper();
             _sqliteTestHelper.SetupCommandDb();
             _sqlCommandStore = new SqliteCommandStore(new SqliteCommandStoreConfiguration(_sqliteTestHelper.ConnectionString, _sqliteTestHelper.TableName));
+            _contextKey = "context-key";
         }
 
         [Fact]
         public void When_There_Is_No_Message_In_The_Sql_Command_Store()
         {
             Guid commandId = Guid.NewGuid();
-            _storedCommand = _sqlCommandStore.Get<MyCommand>(commandId);
+            _storedCommand = _sqlCommandStore.Get<MyCommand>(commandId,_contextKey);
 
            //_should_return_an_empty_command_on_a_missing_command
             _storedCommand.Id.Should().Be(Guid.Empty);
-            _sqlCommandStore.Exists<MyCommand>(commandId).Should().BeFalse();
+            _sqlCommandStore.Exists<MyCommand>(commandId, _contextKey).Should().BeFalse();
         }
 
         public void Dispose()

--- a/tests/Paramore.Brighter.Tests/CommandStore/Sqlite/When_writing_a_message_to_the_command_store.cs
+++ b/tests/Paramore.Brighter.Tests/CommandStore/Sqlite/When_writing_a_message_to_the_command_store.cs
@@ -1,4 +1,4 @@
-#region Licence
+﻿#region Licence
 /* The MIT License (MIT)
 Copyright © 2014 Francesco Pighi <francesco.pighi@gmail.com>
 
@@ -37,6 +37,7 @@ namespace Paramore.Brighter.Tests.CommandStore.Sqlite
         private readonly SqliteTestHelper _sqliteTestHelper;
         private readonly SqliteCommandStore _sqlCommandStore;
         private readonly MyCommand _raisedCommand;
+        private readonly string _contextKey;
         private MyCommand _storedCommand;
 
         public SqliteCommandStoreAddMessageTests()
@@ -46,13 +47,14 @@ namespace Paramore.Brighter.Tests.CommandStore.Sqlite
 
             _sqlCommandStore = new SqliteCommandStore(new SqliteCommandStoreConfiguration(_sqliteTestHelper.ConnectionString, _sqliteTestHelper.TableName));
             _raisedCommand = new MyCommand {Value = "Test"};
-            _sqlCommandStore.Add(_raisedCommand);
+            _contextKey = "context-key";
+            _sqlCommandStore.Add(_raisedCommand, _contextKey);
         }
 
         [Fact]
         public void When_Writing_A_Message_To_The_Command_Store()
         {
-            _storedCommand = _sqlCommandStore.Get<MyCommand>(_raisedCommand.Id);
+            _storedCommand = _sqlCommandStore.Get<MyCommand>(_raisedCommand.Id, _contextKey);
 
             //_should_read_the_command_from_the__sql_command_store
             _storedCommand.Should().NotBeNull();

--- a/tests/Paramore.Brighter.Tests/DynamoDbTestHelper.cs
+++ b/tests/Paramore.Brighter.Tests/DynamoDbTestHelper.cs
@@ -52,7 +52,7 @@ namespace Paramore.Brighter.Tests
             var tableName = $"test_{Guid.NewGuid()}";            
 
             DynamoDbContext = new DynamoDBContext(Client);
-            DynamoDbCommandStoreTestConfiguration = new DynamoDbCommandStoreConfiguration($"command_{tableName}", true, "CommandId");
+            DynamoDbCommandStoreTestConfiguration = new DynamoDbCommandStoreConfiguration($"command_{tableName}", true, "CommandId", "ContextKey");
             DynamoDbMessageStoreTestConfiguration = new DynamoDbMessageStoreConfiguration($"message_{tableName}", true, "MessageId");
         }
 

--- a/tests/Paramore.Brighter.Tests/EventSourcing/TestDoubles/MyStoredCommandHandler.cs
+++ b/tests/Paramore.Brighter.Tests/EventSourcing/TestDoubles/MyStoredCommandHandler.cs
@@ -1,4 +1,4 @@
-#region Licence
+﻿#region Licence
 /* The MIT License (MIT)
 Copyright © 2014 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
 
@@ -29,7 +29,7 @@ namespace Paramore.Brighter.Tests.EventSourcing.TestDoubles
 {
     internal class MyStoredCommandHandler : RequestHandler<MyCommand>
     {
-        [UseCommandSourcing(1, onceOnly:true, timing: HandlerTiming.Before)]
+        [UseCommandSourcing(1, onceOnly:true, contextKey: typeof(MyStoredCommandHandler), timing: HandlerTiming.Before)]
         public override MyCommand Handle(MyCommand command)
         {
             return base.Handle(command);

--- a/tests/Paramore.Brighter.Tests/EventSourcing/TestDoubles/MyStoredCommandHandlerAsync.cs
+++ b/tests/Paramore.Brighter.Tests/EventSourcing/TestDoubles/MyStoredCommandHandlerAsync.cs
@@ -1,4 +1,4 @@
-using System.Threading;
+﻿using System.Threading;
 using System.Threading.Tasks;
 using Paramore.Brighter.Eventsourcing.Attributes;
 using Paramore.Brighter.Tests.CommandProcessors.TestDoubles;
@@ -7,7 +7,7 @@ namespace Paramore.Brighter.Tests.EventSourcing.TestDoubles
 {
     internal class MyStoredCommandHandlerAsync : RequestHandlerAsync<MyCommand> 
     {
-        [UseCommandSourcingAsync(1, onceOnly: true, timing:HandlerTiming.Before)]
+        [UseCommandSourcingAsync(1, onceOnly: true, contextKey: typeof(MyStoredCommandHandlerAsync), timing:HandlerTiming.Before)]
         public override async Task<MyCommand> HandleAsync(MyCommand command, CancellationToken cancellationToken = default(CancellationToken))
         {
             return await base.HandleAsync(command, cancellationToken).ConfigureAwait(ContinueOnCapturedContext);

--- a/tests/Paramore.Brighter.Tests/EventSourcing/When_Handling_A_Command_With_A_Command_Store_Enabled.cs
+++ b/tests/Paramore.Brighter.Tests/EventSourcing/When_Handling_A_Command_With_A_Command_Store_Enabled.cs
@@ -1,4 +1,4 @@
-#region Licence
+﻿#region Licence
 /* The MIT License (MIT)
 Copyright © 2015 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
 
@@ -35,6 +35,7 @@ namespace Paramore.Brighter.Tests.EventSourcing
         private readonly MyCommand _command;
         private readonly IAmACommandStore _commandstore;
         private readonly IAmACommandProcessor _commandProcessor;
+        private readonly string _contextKey;
 
         public CommandProcessorUsingCommandStoreTests()
         {
@@ -50,6 +51,7 @@ namespace Paramore.Brighter.Tests.EventSourcing
 
             _command = new MyCommand {Value = "My Test String"};
 
+            _contextKey = typeof(MyStoredCommandHandler).FullName;
             _commandProcessor = new CommandProcessor(registry, handlerFactory, new InMemoryRequestContextFactory(), new PolicyRegistry());
 
         }
@@ -60,7 +62,7 @@ namespace Paramore.Brighter.Tests.EventSourcing
             _commandProcessor.Send(_command);
 
             //should_store_the_command_to_the_command_store
-            _commandstore.Get<MyCommand>(_command.Id).Value.Should().Be(_command.Value);
+            _commandstore.Get<MyCommand>(_command.Id, _contextKey).Value.Should().Be(_command.Value);
         }
     }
 }

--- a/tests/Paramore.Brighter.Tests/EventSourcing/When_Handling_A_Command_With_A_Command_Store_Enabled_Async.cs
+++ b/tests/Paramore.Brighter.Tests/EventSourcing/When_Handling_A_Command_With_A_Command_Store_Enabled_Async.cs
@@ -1,4 +1,4 @@
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using FluentAssertions;
 using Paramore.Brighter.Tests.CommandProcessors.TestDoubles;
 using Xunit;
@@ -12,6 +12,7 @@ namespace Paramore.Brighter.Tests.EventSourcing
         private readonly MyCommand _command;
         private readonly IAmACommandStoreAsync _commandStore;
         private readonly IAmACommandProcessor _commandProcessor;
+        private readonly string _contextKey;
 
         public CommandProcessorUsingCommandStoreAsyncTests()
         {
@@ -25,6 +26,8 @@ namespace Paramore.Brighter.Tests.EventSourcing
             container.Register<IHandleRequestsAsync<MyCommand>, MyStoredCommandHandlerAsync>();
             container.Register(_commandStore);
 
+            _contextKey = typeof(MyStoredCommandHandlerAsync).FullName;
+
             _command = new MyCommand {Value = "My Test String"};
 
             _commandProcessor = new CommandProcessor(registry, handlerFactory, new InMemoryRequestContextFactory(), new PolicyRegistry());
@@ -36,7 +39,7 @@ namespace Paramore.Brighter.Tests.EventSourcing
             await _commandProcessor.SendAsync(_command);
 
            // should_store_the_command_to_the_command_store
-            _commandStore.GetAsync<MyCommand>(_command.Id).Result.Value.Should().Be(_command.Value);
+            _commandStore.GetAsync<MyCommand>(_command.Id, _contextKey).Result.Value.Should().Be(_command.Value);
         }
     }
 }


### PR DESCRIPTION
At present, the command store writes to the db when a command is first handled, and checks for duplications by checking for the existence of a command of a particular type with a particular id.

This doesn't work for scenarios where there are many handlers for the same command type, particularly if they are in different procesess.

I've introduced the concept of a 'context key' for command sourcing, allow you to specify a way to identify the particular context in which a command is being handled.  I anticipate that you would normally set this to the name (or indeed, type) of the handler, but it's flexible enough for you to decide on some other form of grouping if you want.  It will then whether a particular command has been handled already in a specific context, allowing multiple handlers to work with the command store.