### PR TITLE
Remove new() constraint from commandstore GetAsync and GetAsync method

### DIFF
--- a/src/Paramore.Brighter.CommandStore.MsSql/MsSqlCommandStoreConfiguration.cs
+++ b/src/Paramore.Brighter.CommandStore.MsSql/MsSqlCommandStoreConfiguration.cs
@@ -1,4 +1,4 @@
-#region Licence
+﻿#region Licence
 /* The MIT License (MIT)
 Copyright © 2014 Francesco Pighi <francesco.pighi@gmail.com>
 
@@ -21,6 +21,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE. */
 
 #endregion
+
+using System;
+using Newtonsoft.Json;
 
 namespace Paramore.Brighter.CommandStore.MsSql
 {
@@ -45,6 +48,7 @@ namespace Paramore.Brighter.CommandStore.MsSql
         /// </summary>
         /// <value>The connection string.</value>
         public string ConnectionString { get; private set; }
+
         /// <summary>
         /// Gets the name of the message store table.
         /// </summary>

--- a/src/Paramore.Brighter/Eventsourcing/Exceptions/CommandNotFoundException.cs
+++ b/src/Paramore.Brighter/Eventsourcing/Exceptions/CommandNotFoundException.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace Paramore.Brighter.Eventsourcing.Exceptions
+{
+    public class CommandNotFoundException<T> : Exception where T : IRequest
+    {
+        public CommandNotFoundException(Guid id)
+            :this(id, null)
+        {
+        }
+
+        public CommandNotFoundException(Guid id, Exception innerException)
+            : base($"Command '{id}' of type {typeof(T).FullName} does not exist", innerException)
+        {
+        }
+    }
+}

--- a/src/Paramore.Brighter/Eventsourcing/Handlers/CommandSourcingHandler.cs
+++ b/src/Paramore.Brighter/Eventsourcing/Handlers/CommandSourcingHandler.cs
@@ -54,8 +54,7 @@ namespace Paramore.Brighter.Eventsourcing.Handlers
         {
             _commandStore = commandStore;
         }
-
-
+        
         public override void InitializeFromAttributeParams(params object[] initializerList)
         {
             _onceOnly = (bool) initializerList[0];

--- a/src/Paramore.Brighter/IAmACommandStore.cs
+++ b/src/Paramore.Brighter/IAmACommandStore.cs
@@ -49,7 +49,7 @@ namespace Paramore.Brighter
         /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
         /// <param name="timeoutInMilliseconds"></param>
         /// <returns>T.</returns>
-        T Get<T>(Guid id, string contextKey, int timeoutInMilliseconds = -1) where T : class, IRequest, new();
+        T Get<T>(Guid id, string contextKey, int timeoutInMilliseconds = -1) where T : class, IRequest;
 
         /// <summary>
         /// Checks whether a command with the specified identifier exists in the store

--- a/src/Paramore.Brighter/IAmACommandStoreAsync.cs
+++ b/src/Paramore.Brighter/IAmACommandStoreAsync.cs
@@ -52,7 +52,7 @@ namespace Paramore.Brighter
         /// <param name="timeoutInMilliseconds"></param>
         /// <param name="cancellationToken">Allow the sender to cancel the operation, if the parameter is supplied</param>
         /// <returns><see cref="Task{T}"/>.</returns>
-        Task<T> GetAsync<T>(Guid id, string contextKey, int timeoutInMilliseconds = -1, CancellationToken cancellationToken = default(CancellationToken)) where T : class, IRequest, new();
+        Task<T> GetAsync<T>(Guid id, string contextKey, int timeoutInMilliseconds = -1, CancellationToken cancellationToken = default(CancellationToken)) where T : class, IRequest;
 
         /// <summary>
         /// Checks whether a command with the specified identifier exists in the store

--- a/src/Paramore.Brighter/InMemoryCommandStore.cs
+++ b/src/Paramore.Brighter/InMemoryCommandStore.cs
@@ -28,6 +28,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
+using Paramore.Brighter.Eventsourcing.Exceptions;
 
 namespace Paramore.Brighter
 {
@@ -101,10 +102,12 @@ namespace Paramore.Brighter
         /// <param name="timeoutInMilliseconds">The timeout in milliseconds.</param>
         /// <returns>ICommand.</returns>
         /// <exception cref="System.TypeLoadException"></exception>
-        public T Get<T>(Guid id, string contextKey, int timeoutInMilliseconds = -1) where T : class, IRequest, new()
+        public T Get<T>(Guid id, string contextKey, int timeoutInMilliseconds = -1) where T : class, IRequest
         {
             if (!Exists<T>(id, contextKey))
-                return new T { Id = Guid.Empty };
+            {
+               throw new CommandNotFoundException<T>(id);
+            }
 
             var commandStoreItem = _commands[CreateKey(id, contextKey)];
             if (commandStoreItem.CommandType != typeof (T))
@@ -154,7 +157,7 @@ namespace Paramore.Brighter
         /// <returns><see cref="Task{T}" />.</returns>
         /// <returns><see cref="Task" />Allows the sender to cancel the call, optional</returns>
         /// <exception cref="System.NotImplementedException"></exception>
-        public Task<T> GetAsync<T>(Guid id, string contextKey, int timeoutInMilliseconds = -1, CancellationToken cancellationToken = default(CancellationToken)) where T : class, IRequest, new()
+        public Task<T> GetAsync<T>(Guid id, string contextKey, int timeoutInMilliseconds = -1, CancellationToken cancellationToken = default(CancellationToken)) where T : class, IRequest
         {
             var tcs = new TaskCompletionSource<T>();
 

--- a/tests/Paramore.Brighter.Tests/CommandStore/DynamoDB/When_checking_for_existing_command_async.cs
+++ b/tests/Paramore.Brighter.Tests/CommandStore/DynamoDB/When_checking_for_existing_command_async.cs
@@ -46,7 +46,7 @@ namespace Paramore.Brighter.Tests.CommandStore.DynamoDB
         [Fact]
         public async Task When_checking_a_command_exist_for_a_different_context()
         {
-            var commandExists = await _dynamoDbCommandStore.ExistsAsync<MyCommand>(_command.Id, _contextKey);
+            var commandExists = await _dynamoDbCommandStore.ExistsAsync<MyCommand>(_command.Id, "some other context");
 
             commandExists.Should().BeFalse("because the command exists for a different context.", commandExists);
         }

--- a/tests/Paramore.Brighter.Tests/CommandStore/DynamoDB/When_there_is_no_message_in_the_dynamo_command_store.cs
+++ b/tests/Paramore.Brighter.Tests/CommandStore/DynamoDB/When_there_is_no_message_in_the_dynamo_command_store.cs
@@ -25,6 +25,7 @@ THE SOFTWARE. */
 using System;
 using FluentAssertions;
 using Paramore.Brighter.CommandStore.DynamoDB;
+using Paramore.Brighter.Eventsourcing.Exceptions;
 using Paramore.Brighter.Tests.CommandProcessors.TestDoubles;
 using Xunit;
 
@@ -36,7 +37,6 @@ namespace Paramore.Brighter.Tests.CommandStore.DynamoDB
     {
         private readonly DynamoDbTestHelper _dynamoDbTestHelper;
         private readonly DynamoDbCommandStore _dynamoDbCommandStore;
-        private MyCommand _storedCommand;
 
         public DynamoDbCommandStoreEmptyWhenSearchedTests()
         {            
@@ -49,11 +49,8 @@ namespace Paramore.Brighter.Tests.CommandStore.DynamoDB
         [Fact]
         public void When_There_Is_No_Message_In_The_Sql_Command_Store()
         {
-            _storedCommand = _dynamoDbCommandStore.Get<MyCommand>(Guid.NewGuid(), "some key");
-
-            //_should_return_an_empty_command_on_a_missing_command
-            _storedCommand.Id.Should().Be(Guid.Empty);
-            _storedCommand.Value.Should().Be(null);
+            var exception = Catch.Exception(() => _dynamoDbCommandStore.Get<MyCommand>(Guid.NewGuid(), "some key"));
+            exception.Should().BeOfType<CommandNotFoundException<MyCommand>>();
         }
 
         public void Dispose()

--- a/tests/Paramore.Brighter.Tests/CommandStore/DynamoDB/When_there_is_no_message_in_the_dynamo_command_store_async.cs
+++ b/tests/Paramore.Brighter.Tests/CommandStore/DynamoDB/When_there_is_no_message_in_the_dynamo_command_store_async.cs
@@ -25,6 +25,7 @@ THE SOFTWARE. */
 using System;
 using FluentAssertions;
 using Paramore.Brighter.CommandStore.DynamoDB;
+using Paramore.Brighter.Eventsourcing.Exceptions;
 using Paramore.Brighter.Tests.CommandProcessors.TestDoubles;
 using Xunit;
 
@@ -36,7 +37,6 @@ namespace Paramore.Brighter.Tests.CommandStore.DynamoDB
     {
         private readonly DynamoDbTestHelper _dynamoDbTestHelper;
         private readonly DynamoDbCommandStore _dynamoDbCommandStore;
-        private MyCommand _storedCommand;
 
         public DynamoDbCommandStoreEmptyWhenSearchedAsyncTests()
         {
@@ -49,11 +49,8 @@ namespace Paramore.Brighter.Tests.CommandStore.DynamoDB
         [Fact]
         public async void When_There_Is_No_Message_In_The_Sql_Command_Store()
         {
-            _storedCommand = await _dynamoDbCommandStore.GetAsync<MyCommand>(Guid.NewGuid(), "some key");
-
-            //_should_return_an_empty_command_on_a_missing_command
-            _storedCommand.Id.Should().Be(Guid.Empty);
-            _storedCommand.Value.Should().Be(null);
+            var exception = await Catch.ExceptionAsync(() => _dynamoDbCommandStore.GetAsync<MyCommand>(Guid.NewGuid(), "some key"));
+            exception.Should().BeOfType<CommandNotFoundException<MyCommand>>();
         }
 
         public void Dispose()

--- a/tests/Paramore.Brighter.Tests/CommandStore/MsSsql/When_There_Is_No_Message_In_The_Sql_Command_Store_Async.cs
+++ b/tests/Paramore.Brighter.Tests/CommandStore/MsSsql/When_There_Is_No_Message_In_The_Sql_Command_Store_Async.cs
@@ -27,6 +27,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using Xunit;
 using Paramore.Brighter.CommandStore.MsSql;
+using Paramore.Brighter.Eventsourcing.Exceptions;
 using Paramore.Brighter.Tests.CommandProcessors.TestDoubles;
 
 namespace Paramore.Brighter.Tests.CommandStore.MsSsql
@@ -48,14 +49,17 @@ namespace Paramore.Brighter.Tests.CommandStore.MsSsql
         }
 
         [Fact]
-        public async Task When_There_Is_No_Message_In_The_Sql_Command_Store_Async()
+        public async Task When_There_Is_No_Message_In_The_Sql_Command_Store_And_I_Get_Async()
         {
             Guid commandId = Guid.NewGuid();
-            _storedCommand = await _sqlCommandStore.GetAsync<MyCommand>(commandId, "some-key");
+            var exception = await Catch.ExceptionAsync(() => _sqlCommandStore.GetAsync<MyCommand>(commandId, "some-key"));
+            exception.Should().BeOfType<CommandNotFoundException<MyCommand>>();
+        }
 
-            //_should_return_an_empty_command_on_a_missing_command
-            _storedCommand.Id.Should().Be(Guid.Empty);
-
+        [Fact]
+        public async Task When_There_Is_No_Message_In_The_Sql_Command_Store_And_I_Check_Exists_Async()
+        {
+            Guid commandId = Guid.NewGuid();
             bool exists = await _sqlCommandStore.ExistsAsync<MyCommand>(commandId, "some-key");
             exists.Should().BeFalse();
         }

--- a/tests/Paramore.Brighter.Tests/CommandStore/MsSsql/When_there_is_no_message_in_the_sql_command_store.cs
+++ b/tests/Paramore.Brighter.Tests/CommandStore/MsSsql/When_there_is_no_message_in_the_sql_command_store.cs
@@ -26,6 +26,7 @@ using System;
 using FluentAssertions;
 using Xunit;
 using Paramore.Brighter.CommandStore.MsSql;
+using Paramore.Brighter.Eventsourcing.Exceptions;
 using Paramore.Brighter.Tests.CommandProcessors.TestDoubles;
 
 namespace Paramore.Brighter.Tests.CommandStore.MsSsql
@@ -49,13 +50,18 @@ namespace Paramore.Brighter.Tests.CommandStore.MsSsql
         }
 
         [Fact]
-        public void When_There_Is_No_Message_In_The_Sql_Command_Store()
+        public void When_There_Is_No_Message_In_The_Sql_Command_Store_And_Call_Get()
         {
             Guid commandId = Guid.NewGuid();
-            _storedCommand = _sqlCommandStore.Get<MyCommand>(commandId, _contextKey);
+            var exception = Catch.Exception(() => _storedCommand = _sqlCommandStore.Get<MyCommand>(commandId, _contextKey));
 
-           //_should_return_an_empty_command_on_a_missing_command
-            _storedCommand.Id.Should().Be(Guid.Empty);
+            exception.Should().BeOfType<CommandNotFoundException<MyCommand>>();
+        }
+
+        [Fact]
+        public void When_There_Is_No_Message_In_The_Sql_Command_Store_And_Call_Exists()
+        {
+            Guid commandId = Guid.NewGuid();
             _sqlCommandStore.Exists<MyCommand>(commandId, _contextKey).Should().BeFalse();
         }
 

--- a/tests/Paramore.Brighter.Tests/CommandStore/MySql/When_There_Is_No_Message_In_The_Sql_Command_Store_Async.cs
+++ b/tests/Paramore.Brighter.Tests/CommandStore/MySql/When_There_Is_No_Message_In_The_Sql_Command_Store_Async.cs
@@ -27,6 +27,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using Xunit;
 using Paramore.Brighter.CommandStore.MySql;
+using Paramore.Brighter.Eventsourcing.Exceptions;
 using Paramore.Brighter.Tests.CommandProcessors.TestDoubles;
 
 namespace Paramore.Brighter.Tests.CommandStore.MySql
@@ -50,14 +51,17 @@ namespace Paramore.Brighter.Tests.CommandStore.MySql
         }
 
         [Fact]
-        public async Task When_There_Is_No_Message_In_The_Sql_Command_Store_Async()
+        public async Task When_There_Is_No_Message_In_The_Sql_Command_Store_Get_Async()
         {
             Guid commandId = Guid.NewGuid();
-            _storedCommand = await _mysqlCommandStore.GetAsync<MyCommand>(commandId, _contextKey);
+            var exception = await Catch.ExceptionAsync(() => _mysqlCommandStore.GetAsync<MyCommand>(commandId, _contextKey));
+            exception.Should().BeOfType<CommandNotFoundException<MyCommand>>();
+        }
 
-            //_should_return_an_empty_command_on_a_missing_command
-            _storedCommand.Id.Should().Be(Guid.Empty);
-
+        [Fact]
+        public async Task When_There_Is_No_Message_In_The_Sql_Command_Store_Exists_Async()
+        {
+            Guid commandId = Guid.NewGuid();
             bool exists = await _mysqlCommandStore.ExistsAsync<MyCommand>(commandId, _contextKey);
             exists.Should().BeFalse();
         }

--- a/tests/Paramore.Brighter.Tests/CommandStore/MySql/When_the_message_is_already_in_the_command_store.cs
+++ b/tests/Paramore.Brighter.Tests/CommandStore/MySql/When_the_message_is_already_in_the_command_store.cs
@@ -27,6 +27,7 @@ using FluentAssertions;
 using Xunit;
 using Paramore.Brighter.Tests.CommandProcessors.TestDoubles;
 using Paramore.Brighter.CommandStore.MySql;
+using Paramore.Brighter.Eventsourcing.Exceptions;
 
 namespace Paramore.Brighter.Tests.CommandStore.MySql
 {
@@ -66,10 +67,9 @@ namespace Paramore.Brighter.Tests.CommandStore.MySql
         {
             _mysqlCommandStore.Add(_raisedCommand, "some other key");
 
-            var storedCommand = _mysqlCommandStore.Get<MyCommand>(_raisedCommand.Id, "some other key");
+            _exception = Catch.Exception(() => _mysqlCommandStore.Get<MyCommand>(_raisedCommand.Id, "some other key"));
 
-            //_should_read_the_command_from_the__dynamo_db_command_store
-            storedCommand.Should().NotBeNull();
+            _exception.Should().BeOfType<CommandNotFoundException<MyCommand>>();
         }
 
         public void Dispose()

--- a/tests/Paramore.Brighter.Tests/CommandStore/MySql/When_there_is_no_message_in_the_sql_command_store.cs
+++ b/tests/Paramore.Brighter.Tests/CommandStore/MySql/When_there_is_no_message_in_the_sql_command_store.cs
@@ -26,6 +26,7 @@ using System;
 using FluentAssertions;
 using Xunit;
 using Paramore.Brighter.CommandStore.MySql;
+using Paramore.Brighter.Eventsourcing.Exceptions;
 using Paramore.Brighter.Tests.CommandProcessors.TestDoubles;
 
 namespace Paramore.Brighter.Tests.CommandStore.MySql
@@ -49,13 +50,17 @@ namespace Paramore.Brighter.Tests.CommandStore.MySql
         }
 
         [Fact]
-        public void When_There_Is_No_Message_In_The_Sql_Command_Store()
+        public void When_There_Is_No_Message_In_The_Sql_Command_Store_Get()
         {
             Guid commandId = Guid.NewGuid();
-            _storedCommand = _mysqlCommandStore.Get<MyCommand>(commandId, _contextKey);
+            var exception = Catch.Exception(() => _mysqlCommandStore.Get<MyCommand>(commandId, _contextKey));
+            exception.Should().BeOfType<CommandNotFoundException<MyCommand>>();
+        }
 
-           //_should_return_an_empty_command_on_a_missing_command
-            _storedCommand.Id.Should().Be(Guid.Empty);
+        [Fact]
+        public void When_There_Is_No_Message_In_The_Sql_Command_Store_Exists()
+        {
+            Guid commandId = Guid.NewGuid();
             _mysqlCommandStore.Exists<MyCommand>(commandId, _contextKey).Should().BeFalse();
         }
 

--- a/tests/Paramore.Brighter.Tests/CommandStore/Sqlite/When_There_Is_No_Message_In_The_Sql_Command_Store_Async.cs
+++ b/tests/Paramore.Brighter.Tests/CommandStore/Sqlite/When_There_Is_No_Message_In_The_Sql_Command_Store_Async.cs
@@ -27,6 +27,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using Xunit;
 using Paramore.Brighter.CommandStore.Sqlite;
+using Paramore.Brighter.Eventsourcing.Exceptions;
 using Paramore.Brighter.Tests.CommandProcessors.TestDoubles;
 
 namespace Paramore.Brighter.Tests.CommandStore.Sqlite
@@ -50,14 +51,17 @@ namespace Paramore.Brighter.Tests.CommandStore.Sqlite
         }
 
         [Fact]
-        public async Task When_There_Is_No_Message_In_The_Sql_Command_Store_Async()
+        public async Task When_There_Is_No_Message_In_The_Sql_Command_Store_Get_Async()
         {
             Guid commandId = Guid.NewGuid();
-            _storedCommand = await _sqlCommandStore.GetAsync<MyCommand>(commandId, _contextKey);
+            var exception = await Catch.ExceptionAsync(() => _sqlCommandStore.GetAsync<MyCommand>(commandId, _contextKey));
+            exception.Should().BeOfType<CommandNotFoundException<MyCommand>>();
+        }
 
-            //_should_return_an_empty_command_on_a_missing_command
-            _storedCommand.Id.Should().Be(Guid.Empty);
-
+        [Fact]
+        public async Task When_There_Is_No_Message_In_The_Sql_Command_Store_Exists_Async()
+        {
+            Guid commandId = Guid.NewGuid();
             bool exists = await _sqlCommandStore.ExistsAsync<MyCommand>(commandId, _contextKey);
             exists.Should().BeFalse();
         }

--- a/tests/Paramore.Brighter.Tests/CommandStore/Sqlite/When_there_is_no_message_in_the_sql_command_store.cs
+++ b/tests/Paramore.Brighter.Tests/CommandStore/Sqlite/When_there_is_no_message_in_the_sql_command_store.cs
@@ -26,6 +26,7 @@ using System;
 using FluentAssertions;
 using Xunit;
 using Paramore.Brighter.CommandStore.Sqlite;
+using Paramore.Brighter.Eventsourcing.Exceptions;
 using Paramore.Brighter.Tests.CommandProcessors.TestDoubles;
 
 namespace Paramore.Brighter.Tests.CommandStore.Sqlite
@@ -48,13 +49,17 @@ namespace Paramore.Brighter.Tests.CommandStore.Sqlite
         }
 
         [Fact]
-        public void When_There_Is_No_Message_In_The_Sql_Command_Store()
+        public void When_There_Is_No_Message_In_The_Sql_Command_Store_Get()
         {
             Guid commandId = Guid.NewGuid();
-            _storedCommand = _sqlCommandStore.Get<MyCommand>(commandId,_contextKey);
+            var exception = Catch.Exception(() => _sqlCommandStore.Get<MyCommand>(commandId, _contextKey));
+            exception.Should().BeOfType<CommandNotFoundException<MyCommand>>();
+        }
 
-           //_should_return_an_empty_command_on_a_missing_command
-            _storedCommand.Id.Should().Be(Guid.Empty);
+        [Fact]
+        public void When_There_Is_No_Message_In_The_Sql_Command_Store_Exists()
+        {
+            Guid commandId = Guid.NewGuid();
             _sqlCommandStore.Exists<MyCommand>(commandId, _contextKey).Should().BeFalse();
         }
 


### PR DESCRIPTION
Change the commandstore Get and GetAsync methods to throw an exception if the item doesn't exist (you can check first with the Exist method).  The means the new() constraint can …be removed.