### PR TITLE
Added Configurable AckOnRead and Revved NuGet for ASB #1445

### DIFF
--- a/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusConfiguration.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusConfiguration.cs
@@ -2,11 +2,17 @@
 {
     public class AzureServiceBusConfiguration
     {
-        public AzureServiceBusConfiguration(string connectionString)
+        public AzureServiceBusConfiguration(string connectionString, bool ackOnRead = false )
         {
             ConnectionString = connectionString;
+            AckOnRead = ackOnRead;
         }
 
         public string ConnectionString { get; }
+
+        /// <summary>
+        /// When set to true this will Chanage RecieveMode from ReceiveAndDelete to PeekAndLock
+        /// </summary>
+        public bool AckOnRead{ get; }
     }
 }

--- a/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusConsumer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusConsumer.cs
@@ -24,7 +24,7 @@ namespace Paramore.Brighter.MessagingGateway.AzureServiceBus
         private const string _lockTokenKey = "LockToken";
         
         public AzureServiceBusConsumer(string topicName, string subscriptionName, IAmAMessageProducer messageProducer, IManagementClientWrapper managementClientWrapper, 
-            IMessageReceiverProvider messageReceiverProvider, int batchSize = 10, OnMissingChannel makeChannels = OnMissingChannel.Create, ReceiveMode receiveMode = ReceiveMode.ReceiveAndDelete)
+            IMessageReceiverProvider messageReceiverProvider, int batchSize = 10, ReceiveMode receiveMode = ReceiveMode.ReceiveAndDelete, OnMissingChannel makeChannels = OnMissingChannel.Create)
         {
             _subscriptionName = subscriptionName;
             _topicName = topicName;

--- a/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusConsumer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusConsumer.cs
@@ -19,9 +19,12 @@ namespace Paramore.Brighter.MessagingGateway.AzureServiceBus
         private bool _subscriptionCreated;
         private static readonly Lazy<ILog> _logger = new Lazy<ILog>(LogProvider.For<AzureServiceBusConsumer>);
         private readonly OnMissingChannel _makeChannel;
+        private readonly ReceiveMode _receiveMode;
+
+        private const string _lockTokenKey = "LockToken";
         
         public AzureServiceBusConsumer(string topicName, string subscriptionName, IAmAMessageProducer messageProducer, IManagementClientWrapper managementClientWrapper, 
-            IMessageReceiverProvider messageReceiverProvider, int batchSize = 10, OnMissingChannel makeChannels = OnMissingChannel.Create)
+            IMessageReceiverProvider messageReceiverProvider, int batchSize = 10, OnMissingChannel makeChannels = OnMissingChannel.Create, ReceiveMode receiveMode = ReceiveMode.ReceiveAndDelete)
         {
             _subscriptionName = subscriptionName;
             _topicName = topicName;
@@ -30,16 +33,17 @@ namespace Paramore.Brighter.MessagingGateway.AzureServiceBus
             _messageReceiverProvider = messageReceiverProvider;
             _batchSize = batchSize;
             _makeChannel = makeChannels;
+            _receiveMode = receiveMode;
             
             GetMessageReceiverProvider();
         }
 
         private void GetMessageReceiverProvider()
         {
-            _logger.Value.Info($"Getting message receiver provider for topic {_topicName} and subscription {_subscriptionName}...");
+            _logger.Value.Info($"Getting message receiver provider for topic {_topicName} and subscription {_subscriptionName} with recieve Mode {_receiveMode}...");
             try
             {
-                _messageReceiver = _messageReceiverProvider.Get(_topicName, _subscriptionName, ReceiveMode.ReceiveAndDelete);
+                _messageReceiver = _messageReceiverProvider.Get(_topicName, _subscriptionName, _receiveMode);
             }
             catch (Exception e)
             {
@@ -97,7 +101,9 @@ namespace Paramore.Brighter.MessagingGateway.AzureServiceBus
             var messageBody = System.Text.Encoding.Default.GetString(azureServiceBusMessage.MessageBodyValue ?? Array.Empty<byte>());
             _logger.Value.Debug($"Received message from topic {_topicName} via subscription {_subscriptionName} with body {messageBody}.");
             MessageType messageType = GetMessageType(azureServiceBusMessage);
-            var message = new Message(new MessageHeader(Guid.NewGuid(), _topicName, messageType), new MessageBody(messageBody));
+            var headers = new MessageHeader(Guid.NewGuid(), _topicName, messageType);
+            if(_receiveMode.Equals(ReceiveMode.PeekLock)) headers.Bag.Add(_lockTokenKey, azureServiceBusMessage.LockToken);
+            var message = new Message(headers, new MessageBody(messageBody));
             return message;
         }
 
@@ -169,7 +175,26 @@ namespace Paramore.Brighter.MessagingGateway.AzureServiceBus
 
         public void Acknowledge(Message message)
         {
-            //Not implemented as we use ReceiveMode.ReceiveAndDelete (Brighter will call this method anyway)
+            //Only ACK if ReceiveMode is Peek
+            if (_receiveMode.Equals(ReceiveMode.PeekLock))
+            {
+                try
+                {
+                    EnsureSubscription();
+                    var lockToken = message.Header.Bag[_lockTokenKey].ToString();
+
+                    if (string.IsNullOrEmpty(lockToken))
+                        throw new Exception($"LockToken for message with id {message.Id} is null or empty");
+                    _logger.Value.Debug($"Acknowledging Message with Id {message.Id} Lock Token : {lockToken}");
+
+                    _messageReceiver.Complete(lockToken).Wait();
+                }
+                catch(Exception ex)
+                {
+                    _logger.Value.ErrorException($"Error completing message with id {message.Id}", ex);
+                    throw;
+                }
+            }
         }
 
         public void Reject(Message message)

--- a/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusConsumerFactory.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusConsumerFactory.cs
@@ -1,4 +1,5 @@
-﻿using Paramore.Brighter.MessagingGateway.AzureServiceBus.AzureServiceBusWrappers;
+﻿using Microsoft.Azure.ServiceBus;
+using Paramore.Brighter.MessagingGateway.AzureServiceBus.AzureServiceBusWrappers;
 
 namespace Paramore.Brighter.MessagingGateway.AzureServiceBus
 {
@@ -18,7 +19,7 @@ namespace Paramore.Brighter.MessagingGateway.AzureServiceBus
             return new AzureServiceBusConsumer(subscription.RoutingKey, subscription.ChannelName,
                 new AzureServiceBusMessageProducer(nameSpaceManagerWrapper,
                     new TopicClientProvider(_configuration)), nameSpaceManagerWrapper,
-                new MessageReceiverProvider(_configuration));
+                new MessageReceiverProvider(_configuration), receiveMode: _configuration.AckOnRead ? ReceiveMode.PeekLock : ReceiveMode.ReceiveAndDelete);
         }
     }
 }

