### PR TITLE
issue-303: Removes code that can potentially cause key not found error

### DIFF
--- a/src/Paramore.Brighter.MessagingGateway.RMQ/RMQMessageGatewayConnectionPool.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ/RMQMessageGatewayConnectionPool.cs
@@ -82,7 +82,6 @@ namespace Paramore.Brighter.MessagingGateway.RMQ
 
             lock (s_lock)
             {
-                var connection = s_connectionPool[connectionId];
                 TryRemoveConnection(connectionId);
                 
                 DelayReconnecting();


### PR DESCRIPTION
The problem doesn't seem to be that a message is not resent on connection reset. There is code for that. The problem seems to be that a 'key not found' error (when trying to get a connection using a non existent connectionId key) is thrown. This ' key not found'exception is handled as a general exception in the MessagePump. The general exception doesn't involve re-sending the message. The RMQMessageGatewayConnectionPool now handles the potential of 'key not found'.