### PR TITLE
Only run the Kafka tests locally to see if issues are Confluent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,7 +252,7 @@ jobs:
     - name: Install dependencies
       run: dotnet restore
     - name: Kafka Transport Tests
-      run: dotnet test ./tests/Paramore.Brighter.Kafka.Tests/Paramore.Brighter.Kafka.Tests.csproj --configuration Release --logger "console;verbosity=normal" --blame -v n
+      run: dotnet test ./tests/Paramore.Brighter.Kafka.Tests/Paramore.Brighter.Kafka.Tests.csproj --filter "Category=Kafka&Category!=Confluent" --configuration Release --logger "console;verbosity=normal" --blame -v n
  
   postgres-ci:
     runs-on: ubuntu-latest

--- a/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/When_a_message_is_acknowledged_update_offset.cs
+++ b/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/When_a_message_is_acknowledged_update_offset.cs
@@ -5,10 +5,13 @@ using Confluent.Kafka;
 using FluentAssertions;
 using Paramore.Brighter.Kafka.Tests.TestDoubles;
 using Paramore.Brighter.MessagingGateway.Kafka;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace Paramore.Brighter.Kafka.Tests.MessagingGateway
 {
+    [Collection("Kafka")]
+    [Trait("Category", "Kafka")]
     public class KafkaMessageConsumerUpdateOffset : IDisposable
     {
         private readonly ITestOutputHelper _output;

--- a/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/When_a_set_of_messages_is_sent_preserve_order.cs
+++ b/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/When_a_set_of_messages_is_sent_preserve_order.cs
@@ -11,6 +11,8 @@ using Xunit.Abstractions;
 
 namespace Paramore.Brighter.Kafka.Tests.MessagingGateway
 {
+    [Collection("Kafka")]
+    [Trait("Category", "Kafka")]
     public class KafkaMessageConsumerPreservesOrder : IDisposable
     {
         private readonly ITestOutputHelper _output;

--- a/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/When_a_set_of_messages_is_sent_preserve_order_on_a_confluent_cluster.cs
+++ b/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/When_a_set_of_messages_is_sent_preserve_order_on_a_confluent_cluster.cs
@@ -12,6 +12,9 @@ using Xunit.Abstractions;
 
 namespace Paramore.Brighter.Kafka.Tests.MessagingGateway
 {
+    [Collection("Kafka")]
+    [Trait("Category", "Kafka")]
+    [Trait("Category", "Confluent")]
     public class KafkaMessageConsumerConfluentPreservesOrder : IDisposable
     {
         private const string _groupId = "Kafka Message Producer Assume Topic Test";

--- a/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/When_consumer_assumes_topic_but_missing_on_a_confluent_cluster.cs
+++ b/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/When_consumer_assumes_topic_but_missing_on_a_confluent_cluster.cs
@@ -39,6 +39,8 @@ namespace Paramore.Brighter.Kafka.Tests.MessagingGateway
 {
     [Collection("Kafka")]
     [Trait("Category", "Kafka")]
+    [Trait("Category", "Confluent")]
+    [Trait("Category", "Confluent")]
     public class KafkaConfluentProducerAssumeTests : IDisposable
     {
         private readonly string _queueName = Guid.NewGuid().ToString(); 

--- a/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/When_consumer_declares_topic.cs
+++ b/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/When_consumer_declares_topic.cs
@@ -23,16 +23,12 @@ THE SOFTWARE. */
 #endregion
 
 using System;
-using System.Linq;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Paramore.Brighter.Kafka.Tests.TestDoubles;
 using Paramore.Brighter.MessagingGateway.Kafka;
 using Xunit;
 using Xunit.Abstractions;
-using SaslMechanism = Paramore.Brighter.MessagingGateway.Kafka.SaslMechanism;
-using SecurityProtocol = Paramore.Brighter.MessagingGateway.Kafka.SecurityProtocol;
 
 namespace Paramore.Brighter.Kafka.Tests.MessagingGateway
 {

--- a/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/When_consumer_declares_topic_on_a_confluent_cluster.cs
+++ b/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/When_consumer_declares_topic_on_a_confluent_cluster.cs
@@ -38,6 +38,7 @@ namespace Paramore.Brighter.Kafka.Tests.MessagingGateway
 {
     [Collection("Kafka")]
     [Trait("Category", "Kafka")]
+    [Trait("Category", "Confluent")]
     public class KafkaConfluentConsumerDeclareTests : IDisposable
     {
         private readonly ITestOutputHelper _output;

--- a/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/When_offsets_awaiting_next_acknowledge_sweep_them.cs
+++ b/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/When_offsets_awaiting_next_acknowledge_sweep_them.cs
@@ -10,6 +10,8 @@ using Xunit.Abstractions;
 
 namespace Paramore.Brighter.Kafka.Tests.MessagingGateway
 {
+    [Collection("Kafka")]
+    [Trait("Category", "Kafka")]
     public class KafkaMessageConsumerSweepOffsets : IDisposable
     {
         private readonly ITestOutputHelper _output;

--- a/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/When_posting_a_message_to_a_confluent_cluster.cs
+++ b/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/When_posting_a_message_to_a_confluent_cluster.cs
@@ -37,6 +37,7 @@ namespace Paramore.Brighter.Kafka.Tests.MessagingGateway
 {
     [Collection("Kafka")]
     [Trait("Category", "Kafka")]
+    [Trait("Category", "Confluent")]
     public class KafkaConfluentProducerSendTests : IDisposable
     {
         private readonly ITestOutputHelper _output;


### PR DESCRIPTION
We are timing out on the tests, use the XUnit traits filter to exclude the Confluent tests