### PR TITLE
Update for RMQ 6.0; fix a Kafka deprecation warning

### DIFF
--- a/samples/AWSTaskQueueSamples/Greetings/Greetings.csproj
+++ b/samples/AWSTaskQueueSamples/Greetings/Greetings.csproj
@@ -8,6 +8,7 @@
     <ProjectReference Include="..\..\..\src\Paramore.Brighter\Paramore.Brighter.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0" />
   </ItemGroup>
 </Project>

--- a/samples/AWSTaskQueueSamples/GreetingsPumper/GreetingsPumper.csproj
+++ b/samples/AWSTaskQueueSamples/GreetingsPumper/GreetingsPumper.csproj
@@ -9,4 +9,8 @@
       <ProjectReference Include="..\Greetings\Greetings.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
+    </ItemGroup>
+
 </Project>

--- a/samples/AWSTaskQueueSamples/GreetingsReceiverConsole/GreetingsReceiverConsole.csproj
+++ b/samples/AWSTaskQueueSamples/GreetingsReceiverConsole/GreetingsReceiverConsole.csproj
@@ -8,6 +8,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.3.101" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
     <PackageReference Include="Serilog" Version="2.9.0" />
     <PackageReference Include="Serilog.Sinks.Literate" Version="3.0.0" />
   </ItemGroup>

--- a/samples/AWSTaskQueueSamples/GreetingsSender/GreetingsSender.csproj
+++ b/samples/AWSTaskQueueSamples/GreetingsSender/GreetingsSender.csproj
@@ -8,5 +8,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.3.101" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
   </ItemGroup>
 </Project>

--- a/samples/HelloAsyncListeners/HelloAsyncListeners.csproj
+++ b/samples/HelloAsyncListeners/HelloAsyncListeners.csproj
@@ -6,4 +6,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Paramore.Brighter\Paramore.Brighter.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
+  </ItemGroup>
 </Project>

--- a/samples/HelloWorld/HelloWorld.csproj
+++ b/samples/HelloWorld/HelloWorld.csproj
@@ -6,4 +6,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Paramore.Brighter\Paramore.Brighter.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
+  </ItemGroup>
 </Project>

--- a/samples/HelloWorldAsync/HelloWorldAsync.csproj
+++ b/samples/HelloWorldAsync/HelloWorldAsync.csproj
@@ -6,4 +6,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Paramore.Brighter\Paramore.Brighter.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
+  </ItemGroup>
 </Project>

--- a/samples/KafkaTaskQueueSamples/Greetings/Greetings.csproj
+++ b/samples/KafkaTaskQueueSamples/Greetings/Greetings.csproj
@@ -8,6 +8,7 @@
     <ProjectReference Include="..\..\..\src\Paramore.Brighter\Paramore.Brighter.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0" />
   </ItemGroup>
 </Project>

--- a/samples/KafkaTaskQueueSamples/GreetingsReceiverConsole/GreetingsReceiverConsole.csproj
+++ b/samples/KafkaTaskQueueSamples/GreetingsReceiverConsole/GreetingsReceiverConsole.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
     <PackageReference Include="Serilog" Version="2.9.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
   </ItemGroup>

--- a/samples/KafkaTaskQueueSamples/GreetingsSender/GreetingsSender.csproj
+++ b/samples/KafkaTaskQueueSamples/GreetingsSender/GreetingsSender.csproj
@@ -6,4 +6,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Greetings\Greetings.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
+  </ItemGroup>
 </Project>

--- a/samples/MsSqlMessagingGatewaySamples/CompetingReceiverConsole/CompetingReceiverConsole.csproj
+++ b/samples/MsSqlMessagingGatewaySamples/CompetingReceiverConsole/CompetingReceiverConsole.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
     <PackageReference Include="Serilog" Version="2.9.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
   </ItemGroup>

--- a/samples/MsSqlMessagingGatewaySamples/CompetingSender/CompetingSender.csproj
+++ b/samples/MsSqlMessagingGatewaySamples/CompetingSender/CompetingSender.csproj
@@ -6,4 +6,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Events\Events.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
+  </ItemGroup>
 </Project>

