### PR TITLE
#312 | Sets random delay on reconnect to RMQ

### DIFF
--- a/src/Paramore.Brighter.MessagingGateway.RMQ/RMQMessageGatewayConnectionPool.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ/RMQMessageGatewayConnectionPool.cs
@@ -141,7 +141,7 @@ namespace Paramore.Brighter.MessagingGateway.RMQ
 
         private static void DelayReconnecting()
         {
-            Task.Delay(jitter.Next(5, 100));
+            Task.Delay(jitter.Next(5, 100)).Wait();
         }
 
 


### PR DESCRIPTION
Added a random (between 5 and 100 ms) delay when reconnecting to RMQ.

@iancooper I wasn't sure if this was the right place to add the delay or not? Is the 100 ms too long, is 5 ms too short?