### PR TITLE
Adds OnceOnlyAction parameter to UseCommandSourcing

### DIFF
--- a/src/Paramore.Brighter/Eventsourcing/Attributes/UseCommandSourcingAsyncAttribute.cs
+++ b/src/Paramore.Brighter/Eventsourcing/Attributes/UseCommandSourcingAsyncAttribute.cs
@@ -38,6 +38,7 @@ namespace Paramore.Brighter.Eventsourcing.Attributes
     {
         public bool OnceOnly { get; }
         public string ContextKey { get; }
+        public OnceOnlyAction OnceOnlyAction { get; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="UseCommandSourcingAsyncAttribute"/> class.
@@ -46,11 +47,13 @@ namespace Paramore.Brighter.Eventsourcing.Attributes
         /// <param name="onceOnly">Should we prevent duplicate messages i.e. seen already</param>
         /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
         /// <param name="timing">The timing.</param>
-        public UseCommandSourcingAsyncAttribute(int step, bool onceOnly = false, string contextKey = null, HandlerTiming timing = HandlerTiming.Before)
+        /// <param name="onceOnlyAction">Action to take if prevent duplicate messages, and we receive a duplicate message</param>
+        public UseCommandSourcingAsyncAttribute(int step, bool onceOnly = false, string contextKey = null, HandlerTiming timing = HandlerTiming.Before, OnceOnlyAction onceOnlyAction = OnceOnlyAction.Throw)
             : base(step, timing)
         {
             OnceOnly = onceOnly;
             ContextKey = contextKey;
+            OnceOnlyAction = onceOnlyAction;
         }
 
         /// <summary>
@@ -60,15 +63,16 @@ namespace Paramore.Brighter.Eventsourcing.Attributes
         /// <param name="onceOnly">Should we prevent duplicate messages i.e. seen already</param>
         /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
         /// <param name="timing">The timing.</param>
-        public UseCommandSourcingAsyncAttribute(int step, Type contextKey, bool onceOnly = false, HandlerTiming timing = HandlerTiming.Before)
-            : this(step, onceOnly, contextKey.FullName, timing)
+        /// <param name="onceOnlyAction">Action to take if prevent duplicate messages, and we receive a duplicate message</param>
+        public UseCommandSourcingAsyncAttribute(int step, Type contextKey, bool onceOnly = false, HandlerTiming timing = HandlerTiming.Before, OnceOnlyAction onceOnlyAction = OnceOnlyAction.Throw)
+            : this(step, onceOnly, contextKey.FullName, timing, onceOnlyAction)
         {
         }
 
         public override object[] InitializerParams()
         {
             
-            return new object[]{OnceOnly, ContextKey};
+            return new object[]{OnceOnly, ContextKey, OnceOnlyAction};
         }
 
         /// <summary>

--- a/src/Paramore.Brighter/Eventsourcing/Attributes/UseCommandSourcingAttribute.cs
+++ b/src/Paramore.Brighter/Eventsourcing/Attributes/UseCommandSourcingAttribute.cs
@@ -38,6 +38,7 @@ namespace Paramore.Brighter.Eventsourcing.Attributes
     {
         public string ContextKey { get; }
         public bool OnceOnly { get; }
+        public OnceOnlyAction OnceOnlyAction { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RequestHandlerAttribute"/> class.
@@ -46,11 +47,13 @@ namespace Paramore.Brighter.Eventsourcing.Attributes
         /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
         /// <param name="onceOnly">Should we prevent duplicate messages i.e. seen already</param>
         /// <param name="timing">The timing.</param>
-        public UseCommandSourcingAttribute(int step, string contextKey = null, bool onceOnly=false, HandlerTiming timing = HandlerTiming.Before) 
+        /// <param name="onceOnlyAction">Action to take if prevent duplicate messages, and we receive a duplicate message</param>
+        public UseCommandSourcingAttribute(int step, string contextKey = null, bool onceOnly=false, HandlerTiming timing = HandlerTiming.Before, OnceOnlyAction onceOnlyAction = OnceOnlyAction.Throw) 
             : base(step, timing)
         {
             ContextKey = contextKey;
             OnceOnly = onceOnly;
+            OnceOnlyAction = onceOnlyAction;
         }
 
         /// <summary>
@@ -60,14 +63,15 @@ namespace Paramore.Brighter.Eventsourcing.Attributes
         /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the type of the handler)</param>
         /// <param name="onceOnly">Should we prevent duplicate messages i.e. seen already</param>
         /// <param name="timing">The timing.</param>
-        public UseCommandSourcingAttribute(int step, Type contextKey, bool onceOnly = false, HandlerTiming timing = HandlerTiming.Before) 
-            : this(step, contextKey.FullName, onceOnly, timing)
+        /// <param name="onceOnlyAction">Action to take if prevent duplicate messages, and we receive a duplicate message</param>
+        public UseCommandSourcingAttribute(int step, Type contextKey, bool onceOnly = false, HandlerTiming timing = HandlerTiming.Before, OnceOnlyAction onceOnlyAction = OnceOnlyAction.Throw) 
+            : this(step, contextKey.FullName, onceOnly, timing, onceOnlyAction)
         {
         }
 
         public override object[] InitializerParams()
         {
-            return new object[] {OnceOnly, ContextKey};
+            return new object[] {OnceOnly, ContextKey, OnceOnlyAction};
         }
 
         /// <summary>

--- a/src/Paramore.Brighter/Eventsourcing/OnceOnlyAction.cs
+++ b/src/Paramore.Brighter/Eventsourcing/OnceOnlyAction.cs
@@ -1,0 +1,41 @@
+#region Licence
+/* The MIT License (MIT)
+Copyright © 2014 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+namespace Paramore.Brighter.Eventsourcing
+{
+    /// <summary>
+    /// Action type of the OnceOnly parameter on CommandSourcingAttribute
+    /// </summary>
+    public enum OnceOnlyAction
+    {
+        /// <summary>
+        /// Throw OnceOnlyException when OnceOnly is true
+        /// </summary>
+        Throw,
+        /// <summary>
+        /// Log a WARN message when OnceOnly is true
+        /// </summary>
+        Warn
+    }
+}

--- a/tests/Paramore.Brighter.Tests/EventSourcing/TestDoubles/MyStoredCommandToThrowHandler.cs
+++ b/tests/Paramore.Brighter.Tests/EventSourcing/TestDoubles/MyStoredCommandToThrowHandler.cs
@@ -1,0 +1,48 @@
+#region Licence
+/* The MIT License (MIT)
+Copyright © 2014 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+using Paramore.Brighter.Eventsourcing;
+using Paramore.Brighter.Eventsourcing.Attributes;
+using Paramore.Brighter.Tests.CommandProcessors.TestDoubles;
+
+namespace Paramore.Brighter.Tests.EventSourcing.TestDoubles
+{
+    internal class MyStoredCommandToThrowHandler : RequestHandler<MyCommand>
+    {
+        public static bool CommandReceived { get; set; }
+        
+        [UseCommandSourcing(1, onceOnly: true, onceOnlyAction: OnceOnlyAction.Throw, contextKey: typeof(MyStoredCommandToThrowHandler))]
+        public override MyCommand Handle(MyCommand command)
+        {
+            CommandReceived = true;
+
+            return base.Handle(command);
+        }
+
+        public static bool DidReceive(MyCommand command)
+        {
+            return CommandReceived;
+        }
+    }
+}

--- a/tests/Paramore.Brighter.Tests/EventSourcing/TestDoubles/MyStoredCommandToThrowHandlerAsync.cs
+++ b/tests/Paramore.Brighter.Tests/EventSourcing/TestDoubles/MyStoredCommandToThrowHandlerAsync.cs
@@ -1,0 +1,50 @@
+#region Licence
+/* The MIT License (MIT)
+Copyright © 2014 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+using System.Threading;
+using System.Threading.Tasks;
+using Paramore.Brighter.Eventsourcing;
+using Paramore.Brighter.Eventsourcing.Attributes;
+using Paramore.Brighter.Tests.CommandProcessors.TestDoubles;
+
+namespace Paramore.Brighter.Tests.EventSourcing.TestDoubles
+{
+    internal class MyStoredCommandToThrowHandlerAsync : RequestHandlerAsync<MyCommand>
+    {
+        public static bool CommandReceived { get; set; }
+        
+        [UseCommandSourcingAsync(1, onceOnly: true, onceOnlyAction: OnceOnlyAction.Throw, contextKey: typeof(MyStoredCommandToThrowHandlerAsync))]
+        public override async Task<MyCommand> HandleAsync(MyCommand command, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            CommandReceived = true;
+
+            return await base.HandleAsync(command, cancellationToken).ConfigureAwait(ContinueOnCapturedContext);
+        }
+
+        public static bool DidReceive(MyCommand command)
+        {
+            return CommandReceived;
+        }
+    }
+}

--- a/tests/Paramore.Brighter.Tests/EventSourcing/TestDoubles/MyStoredCommandToWarnHandler.cs
+++ b/tests/Paramore.Brighter.Tests/EventSourcing/TestDoubles/MyStoredCommandToWarnHandler.cs
@@ -1,0 +1,43 @@
+#region Licence
+/* The MIT License (MIT)
+Copyright © 2014 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+using Paramore.Brighter.Eventsourcing;
+using Paramore.Brighter.Eventsourcing.Attributes;
+using Paramore.Brighter.Tests.CommandProcessors.TestDoubles;
+
+namespace Paramore.Brighter.Tests.EventSourcing.TestDoubles
+{
+    internal class MyStoredCommandToWarnHandler : RequestHandler<MyCommand>
+    {
+        public static int ReceivedCount { get; private set; }
+        
+        [UseCommandSourcing(1, onceOnly: true, onceOnlyAction: OnceOnlyAction.Warn, contextKey: typeof(MyStoredCommandToWarnHandler))]
+        public override MyCommand Handle(MyCommand command)
+        {
+            ReceivedCount++;
+
+            return base.Handle(command);
+        }
+    }
+}

--- a/tests/Paramore.Brighter.Tests/EventSourcing/TestDoubles/MyStoredCommandToWarnHandlerAsync.cs
+++ b/tests/Paramore.Brighter.Tests/EventSourcing/TestDoubles/MyStoredCommandToWarnHandlerAsync.cs
@@ -1,0 +1,45 @@
+#region Licence
+/* The MIT License (MIT)
+Copyright © 2014 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+using System.Threading;
+using System.Threading.Tasks;
+using Paramore.Brighter.Eventsourcing;
+using Paramore.Brighter.Eventsourcing.Attributes;
+using Paramore.Brighter.Tests.CommandProcessors.TestDoubles;
+
+namespace Paramore.Brighter.Tests.EventSourcing.TestDoubles
+{
+    internal class MyStoredCommandToWarnHandlerAsync : RequestHandlerAsync<MyCommand>
+    {
+        public static int ReceivedCount { get; private set; }
+        
+        [UseCommandSourcingAsync(1, onceOnly: true, contextKey: typeof(MyStoredCommandToWarnHandlerAsync), onceOnlyAction: OnceOnlyAction.Warn)]
+        public override async Task<MyCommand> HandleAsync(MyCommand command, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            ReceivedCount++;
+
+            return await base.HandleAsync(command, cancellationToken).ConfigureAwait(ContinueOnCapturedContext);
+        }
+    }
+}

--- a/tests/Paramore.Brighter.Tests/EventSourcing/When_Handling_A_Command_Once_Only_With_Throw_Enabled.cs
+++ b/tests/Paramore.Brighter.Tests/EventSourcing/When_Handling_A_Command_Once_Only_With_Throw_Enabled.cs
@@ -1,0 +1,69 @@
+#region Licence
+/* The MIT License (MIT)
+Copyright © 2014 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+using System;
+using System.Threading.Tasks;
+using Paramore.Brighter.Eventsourcing.Exceptions;
+using Paramore.Brighter.Tests.CommandProcessors.TestDoubles;
+using Paramore.Brighter.Tests.EventSourcing.TestDoubles;
+using TinyIoC;
+using Xunit;
+
+namespace Paramore.Brighter.Tests.EventSourcing
+{
+    public class OnceOnlyAttributeWithThrowExceptionTests
+    {
+        private readonly MyCommand _command;
+        private readonly IAmACommandStore _commandStore;
+        private readonly IAmACommandProcessor _commandProcessor;
+
+        public OnceOnlyAttributeWithThrowExceptionTests()
+        {
+            _commandStore = new InMemoryCommandStore();
+            
+            var registry = new SubscriberRegistry();
+            registry.Register<MyCommand, MyStoredCommandToThrowHandler>();
+
+            var container = new TinyIoCContainer();
+            var handlerFactory = new TinyIocHandlerFactory(container);
+            
+            container.Register<IHandleRequests<MyCommand>, MyStoredCommandToThrowHandler>();
+            container.Register(_commandStore);
+
+            _command = new MyCommand {Value = "My Test String"};
+            
+            _commandProcessor = new CommandProcessor(registry, handlerFactory, new InMemoryRequestContextFactory(), new PolicyRegistry());
+        }
+
+        [Fact]
+        public void When_Handling_A_Command_Once_Only_With_Throw_Enabled()
+        {
+            _commandProcessor.Send(_command);
+            
+            Exception ex = Assert.Throws<OnceOnlyException>(() => _commandProcessor.Send(_command));
+            
+            Assert.Equal($"A command with id {_command.Id} has already been handled", ex.Message);
+        }
+    }
+}

--- a/tests/Paramore.Brighter.Tests/EventSourcing/When_Handling_A_Command_Once_Only_With_Throw_Enabled_Async.cs
+++ b/tests/Paramore.Brighter.Tests/EventSourcing/When_Handling_A_Command_Once_Only_With_Throw_Enabled_Async.cs
@@ -1,0 +1,71 @@
+#region Licence
+/* The MIT License (MIT)
+Copyright © 2014 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+using System;
+using System.Threading.Tasks;
+using Paramore.Brighter.Eventsourcing.Exceptions;
+using Paramore.Brighter.Eventsourcing.Handlers;
+using Paramore.Brighter.Tests.CommandProcessors.TestDoubles;
+using Paramore.Brighter.Tests.EventSourcing.TestDoubles;
+using TinyIoC;
+using Xunit;
+
+namespace Paramore.Brighter.Tests.EventSourcing
+{
+    public class OnceOnlyAttributeWithThrowExceptionAsyncTests
+    {
+        private readonly MyCommand _command;
+        private readonly IAmACommandStoreAsync _commandStore;
+        private readonly IAmACommandProcessor _commandProcessor;
+
+        public OnceOnlyAttributeWithThrowExceptionAsyncTests()
+        {
+            _commandStore = new InMemoryCommandStore();
+            
+            var registry = new SubscriberRegistry();
+            registry.RegisterAsync<MyCommand, MyStoredCommandToThrowHandlerAsync>();
+
+            var container = new TinyIoCContainer();
+            var handlerFactory = new TinyIocHandlerFactoryAsync(container);
+
+            container.Register<CommandSourcingHandlerAsync<MyCommand>>();
+            container.Register<IHandleRequestsAsync<MyCommand>, MyStoredCommandToThrowHandlerAsync>();
+            container.Register(_commandStore);
+
+            _command = new MyCommand {Value = "My Test String"};
+            
+            _commandProcessor = new CommandProcessor(registry, handlerFactory, new InMemoryRequestContextFactory(), new PolicyRegistry());
+        }
+
+        [Fact]
+        public async Task When_Handling_A_Command_Once_Only_With_Throw_Enabled()
+        {
+            await _commandProcessor.SendAsync(_command);
+            
+            Exception ex = await Assert.ThrowsAsync<OnceOnlyException>(() => _commandProcessor.SendAsync(_command));
+            
+            Assert.Equal($"A command with id {_command.Id} has already been handled", ex.Message);
+        }
+    }
+}

--- a/tests/Paramore.Brighter.Tests/EventSourcing/When_Handling_A_Command_Once_Only_With_Warn_Enabled.cs
+++ b/tests/Paramore.Brighter.Tests/EventSourcing/When_Handling_A_Command_Once_Only_With_Warn_Enabled.cs
@@ -1,0 +1,69 @@
+#region Licence
+/* The MIT License (MIT)
+Copyright © 2014 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Paramore.Brighter.Eventsourcing.Exceptions;
+using Paramore.Brighter.Tests.CommandProcessors.TestDoubles;
+using Paramore.Brighter.Tests.EventSourcing.TestDoubles;
+using TinyIoC;
+using Xunit;
+
+namespace Paramore.Brighter.Tests.EventSourcing
+{
+    public class OnceOnlyAttributeWithWarnExceptionTests
+    {
+        private readonly MyCommand _command;
+        private readonly IAmACommandStore _commandStore;
+        private readonly IAmACommandProcessor _commandProcessor;
+
+        public OnceOnlyAttributeWithWarnExceptionTests()
+        {
+            _commandStore = new InMemoryCommandStore();
+            
+            var registry = new SubscriberRegistry();
+            registry.Register<MyCommand, MyStoredCommandToWarnHandler>();
+
+            var container = new TinyIoCContainer();
+            var handlerFactory = new TinyIocHandlerFactory(container);
+            
+            container.Register<IHandleRequests<MyCommand>, MyStoredCommandToWarnHandler>();
+            container.Register(_commandStore);
+
+            _command = new MyCommand {Value = "My Test String"};
+            
+            _commandProcessor = new CommandProcessor(registry, handlerFactory, new InMemoryRequestContextFactory(), new PolicyRegistry());
+        }
+
+        [Fact]
+        public void When_Handling_A_Command_Once_Only_With_Warn_Enabled()
+        {
+            _commandProcessor.Send(_command);            
+            _commandProcessor.Send(_command);
+
+            MyStoredCommandToWarnHandler.ReceivedCount.Should().Be(1);
+        }
+    }
+}

--- a/tests/Paramore.Brighter.Tests/EventSourcing/When_Handling_A_Command_Once_Only_With_Warn_Enabled_Async.cs
+++ b/tests/Paramore.Brighter.Tests/EventSourcing/When_Handling_A_Command_Once_Only_With_Warn_Enabled_Async.cs
@@ -1,0 +1,69 @@
+#region Licence
+/* The MIT License (MIT)
+Copyright © 2014 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Paramore.Brighter.Eventsourcing.Exceptions;
+using Paramore.Brighter.Tests.CommandProcessors.TestDoubles;
+using Paramore.Brighter.Tests.EventSourcing.TestDoubles;
+using TinyIoC;
+using Xunit;
+
+namespace Paramore.Brighter.Tests.EventSourcing
+{
+    public class OnceOnlyAttributeWithWarnExceptionAsyncTests
+    {
+        private readonly MyCommand _command;
+        private readonly IAmACommandStoreAsync _commandStore;
+        private readonly IAmACommandProcessor _commandProcessor;
+
+        public OnceOnlyAttributeWithWarnExceptionAsyncTests()
+        {
+            _commandStore = new InMemoryCommandStore();
+            
+            var registry = new SubscriberRegistry();
+            registry.RegisterAsync<MyCommand, MyStoredCommandToWarnHandlerAsync>();
+
+            var container = new TinyIoCContainer();
+            var handlerFactory = new TinyIocHandlerFactoryAsync(container);
+            
+            container.Register<IHandleRequestsAsync<MyCommand>, MyStoredCommandToWarnHandlerAsync>();
+            container.Register(_commandStore);
+
+            _command = new MyCommand {Value = "My Test String"};
+            
+            _commandProcessor = new CommandProcessor(registry, handlerFactory, new InMemoryRequestContextFactory(), new PolicyRegistry());
+        }
+
+        [Fact]
+        public async Task When_Handling_A_Command_Once_Only_With_Warn_Enabled()
+        {
+            await _commandProcessor.SendAsync(_command);
+            await _commandProcessor.SendAsync(_command);
+            
+            MyStoredCommandToWarnHandlerAsync.ReceivedCount.Should().Be(1);
+        }
+    }
+}


### PR DESCRIPTION
* Optional OnceOnlyAction paramater on UseCommandSourcingAttribute
* Defaults to OnceOnlyAction.Throw which causes throwing OnceOnlyException (existing behaviour)
* Option to set to OnceOnlyAction.Warn which logs a WARN message and stops the handler from executing