--- a/samples/MsSqlMessagingGatewaySamples/Events/Events.csproj
+++ b/samples/MsSqlMessagingGatewaySamples/Events/Events.csproj
@@ -8,6 +8,7 @@
     <ProjectReference Include="..\..\..\src\Paramore.Brighter\Paramore.Brighter.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0" />
   </ItemGroup>
 </Project>

--- a/samples/MsSqlMessagingGatewaySamples/GreetingsReceiverConsole/GreetingsReceiverConsole.csproj
+++ b/samples/MsSqlMessagingGatewaySamples/GreetingsReceiverConsole/GreetingsReceiverConsole.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
     <PackageReference Include="Serilog" Version="2.9.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
   </ItemGroup>

--- a/samples/MsSqlMessagingGatewaySamples/GreetingsSender/GreetingsSender.csproj
+++ b/samples/MsSqlMessagingGatewaySamples/GreetingsSender/GreetingsSender.csproj
@@ -6,4 +6,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Events\Events.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
+  </ItemGroup>
 </Project>

--- a/samples/RMQPartitionTesting/GreetingsPumper/GreetingsPumper.csproj
+++ b/samples/RMQPartitionTesting/GreetingsPumper/GreetingsPumper.csproj
@@ -9,4 +9,7 @@
     <ProjectReference Include="..\..\..\src\Paramore.Brighter\Paramore.Brighter.csproj" />
     <ProjectReference Include="..\..\RMQTaskQueueSamples\Greetings\Greetings.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
+  </ItemGroup>
 </Project>

--- a/samples/RMQPartitionTesting/GreetingsReceiverConsole/GreetingsReceiverConsole.csproj
+++ b/samples/RMQPartitionTesting/GreetingsReceiverConsole/GreetingsReceiverConsole.csproj
@@ -10,6 +10,7 @@
     <ProjectReference Include="..\..\RMQTaskQueueSamples\Greetings\Greetings.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
     <PackageReference Include="Serilog" Version="2.9.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
   </ItemGroup>

--- a/samples/RMQRequestReplyExamples/Greetings/Greetings.csproj
+++ b/samples/RMQRequestReplyExamples/Greetings/Greetings.csproj
@@ -8,6 +8,7 @@
     <ProjectReference Include="..\..\..\src\Paramore.Brighter\Paramore.Brighter.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0" />
   </ItemGroup>
 </Project>

--- a/samples/RMQRequestReplyExamples/GreetingsClient/GreetingsClient.csproj
+++ b/samples/RMQRequestReplyExamples/GreetingsClient/GreetingsClient.csproj
@@ -7,6 +7,7 @@
     <ProjectReference Include="..\Greetings\Greetings.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
     <PackageReference Include="Serilog" Version="2.9.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
   </ItemGroup>

--- a/samples/RMQRequestReplyExamples/GreetingsServer/GreetingsServer.csproj
+++ b/samples/RMQRequestReplyExamples/GreetingsServer/GreetingsServer.csproj
@@ -7,6 +7,7 @@
     <ProjectReference Include="..\Greetings\Greetings.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
     <PackageReference Include="Serilog" Version="2.9.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
   </ItemGroup>

--- a/samples/RMQTaskQueueSamples/Greetings/Greetings.csproj
+++ b/samples/RMQTaskQueueSamples/Greetings/Greetings.csproj
@@ -9,6 +9,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="MessagePack" Version="2.1.115" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0" />
   </ItemGroup>
 </Project>

--- a/samples/RMQTaskQueueSamples/GreetingsReceiverConsole/GreetingsReceiverConsole.csproj
+++ b/samples/RMQTaskQueueSamples/GreetingsReceiverConsole/GreetingsReceiverConsole.csproj
@@ -7,6 +7,7 @@
     <ProjectReference Include="..\Greetings\Greetings.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
     <PackageReference Include="Serilog" Version="2.9.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
   </ItemGroup>

--- a/samples/RMQTaskQueueSamples/GreetingsSender/GreetingsSender.csproj
+++ b/samples/RMQTaskQueueSamples/GreetingsSender/GreetingsSender.csproj
@@ -6,4 +6,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Greetings\Greetings.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
+  </ItemGroup>
 </Project>

