### PR TITLE
fix: clean up of dispose and delays in Dispatcher and Dispatcher tests

### DIFF
--- a/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_a_message_dispatcher_has_a_new_connection_added_while_running.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_a_message_dispatcher_has_a_new_connection_added_while_running.cs
@@ -1,4 +1,4 @@
-#region Licence
+﻿#region Licence
 /* The MIT License (MIT)
 Copyright © 2014 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
 
@@ -34,7 +34,7 @@ using Paramore.Brighter.ServiceActivator.TestHelpers;
 
 namespace Paramore.Brighter.Core.Tests.MessageDispatch
 {
-    public class DispatcherAddNewConnectionTests : IDisposable
+    public class DispatcherAddNewConnectionTests : IAsyncLifetime
     {
         private readonly Dispatcher _dispatcher;
         private readonly FakeChannel _channel;
@@ -59,11 +59,10 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch
             _channel.Enqueue(message);
 
             _dispatcher.State.Should().Be(DispatcherState.DS_AWAITING);
-            _dispatcher.Receive();
         }
 
         [Fact]
-        public void When_A_Message_Dispatcher_Has_A_New_Connection_Added_While_Running()
+        public async Task When_A_Message_Dispatcher_Has_A_New_Connection_Added_While_Running()
         {
             _dispatcher.Open(_newSubscription);
 
@@ -71,8 +70,9 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch
             var message = new MyEventMessageMapper().MapToMessage(@event);
             _channel.Enqueue(message);
 
-            Task.Delay(1000).Wait();
 
+            await Task.Delay(500);
+            
             //_should_have_consumed_the_messages_in_the_event_channel
             _channel.Length.Should().Be(0);
             //_should_have_a_running_state
@@ -83,10 +83,19 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch
             _dispatcher.Connections.Should().HaveCount(2);
         }
 
-        public void Dispose()
+
+        public Task InitializeAsync()
         {
-            if (_dispatcher?.State == DispatcherState.DS_RUNNING)
-                _dispatcher.End().Wait();
+            _dispatcher.Receive();
+            var completionSource = new TaskCompletionSource<IDispatcher>();
+            completionSource.SetResult(_dispatcher);
+
+            return completionSource.Task;
+        }
+
+        public Task DisposeAsync()
+        {
+            return _dispatcher?.End();
         }
     }
 }

--- a/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_a_message_dispatcher_starts_different_types_of_performers.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_a_message_dispatcher_starts_different_types_of_performers.cs
@@ -22,7 +22,6 @@ THE SOFTWARE. */
 
 #endregion
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -42,7 +41,7 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch
         private readonly Dispatcher _dispatcher;
         private readonly FakeChannel _eventChannel;
         private readonly FakeChannel _commandChannel;
-        private static int _numberOfConsumers;
+        private int _numberOfConsumers;
 
         public MessageDispatcherMultipleConnectionTests()
         {
@@ -77,11 +76,12 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch
 
 
         [Fact]
-        public void When_A_Message_Dispatcher_Starts_Different_Types_Of_Performers()
+        public async Task When_A_Message_Dispatcher_Starts_Different_Types_Of_Performers()
         {
-            Task.Delay(1000).Wait();
+            _dispatcher.State.Should().Be(DispatcherState.DS_RUNNING);
             _numberOfConsumers = _dispatcher.Consumers.Count();
-            _dispatcher.End().Wait();
+            
+            await _dispatcher.End();
 
            //_should_have_consumed_the_messages_in_the_event_channel
             _eventChannel.Length.Should().Be(0);
@@ -95,6 +95,8 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch
             _numberOfConsumers.Should().Be(2);
         }
 
+
+     
     }
 
 }

--- a/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_a_message_dispatcher_starts_multiple_performers.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_a_message_dispatcher_starts_multiple_performers.cs
@@ -49,7 +49,7 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch
             var messageMapperRegistry = new MessageMapperRegistry(new SimpleMessageMapperFactory((_) => new MyEventMessageMapper()));
             messageMapperRegistry.Register<MyEvent, MyEventMessageMapper>();
 
-            var connection = new Subscription<MyEvent>(new SubscriptionName("test"), noOfPerformers: 3, timeoutInMilliseconds: 1000, channelFactory: new InMemoryChannelFactory(_channel), channelName: new ChannelName("fakeChannel"), routingKey: new RoutingKey("fakekey"));
+            var connection = new Subscription<MyEvent>(new SubscriptionName("test"), noOfPerformers: 3, timeoutInMilliseconds: 100, channelFactory: new InMemoryChannelFactory(_channel), channelName: new ChannelName("fakeChannel"), routingKey: new RoutingKey("fakekey"));
             _dispatcher = new Dispatcher(_commandProcessor, messageMapperRegistry, new List<Subscription> { connection });
 
             var @event = new MyEvent();
@@ -65,10 +65,10 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch
         [Fact]
         public void WhenAMessageDispatcherStartsMultiplePerformers()
         {
+            _dispatcher.State.Should().Be(DispatcherState.DS_RUNNING);
             //should_have_multiple_consumers
             _dispatcher.Consumers.Count().Should().Be(3);
 
-            Task.Delay(1000).Wait();
             _dispatcher.End().Wait();
             
             //_should_have_consumed_the_messages_in_the_channel
@@ -76,5 +76,6 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch
             //_should_have_a_stopped_state
             _dispatcher.State.Should().Be(DispatcherState.DS_STOPPED);
         }
+
     }
 }

