### PR TITLE
Plumbed Channel Creation Mode into the Factories #1444

### DIFF
--- a/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusConsumerFactory.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusConsumerFactory.cs
@@ -21,7 +21,8 @@ namespace Paramore.Brighter.MessagingGateway.AzureServiceBus
                     new TopicClientProvider(_configuration), subscription.MakeChannels), nameSpaceManagerWrapper,
                 new MessageReceiverProvider(_configuration),
                 makeChannels: subscription.MakeChannels,
-                receiveMode: _configuration.AckOnRead ? ReceiveMode.PeekLock : ReceiveMode.ReceiveAndDelete);
+                receiveMode: _configuration.AckOnRead ? ReceiveMode.PeekLock : ReceiveMode.ReceiveAndDelete,
+                batchSize: subscription.BufferSize);
         }
     }
 }

--- a/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusConsumerFactory.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusConsumerFactory.cs
@@ -18,8 +18,10 @@ namespace Paramore.Brighter.MessagingGateway.AzureServiceBus
 
             return new AzureServiceBusConsumer(subscription.RoutingKey, subscription.ChannelName,
                 new AzureServiceBusMessageProducer(nameSpaceManagerWrapper,
-                    new TopicClientProvider(_configuration)), nameSpaceManagerWrapper,
-                new MessageReceiverProvider(_configuration), receiveMode: _configuration.AckOnRead ? ReceiveMode.PeekLock : ReceiveMode.ReceiveAndDelete);
+                    new TopicClientProvider(_configuration), subscription.MakeChannels), nameSpaceManagerWrapper,
+                new MessageReceiverProvider(_configuration),
+                makeChannels: subscription.MakeChannels,
+                receiveMode: _configuration.AckOnRead ? ReceiveMode.PeekLock : ReceiveMode.ReceiveAndDelete);
         }
     }
 }

--- a/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusMessageProducerFactory.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusMessageProducerFactory.cs
@@ -4,12 +4,12 @@ namespace Paramore.Brighter.MessagingGateway.AzureServiceBus
 {
     public static class AzureServiceBusMessageProducerFactory
     {
-        public static AzureServiceBusMessageProducer Get(AzureServiceBusConfiguration configuration)
+        public static AzureServiceBusMessageProducer Get(AzureServiceBusConfiguration configuration, OnMissingChannel makeChannel = OnMissingChannel.Create)
         {
             var nameSpaceManagerWrapper = new ManagementClientWrapper(configuration);
             var topicClientProvider = new TopicClientProvider(configuration);
 
-            return new AzureServiceBusMessageProducer(nameSpaceManagerWrapper, topicClientProvider);
+            return new AzureServiceBusMessageProducer(nameSpaceManagerWrapper, topicClientProvider, makeChannel);
         }
     }
 }


### PR DESCRIPTION
Missed Plumbing in make channels in the Consumer Factory, it doesn't appear to be "Needed" in the Producer Factory as it doesn't appear to be Natively used by Brighter, however I plumbed it in for Completeness