--- a/samples/RedisTaskQueueExamples/Greetings/Greetings.csproj
+++ b/samples/RedisTaskQueueExamples/Greetings/Greetings.csproj
@@ -6,4 +6,7 @@
     <ProjectReference Include="..\..\..\src\Paramore.Brighter.MessagingGateway.Redis\Paramore.Brighter.MessagingGateway.Redis.csproj" />
     <ProjectReference Include="..\..\..\src\Paramore.Brighter\Paramore.Brighter.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
+  </ItemGroup>
 </Project>

--- a/samples/RedisTaskQueueExamples/GreetingsReceiver/GreetingsReceiver.csproj
+++ b/samples/RedisTaskQueueExamples/GreetingsReceiver/GreetingsReceiver.csproj
@@ -8,6 +8,7 @@
     <ProjectReference Include="..\Greetings\Greetings.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
     <PackageReference Include="Serilog" Version="2.9.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
   </ItemGroup>

--- a/samples/RedisTaskQueueExamples/GreetingsSender/GreetingsSender.csproj
+++ b/samples/RedisTaskQueueExamples/GreetingsSender/GreetingsSender.csproj
@@ -6,4 +6,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Greetings\Greetings.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
+  </ItemGroup>
 </Project>

--- a/src/Paramore.Brighter.DynamoDb.Extensions/Paramore.Brighter.DynamoDb.Extensions.csproj
+++ b/src/Paramore.Brighter.DynamoDb.Extensions/Paramore.Brighter.DynamoDb.Extensions.csproj
@@ -6,6 +6,8 @@
 
     <ItemGroup>
       <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.3.106.5" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
+      <PackageReference Include="RabbitMQ.Client" Version="6.0.0" />
     </ItemGroup>
    
 </Project>

--- a/src/Paramore.Brighter.Inbox.DynamoDB/Paramore.Brighter.Inbox.DynamoDB.csproj
+++ b/src/Paramore.Brighter.Inbox.DynamoDB/Paramore.Brighter.Inbox.DynamoDB.csproj
@@ -4,6 +4,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.3.106.5" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.0.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Paramore.Brighter.Inbox.MsSql/Paramore.Brighter.Inbox.MsSql.csproj
+++ b/src/Paramore.Brighter.Inbox.MsSql/Paramore.Brighter.Inbox.MsSql.csproj
@@ -15,6 +15,8 @@
     <ProjectReference Include="..\Paramore.Brighter\Paramore.Brighter.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.0.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.1" />
   </ItemGroup>
 </Project>

--- a/src/Paramore.Brighter.Inbox.MySql/Paramore.Brighter.Inbox.MySql.csproj
+++ b/src/Paramore.Brighter.Inbox.MySql/Paramore.Brighter.Inbox.MySql.csproj
@@ -9,7 +9,9 @@
     <ProjectReference Include="..\Paramore.Brighter\Paramore.Brighter.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
     <PackageReference Include="MySqlConnector" Version="0.66.0" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.0.0" />
     
   </ItemGroup>
 </Project>

--- a/src/Paramore.Brighter.Inbox.Sqlite/Paramore.Brighter.Inbox.Sqlite.csproj
+++ b/src/Paramore.Brighter.Inbox.Sqlite/Paramore.Brighter.Inbox.Sqlite.csproj
@@ -11,6 +11,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="3.1.4" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.0.0" />
     <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
     
   </ItemGroup>

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS/Paramore.Brighter.MessagingGateway.AWSSQS.csproj
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS/Paramore.Brighter.MessagingGateway.AWSSQS.csproj
@@ -12,5 +12,6 @@
     <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.101.169" />
     <PackageReference Include="AWSSDK.SQS" Version="3.3.102.112" />
     <PackageReference Include="AWSSDK.Core" Version="3.3.106.25" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
   </ItemGroup>
 </Project>

--- a/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/Paramore.Brighter.MessagingGateway.AzureServiceBus.csproj
+++ b/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/Paramore.Brighter.MessagingGateway.AzureServiceBus.csproj
@@ -10,6 +10,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="AMQPNetLite" Version="2.4.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
     
   </ItemGroup>
 </Project>