--- a/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusWrappers/BrokeredMessageWrapper.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusWrappers/BrokeredMessageWrapper.cs
@@ -14,5 +14,7 @@ namespace Paramore.Brighter.MessagingGateway.AzureServiceBus.AzureServiceBusWrap
         public byte[] MessageBodyValue => _brokeredMessage.Body;
         
         public IDictionary<string, object> UserProperties => _brokeredMessage.UserProperties;
+
+        public string LockToken => _brokeredMessage.SystemProperties.LockToken;
     }
 }

--- a/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusWrappers/IBrokeredMessageWrapper.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusWrappers/IBrokeredMessageWrapper.cs
@@ -6,6 +6,8 @@ namespace Paramore.Brighter.MessagingGateway.AzureServiceBus.AzureServiceBusWrap
     {
         byte[] MessageBodyValue { get; }
         
-        IDictionary<string, object> UserProperties { get; }   
+        IDictionary<string, object> UserProperties { get; }
+
+        string LockToken { get; }
     }
 }

--- a/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusWrappers/IMessageReceiverWrapper.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusWrappers/IMessageReceiverWrapper.cs
@@ -7,6 +7,8 @@ namespace Paramore.Brighter.MessagingGateway.AzureServiceBus.AzureServiceBusWrap
     public interface IMessageReceiverWrapper
     {
         Task<IEnumerable<IBrokeredMessageWrapper>> Receive(int batchSize, TimeSpan serverWaitTime);
+
+        Task Complete(string lockToken);
         
         void Close();
         

--- a/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusWrappers/MessageReceiverWrapper.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusWrappers/MessageReceiverWrapper.cs
@@ -35,6 +35,11 @@ namespace Paramore.Brighter.MessagingGateway.AzureServiceBus.AzureServiceBusWrap
             Logger.Value.Warn("MessageReceiver connection stopped");
         }
 
+        public async Task Complete(string lockToken)
+        {
+            await _messageReceiver.CompleteAsync(lockToken).ConfigureAwait(false);
+        }
+
         public bool IsClosedOrClosing => _messageReceiver.IsClosedOrClosing;
     }
 }

--- a/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/Paramore.Brighter.MessagingGateway.AzureServiceBus.csproj
+++ b/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/Paramore.Brighter.MessagingGateway.AzureServiceBus.csproj
@@ -6,7 +6,7 @@
     <PackageTags>awssqs;AMQP;Command;Event;Service Activator;Decoupled;Invocation;Messaging;Remote;Command Dispatcher;Command Processor;Request;Service;Task Queue;Work Queue;Retry;Circuit Breaker;Availability</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.3" />
+    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="5.1.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Paramore.Brighter\Paramore.Brighter.csproj" />


### PR DESCRIPTION
AzureServiceBusConfiguration now contains AckOnRead to allow the switching from ReadAndDelete and Peek Lock

Acknowledge is still a NoOp if set to ReadAndDelete

Storing the Lock Token in the Message Bag in the Headers

Revved Nuget Microsoft.Azure.ServiceBus to 5.1.2, the Only Breaking Change in the Change log did not appear to effect us (SessionId Must be same as Partition key)