--- a/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_a_message_fails_to_be_mapped_to_a_request.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_a_message_fails_to_be_mapped_to_a_request.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Paramore.Brighter.Core.Tests.MessageDispatch.TestDoubles;
@@ -31,7 +31,6 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch
         public void When_A_Message_Fails_To_Be_Mapped_To_A_Request ()
         {
             var task = Task.Factory.StartNew(() => _messagePump.Run(), TaskCreationOptions.LongRunning);
-            Task.Delay(1000).Wait();
 
             _channel.Stop();
 

--- a/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_a_message_fails_to_be_mapped_to_a_request_and_the_unacceptable_message_limit_is_reached.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_a_message_fails_to_be_mapped_to_a_request_and_the_unacceptable_message_limit_is_reached.cs
@@ -1,4 +1,4 @@
-#region Licence
+﻿#region Licence
 /* The MIT License (MIT)
 Copyright © 2014 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
 
@@ -53,13 +53,10 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch
         }
 
         [Fact]
-        public void When_A_Message_Fails_To_Be_Mapped_To_A_Request_And_The_Unacceptable_Message_Limit_Is_Reached()
+        public async Task When_A_Message_Fails_To_Be_Mapped_To_A_Request_And_The_Unacceptable_Message_Limit_Is_Reached()
         {
-            var task = Task.Factory.StartNew(() => _messagePump.Run(), TaskCreationOptions.LongRunning);
-            Task.Delay(1000).Wait();
-
-            Task.WaitAll(new[] { task });
-
+            await Task.Factory.StartNew(() => _messagePump.Run(), TaskCreationOptions.LongRunning);
+            
             //should_have_acknowledge_the_3_messages
             _channel.AcknowledgeCount.Should().Be(3);
             //should_dispose_the_input_channel

--- a/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_a_requeue_count_threshold_for_commands_has_been_reached.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_a_requeue_count_threshold_for_commands_has_been_reached.cs
@@ -57,15 +57,15 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch
         }
 
         [Fact]
-        public void When_A_Requeue_Count_Threshold_For_Commands_Has_Been_Reached()
+        public async Task When_A_Requeue_Count_Threshold_For_Commands_Has_Been_Reached()
         {
             var task = Task.Factory.StartNew(() => _messagePump.Run(), TaskCreationOptions.LongRunning);
-            Task.Delay(1000).Wait();
+            await Task.Delay(500);
 
             var quitMessage = new Message(new MessageHeader(Guid.Empty, "", MessageType.MT_QUIT), new MessageBody(""));
             _channel.Enqueue(quitMessage);
 
-            Task.WaitAll(new[] { task });
+            await task;
 
             //_should_send_the_message_via_the_command_processor
             _commandProcessor.Commands[0].Should().Be(CommandType.Send);

--- a/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_a_requeue_count_threshold_for_events_has_been_reached.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_a_requeue_count_threshold_for_events_has_been_reached.cs
@@ -57,15 +57,15 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch
         }
 
         [Fact]
-        public void When_A_Requeue_Count_Threshold_For_Events_Has_Been_Reached()
+        public async Task When_A_Requeue_Count_Threshold_For_Events_Has_Been_Reached()
         {
             var task = Task.Factory.StartNew(() => _messagePump.Run(), TaskCreationOptions.LongRunning);
-            Task.Delay(1000).Wait();
+            await Task.Delay(500);
 
             var quitMessage = new Message(new MessageHeader(Guid.Empty, "", MessageType.MT_QUIT), new MessageBody(""));
             _channel.Enqueue(quitMessage);
 
-            Task.WaitAll(new[] { task });
+            await task;
 
             //_should_publish_the_message_via_the_command_processor
             _commandProcessor.Commands[0].Should().Be(CommandType.Publish);

--- a/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_an_unacceptable_message_is_recieved.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_an_unacceptable_message_is_recieved.cs
@@ -1,4 +1,4 @@
-#region Licence
+﻿#region Licence
 /* The MIT License (MIT)
 Copyright © 2014 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
 
@@ -55,12 +55,11 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch
         public async Task When_An_Unacceptable_Message_Is_Received()
         {
             var task = Task.Factory.StartNew(() => _messagePump.Run(), TaskCreationOptions.LongRunning);
-            Task.Delay(1000).Wait();
 
-            var quitMessage = new Message(new MessageHeader(Guid.Empty, "", MessageType.MT_QUIT), new MessageBody(""));
+            var quitMessage = new Message(new MessageHeader(Guid.NewGuid(), "", MessageType.MT_QUIT), new MessageBody(""));
             _channel.Enqueue(quitMessage);
 
-            Task.WaitAll(new[] { task });
+            await task;
 
             //should_acknowledge_the_message
             _channel.AcknowledgeHappened.Should().BeTrue();

--- a/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_an_unacceptable_message_limit_is_reached.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_an_unacceptable_message_limit_is_reached.cs
@@ -1,4 +1,4 @@
-#region Licence
+﻿#region Licence
 /* The MIT License (MIT)
 Copyright © 2014 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
 
@@ -61,7 +61,6 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch
         public void When_An_Unacceptable_Message_Limit_Is_Reached()
         {
             var task = Task.Factory.StartNew(() => _messagePump.Run(), TaskCreationOptions.LongRunning);
-            Task.Delay(1000).Wait();
 
             Task.WaitAll(new[] { task });
 


### PR DESCRIPTION

- On Start, wait until dispatcher is running before continuing
- Remove delays from tests
- Use more async-y tests