--- a/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaMessageConsumer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaMessageConsumer.cs
@@ -151,15 +151,15 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
                     return new Message[] {new Message()};
                 }
 
-                _logger.Value.DebugFormat($"Usable message retrieved from Kafka stream: {consumeResult.Value}");
-                _logger.Value.Debug($"Partition: {consumeResult.Partition} Offset: {consumeResult.Offset} Vallue: {consumeResult.Value}");
+                _logger.Value.DebugFormat($"Usable message retrieved from Kafka stream: {consumeResult.Message.Value}");
+                _logger.Value.Debug($"Partition: {consumeResult.Partition} Offset: {consumeResult.Offset} Vallue: {consumeResult.Message.Value}");
 
                 var messageHeader =
                     new MessageHeader(Guid.NewGuid(), consumeResult.Topic, MessageType.MT_EVENT)
                     {
                         Bag = {["TopicPartitionOffset"] = consumeResult.TopicPartitionOffset,}
                     };
-                var messageBody = new MessageBody(consumeResult.Value);
+                var messageBody = new MessageBody(consumeResult.Message.Value);
                 return new Message[] {new Message(messageHeader, messageBody)};
             }
             catch (ConsumeException consumeException)

--- a/src/Paramore.Brighter.MessagingGateway.Kafka/Paramore.Brighter.MessagingGateway.Kafka.csproj
+++ b/src/Paramore.Brighter.MessagingGateway.Kafka/Paramore.Brighter.MessagingGateway.Kafka.csproj
@@ -11,6 +11,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Confluent.Kafka" Version="1.4.3" />
-    <PackageReference Include="Polly" Version="7.2.1" />    
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
+    <PackageReference Include="Polly" Version="7.2.1" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.0.0" />    
   </ItemGroup>
 </Project>

--- a/src/Paramore.Brighter.MessagingGateway.MsSql/Paramore.Brighter.MessagingGateway.MsSql.csproj
+++ b/src/Paramore.Brighter.MessagingGateway.MsSql/Paramore.Brighter.MessagingGateway.MsSql.csproj
@@ -9,6 +9,7 @@
     <ProjectReference Include="..\Paramore.Brighter\Paramore.Brighter.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.1" />
     

--- a/src/Paramore.Brighter.MessagingGateway.RESTMS/Paramore.Brighter.MessagingGateway.RESTMS.csproj
+++ b/src/Paramore.Brighter.MessagingGateway.RESTMS/Paramore.Brighter.MessagingGateway.RESTMS.csproj
@@ -9,6 +9,8 @@
     <ProjectReference Include="..\Paramore.Brighter\Paramore.Brighter.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.0.0" />
     <PackageReference Include="System.Runtime.Serialization.Xml" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
     <PackageReference Include="System.Private.DataContractSerialization" Version="4.3.0" />

--- a/src/Paramore.Brighter.MessagingGateway.RMQ/Paramore.Brighter.MessagingGateway.RMQ.csproj
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ/Paramore.Brighter.MessagingGateway.RMQ.csproj
@@ -9,7 +9,8 @@
     <ProjectReference Include="..\Paramore.Brighter\Paramore.Brighter.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="RabbitMQ.Client" Version="5.1.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.0.0" />
     <PackageReference Include="Polly" Version="7.2.1" />
   </ItemGroup>
 </Project>

--- a/src/Paramore.Brighter.MessagingGateway.RMQ/RMQMessageGateway.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ/RMQMessageGateway.cs
@@ -76,7 +76,7 @@ namespace Paramore.Brighter.MessagingGateway.RMQ
             _connectionFactory = new ConnectionFactory
             {
                 Uri = Connection.AmpqUri.Uri,
-                RequestedHeartbeat = connection.Heartbeat
+                RequestedHeartbeat = TimeSpan.FromSeconds(connection.Heartbeat)
             };
 
             DelaySupported = Connection.Exchange.SupportDelay;

--- a/src/Paramore.Brighter.MessagingGateway.RMQ/RMQMessageGatewayConnectionPool.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ/RMQMessageGatewayConnectionPool.cs
@@ -102,10 +102,10 @@ namespace Paramore.Brighter.MessagingGateway.RMQ
 
             s_logger.Value.DebugFormat("RMQMessageGatewayConnectionPool: Creating connection to Rabbit MQ endpoint {0}", connectionFactory.Endpoint);
 
