### PR TITLE
Suppress and log BrokerUnreachableException during ResetConnection

### DIFF
--- a/src/Paramore.Brighter.MessagingGateway.RMQ/RMQMessageGatewayConnectionPool.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ/RMQMessageGatewayConnectionPool.cs
@@ -26,6 +26,7 @@ using System;
 using System.Collections.Generic;
 using Paramore.Brighter.MessagingGateway.RMQ.Logging;
 using RabbitMQ.Client;
+using RabbitMQ.Client.Exceptions;
 
 namespace Paramore.Brighter.MessagingGateway.RMQ
 {
@@ -80,9 +81,19 @@ namespace Paramore.Brighter.MessagingGateway.RMQ
 
             lock (s_lock)
             {
-                var connection = s_connectionPool[connectionId];
                 TryRemoveConnection(connectionId);
-                CreateConnection(connectionFactory);
+
+                try
+                {
+                    CreateConnection(connectionFactory);
+                }
+                catch (BrokerUnreachableException exception)
+                {
+                    s_logger.Value.ErrorException(
+                        "RMQMessagingGateway: Failed to reset connection to Rabbit MQ endpoint {0}",
+                        exception,
+                        connectionFactory.Endpoint);
+                }
             }
         }
 

--- a/src/Paramore.Brighter.ServiceActivator/MessagePumpBase.cs
+++ b/src/Paramore.Brighter.ServiceActivator/MessagePumpBase.cs
@@ -62,13 +62,13 @@ namespace Paramore.Brighter.ServiceActivator
                 catch (ChannelFailureException ex) when (ex.InnerException is BrokenCircuitException)
                 {
                     _logger.Value.WarnFormat("MessagePump: BrokenCircuitException messages from {1} on thread # {0}", Thread.CurrentThread.ManagedThreadId, Channel.Name);
-                    Task.Delay(1000).Wait();
+                    await Task.Delay(1000);
                     continue;
                 }
                 catch (ChannelFailureException)
                 {
                     _logger.Value.WarnFormat("MessagePump: ChannelFailureException messages from {1} on thread # {0}", Thread.CurrentThread.ManagedThreadId, Channel.Name);
-                    Task.Delay(1000).Wait();
+                    await Task.Delay(1000);
                     continue;
                 }
                 catch (Exception exception)
@@ -85,7 +85,7 @@ namespace Paramore.Brighter.ServiceActivator
                 // empty queue
                 if (message.Header.MessageType == MessageType.MT_NONE)
                 {
-                    Task.Delay(500).Wait();
+                    await Task.Delay(500);
                     continue;
                 }
 

--- a/tests/Paramore.Brighter.Tests/MessagingGateway/rmq/When_resetting_a_connection_that_does_not_exist.cs
+++ b/tests/Paramore.Brighter.Tests/MessagingGateway/rmq/When_resetting_a_connection_that_does_not_exist.cs
@@ -1,0 +1,54 @@
+﻿#region Licence
+/* The MIT License (MIT)
+Copyright © 2014 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+using System;
+using FluentAssertions;
+using Paramore.Brighter.MessagingGateway.RMQ;
+using RabbitMQ.Client;
+using Xunit;
+
+namespace Paramore.Brighter.Tests.MessagingGateway.RMQ
+{
+    [Collection("RMQ")]
+    [Trait("Category", "RMQ")]
+    public class RMQMessageGatewayConnectionPoolResetConnectionDoesNotExist
+    {
+        private readonly RMQMessageGatewayConnectionPool _connectionPool;
+
+        public RMQMessageGatewayConnectionPoolResetConnectionDoesNotExist()
+        {
+            _connectionPool = new RMQMessageGatewayConnectionPool("MyConnectionName", 7);
+        }
+
+        [Fact]
+        public void When_resetting_a_connection_that_does_not_exist()
+        {
+            var connectionFactory = new ConnectionFactory {HostName = "invalidhost"};
+
+            Action resetConnection = () => _connectionPool.ResetConnection(connectionFactory);
+
+            resetConnection.Should().NotThrow();
+        }
+    }
+}

--- a/tests/Paramore.Brighter.Tests/MessagingGateway/rmq/When_resetting_a_connection_that_exists.cs
+++ b/tests/Paramore.Brighter.Tests/MessagingGateway/rmq/When_resetting_a_connection_that_exists.cs
@@ -1,0 +1,59 @@
+﻿#region Licence
+/* The MIT License (MIT)
+Copyright © 2014 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+using FakeItEasy;
+using FluentAssertions;
+using Paramore.Brighter.MessagingGateway.RMQ;
+using RabbitMQ.Client;
+using Xunit;
+
+namespace Paramore.Brighter.Tests.MessagingGateway.RMQ
+{
+    [Collection("RMQ")]
+    [Trait("Category", "RMQ")]
+    public class RMQMessageGatewayConnectionPoolResetConnectionExists
+    {
+        private readonly RMQMessageGatewayConnectionPool _connectionPool;
+        private readonly IConnection _originalConnection;
+
+        public RMQMessageGatewayConnectionPoolResetConnectionExists()
+        {
+            _connectionPool = new RMQMessageGatewayConnectionPool("MyConnectionName", 7);
+
+            var connectionFactory = new ConnectionFactory { HostName = "localhost" };
+
+            _originalConnection = _connectionPool.GetConnection(connectionFactory);
+        }
+
+        [Fact]
+        public void When_resetting_a_connection_that_exists()
+        {
+            var connectionFactory = new ConnectionFactory{HostName = "localhost"};
+
+            _connectionPool.ResetConnection(connectionFactory);
+
+            _connectionPool.GetConnection(connectionFactory).Should().NotBeSameAs(_originalConnection);
+        }
+    }
+}


### PR DESCRIPTION
This relates to https://github.com/BrighterCommand/Brighter/issues/485.

The master branch is no longer building for me, so I have based on the 8.0.71 release for now.