-            connectionFactory.RequestedHeartbeat = _connectionHeartbeat;
-            connectionFactory.RequestedConnectionTimeout = 5000;
-            connectionFactory.SocketReadTimeout = 5000;
-            connectionFactory.SocketWriteTimeout = 5000;
+            connectionFactory.RequestedHeartbeat = TimeSpan.FromSeconds(_connectionHeartbeat);
+            connectionFactory.RequestedConnectionTimeout = TimeSpan.FromMilliseconds(5000);
+            connectionFactory.SocketReadTimeout = TimeSpan.FromMilliseconds(5000);
+            connectionFactory.SocketWriteTimeout = TimeSpan.FromMilliseconds(5000);
 
             var connection = connectionFactory.CreateConnection(_connectionName);
 

--- a/src/Paramore.Brighter.MessagingGateway.RMQ/RmqMessageCreator.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ/RmqMessageCreator.cs
@@ -1,4 +1,5 @@
 ﻿#region Licence
+
 /* The MIT License (MIT)
 Copyright © 2014 Bob Gregory 
 
@@ -97,9 +98,11 @@ namespace Paramore.Brighter.MessagingGateway.RMQ
                 else
                 {
                     var messageHeader = timeStamp.Success
-                        ? new MessageHeader(messageId.Result, topic.Result, messageType.Result, timeStamp.Result, handledCount.Result, delayedMilliseconds.Result)
+                        ? new MessageHeader(messageId.Result, topic.Result, messageType.Result, timeStamp.Result, handledCount.Result,
+                            delayedMilliseconds.Result)
                         : new MessageHeader(messageId.Result, topic.Result, messageType.Result);
 
+                    //this effectively transfers ownership of our buffer 
                     message = new Message(messageHeader, new MessageBody(fromQueue.Body, fromQueue.BasicProperties.Type));
 
                     headers.Each(header => message.Header.Bag.Add(header.Key, ParseHeaderValue(header.Value)));
@@ -121,7 +124,7 @@ namespace Paramore.Brighter.MessagingGateway.RMQ
                 s_logger.Value.WarnException("Failed to create message from amqp message", e);
                 message = FailureMessage(topic, messageId);
             }
-            
+
             return message;
         }
 
@@ -245,7 +248,7 @@ namespace Paramore.Brighter.MessagingGateway.RMQ
 
         private HeaderResult<bool> ReadRedeliveredFlag(bool redelivered)
         {
-           return new HeaderResult<bool>(redelivered, true); 
+            return new HeaderResult<bool>(redelivered, true);
         }
 
         private HeaderResult<string> ReadReplyTo(IBasicProperties basicProperties)
@@ -256,13 +259,11 @@ namespace Paramore.Brighter.MessagingGateway.RMQ
             }
 
             return new HeaderResult<string>(null, true);
- 
         }
 
         private static object ParseHeaderValue(object value)
         {
             return value is byte[] bytes ? Encoding.UTF8.GetString(bytes) : value;
         }
-
     }
 }

--- a/src/Paramore.Brighter.MessagingGateway.RMQ/RmqMessagePublisher.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ/RmqMessagePublisher.cs
@@ -228,7 +228,6 @@ internal class RmqMessagePublisher
                 case long _:
                 case short _:
                 case bool _:
-                case BinaryTableValue _:
                     return true;
                 default:
                     return false;

--- a/src/Paramore.Brighter.MessagingGateway.Redis/Paramore.Brighter.MessagingGateway.Redis.csproj
+++ b/src/Paramore.Brighter.MessagingGateway.Redis/Paramore.Brighter.MessagingGateway.Redis.csproj
@@ -10,7 +10,9 @@
     <ProjectReference Include="..\Paramore.Brighter\Paramore.Brighter.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.0.0" />
     <PackageReference Include="ServiceStack.Redis.Core" Version="5.8.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>

--- a/src/Paramore.Brighter.Outbox.DynamoDB/Paramore.Brighter.Outbox.DynamoDB.csproj
+++ b/src/Paramore.Brighter.Outbox.DynamoDB/Paramore.Brighter.Outbox.DynamoDB.csproj
@@ -4,6 +4,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.3.106.5" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.0.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Paramore.Brighter.Outbox.EventStore/Paramore.Brighter.Outbox.EventStore.csproj
+++ b/src/Paramore.Brighter.Outbox.EventStore/Paramore.Brighter.Outbox.EventStore.csproj
@@ -12,5 +12,7 @@
   <ItemGroup>
     <PackageReference Include="EventStore.ClientAPI.NetCore" Version="4.1.0.23" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.0.0" />
   </ItemGroup>
 </Project>

--- a/src/Paramore.Brighter.Outbox.MsSql/Paramore.Brighter.Outbox.MsSql.csproj
+++ b/src/Paramore.Brighter.Outbox.MsSql/Paramore.Brighter.Outbox.MsSql.csproj
@@ -15,6 +15,8 @@
     <ProjectReference Include="..\Paramore.Brighter\Paramore.Brighter.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.0.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.1" />
   </ItemGroup>
 </Project>

--- a/src/Paramore.Brighter.Outbox.MySql/Paramore.Brighter.Outbox.MySql.csproj
+++ b/src/Paramore.Brighter.Outbox.MySql/Paramore.Brighter.Outbox.MySql.csproj
@@ -9,6 +9,8 @@
     <ProjectReference Include="..\Paramore.Brighter\Paramore.Brighter.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
     <PackageReference Include="MySqlConnector" Version="0.66.0" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.0.0" />
   </ItemGroup>
 </Project>

--- a/src/Paramore.Brighter.Outbox.PostgreSql/Paramore.Brighter.Outbox.PostgreSql.csproj
+++ b/src/Paramore.Brighter.Outbox.PostgreSql/Paramore.Brighter.Outbox.PostgreSql.csproj
@@ -9,7 +9,9 @@
     <ProjectReference Include="..\Paramore.Brighter\Paramore.Brighter.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
     <PackageReference Include="Npgsql" Version="4.1.3.1" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.0.0" />
   </ItemGroup>
 </Project>

--- a/src/Paramore.Brighter.Outbox.Sqlite/Paramore.Brighter.Outbox.Sqlite.csproj
+++ b/src/Paramore.Brighter.Outbox.Sqlite/Paramore.Brighter.Outbox.Sqlite.csproj
@@ -11,6 +11,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="3.1.4" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.0.0" />
     <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
   </ItemGroup>
 </Project>

--- a/src/Paramore.Brighter.ServiceActivator/Paramore.Brighter.ServiceActivator.csproj
+++ b/src/Paramore.Brighter.ServiceActivator/Paramore.Brighter.ServiceActivator.csproj
@@ -8,4 +8,8 @@
   <ItemGroup>
     <ProjectReference Include="..\Paramore.Brighter\Paramore.Brighter.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.0.0" />
+  </ItemGroup>
 </Project>

--- a/src/Paramore.Brighter/MessageBody.cs
+++ b/src/Paramore.Brighter/MessageBody.cs
@@ -86,6 +86,21 @@ namespace Paramore.Brighter
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="MessageBody"/> class using a byte array.
+        /// TODO: We don't support the range of options on Span<T> on netstandard2.0 that let's us
+        /// flow through a ReadOnlyMemory<byte> for serialization so we allocate here as well as in
+        /// PullConsumer when we probably don't need this allocation.
+        /// We can fix in .NET 5.0 over the dead-end fork of netstandard2.1
+        /// </summary>
+        /// <param name="body"></param>
+        /// <param name="bodyType"></param>
+        public MessageBody(in ReadOnlyMemory<byte> body, string bodyType)
+        {
+            Bytes = body.ToArray();
+            BodyType = bodyType ?? "JSON";
+         }
+
+         /// <summary>
         /// Initializes a new instance of the <see cref="MessageBody"/> class.
         /// </summary>
         /// <param name="postBack">The continuation to run</param>
@@ -94,7 +109,7 @@ namespace Paramore.Brighter
             PostBack = postBack;
         }
 
-        /// <summary>
+       /// <summary>
         /// Indicates whether the current object is equal to another object of the same type.
         /// </summary>
         /// <param name="other">An object to compare with this object.</param>

--- a/src/Paramore.Brighter/Paramore.Brighter.csproj
+++ b/src/Paramore.Brighter/Paramore.Brighter.csproj
@@ -12,7 +12,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Polly" Version="7.2.1" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.0.0" />
   </ItemGroup>
 </Project>

--- a/tests/Paramore.Brighter.AWSSQS.Tests/Paramore.Brighter.AWSSQS.Tests.csproj
+++ b/tests/Paramore.Brighter.AWSSQS.Tests/Paramore.Brighter.AWSSQS.Tests.csproj
@@ -11,6 +11,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">

--- a/tests/Paramore.Brighter.Core.Tests/Paramore.Brighter.Core.Tests.csproj
+++ b/tests/Paramore.Brighter.Core.Tests/Paramore.Brighter.Core.Tests.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="FakeItEasy" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.4" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.3" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="Serilog.Sinks.TestCorrelator" Version="3.2.0" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/tests/Paramore.Brighter.DynamoDB.Tests/Paramore.Brighter.DynamoDB.Tests.csproj
+++ b/tests/Paramore.Brighter.DynamoDB.Tests/Paramore.Brighter.DynamoDB.Tests.csproj
@@ -12,7 +12,9 @@
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
       <PackageReference Include="FluentAssertions" Version="5.10.3" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+      <PackageReference Include="RabbitMQ.Client" Version="6.0.0" />
       <PackageReference Include="xunit" Version="2.4.1" />
       <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
         <PrivateAssets>all</PrivateAssets>

--- a/tests/Paramore.Brighter.EventStore.Tests/Paramore.Brighter.EventStore.Tests.csproj
+++ b/tests/Paramore.Brighter.EventStore.Tests/Paramore.Brighter.EventStore.Tests.csproj
@@ -12,7 +12,9 @@
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
       <PackageReference Include="FluentAssertions" Version="5.10.3" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+      <PackageReference Include="RabbitMQ.Client" Version="6.0.0" />
       <PackageReference Include="xunit" Version="2.4.1" />
       <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
         <PrivateAssets>all</PrivateAssets>

--- a/tests/Paramore.Brighter.Kafka.Tests/Paramore.Brighter.Kafka.Tests.csproj
+++ b/tests/Paramore.Brighter.Kafka.Tests/Paramore.Brighter.Kafka.Tests.csproj
@@ -11,7 +11,9 @@
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
       <PackageReference Include="FluentAssertions" Version="5.10.3" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+      <PackageReference Include="RabbitMQ.Client" Version="6.0.0" />
       <PackageReference Include="xunit" Version="2.4.1" />
       <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
         <PrivateAssets>all</PrivateAssets>

--- a/tests/Paramore.Brighter.MSSQL.Tests/Paramore.Brighter.MSSQL.Tests.csproj
+++ b/tests/Paramore.Brighter.MSSQL.Tests/Paramore.Brighter.MSSQL.Tests.csproj
@@ -14,7 +14,9 @@
       <PackageReference Include="FluentAssertions" Version="5.10.3" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.4" />
       <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.4" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+      <PackageReference Include="RabbitMQ.Client" Version="6.0.0" />
       <PackageReference Include="xunit" Version="2.4.1" />
       <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
         <PrivateAssets>all</PrivateAssets>

--- a/tests/Paramore.Brighter.MySQL.Tests/Paramore.Brighter.MySQL.Tests.csproj
+++ b/tests/Paramore.Brighter.MySQL.Tests/Paramore.Brighter.MySQL.Tests.csproj
@@ -13,7 +13,9 @@
       <PackageReference Include="FluentAssertions" Version="5.10.3" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.4" />
       <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.4" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+      <PackageReference Include="RabbitMQ.Client" Version="6.0.0" />
       <PackageReference Include="xunit" Version="2.4.1" />
       <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
         <PrivateAssets>all</PrivateAssets>

--- a/tests/Paramore.Brighter.NoOpStore.Tests/Paramore.Brighter.NoOpStore.Tests.csproj
+++ b/tests/Paramore.Brighter.NoOpStore.Tests/Paramore.Brighter.NoOpStore.Tests.csproj
@@ -11,7 +11,9 @@
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
       <PackageReference Include="FluentAssertions" Version="5.10.3" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+      <PackageReference Include="RabbitMQ.Client" Version="6.0.0" />
       <PackageReference Include="xunit" Version="2.4.1" />
       <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
         <PrivateAssets>all</PrivateAssets>

--- a/tests/Paramore.Brighter.PostgresSQL.Tests/Paramore.Brighter.PostgresSQL.Tests.csproj
+++ b/tests/Paramore.Brighter.PostgresSQL.Tests/Paramore.Brighter.PostgresSQL.Tests.csproj
@@ -13,7 +13,9 @@
       <PackageReference Include="FluentAssertions" Version="5.10.3" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.4" />
       <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.4" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+      <PackageReference Include="RabbitMQ.Client" Version="6.0.0" />
       <PackageReference Include="xunit" Version="2.4.1" />
       <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
         <PrivateAssets>all</PrivateAssets>

--- a/tests/Paramore.Brighter.RESTMS.Tests/Paramore.Brighter.RESTMS.Tests.csproj
+++ b/tests/Paramore.Brighter.RESTMS.Tests/Paramore.Brighter.RESTMS.Tests.csproj
@@ -11,7 +11,9 @@
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
       <PackageReference Include="FluentAssertions" Version="5.10.3" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+      <PackageReference Include="RabbitMQ.Client" Version="6.0.0" />
       <PackageReference Include="xunit" Version="2.4.1" />
       <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
         <PrivateAssets>all</PrivateAssets>

--- a/tests/Paramore.Brighter.RMQ.Tests/Paramore.Brighter.RMQ.Tests.csproj
+++ b/tests/Paramore.Brighter.RMQ.Tests/Paramore.Brighter.RMQ.Tests.csproj
@@ -11,7 +11,9 @@
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
       <PackageReference Include="FluentAssertions" Version="5.10.3" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+      <PackageReference Include="RabbitMQ.Client" Version="6.0.0" />
       <PackageReference Include="xunit" Version="2.4.1" />
       <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
         <PrivateAssets>all</PrivateAssets>

--- a/tests/Paramore.Brighter.Redis.Tests/Paramore.Brighter.Redis.Tests.csproj
+++ b/tests/Paramore.Brighter.Redis.Tests/Paramore.Brighter.Redis.Tests.csproj
@@ -11,7 +11,9 @@
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
       <PackageReference Include="FluentAssertions" Version="5.10.3" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+      <PackageReference Include="RabbitMQ.Client" Version="6.0.0" />
       <PackageReference Include="xunit" Version="2.4.1" />
       <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
         <PrivateAssets>all</PrivateAssets>

--- a/tests/Paramore.Brighter.Sqlite.Tests/Paramore.Brighter.Sqlite.Tests.csproj
+++ b/tests/Paramore.Brighter.Sqlite.Tests/Paramore.Brighter.Sqlite.Tests.csproj
@@ -11,7 +11,9 @@
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
       <PackageReference Include="FluentAssertions" Version="5.10.3" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+      <PackageReference Include="RabbitMQ.Client" Version="6.0.0" />
       <PackageReference Include="xunit" Version="2.4.1" />
       <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
         <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
EDITED For clarity

This PR deals with package upgrades that required code changes
 - It fixes a Kakfa deprecation warning
- It fixes RMQ client switching to ReadOnlyMemory<byte>. (detail below)
- It also update the DependencyInjection package) to ensure it was not built against out-of-date packages

DETAIL ON RMQ PACKAGE CHANGE
-------------------------------------

- Because we have to copy the body before returning from PullConsumer, and we buffer messages, we have to copy the supplied body
- Because we are netstandard20, and not nestandard21 we have to copy into our MessageBody as we don't have Span<T> overloads for classes like Encoding
- So we now have two allocations, although RMQ has a pool, which really makes the situation worse :-(
- Advice is wait until .NET50, don't go to nestandard21 as breaking changes, so we may be able to remove one allocation then.
- To be fair, we could probably do a lot to reduce our allocations and that is a project in itself, so I am not sure this is really a crisis for us as we probably have a lot of allocations to deal with