### PR TITLE
Replace liblog with Microsoft.Extensions.Logging #242

### DIFF
--- a/samples/AWSTaskQueueSamples/GreetingsSender/GreetingsSender.csproj
+++ b/samples/AWSTaskQueueSamples/GreetingsSender/GreetingsSender.csproj
@@ -8,6 +8,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
     <PackageReference Include="Serilog" Version="2.10.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
   </ItemGroup>
   <ItemGroup>

--- a/samples/AWSTaskQueueSamples/GreetingsSender/Program.cs
+++ b/samples/AWSTaskQueueSamples/GreetingsSender/Program.cs
@@ -26,10 +26,12 @@ using Amazon;
 using Amazon.Runtime.CredentialManagement;
 using Greetings.Ports.Commands;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Paramore.Brighter;
 using Paramore.Brighter.Extensions.DependencyInjection;
 using Paramore.Brighter.MessagingGateway.AWSSQS;
 using Serilog;
+using Serilog.Extensions.Logging;
 
 namespace GreetingsSender
 {
@@ -44,8 +46,8 @@ namespace GreetingsSender
                 .CreateLogger();
 
             var serviceCollection = new ServiceCollection();
-
-
+            serviceCollection.AddSingleton<ILoggerFactory>(new SerilogLoggerFactory());
+            
             if (new CredentialProfileStoreChain().TryGetAWSCredentials("default", out var credentials))
             {
                 var awsConnection = new AWSMessagingGatewayConnection(credentials, RegionEndpoint.EUWest1);

--- a/samples/HelloAsyncListeners/HelloAsyncListeners.csproj
+++ b/samples/HelloAsyncListeners/HelloAsyncListeners.csproj
@@ -8,6 +8,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
     <PackageReference Include="Serilog" Version="2.10.0" />
+    <PackageReference Include="Serilog.Extensions.Hosting" Version="4.1.2" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
   </ItemGroup>
   <ItemGroup>

--- a/samples/HelloAsyncListeners/Program.cs
+++ b/samples/HelloAsyncListeners/Program.cs
@@ -24,6 +24,7 @@ namespace HelloAsyncListeners
                         services.AddHostedService<RunCommandProcessor>();
                     }
                 )
+                .UseSerilog()
                 .UseConsoleLifetime()
                 .Build();
 

--- a/samples/HelloWorld/HelloWorld.csproj
+++ b/samples/HelloWorld/HelloWorld.csproj
@@ -7,6 +7,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="5.0.0" />
     <PackageReference Include="Serilog" Version="2.10.0" />
+    <PackageReference Include="Serilog.Extensions.Hosting" Version="4.1.2" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
   </ItemGroup>
   <ItemGroup>

--- a/samples/HelloWorld/Program.cs
+++ b/samples/HelloWorld/Program.cs
@@ -25,9 +25,11 @@ THE SOFTWARE. */
 
 using System;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Paramore.Brighter;
 using Paramore.Brighter.Extensions.DependencyInjection;
 using Serilog;
+using Serilog.Extensions.Logging;
 
 namespace HelloWorld
 {
@@ -53,7 +55,7 @@ namespace HelloWorld
         private static ServiceProvider CreateServices()
         {
             var serviceCollection = new ServiceCollection();
-
+            serviceCollection.AddSingleton<ILoggerFactory>(new SerilogLoggerFactory());
             serviceCollection
                 .AddBrighter()
                 .AutoFromAssemblies();

--- a/samples/HelloWorldAsync/HelloWorldAsync.csproj
+++ b/samples/HelloWorldAsync/HelloWorldAsync.csproj
@@ -8,6 +8,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
     <PackageReference Include="Serilog" Version="2.10.0" />
+    <PackageReference Include="Serilog.Extensions.Hosting" Version="4.1.2" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
   </ItemGroup>
   <ItemGroup>

--- a/samples/HelloWorldAsync/Program.cs
+++ b/samples/HelloWorldAsync/Program.cs
@@ -47,8 +47,10 @@ namespace HelloWorldAsync
                     {
                         services.AddBrighter().AutoFromAssemblies();
                         services.AddHostedService<RunCommandProcessor>();
+                        
                     }
                 )
+                .UseSerilog()
                 .UseConsoleLifetime()
                 .Build();
 

--- a/samples/KafkaPartitionTesting/GreetingsSender/Adapters/Program.cs
+++ b/samples/KafkaPartitionTesting/GreetingsSender/Adapters/Program.cs
@@ -72,11 +72,6 @@ namespace GreetingsSender.Adapters
         private static IHost BuildHost()
         {
             return new HostBuilder()
-                .ConfigureLogging(loggingBuilder =>
-                {
-                    loggingBuilder.AddConsole();
-                    loggingBuilder.AddDebug();
-                })
                .ConfigureServices((hostContext, services) =>
                 {
                     var retryPolicy = Policy.Handle<Exception>().WaitAndRetry(new[]
@@ -130,6 +125,7 @@ namespace GreetingsSender.Adapters
 
                     services.AddHostedService<TimedMessageGenerator>();
                 })
+               .UseSerilog()
                 .UseConsoleLifetime()
                 .Build();
         }

--- a/samples/KafkaPartitionTesting/GreetingsSender/Adapters/TimedMessageGenerator.cs
+++ b/samples/KafkaPartitionTesting/GreetingsSender/Adapters/TimedMessageGenerator.cs
@@ -11,7 +11,7 @@ namespace GreetingsSender.Adapters
     public class TimedMessageGenerator : IHostedService, IDisposable
     {
         private readonly IAmACommandProcessor _processor;
-        private readonly ILogger<TimedMessageGenerator> _logger;
+        private readonly ILogger<TimedMessageGenerator> s_logger;
         private readonly IHostApplicationLifetime _appLifetime;
         private Timer _timer;
         private long _iteration = 0;
@@ -22,13 +22,13 @@ namespace GreetingsSender.Adapters
             IHostApplicationLifetime appLifetime)
         {
             _processor = processor;
-            _logger = logger;
+            s_logger = logger;
             _appLifetime = appLifetime;
         }
 
         public Task StartAsync(CancellationToken cancellationToken)
         {
-            _logger.LogInformation("Kafka Message Generator is starting.");
+            s_logger.LogInformation("Kafka Message Generator is starting.");
 
             _timer = new Timer(DoWork, null, TimeSpan.Zero, TimeSpan.FromSeconds(5));
 
@@ -37,7 +37,7 @@ namespace GreetingsSender.Adapters
 
         public Task StopAsync(CancellationToken cancellationToken)
         {
-            _logger.LogInformation("Kafka Message Generator is stopping.");
+            s_logger.LogInformation("Kafka Message Generator is stopping.");
 
             _timer?.Change(Timeout.Infinite, 0);
 
@@ -56,11 +56,11 @@ namespace GreetingsSender.Adapters
             }
             catch (Exception e)
             {
-                _logger.LogError($"Kafka Message Generator is stopping due to {e.Message}");
+                s_logger.LogError($"Kafka Message Generator is stopping due to {e.Message}");
                 _appLifetime.StopApplication();
             }
 
-            _logger.LogInformation($"Sending message with id {greetingEvent.Id} and greeting {greetingEvent.Greeting}");
+            s_logger.LogInformation($"Sending message with id {greetingEvent.Id} and greeting {greetingEvent.Greeting}");
         }
 
         public void Dispose()

--- a/samples/KafkaTaskQueueSamples/GreetingsSender/Adapters/Program.cs
+++ b/samples/KafkaTaskQueueSamples/GreetingsSender/Adapters/Program.cs
@@ -28,7 +28,6 @@ using System;
 using System.Threading.Tasks;
 using Greetings.Ports.Commands;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.DependencyInjection;
 using Paramore.Brighter;
 using Paramore.Brighter.Extensions.DependencyInjection;
@@ -72,26 +71,25 @@ namespace GreetingsSender.Adapters
         private static IHost BuildHost()
         {
             return new HostBuilder()
-                .ConfigureLogging(loggingBuilder =>
-                {
-                    loggingBuilder.AddConsole();
-                    loggingBuilder.AddDebug();
-                })
-               .ConfigureServices((hostContext, services) =>
+                .ConfigureServices((hostContext, services) =>
                 {
                     var retryPolicy = Policy.Handle<Exception>().WaitAndRetry(new[]
                     {
-                        TimeSpan.FromMilliseconds(50), TimeSpan.FromMilliseconds(100), TimeSpan.FromMilliseconds(150)
+                        TimeSpan.FromMilliseconds(50), TimeSpan.FromMilliseconds(100),
+                        TimeSpan.FromMilliseconds(150)
                     });
 
-                    var circuitBreakerPolicy = Policy.Handle<Exception>().CircuitBreaker(1, TimeSpan.FromMilliseconds(500));
+                    var circuitBreakerPolicy =
+                        Policy.Handle<Exception>().CircuitBreaker(1, TimeSpan.FromMilliseconds(500));
 
                     var retryPolicyAsync = Policy.Handle<Exception>().WaitAndRetryAsync(new[]
                     {
-                        TimeSpan.FromMilliseconds(50), TimeSpan.FromMilliseconds(100), TimeSpan.FromMilliseconds(150)
+                        TimeSpan.FromMilliseconds(50), TimeSpan.FromMilliseconds(100),
+                        TimeSpan.FromMilliseconds(150)
                     });
 
-                    var circuitBreakerPolicyAsync = Policy.Handle<Exception>().CircuitBreakerAsync(1, TimeSpan.FromMilliseconds(500));
+                    var circuitBreakerPolicyAsync = Policy.Handle<Exception>()
+                        .CircuitBreakerAsync(1, TimeSpan.FromMilliseconds(500));
 
                     var policyRegistry = new PolicyRegistry()
                     {
@@ -104,7 +102,7 @@ namespace GreetingsSender.Adapters
                     var producer = new KafkaMessageProducerFactory(
                             new KafkaMessagingGatewayConfiguration()
                             {
-                                Name = "paramore.brighter.greetingsender", 
+                                Name = "paramore.brighter.greetingsender",
                                 BootStrapServers = new[] {"localhost:9092"}
                             },
                             new KafkaPublication()
@@ -126,6 +124,7 @@ namespace GreetingsSender.Adapters
 
                     services.AddHostedService<TimedMessageGenerator>();
                 })
+                .UseSerilog()
                 .UseConsoleLifetime()
                 .Build();
         }

--- a/samples/MsSqlMessagingGatewaySamples/GreetingsSender/GreetingsSender.csproj
+++ b/samples/MsSqlMessagingGatewaySamples/GreetingsSender/GreetingsSender.csproj
@@ -7,6 +7,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="5.0.0" />
     <PackageReference Include="Serilog" Version="2.10.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
   </ItemGroup>
   <ItemGroup>

--- a/samples/MsSqlMessagingGatewaySamples/GreetingsSender/Program.cs
+++ b/samples/MsSqlMessagingGatewaySamples/GreetingsSender/Program.cs
@@ -1,9 +1,11 @@
 ﻿using Events.Ports.Commands;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Paramore.Brighter;
 using Paramore.Brighter.Extensions.DependencyInjection;
 using Paramore.Brighter.MessagingGateway.MsSql;
 using Serilog;
+using Serilog.Extensions.Logging;
 
 namespace GreetingsSender
 {
@@ -18,6 +20,7 @@ namespace GreetingsSender
                 .CreateLogger();
 
             var serviceCollection = new ServiceCollection();
+            serviceCollection.AddSingleton<ILoggerFactory>(new SerilogLoggerFactory());
 
             var messagingConfiguration = new MsSqlMessagingGatewayConfiguration(@"Database=BrighterSqlQueue;Server=.\sqlexpress;Integrated Security=SSPI;", "QueueData");
             var producer = new MsSqlMessageProducer(messagingConfiguration);

--- a/samples/RMQPartitionTesting/GreetingsPumper/GreetingsPumper.csproj
+++ b/samples/RMQPartitionTesting/GreetingsPumper/GreetingsPumper.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="5.0.0" />
     <PackageReference Include="Serilog" Version="2.10.0" />
+    <PackageReference Include="Serilog.Extensions.Hosting" Version="4.1.2" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
   </ItemGroup>
   <ItemGroup>

--- a/samples/RMQPartitionTesting/GreetingsPumper/Program.cs
+++ b/samples/RMQPartitionTesting/GreetingsPumper/Program.cs
@@ -53,6 +53,7 @@ namespace GreetingsPumper
                     }
                 )
                 .UseConsoleLifetime()
+                .UseSerilog()
                 .Build();
 
             await host.RunAsync();

--- a/samples/RMQPartitionTesting/GreetingsPumper/TimeOutboxSweeper.cs
+++ b/samples/RMQPartitionTesting/GreetingsPumper/TimeOutboxSweeper.cs
@@ -4,7 +4,6 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Paramore.Brighter;
-using Serilog;
 using ILogger = Microsoft.Extensions.Logging.ILogger;
 
 namespace GreetingsReceiverConsole
@@ -13,19 +12,19 @@ namespace GreetingsReceiverConsole
     {
         private readonly IAmAnOutboxViewer<Message> _outbox;
         private readonly IAmACommandProcessor _commandProcessor;
-        private readonly ILogger _logger;
+        private readonly ILogger s_logger;
         private Timer _timer;
 
         public TimedOutboxSweeper (IAmAnOutboxViewer<Message> outbox, IAmACommandProcessor commandProcessor, ILogger<TimedOutboxSweeper > logger)
         {
             _outbox = outbox;
             _commandProcessor = commandProcessor;
-            _logger = logger;
+            s_logger = logger;
         }
 
         public Task StartAsync(CancellationToken cancellationToken)
         {
-            _logger.LogInformation("Outbox Sweeper Service is starting.");
+            s_logger.LogInformation("Outbox Sweeper Service is starting.");
 
             _timer = new Timer(DoWork, null, TimeSpan.Zero, TimeSpan.FromSeconds(5));
 
@@ -34,7 +33,7 @@ namespace GreetingsReceiverConsole
 
         private void DoWork(object state)
         {
-            _logger.LogInformation("Outbox Sweeper looking for unsent messages");
+            s_logger.LogInformation("Outbox Sweeper looking for unsent messages");
 
             var outBoxSweeper = new OutboxSweeper(
                 milliSecondsSinceSent:5000, 
@@ -43,13 +42,13 @@ namespace GreetingsReceiverConsole
 
             outBoxSweeper.Sweep();
             
-            _logger.LogInformation("Outbox Sweeper sleeping");
+            s_logger.LogInformation("Outbox Sweeper sleeping");
            
         }
 
         public Task StopAsync(CancellationToken cancellationToken)
         {
-            _logger.LogInformation("Outbox Sweeper Service is stopping.");
+            s_logger.LogInformation("Outbox Sweeper Service is stopping.");
 
             _timer?.Change(Timeout.Infinite, 0);
 

--- a/samples/RMQRequestReplyExamples/GreetingsClient/GreetingsClient.csproj
+++ b/samples/RMQRequestReplyExamples/GreetingsClient/GreetingsClient.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
     <PackageReference Include="Serilog" Version="2.10.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
   </ItemGroup>
 </Project>

--- a/samples/RMQRequestReplyExamples/GreetingsClient/Program.cs
+++ b/samples/RMQRequestReplyExamples/GreetingsClient/Program.cs
@@ -23,14 +23,14 @@ THE SOFTWARE. */
 #endregion
 
 using System;
-using Greetings.Ports.CommandHandlers;
 using Greetings.Ports.Commands;
-using Greetings.Ports.Mappers;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Paramore.Brighter;
 using Paramore.Brighter.Extensions.DependencyInjection;
 using Paramore.Brighter.MessagingGateway.RMQ;
 using Serilog;
+using Serilog.Extensions.Logging;
 
 namespace GreetingsSender
 {
@@ -45,6 +45,7 @@ namespace GreetingsSender
                 .CreateLogger();
 
             var serviceCollection = new ServiceCollection();
+            serviceCollection.AddSingleton<ILoggerFactory>(new SerilogLoggerFactory());
 
             var rmqConnection = new RmqMessagingGatewayConnection
             {

--- a/samples/RMQTaskQueueSamples/GreetingsSender/GreetingsSender.csproj
+++ b/samples/RMQTaskQueueSamples/GreetingsSender/GreetingsSender.csproj
@@ -7,6 +7,8 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="5.0.0" />
     <PackageReference Include="Serilog" Version="2.10.0" />
+    <PackageReference Include="Serilog.Extensions.Hosting" Version="4.1.2" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
   </ItemGroup>
   <ItemGroup>

--- a/samples/RMQTaskQueueSamples/GreetingsSender/Program.cs
+++ b/samples/RMQTaskQueueSamples/GreetingsSender/Program.cs
@@ -25,10 +25,12 @@ THE SOFTWARE. */
 using System;
 using Greetings.Ports.Commands;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Paramore.Brighter;
 using Paramore.Brighter.Extensions.DependencyInjection;
 using Paramore.Brighter.MessagingGateway.RMQ;
 using Serilog;
+using Serilog.Extensions.Logging;
 
 namespace GreetingsSender
 {
@@ -43,7 +45,8 @@ namespace GreetingsSender
                 .CreateLogger();
 
             var serviceCollection = new ServiceCollection();
-            
+            serviceCollection.AddSingleton<ILoggerFactory>(new SerilogLoggerFactory());
+
             var rmqConnection = new RmqMessagingGatewayConnection
             {
                 AmpqUri = new AmqpUriSpecification(new Uri("amqp://guest:guest@localhost:5672")),

--- a/samples/RedisTaskQueueExamples/GreetingsSender/GreetingsSender.csproj
+++ b/samples/RedisTaskQueueExamples/GreetingsSender/GreetingsSender.csproj
@@ -7,6 +7,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="5.0.0" />
     <PackageReference Include="Serilog" Version="2.10.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0" />
   </ItemGroup>

--- a/samples/RedisTaskQueueExamples/GreetingsSender/Program.cs
+++ b/samples/RedisTaskQueueExamples/GreetingsSender/Program.cs
@@ -26,10 +26,12 @@ THE SOFTWARE. */
 using System;
 using Greetings.Ports.Events;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Paramore.Brighter;
 using Paramore.Brighter.Extensions.DependencyInjection;
 using Paramore.Brighter.MessagingGateway.Redis;
 using Serilog;
+using Serilog.Extensions.Logging;
 
 namespace GreetingsSender
 {
@@ -44,6 +46,7 @@ namespace GreetingsSender
                 .CreateLogger();
 
             var serviceCollection = new ServiceCollection();
+            serviceCollection.AddSingleton<ILoggerFactory>(new SerilogLoggerFactory());
 
             var redisConnection = new RedisMessagingGatewayConfiguration
             {

--- a/src/Paramore.Brighter.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Paramore.Brighter.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Paramore.Brighter.Logging;
 
 namespace Paramore.Brighter.Extensions.DependencyInjection
 {
@@ -46,6 +48,8 @@ namespace Paramore.Brighter.Extensions.DependencyInjection
                 ? policyBuilder.DefaultPolicy()
                 : policyBuilder.Policies(options.PolicyRegistry);
 
+            var loggerFactory = provider.GetService<ILoggerFactory>();
+            ApplicationLogging.LoggerFactory = loggerFactory;
             
             INeedARequestContext taskQueuesBuilder;
             if (options.ChannelFactory is null)

--- a/src/Paramore.Brighter.Inbox.DynamoDB/DynamoDbInbox.cs
+++ b/src/Paramore.Brighter.Inbox.DynamoDB/DynamoDbInbox.cs
@@ -32,13 +32,11 @@ using Amazon.DynamoDBv2;
 using Amazon.DynamoDBv2.DataModel;
 using Amazon.DynamoDBv2.DocumentModel;
 using Paramore.Brighter.Inbox.Exceptions;
-using Paramore.Brighter.Logging;
 
 namespace Paramore.Brighter.Inbox.DynamoDB
 {
     public class DynamoDbInbox : IAmAnInbox, IAmAnInboxAsync
     {
-        private static readonly Lazy<ILog> _logger = new Lazy<ILog>(LogProvider.For<DynamoDbInbox>);
        
         private readonly DynamoDBContext _context;
 

--- a/src/Paramore.Brighter.Inbox.MsSql/MsSqlInbox.cs
+++ b/src/Paramore.Brighter.Inbox.MsSql/MsSqlInbox.cs
@@ -30,6 +30,7 @@ using System.Data.SqlClient;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Paramore.Brighter.Inbox.Exceptions;
 using Paramore.Brighter.Logging;
 
@@ -40,7 +41,7 @@ namespace Paramore.Brighter.Inbox.MsSql
     /// </summary>
     public class MsSqlInbox : IAmAnInbox, IAmAnInboxAsync
     {
-        private static readonly Lazy<ILog> s_logger = new Lazy<ILog>(LogProvider.For<MsSqlInbox>);
+        private static readonly ILogger s_logger = ApplicationLogging.CreateLogger<MsSqlInbox>();
 
         private const int MsSqlDuplicateKeyError_UniqueIndexViolation = 2601;
         private const int MsSqlDuplicateKeyError_UniqueConstraintViolation = 2627;
@@ -80,7 +81,7 @@ namespace Paramore.Brighter.Inbox.MsSql
                 {
                     if (sqlException.Number == MsSqlDuplicateKeyError_UniqueIndexViolation || sqlException.Number == MsSqlDuplicateKeyError_UniqueConstraintViolation)
                     {
-                        s_logger.Value.WarnFormat(
+                        s_logger.LogWarning(
                             "MsSqlOutbox: A duplicate Command with the CommandId {0} was inserted into the Outbox, ignoring and continuing",
                             command.Id);
                         return;
@@ -157,7 +158,7 @@ namespace Paramore.Brighter.Inbox.MsSql
                 {
                     if (sqlException.Number == MsSqlDuplicateKeyError_UniqueIndexViolation || sqlException.Number == MsSqlDuplicateKeyError_UniqueConstraintViolation)
                     {
-                        s_logger.Value.WarnFormat(
+                        s_logger.LogWarning(
                             "MsSqlOutbox: A duplicate Command with the CommandId {0} was inserted into the Outbox, ignoring and continuing",
                             command.Id);
                         return;

--- a/src/Paramore.Brighter.Inbox.MySql/MySqlInbox.cs
+++ b/src/Paramore.Brighter.Inbox.MySql/MySqlInbox.cs
@@ -29,6 +29,7 @@ using System.Data.Common;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using MySqlConnector;
 using Paramore.Brighter.Inbox.Exceptions;
 using Paramore.Brighter.Logging;
@@ -40,7 +41,7 @@ namespace Paramore.Brighter.Inbox.MySql
     /// </summary>
     public class MySqlInbox : IAmAnInbox, IAmAnInboxAsync
     {
-        private static readonly Lazy<ILog> _logger = new Lazy<ILog>(LogProvider.For<MySqlInbox>);
+        private static readonly ILogger s_logger = ApplicationLogging.CreateLogger<MySqlInbox>();
 
         private const int MySqlDuplicateKeyError = 1062;
         private readonly MySqlInboxConfiguration _configuration;
@@ -79,7 +80,7 @@ namespace Paramore.Brighter.Inbox.MySql
                 {
                     if (sqlException.Number == MySqlDuplicateKeyError)
                     {
-                        _logger.Value.WarnFormat(
+                        s_logger.LogWarning(
                             "MySqlOutbox: A duplicate Command with the CommandId {0} was inserted into the Outbox, ignoring and continuing",
                             command.Id);
                         return;
@@ -188,7 +189,7 @@ namespace Paramore.Brighter.Inbox.MySql
                 {
                     if (sqlException.Number == MySqlDuplicateKeyError)
                     {
-                        _logger.Value.WarnFormat(
+                        s_logger.LogWarning(
                             "MySqlOutbox: A duplicate Command with the CommandId {0} was inserted into the Outbox, ignoring and continuing",
                             command.Id);
                         return;

--- a/src/Paramore.Brighter.Inbox.Postgres/PostgresSqlInbox.cs
+++ b/src/Paramore.Brighter.Inbox.Postgres/PostgresSqlInbox.cs
@@ -29,6 +29,7 @@ using System.Data.Common;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Npgsql;
 using NpgsqlTypes;
 using Paramore.Brighter.Inbox.Exceptions;
@@ -39,7 +40,7 @@ namespace Paramore.Brighter.Inbox.Postgres
     public class PostgresSqlInbox : IAmAnInbox, IAmAnInboxAsync
     {
         private readonly PostgresSqlInboxConfiguration _configuration;
-        private static readonly Lazy<ILog> _logger = new Lazy<ILog>(LogProvider.For<PostgresSqlInbox>);
+        private static readonly ILogger s_logger = ApplicationLogging.CreateLogger<PostgresSqlInbox>();
         /// <summary>
         ///     If false we the default thread synchronization context to run any continuation, if true we re-use the original
         ///     synchronization context.
@@ -73,7 +74,7 @@ namespace Paramore.Brighter.Inbox.Postgres
                   {
                       if (sqlException.SqlState == PostgresErrorCodes.UniqueViolation)
                       {
-                          _logger.Value.WarnFormat(
+                          s_logger.LogWarning(
                               "PostgresSqlOutbox: A duplicate Command with the CommandId {0} was inserted into the Outbox, ignoring and continuing",
                               command.Id);
                           return;
@@ -125,7 +126,7 @@ namespace Paramore.Brighter.Inbox.Postgres
                 {
                     if (sqlException.SqlState == PostgresErrorCodes.UniqueViolation)
                     {
-                        _logger.Value.WarnFormat(
+                        s_logger.LogWarning(
                             "PostgresSqlOutbox: A duplicate Command with the CommandId {0} was inserted into the Outbox, ignoring and continuing",
                             command.Id);
                         return;

--- a/src/Paramore.Brighter.Inbox.Sqlite/SqliteInbox.cs
+++ b/src/Paramore.Brighter.Inbox.Sqlite/SqliteInbox.cs
@@ -30,6 +30,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging;
 using Paramore.Brighter.Inbox.Exceptions;
 using Paramore.Brighter.Logging;
 
@@ -40,7 +41,7 @@ namespace Paramore.Brighter.Inbox.Sqlite
     /// </summary>
     public class SqliteInbox : IAmAnInbox, IAmAnInboxAsync
     {
-        private static readonly Lazy<ILog> _logger = new Lazy<ILog>(LogProvider.For<SqliteInbox>);
+        private static readonly ILogger s_logger = ApplicationLogging.CreateLogger<SqliteInbox>();
 
         private const int SqliteDuplicateKeyError = 1555;
         private const int SqliteUniqueKeyError = 19;
@@ -74,7 +75,7 @@ namespace Paramore.Brighter.Inbox.Sqlite
                     {
                         if (IsExceptionUnqiueOrDuplicateIssue(sqliteException))
                         {
-                            _logger.Value.WarnFormat(
+                            s_logger.LogWarning(
                                 "MsSqlOutbox: A duplicate Command with the CommandId {0} was inserted into the Outbox, ignoring and continuing",
                                 command.Id);
                         }
@@ -169,7 +170,7 @@ namespace Paramore.Brighter.Inbox.Sqlite
                     catch (SqliteException sqliteException)
                     {
                         if (!IsExceptionUnqiueOrDuplicateIssue(sqliteException)) throw;
-                        _logger.Value.WarnFormat(
+                        s_logger.LogWarning(
                             "MsSqlOutbox: A duplicate Command with the CommandId {0} was inserted into the Outbox, ignoring and continuing",
                             command.Id);
                     }

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS/AWSMessagingGateway.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS/AWSMessagingGateway.cs
@@ -3,13 +3,14 @@ using System.Collections.Generic;
 using System.Net;
 using Amazon.SimpleNotificationService;
 using Amazon.SimpleNotificationService.Model;
+using Microsoft.Extensions.Logging;
 using Paramore.Brighter.Logging;
 
 namespace Paramore.Brighter.MessagingGateway.AWSSQS
 {
     public class AWSMessagingGateway
     {
-        protected static readonly Lazy<ILog> _logger = new Lazy<ILog>(LogProvider.For<ChannelFactory>);
+        protected static readonly ILogger s_logger = ApplicationLogging.CreateLogger<AWSMessagingGateway>();
         protected AWSMessagingGatewayConnection _awsConnection;
         protected string _channelTopicArn;
 

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS/SqsMessageCreator.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS/SqsMessageCreator.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Text.Json;
 using Amazon.SQS.Model;
+using Microsoft.Extensions.Logging;
 using Paramore.Brighter.Logging;
 
 namespace Paramore.Brighter.MessagingGateway.AWSSQS
@@ -21,7 +22,7 @@ namespace Paramore.Brighter.MessagingGateway.AWSSQS
     
     internal class SqsMessageCreator
     {
-        private static readonly Lazy<ILog> _logger = new Lazy<ILog>(LogProvider.For<SqsMessageCreator>);
+        private static readonly ILogger s_logger= ApplicationLogging.CreateLogger<SqsMessageCreator>();
 
         public Message CreateMessage(Amazon.SQS.Model.Message sqsMessage)
         {
@@ -76,7 +77,7 @@ namespace Paramore.Brighter.MessagingGateway.AWSSQS
             }
             catch (Exception e)
             {
-                _logger.Value.WarnException("Failed to create message from amqp message", e);
+                s_logger.LogWarning(e, "Failed to create message from amqp message");
                 message = FailureMessage(topic, messageId);
             }
             

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS/SqsMessageProducer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS/SqsMessageProducer.cs
@@ -12,9 +12,8 @@
 // <summary></summary>
 // ***********************************************************************
 
-using System;
 using Amazon.SimpleNotificationService;
-using Paramore.Brighter.Logging;
+using Microsoft.Extensions.Logging;
 
 namespace Paramore.Brighter.MessagingGateway.AWSSQS
 {
@@ -57,7 +56,7 @@ namespace Paramore.Brighter.MessagingGateway.AWSSQS
         /// <param name="message">The message.</param>
         public void Send(Message message)
         {
-            _logger.Value.DebugFormat("SQSMessageProducer: Publishing message with topic {0} and id {1} and message: {2}", 
+            s_logger.LogDebug("SQSMessageProducer: Publishing message with topic {0} and id {1} and message: {2}", 
                 message.Header.Topic, message.Id, message.Body);
 
             using (var client = new AmazonSimpleNotificationServiceClient(_connection.Credentials, _connection.Region))

--- a/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusConsumer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusConsumer.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Microsoft.Azure.ServiceBus;
 using Microsoft.Azure.ServiceBus.Management;
+using Microsoft.Extensions.Logging;
 using Paramore.Brighter.Logging;
 using Paramore.Brighter.MessagingGateway.AzureServiceBus.AzureServiceBusWrappers;
 
@@ -17,7 +18,7 @@ namespace Paramore.Brighter.MessagingGateway.AzureServiceBus
         private IMessageReceiverWrapper _messageReceiver;
         private readonly string _subscriptionName;
         private bool _subscriptionCreated;
-        private static readonly Lazy<ILog> _logger = new Lazy<ILog>(LogProvider.For<AzureServiceBusConsumer>);
+        private static readonly ILogger s_logger = ApplicationLogging.CreateLogger<AzureServiceBusConsumer>();
         private readonly OnMissingChannel _makeChannel;
         private readonly ReceiveMode _receiveMode;
 
@@ -40,20 +41,20 @@ namespace Paramore.Brighter.MessagingGateway.AzureServiceBus
 
         private void GetMessageReceiverProvider()
         {
-            _logger.Value.Info($"Getting message receiver provider for topic {_topicName} and subscription {_subscriptionName} with recieve Mode {_receiveMode}...");
+            s_logger.LogInformation($"Getting message receiver provider for topic {_topicName} and subscription {_subscriptionName} with receive Mode {_receiveMode}...");
             try
             {
                 _messageReceiver = _messageReceiverProvider.Get(_topicName, _subscriptionName, _receiveMode);
             }
             catch (Exception e)
             {
-                _logger.Value.ErrorException($"Failed to get message receiver provider for topic {_topicName} and subscription {_subscriptionName}.", e);
+                s_logger.LogError(e, $"Failed to get message receiver provider for topic {_topicName} and subscription {_subscriptionName}.");
             }
         }
 
         public Message[] Receive(int timeoutInMilliseconds)
         {
-            _logger.Value.Debug($"Preparing to retrieve next message(s) from topic {_topicName} via subscription {_subscriptionName} with timeout {timeoutInMilliseconds} and batch size {_batchSize}.");
+            s_logger.LogDebug($"Preparing to retrieve next message(s) from topic {_topicName} via subscription {_subscriptionName} with timeout {timeoutInMilliseconds} and batch size {_batchSize}.");
 
             IEnumerable<IBrokeredMessageWrapper> messages;
             EnsureSubscription();
@@ -68,13 +69,13 @@ namespace Paramore.Brighter.MessagingGateway.AzureServiceBus
             {
                 if (_messageReceiver.IsClosedOrClosing)
                 {
-                    _logger.Value.Debug("Message Receiver is closing...");
+                    s_logger.LogDebug("Message Receiver is closing...");
                     var message = new Message(new MessageHeader(Guid.NewGuid(), _topicName, MessageType.MT_QUIT), new MessageBody(string.Empty));
                     messagesToReturn.Add(message);
                     return messagesToReturn.ToArray();
                 }
 
-                _logger.Value.ErrorException("Failing to receive messages.", e);
+                s_logger.LogError(e, "Failing to receive messages.");
 
                 //The connection to Azure Service bus may have failed so we re-establish the connection.
                 GetMessageReceiverProvider();
@@ -95,11 +96,11 @@ namespace Paramore.Brighter.MessagingGateway.AzureServiceBus
         {
             if (azureServiceBusMessage.MessageBodyValue == null)
             {
-                _logger.Value.Warn($"Null message body received from topic {_topicName} via subscription {_subscriptionName}.");
+                s_logger.LogWarning($"Null message body received from topic {_topicName} via subscription {_subscriptionName}.");
             }
 
             var messageBody = System.Text.Encoding.Default.GetString(azureServiceBusMessage.MessageBodyValue ?? Array.Empty<byte>());
-            _logger.Value.Debug($"Received message from topic {_topicName} via subscription {_subscriptionName} with body {messageBody}.");
+            s_logger.LogDebug($"Received message from topic {_topicName} via subscription {_subscriptionName} with body {messageBody}.");
             MessageType messageType = GetMessageType(azureServiceBusMessage);
             var headers = new MessageHeader(Guid.NewGuid(), _topicName, messageType);
             if(_receiveMode.Equals(ReceiveMode.PeekLock)) headers.Bag.Add(_lockTokenKey, azureServiceBusMessage.LockToken);
@@ -143,12 +144,12 @@ namespace Paramore.Brighter.MessagingGateway.AzureServiceBus
             }
             catch (MessagingEntityAlreadyExistsException)
             {
-                _logger.Value.Warn($"Message entity already exists with topic {_topicName} and subscription {_subscriptionName}.");
+                s_logger.LogWarning($"Message entity already exists with topic {_topicName} and subscription {_subscriptionName}.");
                 _subscriptionCreated = true;
             }
             catch (Exception e)
             {
-                _logger.Value.ErrorException("Failing to check or create subscription.", e);
+                s_logger.LogError(e, "Failing to check or create subscription.");
                 
                 //The connection to Azure Service bus may have failed so we re-establish the connection.
                 _managementClientWrapper.Reset();
@@ -161,7 +162,7 @@ namespace Paramore.Brighter.MessagingGateway.AzureServiceBus
         {
             var topic = message.Header.Topic;
 
-            _logger.Value.Info($"Requeuing message with topic {topic} and id {message.Id}.");
+            s_logger.LogInformation($"Requeuing message with topic {topic} and id {message.Id}.");
 
             if (delayMilliseconds > 0)
             {
@@ -185,13 +186,13 @@ namespace Paramore.Brighter.MessagingGateway.AzureServiceBus
 
                     if (string.IsNullOrEmpty(lockToken))
                         throw new Exception($"LockToken for message with id {message.Id} is null or empty");
-                    _logger.Value.Debug($"Acknowledging Message with Id {message.Id} Lock Token : {lockToken}");
+                    s_logger.LogDebug($"Acknowledging Message with Id {message.Id} Lock Token : {lockToken}");
 
                     _messageReceiver.Complete(lockToken).Wait();
                 }
                 catch(Exception ex)
                 {
-                    _logger.Value.ErrorException($"Error completing message with id {message.Id}", ex);
+                    s_logger.LogError(ex, $"Error completing message with id {message.Id}");
                     throw;
                 }
             }
@@ -199,7 +200,7 @@ namespace Paramore.Brighter.MessagingGateway.AzureServiceBus
 
         public void Reject(Message message)
         {
-            _logger.Value.Warn("Reject method NOT IMPLEMENTED.");
+            s_logger.LogWarning("Reject method NOT IMPLEMENTED.");
         }
 
         public void Reject(Message message, bool requeue)
@@ -212,14 +213,14 @@ namespace Paramore.Brighter.MessagingGateway.AzureServiceBus
 
         public void Purge()
         {
-            _logger.Value.Warn("Purge method NOT IMPLEMENTED.");
+            s_logger.LogWarning("Purge method NOT IMPLEMENTED.");
         }
 
         public void Dispose()
         {
-            _logger.Value.Info("Disposing the consumer...");
+            s_logger.LogInformation("Disposing the consumer...");
             _messageReceiver.Close();
-            _logger.Value.Info("Consumer disposed.");
+            s_logger.LogInformation("Consumer disposed.");
         }
     }
 }

--- a/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusWrappers/ManagementClientWrapper.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusWrappers/ManagementClientWrapper.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Microsoft.Azure.ServiceBus.Management;
+using Microsoft.Extensions.Logging;
 using Paramore.Brighter.Logging;
 
 namespace Paramore.Brighter.MessagingGateway.AzureServiceBus.AzureServiceBusWrappers
@@ -7,7 +8,7 @@ namespace Paramore.Brighter.MessagingGateway.AzureServiceBus.AzureServiceBusWrap
     public class ManagementClientWrapper : IManagementClientWrapper
     {
         private ManagementClient _managementClient;
-        private static readonly Lazy<ILog> Logger = new Lazy<ILog>(LogProvider.For<ManagementClientWrapper>);
+        private static readonly ILogger s_logger = ApplicationLogging.CreateLogger<ManagementClientWrapper>();
         private readonly AzureServiceBusConfiguration _configuration;
         
         public ManagementClientWrapper(AzureServiceBusConfiguration configuration)
@@ -18,7 +19,7 @@ namespace Paramore.Brighter.MessagingGateway.AzureServiceBus.AzureServiceBusWrap
 
         private void Initialise()
         {
-            Logger.Value.Debug("Initialising new management client wrapper...");
+            s_logger.LogDebug("Initialising new management client wrapper...");
             
             try
             {
@@ -31,22 +32,22 @@ namespace Paramore.Brighter.MessagingGateway.AzureServiceBus.AzureServiceBusWrap
             }
             catch (Exception e)
             {
-                Logger.Value.ErrorException("Failed to initialise new management client wrapper.", e);
+                s_logger.LogError(e,"Failed to initialise new management client wrapper.");
                 throw;
             }
 
-            Logger.Value.Debug("New management client wrapper initialised.");
+            s_logger.LogDebug("New management client wrapper initialised.");
         }
 
         public void Reset()
         {
-            Logger.Value.Warn("Resetting management client wrapper...");
+            s_logger.LogWarning("Resetting management client wrapper...");
             Initialise();
         }
 
         public bool TopicExists(string topic)
         {
-            Logger.Value.Debug($"Checking if topic {topic} exists...");
+            s_logger.LogDebug("Checking if topic {Topic} exists...", topic);
             
             bool result;
 
@@ -56,17 +57,17 @@ namespace Paramore.Brighter.MessagingGateway.AzureServiceBus.AzureServiceBusWrap
             }
             catch (Exception e)
             {
-                Logger.Value.ErrorException($"Failed to check if topic {topic} exists.", e);
+                s_logger.LogError(e,"Failed to check if topic {Topic} exists.", topic);
                 throw;
             }
 
             if (result)
             {
-                Logger.Value.Debug($"Topic {topic} exists.");
+                s_logger.LogDebug("Topic {Topic} exists.", topic);
             }
             else
             {
-                Logger.Value.Warn($"Topic {topic} does not exist.");
+                s_logger.LogWarning("Topic {Topic} does not exist.", topic);
             }
             
             return result;
@@ -74,7 +75,7 @@ namespace Paramore.Brighter.MessagingGateway.AzureServiceBus.AzureServiceBusWrap
 
         public void CreateTopic(string topic)
         {
-            Logger.Value.Info($"Creating topic {topic}...");
+            s_logger.LogInformation("Creating topic {Topic}...", topic);
 
             try
             {
@@ -82,16 +83,16 @@ namespace Paramore.Brighter.MessagingGateway.AzureServiceBus.AzureServiceBusWrap
             }
             catch (Exception e)
             {
-                Logger.Value.ErrorException($"Failed to create topic {topic}.", e);
+                s_logger.LogError(e,"Failed to create topic {Topic}.", topic);
                 throw;
             }
             
-            Logger.Value.Info($"Topic {topic} created.");
+            s_logger.LogInformation("Topic {Topic} created.", topic);
         }
 
         public bool SubscriptionExists(string topicName, string subscriptionName)
         {
-            Logger.Value.Debug($"Checking if subscription {subscriptionName} for topic {topicName} exists...");
+            s_logger.LogDebug("Checking if subscription {SubscriptionName} for topic {TopicName} exists...", subscriptionName, topicName);
 
             bool result;
 
@@ -101,17 +102,17 @@ namespace Paramore.Brighter.MessagingGateway.AzureServiceBus.AzureServiceBusWrap
             }
             catch (Exception e)
             {
-                Logger.Value.ErrorException($"Failed to check if subscription {subscriptionName} for topic {topicName} exists.", e);
+                s_logger.LogError(e,"Failed to check if subscription {SubscriptionName} for topic {TopicName} exists.", subscriptionName, topicName);
                 throw;
             }
             
             if (result)
             {
-                Logger.Value.Debug($"Subscription {subscriptionName} for topic {topicName} exists.");
+                s_logger.LogDebug("Subscription {SubscriptionName} for topic {TopicName} exists.", subscriptionName, topicName);
             }
             else
             {
-                Logger.Value.Warn($"Subscription {subscriptionName} for topic {topicName} does not exist.");
+                s_logger.LogWarning("Subscription {SubscriptionName} for topic {TopicName} does not exist.", subscriptionName, topicName);
             }
 
             return result;
@@ -119,7 +120,7 @@ namespace Paramore.Brighter.MessagingGateway.AzureServiceBus.AzureServiceBusWrap
 
         public void CreateSubscription(string topicName, string subscriptionName, int maxDeliveryCount = 2000)
         {
-            Logger.Value.Info($"Creating subscription {subscriptionName} for topic {topicName}...");
+            s_logger.LogInformation("Creating subscription {SubscriptionName} for topic {TopicName}...", subscriptionName, topicName);
 
             if (!TopicExists(topicName))
             {
@@ -137,11 +138,11 @@ namespace Paramore.Brighter.MessagingGateway.AzureServiceBus.AzureServiceBusWrap
             }
             catch (Exception e)
             {
-                Logger.Value.ErrorException($"Failed to create subscription {subscriptionName} for topic {topicName}.", e);
+                s_logger.LogError(e,"Failed to create subscription {SubscriptionName} for topic {TopicName}.", subscriptionName, topicName);
                 throw;
             }
             
-            Logger.Value.Info($"Subscription {subscriptionName} for topic {topicName} created.");
+            s_logger.LogInformation("Subscription {SubscriptionName} for topic {TopicName} created.", subscriptionName, topicName);
         }
     }
 }

--- a/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusWrappers/MessageReceiverWrapper.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusWrappers/MessageReceiverWrapper.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Azure.ServiceBus.Core;
+using Microsoft.Extensions.Logging;
 using Paramore.Brighter.Logging;
 
 namespace Paramore.Brighter.MessagingGateway.AzureServiceBus.AzureServiceBusWrappers
@@ -10,7 +11,7 @@ namespace Paramore.Brighter.MessagingGateway.AzureServiceBus.AzureServiceBusWrap
     public class MessageReceiverWrapper : IMessageReceiverWrapper
     {
         private readonly IMessageReceiver _messageReceiver;
-        private static readonly Lazy<ILog> Logger = new Lazy<ILog>(LogProvider.For<MessageReceiverWrapper>);
+        private static readonly ILogger s_logger = ApplicationLogging.CreateLogger<MessageReceiverWrapper>();
 
         public MessageReceiverWrapper(IMessageReceiver messageReceiver)
         {
@@ -30,9 +31,9 @@ namespace Paramore.Brighter.MessagingGateway.AzureServiceBus.AzureServiceBusWrap
       
         public void Close()
         {
-            Logger.Value.Warn("Closing the MessageReceiver connection");
+            s_logger.LogWarning("Closing the MessageReceiver connection");
             _messageReceiver.CloseAsync().GetAwaiter().GetResult();
-            Logger.Value.Warn("MessageReceiver connection stopped");
+            s_logger.LogWarning("MessageReceiver connection stopped");
         }
 
         public async Task Complete(string lockToken)

--- a/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaMessageCreator.cs
+++ b/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaMessageCreator.cs
@@ -1,9 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.Design;
 using System.Linq;
 using System.Text;
 using Confluent.Kafka;
+using Microsoft.Extensions.Logging;
 using Paramore.Brighter.Extensions;
 using Paramore.Brighter.Logging;
 
@@ -11,7 +10,7 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
 {
     internal class KafkaMessageCreator
     {
-        private static readonly Lazy<ILog> s_logger = new Lazy<ILog>(LogProvider.For<KafkaMessageCreator>);
+        private static readonly ILogger s_logger = ApplicationLogging.CreateLogger<KafkaMessageCreator>();
 
         public Message CreateMessage(ConsumeResult<string, string> consumeResult)
         {
@@ -60,7 +59,7 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
             }
             catch (Exception e)
             {
-                s_logger.Value.WarnException("Failed to create message from amqp message", e);
+                s_logger.LogWarning(e, "Failed to create message from amqp message");
                 message = FailureMessage(topic, messageId);
             }
 
@@ -89,7 +88,7 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
                 }
                 else
                 {
-                    s_logger.Value.DebugFormat("Could not parse message correlation id: {0}", correlationValue);
+                    s_logger.LogDebug("Could not parse message correlation id: {0}", correlationValue);
                     return new HeaderResult<Guid>(Guid.Empty, false);
                 }
             }
@@ -136,7 +135,7 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
                 {
                     if (string.IsNullOrEmpty(s))
                     {
-                        s_logger.Value.DebugFormat("No message id found in message MessageId, new message id is {0}", newMessageId);
+                        s_logger.LogDebug("No message id found in message MessageId, new message id is {0}", newMessageId);
                         return new HeaderResult<Guid>(newMessageId, true);
                     }
 
@@ -145,7 +144,7 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
                         return new HeaderResult<Guid>(messageId, true);
                     }
 
-                    s_logger.Value.DebugFormat("Could not parse message MessageId, new message id is {0}", Guid.Empty);
+                    s_logger.LogDebug("Could not parse message MessageId, new message id is {0}", Guid.Empty);
                     return new HeaderResult<Guid>(Guid.Empty, false);
                 });
         }
@@ -157,7 +156,7 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
                 {
                     if (string.IsNullOrEmpty(s))
                     {
-                         s_logger.Value.DebugFormat("No partition key found in message");
+                         s_logger.LogDebug("No partition key found in message");
                          return new HeaderResult<string>(string.Empty, true);
                     }
 
@@ -183,7 +182,7 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
                 catch (Exception e)
                 {
                     var firstTwentyBytes = BitConverter.ToString(lastHeader.Take(20).ToArray());
-                    s_logger.Value.WarnException("Failed to read the value of header {0} as UTF-8, first 20 byes follow: \n\t{1}", e, key, firstTwentyBytes);
+                    s_logger.LogWarning(e, "Failed to read the value of header {0} as UTF-8, first 20 byes follow: \n\t{1}", key, firstTwentyBytes);
                     return new HeaderResult<string>(null, false);
                 }
             }

--- a/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaMessageProducer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaMessageProducer.cs
@@ -25,6 +25,7 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Confluent.Kafka;
+using Microsoft.Extensions.Logging;
 using Paramore.Brighter.Logging;
 
 namespace Paramore.Brighter.MessagingGateway.Kafka
@@ -109,7 +110,7 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
             _producer = new ProducerBuilder<string, string>(_producerConfig)
                 .SetErrorHandler((consumer, error) =>
                 {
-                    _logger.Value.Error($"Code: {error.Code}, Reason: {error.Reason}, Fatal: {error.IsFatal}");
+                    s_logger.LogError($"Code: {error.Code}, Reason: {error.Reason}, Fatal: {error.IsFatal}");
                     _hasFatalProducerError = error.IsFatal;
                 })
                 .Build();
@@ -129,7 +130,7 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
 
             try
             {
-                _logger.Value.DebugFormat(
+                s_logger.LogDebug(
                     "Sending message to Kafka. Servers {0} Topic: {1} Body: {2}",
                     _producerConfig.BootstrapServers,
                     message.Header.Topic,
@@ -141,9 +142,8 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
             }
             catch (ProduceException<string, string> pe)
             {
-                _logger.Value.ErrorException(
+                s_logger.LogError(pe,
                     "Error sending message to Kafka servers {0} because {1} ",
-                    pe,
                     _producerConfig.BootstrapServers,
                     pe.Error.Reason
                 );
@@ -151,9 +151,8 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
             }
             catch (InvalidOperationException ioe)
             {
-                _logger.Value.ErrorException(
+                s_logger.LogError(ioe,
                     "Error sending message to Kafka servers {0} because {1} ",
-                    ioe,
                     _producerConfig.BootstrapServers,
                     ioe.Message
                 );
@@ -162,9 +161,8 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
             }
             catch (ArgumentException ae)
             {
-                _logger.Value.ErrorException(
+                s_logger.LogError(ae,
                     "Error sending message to Kafka servers {0} because {1} ",
-                    ae,
                     _producerConfig.BootstrapServers,
                     ae.Message
                 );
@@ -173,9 +171,7 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
             }
             catch (KafkaException kafkaException)
             {
-                _logger.Value.ErrorException(
-                    $"KafkaMessageProducer: There was an error sending to topic {Topic})",
-                    kafkaException);
+                s_logger.LogError(kafkaException, $"KafkaMessageProducer: There was an error sending to topic {Topic})");
                 
                 if (kafkaException.Error.IsFatal) //this can't be recovered and requires a new consumer
                     throw;
@@ -200,7 +196,7 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
                  throw new ChannelFailureException($"Producer is in unrecoverable state");
             try
             {
-                _logger.Value.DebugFormat(
+                s_logger.LogDebug(
                     "Sending message to Kafka. Servers {0} Topic: {1} Body: {2}",
                     _producerConfig.BootstrapServers,
                     message.Header.Topic,
@@ -212,9 +208,8 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
             }
             catch (ProduceException<string, string> pe)
             {
-                _logger.Value.ErrorException(
+                s_logger.LogError(pe,
                     "Error sending message to Kafka servers {0} because {1} ",
-                    pe,
                     _producerConfig.BootstrapServers,
                     pe.Error.Reason
                 );
@@ -222,9 +217,8 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
             }
             catch (InvalidOperationException ioe)
             {
-                _logger.Value.ErrorException(
+                s_logger.LogError(ioe,
                     "Error sending message to Kafka servers {0} because {1} ",
-                    ioe,
                     _producerConfig.BootstrapServers,
                     ioe.Message
                 );
@@ -233,9 +227,8 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
             }
             catch (ArgumentException ae)
             {
-                 _logger.Value.ErrorException(
+                 s_logger.LogError(ae,
                      "Error sending message to Kafka servers {0} because {1} ",
-                     ae,
                      _producerConfig.BootstrapServers,
                      ae.Message
                  );

--- a/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaMessagePublisher.cs
+++ b/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaMessagePublisher.cs
@@ -3,13 +3,11 @@ using System.Linq;
 using System.Threading.Tasks;
 using Confluent.Kafka;
 using Paramore.Brighter.Extensions;
-using Paramore.Brighter.Logging;
 
 namespace Paramore.Brighter.MessagingGateway.Kafka
 {
     internal class KafkaMessagePublisher
     {
-        private static readonly Lazy<ILog> _logger = new Lazy<ILog>(LogProvider.For<KafkaMessagePublisher>);
         private readonly IProducer<string, string> _producer;
         private static readonly string[] _headersToReset =
         {

--- a/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaMessagingGateway.cs
+++ b/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaMessagingGateway.cs
@@ -4,13 +4,14 @@ using System.Linq;
 using System.Threading.Tasks;
 using Confluent.Kafka;
 using Confluent.Kafka.Admin;
+using Microsoft.Extensions.Logging;
 using Paramore.Brighter.Logging;
 
 namespace Paramore.Brighter.MessagingGateway.Kafka
 {
     public class KafkaMessagingGateway
     {
-        protected static readonly Lazy<ILog> _logger = new Lazy<ILog>(LogProvider.For<KafkaMessageProducer>);
+        protected static readonly ILogger s_logger = ApplicationLogging.CreateLogger<KafkaMessageProducer>();
         protected ClientConfig _clientConfig;
         protected OnMissingChannel MakeChannels;
         protected RoutingKey Topic;
@@ -55,7 +56,7 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
                         throw new ChannelFailureException($"An error occured creating topic {Topic.Value}: {e.Results[0].Error.Reason}");
                     }
 
-                    _logger.Value.Debug("Topic already exists");
+                    s_logger.LogDebug("Topic already exists");
                 }
             }
         }
@@ -77,7 +78,7 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
                             return false;
                         else
                         {
-                            _logger.Value.Warn($"Topic {matchingTopic.Topic} is in error with code: {matchingTopic.Error.Code} and reason: {matchingTopic.Error.Reason}");
+                            s_logger.LogWarning($"Topic {matchingTopic.Topic} is in error with code: {matchingTopic.Error.Code} and reason: {matchingTopic.Error.Reason}");
                             return false;
                         }
 

--- a/src/Paramore.Brighter.MessagingGateway.MsSql/ChannelFactory.cs
+++ b/src/Paramore.Brighter.MessagingGateway.MsSql/ChannelFactory.cs
@@ -1,11 +1,12 @@
 ﻿using System;
+using Microsoft.Extensions.Logging;
 using Paramore.Brighter.Logging;
 
 namespace Paramore.Brighter.MessagingGateway.MsSql
 {
     public class ChannelFactory : IAmAChannelFactory
     {
-        private static readonly Lazy<ILog> Logger = new Lazy<ILog>(LogProvider.For<ChannelFactory>);
+        private static readonly ILogger s_logger = ApplicationLogging.CreateLogger<ChannelFactory>();
         private readonly MsSqlMessageConsumerFactory _msSqlMessageConsumerFactory;
 
         /// <summary>
@@ -29,7 +30,7 @@ namespace Paramore.Brighter.MessagingGateway.MsSql
             if (rmqSubscription == null)
                 throw new ConfigurationException("We expect an MsSqlSubscription or MsSqlSubscription<T> as a parameter");
             
-            Logger.Value.Debug($"MsSqlInputChannelFactory: create input channel {subscription.ChannelName} for topic {subscription.RoutingKey}");
+            s_logger.LogDebug("MsSqlInputChannelFactory: create input channel {ChannelName} for topic {RoutingKey}", subscription.ChannelName, subscription.RoutingKey);
             return new Channel(
                 subscription.ChannelName,
                 _msSqlMessageConsumerFactory.Create(subscription),

--- a/src/Paramore.Brighter.MessagingGateway.MsSql/MsSqlMessageConsumer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.MsSql/MsSqlMessageConsumer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Paramore.Brighter.Logging;
 using Paramore.Brighter.MessagingGateway.MsSql.SqlQueues;
 
@@ -8,7 +9,7 @@ namespace Paramore.Brighter.MessagingGateway.MsSql
     public class MsSqlMessageConsumer : IAmAMessageConsumer
     {
         private readonly string _topic;
-        private static readonly Lazy<ILog> Logger = new Lazy<ILog>(LogProvider.For<MsSqlMessageConsumer>);
+        private static readonly ILogger s_logger = ApplicationLogging.CreateLogger<MsSqlMessageConsumer>();
         private readonly MsSqlMessageQueue<Message> _sqlQ;
 
         public MsSqlMessageConsumer(
@@ -48,7 +49,7 @@ namespace Paramore.Brighter.MessagingGateway.MsSql
         /// <param name="message">The message.</param>
         public void Reject(Message message)
         {
-            Logger.Value.Info(
+            s_logger.LogInformation(
                 $"MsSqlMessagingConsumer: rejecting message with topic {message.Header.Topic} and id {message.Id.ToString()}, NOT IMPLEMENTED");
         }
 
@@ -57,7 +58,7 @@ namespace Paramore.Brighter.MessagingGateway.MsSql
         /// </summary>
         public void Purge()
         {
-            Logger.Value.Debug("MsSqlMessagingConsumer: purging queue");
+            s_logger.LogDebug("MsSqlMessagingConsumer: purging queue");
             _sqlQ.Purge();
         }
 
@@ -70,8 +71,7 @@ namespace Paramore.Brighter.MessagingGateway.MsSql
         {
             var topic = message.Header.Topic;
 
-            Logger.Value.Debug(
-                $"MsSqlMessagingConsumer: requeuing message with topic {topic} and id {message.Id.ToString()}");
+            s_logger.LogDebug($"MsSqlMessagingConsumer: re-queuing message with topic {topic} and id {message.Id.ToString()}");
 
             _sqlQ.Send(message, topic);
         }

--- a/src/Paramore.Brighter.MessagingGateway.MsSql/MsSqlMessageConsumerFactory.cs
+++ b/src/Paramore.Brighter.MessagingGateway.MsSql/MsSqlMessageConsumerFactory.cs
@@ -1,11 +1,12 @@
 ﻿using System;
+using Microsoft.Extensions.Logging;
 using Paramore.Brighter.Logging;
 
 namespace Paramore.Brighter.MessagingGateway.MsSql
 {
     public class MsSqlMessageConsumerFactory : IAmAMessageConsumerFactory
     {
-        private static readonly Lazy<ILog> Logger = new Lazy<ILog>(LogProvider.For<MsSqlMessageConsumerFactory>);
+        private static readonly ILogger s_logger = ApplicationLogging.CreateLogger<MsSqlMessageConsumerFactory>();
         private readonly MsSqlMessagingGatewayConfiguration _msSqlMessagingGatewayConfiguration;
 
         public MsSqlMessageConsumerFactory(MsSqlMessagingGatewayConfiguration msSqlMessagingGatewayConfiguration)
@@ -23,7 +24,7 @@ namespace Paramore.Brighter.MessagingGateway.MsSql
          public IAmAMessageConsumer Create(Subscription subscription)
         {
             if (subscription.ChannelName == null) throw new ArgumentNullException(nameof(subscription.ChannelName));
-            Logger.Value.Debug($"MsSqlMessageConsumerFactory: create consumer for topic {subscription.ChannelName}");
+            s_logger.LogDebug($"MsSqlMessageConsumerFactory: create consumer for topic {subscription.ChannelName}");
             return new MsSqlMessageConsumer(_msSqlMessagingGatewayConfiguration, subscription.ChannelName);
         }
     }

--- a/src/Paramore.Brighter.MessagingGateway.MsSql/MsSqlMessageProducer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.MsSql/MsSqlMessageProducer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Paramore.Brighter.Logging;
 using Paramore.Brighter.MessagingGateway.MsSql.SqlQueues;
 
@@ -10,7 +11,7 @@ namespace Paramore.Brighter.MessagingGateway.MsSql
         public int MaxOutStandingMessages { get; set; } = -1;
         public int MaxOutStandingCheckIntervalMilliSeconds { get; set; } = 0;
         
-        private static readonly Lazy<ILog> Logger = new Lazy<ILog>(LogProvider.For<MsSqlMessageProducer>);
+        private static readonly ILogger s_logger = ApplicationLogging.CreateLogger<MsSqlMessageProducer>();
         private readonly MsSqlMessageQueue<Message> _sqlQ;
         private Publication _publication; // -- placeholder for future use
 
@@ -28,7 +29,7 @@ namespace Paramore.Brighter.MessagingGateway.MsSql
         {
             var topic = message.Header.Topic;
 
-            Logger.Value.Debug($"MsSqlMessageProducer: send message with topic {topic} and id {message.Id.ToString()}");
+            s_logger.LogDebug($"MsSqlMessageProducer: send message with topic {topic} and id {message.Id.ToString()}");
 
             _sqlQ.Send(message, topic);
         }
@@ -44,7 +45,7 @@ namespace Paramore.Brighter.MessagingGateway.MsSql
         {
             var topic = message.Header.Topic;
 
-            Logger.Value.Debug(
+            s_logger.LogDebug(
                 $"MsSqlMessageProducer: send async message with topic {topic} and id {message.Id.ToString()}");
 
             await _sqlQ.SendAsync(message, topic);

--- a/src/Paramore.Brighter.MessagingGateway.MsSql/MsSqlMessageProducerFactory.cs
+++ b/src/Paramore.Brighter.MessagingGateway.MsSql/MsSqlMessageProducerFactory.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Microsoft.Extensions.Logging;
 using Paramore.Brighter.Logging;
 
 namespace Paramore.Brighter.MessagingGateway.MsSql
@@ -6,7 +7,7 @@ namespace Paramore.Brighter.MessagingGateway.MsSql
     public class MsSqlMessageProducerFactory : IAmAMessageProducerFactory
     {
         private readonly MsSqlMessagingGatewayConfiguration _msSqlMessagingGatewayConfiguration;
-        private static readonly Lazy<ILog> Logger = new Lazy<ILog>(LogProvider.For<MsSqlMessageProducerFactory>);
+        private static readonly ILogger s_logger = ApplicationLogging.CreateLogger<MsSqlMessageProducerFactory>();
         private Publication _publication; //-- placeholder for future use
 
         public MsSqlMessageProducerFactory(
@@ -20,7 +21,7 @@ namespace Paramore.Brighter.MessagingGateway.MsSql
 
         public IAmAMessageProducer Create()
         {
-            Logger.Value.Debug($"MsSqlMessageProducerFactory: create producer");
+            s_logger.LogDebug("MsSqlMessageProducerFactory: create producer");
             return new MsSqlMessageProducer(_msSqlMessagingGatewayConfiguration, _publication);
         }
     }

--- a/src/Paramore.Brighter.MessagingGateway.RESTMS/Domain.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RESTMS/Domain.cs
@@ -24,6 +24,7 @@ THE SOFTWARE. */
 #endregion
 
 using System;
+using Microsoft.Extensions.Logging;
 using Paramore.Brighter.Logging;
 using Paramore.Brighter.MessagingGateway.RESTMS.Exceptions;
 using Paramore.Brighter.MessagingGateway.RESTMS.Model;
@@ -32,7 +33,7 @@ namespace Paramore.Brighter.MessagingGateway.RESTMS
 {
     internal class Domain
     {
-        private static readonly Lazy<ILog> _logger = new Lazy<ILog>(LogProvider.For<Domain>);
+        private static readonly ILogger s_logger = ApplicationLogging.CreateLogger<Domain>();
 
         private readonly RestMSMessageGateway _gateway;
 
@@ -48,7 +49,7 @@ namespace Paramore.Brighter.MessagingGateway.RESTMS
         /// <exception cref="RestMSClientException"></exception>
         public RestMSDomain GetDomain()
         {
-            _logger.Value.DebugFormat("Getting the default domain from the RestMS server: {0}", _gateway.Configuration.RestMS.Uri.AbsoluteUri);
+            s_logger.LogDebug("Getting the default domain from the RestMS server: {0}", _gateway.Configuration.RestMS.Uri.AbsoluteUri);
 
             try
             {
@@ -60,7 +61,7 @@ namespace Paramore.Brighter.MessagingGateway.RESTMS
             {
                 foreach (var exception in ae.Flatten().InnerExceptions)
                 {
-                    _logger.Value.ErrorFormat("Threw exception getting Domain from RestMS Server {0}", exception.Message);
+                    s_logger.LogError(exception,"Threw exception getting Domain from RestMS Server {0}", exception.Message);
                 }
 
                 throw new RestMSClientException("Error retrieving the domain from the RestMS server, see log for details");

--- a/src/Paramore.Brighter.MessagingGateway.RESTMS/Feed.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RESTMS/Feed.cs
@@ -25,6 +25,7 @@ THE SOFTWARE. */
 
 using System;
 using System.Linq;
+using Microsoft.Extensions.Logging;
 using Paramore.Brighter.Logging;
 using Paramore.Brighter.MessagingGateway.RESTMS.Exceptions;
 using Paramore.Brighter.MessagingGateway.RESTMS.Model;
@@ -33,7 +34,7 @@ namespace Paramore.Brighter.MessagingGateway.RESTMS
 {
     internal class Feed
     {
-        private static readonly Lazy<ILog> _logger = new Lazy<ILog>(LogProvider.For<Feed>);
+        private static readonly ILogger s_logger = ApplicationLogging.CreateLogger<Feed>();
 
         private readonly RestMSMessageGateway _gateway;
 
@@ -56,7 +57,7 @@ namespace Paramore.Brighter.MessagingGateway.RESTMS
         public void EnsureFeedExists(RestMSDomain domain)
         {
             var feedName = _gateway.Configuration.Feed.Name;
-            _logger.Value.DebugFormat("Checking for existence of the feed {0} on the RestMS server: {1}", feedName, _gateway.Configuration.RestMS.Uri.AbsoluteUri);
+            s_logger.LogDebug("Checking for existence of the feed {0} on the RestMS server: {1}", feedName, _gateway.Configuration.RestMS.Uri.AbsoluteUri);
             var isFeedDeclared = IsFeedDeclared(domain, feedName);
             if (!isFeedDeclared)
             {
@@ -71,7 +72,7 @@ namespace Paramore.Brighter.MessagingGateway.RESTMS
 
         private RestMSDomain CreateFeed(string domainUri, string name)
         {
-            _logger.Value.DebugFormat("Creating the feed {0} on the RestMS server: {1}", name, _gateway.Configuration.RestMS.Uri.AbsoluteUri);
+            s_logger.LogDebug("Creating the feed {0} on the RestMS server: {1}", name, _gateway.Configuration.RestMS.Uri.AbsoluteUri);
             var client = _gateway.Client();
             try
             {
@@ -92,10 +93,10 @@ namespace Paramore.Brighter.MessagingGateway.RESTMS
             {
                 foreach (var exception in ae.Flatten().InnerExceptions)
                 {
-                    _logger.Value.ErrorFormat("Threw exception adding Feed {0} to RestMS Server {1}", name, exception.Message);
+                    s_logger.LogError(exception,"Threw exception adding Feed {0} to RestMS Server {1}", name, exception.Message);
                 }
 
-                throw new RestMSClientException(string.Format("Error adding the Feed {0} to the RestMS server, see log for details", name));
+                throw new RestMSClientException($"Error adding the Feed {name} to the RestMS server, see log for details");
             }
         }
 

--- a/src/Paramore.Brighter.MessagingGateway.RESTMS/Join.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RESTMS/Join.cs
@@ -25,6 +25,7 @@ THE SOFTWARE. */
 
 using System;
 using System.Linq;
+using Microsoft.Extensions.Logging;
 using Paramore.Brighter.Logging;
 using Paramore.Brighter.MessagingGateway.RESTMS.Exceptions;
 using Paramore.Brighter.MessagingGateway.RESTMS.Model;
@@ -33,7 +34,7 @@ namespace Paramore.Brighter.MessagingGateway.RESTMS
 {
     internal class Join
     {
-        private static readonly Lazy<ILog> _logger = new Lazy<ILog>(LogProvider.For<Join>);
+        private static readonly ILogger s_logger = ApplicationLogging.CreateLogger<Join>();
 
         private readonly RestMSMessageGateway _gateway;
         private readonly Feed _feed;
@@ -46,7 +47,7 @@ namespace Paramore.Brighter.MessagingGateway.RESTMS
 
         public RestMSJoin CreateJoin(string pipeUri, string routingKey)
         {
-            _logger.Value.DebugFormat("Creating the join with key {0} for pipe {1}", routingKey, pipeUri);
+            s_logger.LogDebug("Creating the join with key {0} for pipe {1}", routingKey, pipeUri);
             var client = _gateway.Client();
             try
             {
@@ -73,7 +74,7 @@ namespace Paramore.Brighter.MessagingGateway.RESTMS
             {
                 foreach (var exception in ae.Flatten().InnerExceptions)
                 {
-                    _logger.Value.ErrorFormat("Threw exception adding join with routingKey {0} to Pipe {1} on RestMS Server {2}", routingKey, pipeUri, exception.Message);
+                    s_logger.LogError(exception,"Threw exception adding join with routingKey {0} to Pipe {1} on RestMS Server {2}", routingKey, pipeUri, exception.Message);
                 }
 
                 throw new RestMSClientException(string.Format("Error adding the join with routingKey {0} to Pipe {1} to the RestMS server, see log for details", routingKey, pipeUri));

--- a/src/Paramore.Brighter.MessagingGateway.RESTMS/Parsers/XmlRequestBuilder.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RESTMS/Parsers/XmlRequestBuilder.cs
@@ -26,6 +26,7 @@ using System;
 using System.IO;
 using System.Xml;
 using System.Xml.Serialization;
+using Microsoft.Extensions.Logging;
 using Paramore.Brighter.Logging;
 
 namespace Paramore.Brighter.MessagingGateway.RESTMS.Parsers
@@ -64,8 +65,8 @@ namespace Paramore.Brighter.MessagingGateway.RESTMS.Parsers
             }
             catch (Exception e)
             {
-                var logger = LogProvider.For<XmlRequestBuilder>();
-                logger.Trace(e.Message);
+                var logger = ApplicationLogging.CreateLogger<XmlRequestBuilder>();
+                logger.LogTrace(e.Message);
                 body = null;
                 return false;
             }

--- a/src/Paramore.Brighter.MessagingGateway.RESTMS/Parsers/XmlResultParser.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RESTMS/Parsers/XmlResultParser.cs
@@ -25,6 +25,7 @@ THE SOFTWARE. */
 using System;
 using System.IO;
 using System.Xml.Serialization;
+using Microsoft.Extensions.Logging;
 using Paramore.Brighter.Logging;
 
 namespace Paramore.Brighter.MessagingGateway.RESTMS.Parsers
@@ -49,8 +50,8 @@ namespace Paramore.Brighter.MessagingGateway.RESTMS.Parsers
             }
             catch (Exception e)
             {
-                var logger = LogProvider.For<XmlResultParser>();
-                logger.Trace(e.Message);
+                var logger = ApplicationLogging.CreateLogger<XmlResultParser>();
+                logger.LogTrace(e.Message);
                 domainObject = default(T);
                 return false;
             }

--- a/src/Paramore.Brighter.MessagingGateway.RESTMS/Pipe.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RESTMS/Pipe.cs
@@ -25,6 +25,7 @@ THE SOFTWARE. */
 
 using System;
 using System.Linq;
+using Microsoft.Extensions.Logging;
 using Paramore.Brighter.Logging;
 using Paramore.Brighter.MessagingGateway.RESTMS.Exceptions;
 using Paramore.Brighter.MessagingGateway.RESTMS.Model;
@@ -33,7 +34,7 @@ namespace Paramore.Brighter.MessagingGateway.RESTMS
 {
     internal class Pipe
     {
-        private static readonly Lazy<ILog> _logger = new Lazy<ILog>(LogProvider.For<Pipe>);
+        private static readonly ILogger s_logger = ApplicationLogging.CreateLogger<Pipe>();
 
         private readonly RestMSMessageGateway _gateway;
         private readonly Join _join;
@@ -49,7 +50,7 @@ namespace Paramore.Brighter.MessagingGateway.RESTMS
 
         public void EnsurePipeExists(string pipeTitle, string routingKey, RestMSDomain domain)
         {
-            _logger.Value.DebugFormat("Checking for existence of the pipe {0} on the RestMS server: {1}", pipeTitle, _gateway.Configuration.RestMS.Uri.AbsoluteUri);
+            s_logger.LogDebug("Checking for existence of the pipe {0} on the RestMS server: {1}", pipeTitle, _gateway.Configuration.RestMS.Uri.AbsoluteUri);
             var pipeExists = PipeExists(pipeTitle, domain);
             if (!pipeExists)
             {
@@ -70,7 +71,7 @@ namespace Paramore.Brighter.MessagingGateway.RESTMS
             /*TODO: Optimize this by using a repository approach with the repository checking for modification 
             through etag and serving existing version if not modified and grabbing new version if changed*/
 
-            _logger.Value.DebugFormat("Getting the pipe from the RestMS server: {0}", PipeUri);
+            s_logger.LogDebug("Getting the pipe from the RestMS server: {0}", PipeUri);
             var client = _gateway.Client();
 
             try
@@ -83,7 +84,7 @@ namespace Paramore.Brighter.MessagingGateway.RESTMS
             {
                 foreach (var exception in ae.Flatten().InnerExceptions)
                 {
-                    _logger.Value.ErrorFormat("Threw exception getting Pipe {0} from RestMS Server {1}", PipeUri, exception.Message);
+                    s_logger.LogError(exception, "Threw exception getting Pipe {0} from RestMS Server {1}", PipeUri, exception.Message);
                 }
 
                 throw new RestMSClientException("Error retrieving the domain from the RestMS server, see log for details");
@@ -92,7 +93,7 @@ namespace Paramore.Brighter.MessagingGateway.RESTMS
 
         private RestMSDomain CreatePipe(string domainUri, string title)
         {
-            _logger.Value.DebugFormat("Creating the pipe {0} on the RestMS server: {1}", title, _gateway.Configuration.RestMS.Uri.AbsoluteUri);
+            s_logger.LogDebug("Creating the pipe {0} on the RestMS server: {1}", title, _gateway.Configuration.RestMS.Uri.AbsoluteUri);
             var client = _gateway.Client();
             try
             {
@@ -114,7 +115,7 @@ namespace Paramore.Brighter.MessagingGateway.RESTMS
             {
                 foreach (var exception in ae.Flatten().InnerExceptions)
                 {
-                    _logger.Value.ErrorFormat("Threw exception adding Pipe {0} to RestMS Server {1}", title, exception.Message);
+                    s_logger.LogError(exception, "Threw exception adding Pipe {0} to RestMS Server {1}", title, exception.Message);
                 }
 
                 throw new RestMSClientException(string.Format("Error adding the Feed {0} to the RestMS server, see log for details", title));

--- a/src/Paramore.Brighter.MessagingGateway.RESTMS/RestMSMessageGateway.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RESTMS/RestMSMessageGateway.cs
@@ -26,6 +26,7 @@ using System;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading;
+using Microsoft.Extensions.Logging;
 using Paramore.Brighter.Logging;
 using Paramore.Brighter.MessagingGateway.RESTMS.MessagingGatewayConfiguration;
 using Paramore.Brighter.MessagingGateway.RESTMS.Parsers;
@@ -37,7 +38,7 @@ namespace Paramore.Brighter.MessagingGateway.RESTMS
     /// </summary>
     public class RestMSMessageGateway
     {
-        private static readonly Lazy<ILog> _logger = new Lazy<ILog>(LogProvider.For<RestMSMessageGateway>);
+        private static readonly ILogger s_logger = ApplicationLogging.CreateLogger<RestMSMessageGateway>();
 
         private ThreadLocal<HttpClient> _client;
         private readonly double _timeout;
@@ -101,8 +102,8 @@ namespace Paramore.Brighter.MessagingGateway.RESTMS
             T domainObject;
             if (!XmlResultParser.TryParse(entityBody, out domainObject))
             {
-                var errorString = string.Format("Could not parse entity body as a domain => {0}", entityBody);
-                _logger.Value.ErrorFormat(errorString);
+                var errorString = $"Could not parse entity body as a domain => {entityBody}";
+                s_logger.LogError(errorString);
                 throw new ResultParserException(errorString);
             }
             return domainObject;

--- a/src/Paramore.Brighter.MessagingGateway.RESTMS/RestMsMessageConsumer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RESTMS/RestMsMessageConsumer.cs
@@ -26,6 +26,7 @@ using System;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Paramore.Brighter.Logging;
 using Paramore.Brighter.MessagingGateway.RESTMS.Exceptions;
 using Paramore.Brighter.MessagingGateway.RESTMS.MessagingGatewayConfiguration;
@@ -38,7 +39,7 @@ namespace Paramore.Brighter.MessagingGateway.RESTMS
     /// </summary>
     public class RestMsMessageConsumer : RestMSMessageGateway, IAmAMessageConsumer
     {
-        private static readonly Lazy<ILog> _logger = new Lazy<ILog>(LogProvider.For<RestMsMessageConsumer>);
+        private static readonly ILogger s_logger = ApplicationLogging.CreateLogger<RestMsMessageConsumer>();
 
         private readonly string _queueName;
         private readonly string _routingKey;
@@ -87,12 +88,12 @@ namespace Paramore.Brighter.MessagingGateway.RESTMS
             }
             catch (RestMSClientException rmse)
             {
-                _logger.Value.ErrorFormat("Error sending to the RestMS server: {0}", rmse.ToString());
+                s_logger.LogError("Error sending to the RestMS server: {0}", rmse.ToString());
                 throw;
             }
             catch (HttpRequestException he)
             {
-                _logger.Value.ErrorFormat("HTTP error on request to the RestMS server: {0}", he.ToString());
+                s_logger.LogError("HTTP error on request to the RestMS server: {0}", he.ToString());
                 throw;
             }
         }
@@ -123,12 +124,12 @@ namespace Paramore.Brighter.MessagingGateway.RESTMS
             }
             catch (RestMSClientException rmse)
             {
-                _logger.Value.ErrorFormat("Error sending to the RestMS server: {0}", rmse.ToString());
+                s_logger.LogError("Error sending to the RestMS server: {0}", rmse.ToString());
                 throw;
             }
             catch (HttpRequestException he)
             {
-                _logger.Value.ErrorFormat("HTTP error on request to the RestMS server: {0}", he.ToString());
+                s_logger.LogError("HTTP error on request to the RestMS server: {0}", he.ToString());
                 throw;
             }
         }
@@ -157,12 +158,12 @@ namespace Paramore.Brighter.MessagingGateway.RESTMS
             }
             catch (RestMSClientException rmse)
             {
-                _logger.Value.ErrorFormat("Error sending to the RestMS server: {0}", rmse.ToString());
+                s_logger.LogError("Error sending to the RestMS server: {0}", rmse.ToString());
                 throw;
             }
             catch (HttpRequestException he)
             {
-                _logger.Value.ErrorFormat("HTTP error on request to the RestMS server: {0}", he.ToString());
+                s_logger.LogError("HTTP error on request to the RestMS server: {0}", he.ToString());
                 throw;
             }
         }
@@ -206,7 +207,7 @@ namespace Paramore.Brighter.MessagingGateway.RESTMS
                 return;
             }
 
-            _logger.Value.DebugFormat("Deleting the message {0} from the pipe: {0}", message.Id, pipe.Href);
+            s_logger.LogDebug("Deleting the message {0} from the pipe: {0}", message.Id, pipe.Href);
             SendDeleteMessage(matchingMessage);
         }
 
@@ -217,7 +218,7 @@ namespace Paramore.Brighter.MessagingGateway.RESTMS
                 return new Message[] {new Message()};
             }
 
-            _logger.Value.DebugFormat("Getting the message from the RestMS server: {0}", messageUri);
+            s_logger.LogDebug("Getting the message from the RestMS server: {0}", messageUri);
             var client = Client();
 
             try
@@ -231,7 +232,7 @@ namespace Paramore.Brighter.MessagingGateway.RESTMS
             {
                 foreach (var exception in ae.Flatten().InnerExceptions)
                 {
-                    _logger.Value.ErrorFormat("Threw exception getting Pipe {0} from RestMS Server {1}", _pipe.PipeUri, exception.Message);
+                    s_logger.LogError("Threw exception getting Pipe {0} from RestMS Server {1}", _pipe.PipeUri, exception.Message);
                 }
 
                 throw new RestMSClientException(string.Format("Error retrieving the domain from the RestMS server, see log for details"));

--- a/src/Paramore.Brighter.MessagingGateway.RESTMS/RestMsMessageProducer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RESTMS/RestMsMessageProducer.cs
@@ -27,6 +27,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Text;
+using Microsoft.Extensions.Logging;
 using Paramore.Brighter.Logging;
 using Paramore.Brighter.MessagingGateway.RESTMS.Exceptions;
 using Paramore.Brighter.MessagingGateway.RESTMS.MessagingGatewayConfiguration;
@@ -43,7 +44,7 @@ namespace Paramore.Brighter.MessagingGateway.RESTMS
         public int MaxOutStandingMessages { get; set; } = -1;
         public int MaxOutStandingCheckIntervalMilliSeconds { get; set; } = 0;
          
-        private static readonly Lazy<ILog> _logger = new Lazy<ILog>(LogProvider.For<RestMsMessageProducer>);
+        private static readonly ILogger s_logger = ApplicationLogging.CreateLogger<RestMsMessageProducer>();
 
         private readonly Feed _feed;
         private readonly Domain _domain;
@@ -72,12 +73,12 @@ namespace Paramore.Brighter.MessagingGateway.RESTMS
             }
             catch (RestMSClientException rmse)
             {
-                _logger.Value.ErrorFormat("Error sending to the RestMS server: {0}", rmse.ToString());
+                s_logger.LogError("Error sending to the RestMS server: {0}", rmse.ToString());
                 throw;
             }
             catch (HttpRequestException he)
             {
-                _logger.Value.ErrorFormat("HTTP error on request to the RestMS server: {0}", he.ToString());
+                s_logger.LogError("HTTP error on request to the RestMS server: {0}", he.ToString());
                 throw;
             }
         }
@@ -154,7 +155,7 @@ namespace Paramore.Brighter.MessagingGateway.RESTMS
             {
                 foreach (var exception in ae.Flatten().InnerExceptions)
                 {
-                    _logger.Value.ErrorFormat("Threw exception sending message to feed {0} with Id {1} due to {2}", feedName, message.Header.Id, exception.Message);
+                    s_logger.LogError("Threw exception sending message to feed {0} with Id {1} due to {2}", feedName, message.Header.Id, exception.Message);
                 }
 
                 throw new RestMSClientException(string.Format("Error sending message to feed {0} with Id {1} , see log for details", feedName, message.Header.Id));

--- a/src/Paramore.Brighter.MessagingGateway.RMQ/ConnectionPolicyFactory.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ/ConnectionPolicyFactory.cs
@@ -23,6 +23,7 @@ THE SOFTWARE. */
 #endregion
 
 using System;
+using Microsoft.Extensions.Logging;
 using Paramore.Brighter.Logging;
 using Polly;
 using RabbitMQ.Client.Exceptions;
@@ -34,7 +35,7 @@ namespace Paramore.Brighter.MessagingGateway.RMQ
     /// </summary>
     public class ConnectionPolicyFactory
     {
-        private static readonly Lazy<ILog> _logger = new Lazy<ILog>(LogProvider.For<ConnectionPolicyFactory>);
+        private static readonly ILogger s_logger = ApplicationLogging.CreateLogger<ConnectionPolicyFactory>();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ConnectionPolicyFactory"/> class.
@@ -64,9 +65,8 @@ namespace Paramore.Brighter.MessagingGateway.RMQ
                     {
                         if (exception is BrokerUnreachableException)
                         {
-                            _logger.Value.WarnException(
+                            s_logger.LogWarning(exception,
                                 "RMQMessagingGateway: BrokerUnreachableException error on connecting to queue {0} exchange {1} on subscription {2}. Will retry {3} times",
-                                exception,
                                 context["queueName"],
                                 connection.Exchange.Name,
                                 connection.AmpqUri.GetSanitizedUri(),
@@ -74,9 +74,8 @@ namespace Paramore.Brighter.MessagingGateway.RMQ
                         }
                         else
                         {
-                            _logger.Value.WarnException(
+                            s_logger.LogWarning(exception,
                                 "RMQMessagingGateway: Exception on subscription to queue {0} via exchange {1} on subscription {2}",
-                                exception,
                                 context["queueName"],
                                 connection.Exchange.Name,
                                 connection.AmpqUri.GetSanitizedUri());

--- a/src/Paramore.Brighter.MessagingGateway.RMQ/PullConsumer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ/PullConsumer.cs
@@ -25,7 +25,8 @@ THE SOFTWARE. */
  using System;
 using System.Collections.Concurrent;
 using System.Threading.Tasks;
-using Paramore.Brighter.Logging;
+ using Microsoft.Extensions.Logging;
+ using Paramore.Brighter.Logging;
 using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
 
@@ -33,7 +34,7 @@ namespace Paramore.Brighter.MessagingGateway.RMQ
 {
     public class PullConsumer : DefaultBasicConsumer
     {
-        private static readonly Lazy<ILog> _logger = new Lazy<ILog>(LogProvider.For<RmqMessageConsumer>);
+        private static readonly ILogger s_logger = ApplicationLogging.CreateLogger<RmqMessageConsumer>();
         
         //we do end up creating a second buffer to the Brighter Channel, but controlling the flow from RMQ depends
         //on us being able to buffer up to the set QoS and then pull. This matches other implementations.
@@ -120,7 +121,7 @@ namespace Paramore.Brighter.MessagingGateway.RMQ
             catch (Exception e)
             {
                 //don't impede shutdown, just log
-                _logger.Value.WarnFormat("Tried to nack unhandled messages on shutdown but failed for {0}",
+                s_logger.LogWarning("Tried to nack unhandled messages on shutdown but failed for {0}",
                     e.Message);
             }
            

--- a/src/Paramore.Brighter.MessagingGateway.RMQ/RmqMessageConsumer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ/RmqMessageConsumer.cs
@@ -29,6 +29,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Paramore.Brighter.Logging;
 using Polly.CircuitBreaker;
 using RabbitMQ.Client;
@@ -44,7 +45,7 @@ namespace Paramore.Brighter.MessagingGateway.RMQ
     /// </summary>
     public class RmqMessageConsumer : RmqMessageGateway, IAmAMessageConsumer
     {
-        private static readonly Lazy<ILog> _logger = new Lazy<ILog>(LogProvider.For<RmqMessageConsumer>);
+        private static readonly ILogger s_logger= ApplicationLogging.CreateLogger<RmqMessageConsumer>();
 
         private PullConsumer _consumer;
         private readonly string _queueName;
@@ -143,13 +144,12 @@ namespace Paramore.Brighter.MessagingGateway.RMQ
             try
             {
                 EnsureBroker();
-                _logger.Value.InfoFormat("RmqMessageConsumer: Acknowledging message {0} as completed with delivery tag {1}", message.Id, deliveryTag);
+                s_logger.LogInformation("RmqMessageConsumer: Acknowledging message {0} as completed with delivery tag {1}", message.Id, deliveryTag);
                 Channel.BasicAck(deliveryTag, false);
             }
             catch (Exception exception)
             {
-                _logger.Value.ErrorException("RmqMessageConsumer: Error acknowledging message {0} as completed with delivery tag {1}", exception, message.Id,
-                    deliveryTag);
+                s_logger.LogError(exception, "RmqMessageConsumer: Error acknowledging message {0} as completed with delivery tag {1}", message.Id, deliveryTag);
                 throw;
             }
         }
@@ -163,7 +163,7 @@ namespace Paramore.Brighter.MessagingGateway.RMQ
             {
                 //Why bind a queue? Because we use purge to initialize a queue for RPC
                 EnsureChannel();
-                _logger.Value.DebugFormat("RmqMessageConsumer: Purging channel {0}", _queueName);
+                s_logger.LogDebug("RmqMessageConsumer: Purging channel {0}", _queueName);
 
                 try { Channel.QueuePurge(_queueName); }
                 catch (OperationInterruptedException operationInterruptedException)
@@ -175,7 +175,7 @@ namespace Paramore.Brighter.MessagingGateway.RMQ
             }
             catch (Exception exception)
             {
-                _logger.Value.ErrorException("RmqMessageConsumer: Error purging channel {0}", exception, _queueName);
+                s_logger.LogError(exception, "RmqMessageConsumer: Error purging channel {0}", _queueName);
                 throw;
             }
         }
@@ -189,7 +189,7 @@ namespace Paramore.Brighter.MessagingGateway.RMQ
         {
             try
             {
-                _logger.Value.DebugFormat("RmqMessageConsumer: Re-queueing message {0} with a delay of {1} milliseconds", message.Id, delayMilliseconds);
+                s_logger.LogDebug("RmqMessageConsumer: Re-queueing message {0} with a delay of {1} milliseconds", message.Id, delayMilliseconds);
                 EnsureBroker(_queueName);
                 var rmqMessagePublisher = new RmqMessagePublisher(Channel, Connection);
                 if (DelaySupported)
@@ -208,7 +208,7 @@ namespace Paramore.Brighter.MessagingGateway.RMQ
             }
             catch (Exception exception)
             {
-                _logger.Value.ErrorException("RmqMessageConsumer: Error re-queueing message {0}", exception, message.Id);
+                s_logger.LogError(exception, "RmqMessageConsumer: Error re-queueing message {0}", message.Id);
                 throw;
             }
         }
@@ -222,12 +222,12 @@ namespace Paramore.Brighter.MessagingGateway.RMQ
             try
             {
                 EnsureBroker(_queueName);
-                _logger.Value.InfoFormat("RmqMessageConsumer: NoAck message {0} with delivery tag {1}", message.Id, message.DeliveryTag);
+                s_logger.LogInformation("RmqMessageConsumer: NoAck message {0} with delivery tag {1}", message.Id, message.DeliveryTag);
                 Channel.BasicReject(message.DeliveryTag, false);
             }
             catch (Exception exception)
             {
-                _logger.Value.ErrorException("RmqMessageConsumer: Error try to NoAck message {0}", exception, message.Id);
+                s_logger.LogError(exception, "RmqMessageConsumer: Error try to NoAck message {0}", message.Id);
                 throw;
             }
         }
@@ -240,8 +240,7 @@ namespace Paramore.Brighter.MessagingGateway.RMQ
         /// <returns>Message.</returns>
         public Message[] Receive(int timeoutInMilliseconds)
         {
-            _logger.Value.DebugFormat(
-                "RmqMessageConsumer: Preparing to retrieve next message from queue {0} with routing key {1} via exchange {2} on subscription {3}", _queueName,
+            s_logger.LogDebug("RmqMessageConsumer: Preparing to retrieve next message from queue {0} with routing key {1} via exchange {2} on subscription {3}", _queueName,
                 _routingKeys, Connection.Exchange.Name, Connection.AmpqUri.GetSanitizedUri());
 
             try
@@ -258,7 +257,7 @@ namespace Paramore.Brighter.MessagingGateway.RMQ
                         var message = _messageCreator.CreateMessage(results[i]);
                         messages[i] = message;
 
-                        _logger.Value.InfoFormat(
+                        s_logger.LogInformation(
                             "RmqMessageConsumer: Received message from queue {0} with routing key {1} via exchange {2} on subscription {3}, message: {4}",
                             _queueName, _routingKeys, Connection.Exchange.Name, Connection.AmpqUri.GetSanitizedUri(),
                             JsonSerializer.Serialize(message, JsonSerialisationOptions.Options),
@@ -274,9 +273,8 @@ namespace Paramore.Brighter.MessagingGateway.RMQ
             }
             catch (EndOfStreamException endOfStreamException)
             {
-                _logger.Value.DebugException(
+                s_logger.LogDebug(endOfStreamException,
                     "RmqMessageConsumer: The model closed, or the subscription went away. Listening to queue {0} via exchange {1} via exchange {2} on subscription {3}",
-                    endOfStreamException,
                     _queueName,
                     _routingKeys,
                     Connection.Exchange.Name,
@@ -285,9 +283,8 @@ namespace Paramore.Brighter.MessagingGateway.RMQ
             }
             catch (BrokerUnreachableException bue)
             {
-                _logger.Value.ErrorException(
+                s_logger.LogError(bue,
                     "RmqMessageConsumer: There broker was unreachable listening to queue {0} via exchange {1} via exchange {2} on subscription {3}",
-                    bue,
                     _queueName,
                     _routingKeys,
                     Connection.Exchange.Name,
@@ -297,9 +294,8 @@ namespace Paramore.Brighter.MessagingGateway.RMQ
             }
             catch (AlreadyClosedException ace)
             {
-                _logger.Value.ErrorException(
+                s_logger.LogError(ace,
                     "RmqMessageConsumer: There subscription was already closed when listening to queue {0} via exchange {1} via exchange {2} on subscription {3}",
-                    ace,
                     _queueName,
                     _routingKeys,
                     Connection.Exchange.Name,
@@ -309,9 +305,8 @@ namespace Paramore.Brighter.MessagingGateway.RMQ
             }
             catch (OperationInterruptedException oie)
             {
-                _logger.Value.ErrorException(
+                s_logger.LogError(oie,
                     "RmqMessageConsumer: There was an error listening to queue {0} via exchange {1} via exchange {2} on subscription {3}",
-                    oie,
                     _queueName,
                     _routingKeys,
                     Connection.Exchange.Name,
@@ -320,9 +315,8 @@ namespace Paramore.Brighter.MessagingGateway.RMQ
             }
             catch (TimeoutException te)
             {
-                _logger.Value.ErrorException(
+                s_logger.LogError(te,
                     "RmqMessageConsumer: The socket timed out whilst listening to queue {0} via exchange {1} via exchange {2} on subscription {3}",
-                    te,
                     _queueName,
                     _routingKeys,
                     Connection.Exchange.Name,
@@ -332,9 +326,8 @@ namespace Paramore.Brighter.MessagingGateway.RMQ
             }
             catch (NotSupportedException nse)
             {
-                _logger.Value.ErrorException(
+                s_logger.LogError(nse,
                     "RmqMessageConsumer: There was an error listening to queue {0} via exchange {1} via exchange {2} on subscription {3}",
-                    nse,
                     _queueName,
                     _routingKeys,
                     Connection.Exchange.Name,
@@ -343,7 +336,7 @@ namespace Paramore.Brighter.MessagingGateway.RMQ
             }
             catch (BrokenCircuitException bce)
             {
-                _logger.Value.WarnFormat(
+                s_logger.LogWarning(bce,
                     "CIRCUIT BROKEN: RmqMessageConsumer: There was an error listening to queue {0} via exchange {1} via exchange {2} on subscription {3}",
                     _queueName,
                     _routingKeys,
@@ -353,8 +346,8 @@ namespace Paramore.Brighter.MessagingGateway.RMQ
             }
             catch (Exception exception)
             {
-                _logger.Value.ErrorException(
-                    "RmqMessageConsumer: There was an error listening to queue {0} via exchange {1} via exchange {2} on subscription {3}", exception, _queueName,
+                s_logger.LogError(exception,
+                    "RmqMessageConsumer: There was an error listening to queue {0} via exchange {1} via exchange {2} on subscription {3}", _queueName,
                     _routingKeys, Connection.Exchange.Name, Connection.AmpqUri.GetSanitizedUri());
                 throw;
             }
@@ -382,7 +375,7 @@ namespace Paramore.Brighter.MessagingGateway.RMQ
 
                 CreateConsumer();
 
-                _logger.Value.InfoFormat(
+                s_logger.LogInformation(
                     "RmqMessageConsumer: Created rabbitmq channel {4} for queue {0} with routing key/s {1} via exchange {2} on subscription {3}",
                     _queueName,
                     _routingKeys,
@@ -414,7 +407,7 @@ namespace Paramore.Brighter.MessagingGateway.RMQ
 
             _consumer.HandleBasicConsumeOk(_consumerTag);
 
-            _logger.Value.InfoFormat("RmqMessageConsumer: Created consumer for queue {0} with routing key {1} via exchange {2} on subscription {3}",
+            s_logger.LogInformation("RmqMessageConsumer: Created consumer for queue {0} with routing key {1} via exchange {2} on subscription {3}",
                 _queueName,
                 _routingKeys,
                 Connection.Exchange.Name,
@@ -424,7 +417,7 @@ namespace Paramore.Brighter.MessagingGateway.RMQ
 
         private void CreateQueue()
         {
-            _logger.Value.DebugFormat("RmqMessageConsumer: Creating queue {0} on subscription {1}", _queueName, Connection.AmpqUri.GetSanitizedUri());
+            s_logger.LogDebug("RmqMessageConsumer: Creating queue {0} on subscription {1}", _queueName, Connection.AmpqUri.GetSanitizedUri());
             Channel.QueueDeclare(_queueName, _isDurable, false, false, SetQueueArguments());
             if (_hasDlq) Channel.QueueDeclare(_deadLetterQueueName, _isDurable, false,false);
         }
@@ -442,7 +435,7 @@ namespace Paramore.Brighter.MessagingGateway.RMQ
 
         private void ValidateQueue()
         {
-            _logger.Value.DebugFormat("RmqMessageConsumer: Validating queue {0} on subscription {1}", _queueName, Connection.AmpqUri.GetSanitizedUri());
+            s_logger.LogDebug("RmqMessageConsumer: Validating queue {0} on subscription {1}", _queueName, Connection.AmpqUri.GetSanitizedUri());
 
             try
             {

--- a/src/Paramore.Brighter.MessagingGateway.RMQ/RmqMessageGateway.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ/RmqMessageGateway.cs
@@ -25,6 +25,7 @@ THE SOFTWARE. */
 
 using System;
 using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
 using Paramore.Brighter.Logging;
 using Polly;
 using RabbitMQ.Client;
@@ -50,7 +51,7 @@ namespace Paramore.Brighter.MessagingGateway.RMQ
     /// </summary>
     public class RmqMessageGateway : IDisposable
     {
-        private static readonly Lazy<ILog> _logger = new Lazy<ILog>(LogProvider.For<RmqMessageGateway>);
+        private static readonly ILogger s_logger = ApplicationLogging.CreateLogger<RmqMessageGateway>();
         private readonly Policy _circuitBreakerPolicy;
         private readonly ConnectionFactory _connectionFactory;
         private readonly Policy _retryPolicy;
@@ -125,12 +126,10 @@ namespace Paramore.Brighter.MessagingGateway.RMQ
                 connection.ConnectionBlocked += HandleBlocked;
                 connection.ConnectionUnblocked += HandleUnBlocked;
 
-                _logger.Value.DebugFormat("RMQMessagingGateway: Opening channel to Rabbit MQ on subscription {0}",
+                s_logger.LogDebug("RMQMessagingGateway: Opening channel to Rabbit MQ on subscription {0}",
                     Connection.AmpqUri.GetSanitizedUri());
 
                 Channel = connection.CreateModel();
-                
-               _logger.Value.DebugFormat("RMQMessagingGateway: Declaring exchange {0} on subscription {1}", Connection.Exchange.Name, Connection.AmpqUri.GetSanitizedUri());
 
                 //desired state configuration of the exchange
                 Channel.DeclareExchangeForConnection(Connection, makeExchange);
@@ -139,13 +138,13 @@ namespace Paramore.Brighter.MessagingGateway.RMQ
 
         private void HandleBlocked(object sender, ConnectionBlockedEventArgs args)
         {
-            _logger.Value.WarnFormat("RMQMessagingGateway: Subscription to {0} blocked. Reason: {1}", 
+            s_logger.LogWarning("RMQMessagingGateway: Subscription to {0} blocked. Reason: {1}", 
                 Connection.AmpqUri.GetSanitizedUri(), args.Reason);
         }
 
         private void HandleUnBlocked(object sender, EventArgs args)
-        {
-            _logger.Value.InfoFormat("RMQMessagingGateway: Subscription to {0} unblocked", Connection.AmpqUri.GetSanitizedUri());
+        { 
+            s_logger.LogInformation("RMQMessagingGateway: Subscription to {0} unblocked", Connection.AmpqUri.GetSanitizedUri());
         }
 
         protected void ResetConnectionToBroker()

--- a/src/Paramore.Brighter.MessagingGateway.RMQ/RmqMessageGatewayConnectionPool.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ/RmqMessageGatewayConnectionPool.cs
@@ -25,6 +25,7 @@ THE SOFTWARE. */
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Paramore.Brighter.Logging;
 using RabbitMQ.Client;
 using RabbitMQ.Client.Exceptions;
@@ -40,7 +41,7 @@ namespace Paramore.Brighter.MessagingGateway.RMQ
         private readonly ushort _connectionHeartbeat;
         private static readonly Dictionary<string, PooledConnection> s_connectionPool = new Dictionary<string, PooledConnection>();
         private static readonly object s_lock = new object();
-        private static readonly Lazy<ILog> s_logger = new Lazy<ILog>(LogProvider.For<RmqMessageGatewayConnectionPool>);
+        private static readonly ILogger s_logger = ApplicationLogging.CreateLogger<RmqMessageGatewayConnectionPool>();
         private static readonly Random jitter = new Random();
 
         public RmqMessageGatewayConnectionPool(string connectionName, ushort connectionHeartbeat)
@@ -89,7 +90,7 @@ namespace Paramore.Brighter.MessagingGateway.RMQ
             }
                 catch (BrokerUnreachableException exception)
                 {
-                    s_logger.Value.ErrorException("RmqMessageGatewayConnectionPool: Failed to reset subscription to Rabbit MQ endpoint {0}", exception, connectionFactory.Endpoint);
+                    s_logger.LogError(exception, "RmqMessageGatewayConnectionPool: Failed to reset subscription to Rabbit MQ endpoint {0}", connectionFactory.Endpoint);
         }
             }
         }
@@ -100,7 +101,7 @@ namespace Paramore.Brighter.MessagingGateway.RMQ
 
             TryRemoveConnection(connectionId);
 
-            s_logger.Value.DebugFormat("RmqMessageGatewayConnectionPool: Creating subscription to Rabbit MQ endpoint {0}", connectionFactory.Endpoint);
+            s_logger.LogDebug("RmqMessageGatewayConnectionPool: Creating subscription to Rabbit MQ endpoint {0}", connectionFactory.Endpoint);
 
             connectionFactory.RequestedHeartbeat = TimeSpan.FromSeconds(_connectionHeartbeat);
             connectionFactory.RequestedConnectionTimeout = TimeSpan.FromMilliseconds(5000);
@@ -109,12 +110,12 @@ namespace Paramore.Brighter.MessagingGateway.RMQ
 
             var connection = connectionFactory.CreateConnection(_connectionName);
 
-            s_logger.Value.DebugFormat("RmqMessageGatewayConnectionPool: new connected to {0} added to pool named {1}", connection.Endpoint, connection.ClientProvidedName);
+            s_logger.LogDebug("RmqMessageGatewayConnectionPool: new connected to {0} added to pool named {1}", connection.Endpoint, connection.ClientProvidedName);
 
 
             void ShutdownHandler(object sender, ShutdownEventArgs e)
             {
-                s_logger.Value.WarnFormat("RmqMessageGatewayConnectionPool: The subscription {0} has been shutdown due to {1}", connection.Endpoint, e.ToString());
+                s_logger.LogWarning("RmqMessageGatewayConnectionPool: The subscription {0} has been shutdown due to {1}", connection.Endpoint, e.ToString());
 
                 lock (s_lock)
                 {

--- a/src/Paramore.Brighter.MessagingGateway.RMQ/RmqMessageProducer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ/RmqMessageProducer.cs
@@ -26,6 +26,7 @@ using System;
 using System.IO;
 using System.Text.Json;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Paramore.Brighter.Logging;
 
 namespace Paramore.Brighter.MessagingGateway.RMQ
@@ -40,7 +41,7 @@ namespace Paramore.Brighter.MessagingGateway.RMQ
         public int MaxOutStandingMessages { get; set; } = -1;
         public int MaxOutStandingCheckIntervalMilliSeconds { get; set; } = 0;
         
-         private static readonly Lazy<ILog> _logger = new Lazy<ILog>(LogProvider.For<RmqMessageProducer>);
+         private static readonly ILogger s_logger = ApplicationLogging.CreateLogger<RmqMessageProducer>();
 
         static readonly object _lock = new object();
         private readonly Publication _publication;
@@ -91,14 +92,14 @@ namespace Paramore.Brighter.MessagingGateway.RMQ
             {
                 lock (_lock)
                 {
-                    _logger.Value.DebugFormat("RmqMessageProducer: Preparing  to send message via exchange {0}", Connection.Exchange.Name);
+                    s_logger.LogDebug("RmqMessageProducer: Preparing  to send message via exchange {0}", Connection.Exchange.Name);
                     EnsureBroker(makeExchange: _publication.MakeChannels);
                     
                     var rmqMessagePublisher = new RmqMessagePublisher(Channel, Connection);
 
                     message.Persist = Connection.PersistMessages;
 
-                    _logger.Value.DebugFormat(
+                    s_logger.LogDebug(
                         "RmqMessageProducer: Publishing message to exchange {0} on subscription {1} with a delay of {5} and topic {2} and persisted {6} and id {3} and body: {4}",
                         Connection.Exchange.Name, Connection.AmpqUri.GetSanitizedUri(), message.Header.Topic,
                         message.Id, message.Body.Value, delayMilliseconds, message.Persist);
@@ -113,7 +114,7 @@ namespace Paramore.Brighter.MessagingGateway.RMQ
                         rmqMessagePublisher.PublishMessage(message, 0);
                     }
 
-                    _logger.Value.InfoFormat(
+                    s_logger.LogInformation(
                         "RmqMessageProducer: Published message to exchange {0} on subscription {1} with a delay of {6} and topic {2} and persisted {7} and id {3} and message: {4} at {5}",
                         Connection.Exchange.Name, Connection.AmpqUri.GetSanitizedUri(), message.Header.Topic,
                         message.Id, JsonSerializer.Serialize(message, JsonSerialisationOptions.Options), DateTime.UtcNow, delayMilliseconds, message.Persist);
@@ -121,7 +122,7 @@ namespace Paramore.Brighter.MessagingGateway.RMQ
             }
             catch (IOException io)
             {
-                _logger.Value.ErrorFormat(
+                s_logger.LogError(io,
                     "RmqMessageProducer: Error talking to the socket on {0}, resetting subscription",
                     Connection.AmpqUri.GetSanitizedUri()
                     );

--- a/src/Paramore.Brighter.MessagingGateway.RMQ/RmqMessagePublisher.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ/RmqMessagePublisher.cs
@@ -26,10 +26,10 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Extensions.Logging;
 using Paramore.Brighter.Extensions;
 using Paramore.Brighter.Logging;
 using RabbitMQ.Client;
-using RabbitMQ.Client.Exceptions;
 
 namespace Paramore.Brighter.MessagingGateway.RMQ
 {
@@ -38,7 +38,7 @@ namespace Paramore.Brighter.MessagingGateway.RMQ
     /// </summary>
 internal class RmqMessagePublisher
     {
-        private static readonly Lazy<ILog> _logger = new Lazy<ILog>(LogProvider.For<RmqMessagePublisher>);
+        private static readonly ILogger s_logger = ApplicationLogging.CreateLogger<RmqMessagePublisher>();
         private static readonly string[] _headersToReset =
         {
             HeaderNames.DELAY_MILLISECONDS,
@@ -135,7 +135,7 @@ internal class RmqMessagePublisher
             var messageId = Guid.NewGuid() ;
             const string deliveryTag = "1";
 
-            _logger.Value.InfoFormat("RmqMessagePublisher: Regenerating message {0} with DeliveryTag of {1} to {2} with DeliveryTag of {3}", message.Id, deliveryTag, messageId, 1);
+            s_logger.LogInformation("RmqMessagePublisher: Regenerating message {0} with DeliveryTag of {1} to {2} with DeliveryTag of {3}", message.Id, deliveryTag, messageId, 1);
 
             var headers = new Dictionary<string, object>
             {

--- a/src/Paramore.Brighter.MessagingGateway.Redis/RedisMessageCreator.cs
+++ b/src/Paramore.Brighter.MessagingGateway.Redis/RedisMessageCreator.cs
@@ -26,6 +26,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
+using Microsoft.Extensions.Logging;
 using Paramore.Brighter.Logging;
 using ServiceStack;
 
@@ -33,7 +34,7 @@ namespace Paramore.Brighter.MessagingGateway.Redis
 {
     public class RedisMessageCreator
     {
-        private static readonly Lazy<ILog> _logger = new Lazy<ILog>(LogProvider.For<RedisMessageCreator>);
+        private static readonly ILogger s_logger= ApplicationLogging.CreateLogger<RedisMessageCreator>();
         
         /// <summary>
         /// Create a Brighter Message from the Redis raw content
@@ -62,7 +63,7 @@ namespace Paramore.Brighter.MessagingGateway.Redis
                 var header = reader.ReadLine();
                 if (header.TrimEnd() != "<HEADER")
                 {
-                    _logger.Value.ErrorFormat("Expected message to begin with <HEADER, but was {0}", redisMessage);
+                    s_logger.LogError("Expected message to begin with <HEADER, but was {0}", redisMessage);
                     return message;
                 }
                 
@@ -71,14 +72,14 @@ namespace Paramore.Brighter.MessagingGateway.Redis
                 header = reader.ReadLine();
                 if (header.TrimStart() != "HEADER/>")
                 {
-                    _logger.Value.ErrorFormat("Expected message to find end of HEADER/>, but was {0}", redisMessage);
+                    s_logger.LogError("Expected message to find end of HEADER/>, but was {0}", redisMessage);
                     return message;
                 }
 
                 var body = reader.ReadLine();
                 if (body.TrimEnd() != "<BODY")
                 {
-                    _logger.Value.ErrorFormat("Expected message to have beginning of <BODY, but was {0}", redisMessage);
+                    s_logger.LogError("Expected message to have beginning of <BODY, but was {0}", redisMessage);
                     return message;
                 }
                 
@@ -87,7 +88,7 @@ namespace Paramore.Brighter.MessagingGateway.Redis
                 body = reader.ReadLine();
                 if (body.TrimStart() != "BODY/>")
                 {
-                    _logger.Value.ErrorFormat("Expected message to find end of BODY/>, but was {0}", redisMessage);
+                    s_logger.LogError("Expected message to find end of BODY/>, but was {0}", redisMessage);
                     return message;
                 }
                 

--- a/src/Paramore.Brighter.Outbox.DynamoDB/DynamoDbOutbox.cs
+++ b/src/Paramore.Brighter.Outbox.DynamoDB/DynamoDbOutbox.cs
@@ -31,7 +31,6 @@ using System.Threading.Tasks;
 using Amazon.DynamoDBv2;
 using Amazon.DynamoDBv2.DataModel;
 using Amazon.DynamoDBv2.DocumentModel;
-using Paramore.Brighter.Logging;
 
 namespace Paramore.Brighter.Outbox.DynamoDB
 {
@@ -41,8 +40,6 @@ namespace Paramore.Brighter.Outbox.DynamoDB
         IAmAnOutboxViewer<Message>,
         IAmAnOutboxViewerAsync<Message>
     {
-        private static readonly Lazy<ILog> _logger = new Lazy<ILog>(LogProvider.For<DynamoDbOutbox>);
-        
         private readonly DynamoDbConfiguration _configuration;
         private readonly DynamoDBContext _context;
 

--- a/src/Paramore.Brighter.Outbox.EventStore/EventStoreOutbox.cs
+++ b/src/Paramore.Brighter.Outbox.EventStore/EventStoreOutbox.cs
@@ -30,8 +30,10 @@ using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using EventStore.ClientAPI;
 using Paramore.Brighter.Logging;
+using ILogger = Microsoft.Extensions.Logging.ILogger;
 
 namespace Paramore.Brighter.Outbox.EventStore
 {
@@ -44,7 +46,7 @@ namespace Paramore.Brighter.Outbox.EventStore
         IAmAnOutboxViewer<Message>,
         IAmAnOutboxViewerAsync<Message>
     {
-        private static readonly Lazy<ILog> _logger = new Lazy<ILog>(LogProvider.For<EventStoreOutbox>);
+        private static readonly ILogger s_logger = ApplicationLogging.CreateLogger<EventStoreOutbox>();
 
         private readonly IEventStoreConnection _eventStore;
 
@@ -80,7 +82,7 @@ namespace Paramore.Brighter.Outbox.EventStore
         /// <returns>Task.</returns>
         public void Add(Message message, int outBoxTimeout = -1)
         {
-            _logger.Value.DebugFormat("Adding message to Event Store Outbox: {0}", JsonSerializer.Serialize(message, JsonSerialisationOptions.Options));
+            s_logger.LogDebug("Adding message to Event Store Outbox: {0}", JsonSerializer.Serialize(message, JsonSerialisationOptions.Options));
 
             var headerBag = message.Header.Bag;
             var streamId = ExtractStreamIdFromHeader(headerBag, message.Id);
@@ -102,7 +104,7 @@ namespace Paramore.Brighter.Outbox.EventStore
         public async Task AddAsync(Message message, int outBoxTimeout = -1,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            _logger.Value.DebugFormat("Adding message to Event Store Outbox: {0}", JsonSerializer.Serialize(message, JsonSerialisationOptions.Options));
+            s_logger.LogDebug("Adding message to Event Store Outbox: {0}", JsonSerializer.Serialize(message, JsonSerialisationOptions.Options));
 
             var streamId = ExtractStreamIdFromHeader(message.Header.Bag, message.Id);
             var eventNumber = ExtractEventNumberFromHeader(message.Header.Bag, message.Id);

--- a/src/Paramore.Brighter.Outbox.MsSql/MsSqlOutbox.cs
+++ b/src/Paramore.Brighter.Outbox.MsSql/MsSqlOutbox.cs
@@ -31,6 +31,7 @@ using System.Data.SqlClient;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Paramore.Brighter.Logging;
 
 namespace Paramore.Brighter.Outbox.MsSql
@@ -44,7 +45,7 @@ namespace Paramore.Brighter.Outbox.MsSql
         IAmAnOutboxViewer<Message>,
         IAmAnOutboxViewerAsync<Message>
     {
-        private static readonly Lazy<ILog> _logger = new Lazy<ILog>(LogProvider.For<MsSqlOutbox>);
+        private static readonly ILogger s_logger = ApplicationLogging.CreateLogger<MsSqlOutbox>();
 
         private const int MsSqlDuplicateKeyError_UniqueIndexViolation = 2601;
         private const int MsSqlDuplicateKeyError_UniqueConstraintViolation = 2627;
@@ -93,7 +94,7 @@ namespace Paramore.Brighter.Outbox.MsSql
                         if (sqlException.Number == MsSqlDuplicateKeyError_UniqueIndexViolation ||
                             sqlException.Number == MsSqlDuplicateKeyError_UniqueConstraintViolation)
                         {
-                            _logger.Value.WarnFormat(
+                            s_logger.LogWarning(
                                 "MsSqlOutbox: A duplicate Message with the MessageId {0} was inserted into the Outbox, ignoring and continuing",
                                 message.Id);
                             return;
@@ -129,7 +130,7 @@ namespace Paramore.Brighter.Outbox.MsSql
                         if (sqlException.Number == MsSqlDuplicateKeyError_UniqueIndexViolation ||
                             sqlException.Number == MsSqlDuplicateKeyError_UniqueConstraintViolation)
                         {
-                            _logger.Value.WarnFormat(
+                            s_logger.LogWarning(
                                 "MsSqlOutbox: A duplicate Message with the MessageId {0} was inserted into the Outbox, ignoring and continuing",
                                 message.Id);
                             return;

--- a/src/Paramore.Brighter.Outbox.MySql/MySqlOutbox.cs
+++ b/src/Paramore.Brighter.Outbox.MySql/MySqlOutbox.cs
@@ -31,6 +31,7 @@ using System.Linq;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using MySqlConnector;
 using Paramore.Brighter.Logging;
 
@@ -45,7 +46,7 @@ namespace Paramore.Brighter.Outbox.MySql
         IAmAnOutboxViewer<Message>,
         IAmAnOutboxViewerAsync<Message>
     {
-        private static readonly Lazy<ILog> _logger = new Lazy<ILog>(LogProvider.For<MySqlOutbox>);
+        private static readonly ILogger s_logger = ApplicationLogging.CreateLogger<MySqlOutbox>();
 
         private const int MySqlDuplicateKeyError = 1062;
         private readonly MySqlOutboxConfiguration _configuration;
@@ -99,7 +100,7 @@ namespace Paramore.Brighter.Outbox.MySql
                     {
                         if (IsExceptionUnqiueOrDuplicateIssue(sqlException))
                         {
-                            _logger.Value.WarnFormat("MsSqlOutbox: A duplicate Message with the MessageId {0} was inserted into the Outbox, ignoring and continuing",
+                            s_logger.LogWarning("MsSqlOutbox: A duplicate Message with the MessageId {0} was inserted into the Outbox, ignoring and continuing",
                                 message.Id);
                             return;
                         }
@@ -131,7 +132,7 @@ namespace Paramore.Brighter.Outbox.MySql
                     {
                         if (IsExceptionUnqiueOrDuplicateIssue(sqlException))
                         {
-                            _logger.Value.WarnFormat("MsSqlOutbox: A duplicate Message with the MessageId {0} was inserted into the Outbox, ignoring and continuing",
+                            s_logger.LogWarning("MsSqlOutbox: A duplicate Message with the MessageId {0} was inserted into the Outbox, ignoring and continuing",
                                 message.Id);
                             return;
                         }

--- a/src/Paramore.Brighter.Outbox.PostgreSql/PostgreSqlOutbox.cs
+++ b/src/Paramore.Brighter.Outbox.PostgreSql/PostgreSqlOutbox.cs
@@ -30,12 +30,13 @@ using System.Data;
 using NpgsqlTypes;
 using Paramore.Brighter.Logging;
 using System.Text.Json;
+using Microsoft.Extensions.Logging;
 
 namespace Paramore.Brighter.Outbox.PostgreSql
 {
     public class PostgreSqlOutbox : IAmAnOutbox<Message>, IAmAnOutboxViewer<Message>
     {
-        private static readonly Lazy<ILog> _logger = new Lazy<ILog>(LogProvider.For<PostgreSqlOutbox>);
+        private static readonly ILogger s_logger = ApplicationLogging.CreateLogger<PostgreSqlOutbox>();
         private readonly PostgreSqlOutboxConfiguration _configuration;
 
         public bool ContinueOnCapturedContext
@@ -74,7 +75,7 @@ namespace Paramore.Brighter.Outbox.PostgreSql
                     {
                         if (sqlException.SqlState == PostgresErrorCodes.UniqueViolation)
                         {
-                            _logger.Value.WarnFormat(
+                            s_logger.LogWarning(
                                 "PostgresSQLOutbox: A duplicate Message with the MessageId {0} was inserted into the Outbox, ignoring and continuing",
                                 message.Id);
                             return;

--- a/src/Paramore.Brighter.Outbox.Sqlite/SqliteOutbox.cs
+++ b/src/Paramore.Brighter.Outbox.Sqlite/SqliteOutbox.cs
@@ -31,6 +31,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging;
 using Paramore.Brighter.Logging;
 
 namespace Paramore.Brighter.Outbox.Sqlite
@@ -44,7 +45,7 @@ namespace Paramore.Brighter.Outbox.Sqlite
         IAmAnOutboxViewer<Message>,
         IAmAnOutboxViewerAsync<Message>
     {
-        private static readonly Lazy<ILog> _logger = new Lazy<ILog>(LogProvider.For<SqliteOutbox>);
+        private static readonly ILogger s_logger = ApplicationLogging.CreateLogger<SqliteOutbox>();
 
         private const int SqliteDuplicateKeyError = 1555;
         private const int SqliteUniqueKeyError = 19;
@@ -97,7 +98,7 @@ namespace Paramore.Brighter.Outbox.Sqlite
                     {
                         if (IsExceptionUnqiueOrDuplicateIssue(sqlException))
                         {
-                            _logger.Value.WarnFormat(
+                            s_logger.LogWarning(
                                 "MsSqlOutbox: A duplicate Message with the MessageId {0} was inserted into the Outbox, ignoring and continuing",
                                 message.Id);
                             return;
@@ -130,7 +131,7 @@ namespace Paramore.Brighter.Outbox.Sqlite
                     {
                         if (IsExceptionUnqiueOrDuplicateIssue(sqlException))
                         {
-                            _logger.Value.WarnFormat("MsSqlOutbox: A duplicate Message with the MessageId {0} was inserted into the Outbox, ignoring and continuing",
+                            s_logger.LogWarning("MsSqlOutbox: A duplicate Message with the MessageId {0} was inserted into the Outbox, ignoring and continuing",
                                 message.Id);
                             return;
                         }

--- a/src/Paramore.Brighter.ServiceActivator.Extensions.Hosting/ServiceActivatorHostedService.cs
+++ b/src/Paramore.Brighter.ServiceActivator.Extensions.Hosting/ServiceActivatorHostedService.cs
@@ -12,7 +12,7 @@ namespace Paramore.Brighter.ServiceActivator.Extensions.Hosting
 
         public ServiceActivatorHostedService(ILogger<ServiceActivatorHostedService> logger, IDispatcher dispatcher)
         {
-            _logger = logger;
+            _logger= logger;
             _dispatcher = dispatcher;
         }
 

--- a/src/Paramore.Brighter.ServiceActivator/MessagePumpAsync.cs
+++ b/src/Paramore.Brighter.ServiceActivator/MessagePumpAsync.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Threading;
-using System.Threading.Tasks;
-using Paramore.Brighter.Logging;
+using Microsoft.Extensions.Logging;
 
 namespace Paramore.Brighter.ServiceActivator
 {
@@ -25,7 +24,7 @@ namespace Paramore.Brighter.ServiceActivator
 
         protected override void DispatchRequest(MessageHeader messageHeader, TRequest request)
         {
-            _logger.Value.DebugFormat("MessagePump: Dispatching message {0} from {2} on thread # {1}", request.Id, Thread.CurrentThread.ManagedThreadId, Channel.Name);
+            s_logger.LogDebug("MessagePump: Dispatching message {0} from {2} on thread # {1}", request.Id, Thread.CurrentThread.ManagedThreadId, Channel.Name);
 
             var messageType = messageHeader.MessageType;
             

--- a/src/Paramore.Brighter.ServiceActivator/MessagePumpBlocking.cs
+++ b/src/Paramore.Brighter.ServiceActivator/MessagePumpBlocking.cs
@@ -1,6 +1,5 @@
 ﻿using System.Threading;
-using System.Threading.Tasks;
-using Paramore.Brighter.Logging;
+using Microsoft.Extensions.Logging;
 
 namespace Paramore.Brighter.ServiceActivator
 {
@@ -22,7 +21,7 @@ namespace Paramore.Brighter.ServiceActivator
 
         protected override void DispatchRequest(MessageHeader messageHeader, TRequest request)
         {
-            _logger.Value.DebugFormat("MessagePump: Dispatching message {0} from {2} on thread # {1}", request.Id, Thread.CurrentThread.ManagedThreadId, Channel.Name);
+            s_logger.LogDebug("MessagePump: Dispatching message {0} from {2} on thread # {1}", request.Id, Thread.CurrentThread.ManagedThreadId, Channel.Name);
 
             var messageType = messageHeader.MessageType;
 

--- a/src/Paramore.Brighter.ServiceActivator/Ports/Handlers/ConfigurationCommandHandler.cs
+++ b/src/Paramore.Brighter.ServiceActivator/Ports/Handlers/ConfigurationCommandHandler.cs
@@ -23,6 +23,7 @@ THE SOFTWARE. */
 #endregion
 
 using System;
+using Microsoft.Extensions.Logging;
 using Paramore.Brighter.Logging;
 using Paramore.Brighter.ServiceActivator.Ports.Commands;
 
@@ -33,7 +34,7 @@ namespace Paramore.Brighter.ServiceActivator.Ports.Handlers
     /// </summary>
     public class ConfigurationCommandHandler : RequestHandler<ConfigurationCommand>
     {
-        private static readonly Lazy<ILog> _logger = new Lazy<ILog>(LogProvider.For<ConfigurationCommandHandler>);
+        private static readonly ILogger s_logger= ApplicationLogging.CreateLogger<ConfigurationCommandHandler>();
 
         private readonly IDispatcher _dispatcher;
 
@@ -53,34 +54,34 @@ namespace Paramore.Brighter.ServiceActivator.Ports.Handlers
         /// <returns>TRequest.</returns>
         public override ConfigurationCommand Handle(ConfigurationCommand command)
         {
-            _logger.Value.DebugFormat("Handling Configuration Command of Type: {0}", command.Type);
+            s_logger.LogDebug("Handling Configuration Command of Type: {0}", command.Type);
 
             switch (command.Type)
             {
                 case ConfigurationCommandType.CM_STOPALL:
-                    _logger.Value.DebugFormat("Configuration Command received and now stopping all consumers. Begin at {0}", DateTime.UtcNow.ToString("o"));
-                    _logger.Value.Debug("--------------------------------------------------------------------------");
-                    _logger.Value.Debug("...");
+                    s_logger.LogDebug("Configuration Command received and now stopping all consumers. Begin at {0}", DateTime.UtcNow.ToString("o"));
+                    s_logger.LogDebug("--------------------------------------------------------------------------");
+                    s_logger.LogDebug("...");
                     _dispatcher.End().Wait();
-                    _logger.Value.DebugFormat("All consumers stopped in response to configuration command. Stopped at {0}", DateTime.UtcNow.ToString("o"));
-                    _logger.Value.Debug("--------------------------------------------------------------------------");
+                    s_logger.LogDebug("All consumers stopped in response to configuration command. Stopped at {0}", DateTime.UtcNow.ToString("o"));
+                    s_logger.LogDebug("--------------------------------------------------------------------------");
                     break;
                 case ConfigurationCommandType.CM_STARTALL:
-                    _logger.Value.Debug("--------------------------------------------------------------------------");
-                    _logger.Value.DebugFormat("Configuration Command received and now starting all consumers. Begin at {0}", DateTime.UtcNow.ToString("o"));
-                    _logger.Value.Debug("--------------------------------------------------------------------------");
+                    s_logger.LogDebug("--------------------------------------------------------------------------");
+                    s_logger.LogDebug("Configuration Command received and now starting all consumers. Begin at {0}", DateTime.UtcNow.ToString("o"));
+                    s_logger.LogDebug("--------------------------------------------------------------------------");
                     _dispatcher.Receive();
                     break;
                 case ConfigurationCommandType.CM_STOPCHANNEL:
-                    _logger.Value.Debug("--------------------------------------------------------------------------");
-                    _logger.Value.DebugFormat("Configuration Command received and now stopping channel {0}", command.SubscriptionName);
-                    _logger.Value.Debug("--------------------------------------------------------------------------");
+                    s_logger.LogDebug("--------------------------------------------------------------------------");
+                    s_logger.LogDebug("Configuration Command received and now stopping channel {0}", command.SubscriptionName);
+                    s_logger.LogDebug("--------------------------------------------------------------------------");
                     _dispatcher.Shut(command.SubscriptionName);
                     break;
                 case ConfigurationCommandType.CM_STARTCHANNEL:
-                    _logger.Value.Debug("--------------------------------------------------------------------------");
-                    _logger.Value.DebugFormat("Configuration Command received and now starting channel {0}", command.SubscriptionName);
-                    _logger.Value.Debug("--------------------------------------------------------------------------");
+                    s_logger.LogDebug("--------------------------------------------------------------------------");
+                    s_logger.LogDebug("Configuration Command received and now starting channel {0}", command.SubscriptionName);
+                    s_logger.LogDebug("--------------------------------------------------------------------------");
                     _dispatcher.Open(command.SubscriptionName);
                     break;
                 default:

--- a/src/Paramore.Brighter/CommandProcessor.cs
+++ b/src/Paramore.Brighter/CommandProcessor.cs
@@ -27,6 +27,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Paramore.Brighter.FeatureSwitch;
 using Paramore.Brighter.Logging;
 using Polly;
@@ -41,7 +42,7 @@ namespace Paramore.Brighter
     /// </summary>
     public class CommandProcessor : IAmACommandProcessor, IDisposable
     {
-        private static readonly Lazy<ILog> _logger = new Lazy<ILog>(LogProvider.For<CommandProcessor>);
+        private static readonly ILogger s_logger = ApplicationLogging.CreateLogger<CommandProcessor>();
 
         private readonly IAmAMessageMapperRegistry _mapperRegistry;
         private readonly IAmASubscriberRegistry _subscriberRegistry;
@@ -60,12 +61,12 @@ namespace Paramore.Brighter
         private readonly object _checkOutStandingMessagesObject = new object();
 
         //Uses -1 to indicate no outbox and will thus force a throw on a failed publish
-        private static int _outStandingCount = 0;
+        private int _outStandingCount;
 
         // the following are not readonly to allow setting them to null on dispose
         private IAmAMessageProducer _messageProducer;
         private IAmAMessageProducerAsync _asyncMessageProducer;
-        private IAmAChannelFactory _responseChannelFactory;
+        private readonly IAmAChannelFactory _responseChannelFactory;
         private bool _disposed;
 
         /// <summary>
@@ -338,7 +339,6 @@ namespace Paramore.Brighter
         /// <param name="outboxTimeout">How long should we wait to write to the outbox</param>
         /// <param name="featureSwitchRegistry">The feature switch config provider.</param>
         /// <param name="inboxConfiguration">Do we want to insert an inbox handler into pipelines without the attribute. Null (default = no), yes = how to configure</param>
-        /// <param name="responseChannelFactory">Add response channel if doing request reply</param>
         public CommandProcessor(
             IAmASubscriberRegistry subscriberRegistry,
             IAmAHandlerFactory handlerFactory,
@@ -385,7 +385,7 @@ namespace Paramore.Brighter
 
             using (var builder = new PipelineBuilder<T>(_subscriberRegistry, _handlerFactory, _inboxConfiguration))
             {
-                _logger.Value.InfoFormat("Building send pipeline for command: {0} {1}", command.GetType(), command.Id);
+                s_logger.LogInformation("Building send pipeline for command: {0} {1}", command.GetType(), command.Id);
                 var handlerChain = builder.Build(requestContext);
 
                 AssertValidSendPipeline(command, handlerChain.Count());
@@ -414,7 +414,7 @@ namespace Paramore.Brighter
 
             using (var builder = new PipelineBuilder<T>(_subscriberRegistry, _asyncHandlerFactory, _inboxConfiguration))
             {
-                _logger.Value.InfoFormat("Building send async pipeline for command: {0} {1}", command.GetType(), command.Id);
+                s_logger.LogInformation("Building send async pipeline for command: {0} {1}", command.GetType(), command.Id);
                 var handlerChain = builder.BuildAsync(requestContext, continueOnCapturedContext);
 
                 AssertValidSendPipeline(command, handlerChain.Count());
@@ -443,12 +443,12 @@ namespace Paramore.Brighter
 
             using (var builder = new PipelineBuilder<T>(_subscriberRegistry, _handlerFactory, _inboxConfiguration))
             {
-                _logger.Value.InfoFormat("Building send pipeline for event: {0} {1}", @event.GetType(), @event.Id);
+                s_logger.LogInformation("Building send pipeline for event: {0} {1}", @event.GetType(), @event.Id);
                 var handlerChain = builder.Build(requestContext);
 
                 var handlerCount = handlerChain.Count();
 
-                _logger.Value.InfoFormat("Found {0} pipelines for event: {1} {2}", handlerCount, @event.GetType(), @event.Id);
+                s_logger.LogInformation("Found {0} pipelines for event: {1} {2}", handlerCount, @event.GetType(), @event.Id);
 
                 var exceptions = new List<Exception>();
                 foreach (var handleRequests in handlerChain)
@@ -494,12 +494,12 @@ namespace Paramore.Brighter
 
             using (var builder = new PipelineBuilder<T>(_subscriberRegistry, _asyncHandlerFactory, _inboxConfiguration))
             {
-                _logger.Value.InfoFormat("Building send async pipeline for event: {0} {1}", @event.GetType(), @event.Id);
+                s_logger.LogInformation("Building send async pipeline for event: {0} {1}", @event.GetType(), @event.Id);
 
                 var handlerChain = builder.BuildAsync(requestContext, continueOnCapturedContext);
                 var handlerCount = handlerChain.Count();
 
-                _logger.Value.InfoFormat("Found {0} async pipelines for event: {1} {2}", handlerCount, @event.GetType(), @event.Id);
+                s_logger.LogInformation("Found {0} async pipelines for event: {1} {2}", handlerCount, @event.GetType(), @event.Id);
 
                 var exceptions = new List<Exception>();
                 foreach (var handler in handlerChain)
@@ -570,7 +570,7 @@ namespace Paramore.Brighter
         /// <returns></returns>
         public Guid DepositPost<T>(T request) where T : class, IRequest
         {
-            _logger.Value.InfoFormat("Save request: {0} {1}", request.GetType(), request.Id);
+            s_logger.LogInformation("Save request: {0} {1}", request.GetType(), request.Id);
 
             if (_outBox == null)
                 throw new InvalidOperationException("No outbox defined.");
@@ -605,7 +605,7 @@ namespace Paramore.Brighter
         public async Task<Guid> DepositPostAsync<T>(T request, bool continueOnCapturedContext = false,
             CancellationToken cancellationToken = default(CancellationToken)) where T : class, IRequest
         {
-            _logger.Value.InfoFormat("Save request: {0} {1}", request.GetType(), request.Id);
+            s_logger.LogInformation("Save request: {0} {1}", request.GetType(), request.Id);
 
             if (_asyncOutbox == null)
                 throw new InvalidOperationException("No async outbox defined.");
@@ -649,7 +649,7 @@ namespace Paramore.Brighter
                 if (message == null)
                     throw new NullReferenceException($"Message with Id {messageId} not found in the Outbox");
 
-                _logger.Value.InfoFormat("Decoupled invocation of message: Topic:{0} Id:{1}", message.Header.Topic, messageId.ToString());
+                s_logger.LogInformation("Decoupled invocation of message: Topic:{0} Id:{1}", message.Header.Topic, messageId.ToString());
 
                 if (_messageProducer is ISupportPublishConfirmation producer)
                 {
@@ -690,7 +690,7 @@ namespace Paramore.Brighter
                 if (message == null)
                     throw new NullReferenceException($"Message with Id {messageId} not found in the Outbox");
 
-                _logger.Value.InfoFormat("Decoupled invocation of message: Topic:{0} Id:{1}", message.Header.Topic, messageId.ToString());
+                s_logger.LogInformation("Decoupled invocation of message: Topic:{0} Id:{1}", message.Header.Topic, messageId.ToString());
 
                 if (_messageProducer is ISupportPublishConfirmation producer)
                 {
@@ -762,7 +762,7 @@ namespace Paramore.Brighter
                         routingKey: new RoutingKey(routingKey))))
             {
 
-                _logger.Value.InfoFormat("Create reply queue for topic {0}", routingKey);
+                s_logger.LogInformation("Create reply queue for topic {0}", routingKey);
                 request.ReplyAddress.Topic = routingKey;
                 request.ReplyAddress.CorrelationId = channelName;
 
@@ -774,25 +774,26 @@ namespace Paramore.Brighter
                 var outMessage = outMessageMapper.MapToMessage(request);
 
                 //We don't store the message, if we continue to fail further retry is left to the sender 
-                _logger.Value.DebugFormat("Sending request  with routingkey {0}", routingKey);
+                //s_logger.LogDebug("Sending request  with routingkey {0}", routingKey);
+                s_logger.LogDebug("Sending request  with routingkey {0}", routingKey);
                 Retry(() => _messageProducer.Send(outMessage));
 
                 Message responseMessage = null;
 
                 //now we block on the receiver to try and get the message, until timeout.
-                _logger.Value.DebugFormat("Awaiting response on {0}", routingKey);
+                s_logger.LogDebug("Awaiting response on {0}", routingKey);
                 Retry(() => responseMessage = responseChannel.Receive(timeOutInMilliseconds));
 
                 TResponse response = default(TResponse);
                 if (responseMessage.Header.MessageType != MessageType.MT_NONE)
                 {
-                    _logger.Value.DebugFormat("Reply received from {0}", routingKey);
+                    s_logger.LogDebug("Reply received from {0}", routingKey);
                     //map to request is map to a response, but it is a request from consumer point of view. Confusing, but...
                     response = inMessageMapper.MapToRequest(responseMessage);
                     Send(response);
                 }
 
-                _logger.Value.InfoFormat("Deleting queue for routingkey: {0}", routingKey);
+                s_logger.LogInformation("Deleting queue for routingkey: {0}", routingKey);
 
                 return response;
 
@@ -830,7 +831,7 @@ namespace Paramore.Brighter
 
         private void AssertValidSendPipeline<T>(T command, int handlerCount) where T : class, IRequest
         {
-            _logger.Value.InfoFormat("Found {0} pipelines for command: {1} {2}", handlerCount, typeof(T), command.Id);
+            s_logger.LogInformation("Found {0} pipelines for command: {1} {2}", handlerCount, typeof(T), command.Id);
 
             if (handlerCount > 1)
                 throw new ArgumentException($"More than one handler was found for the typeof command {typeof(T)} - a command should only have one handler.");
@@ -851,7 +852,7 @@ namespace Paramore.Brighter
             if (_asyncMessageProducer != null)
                 maxOutStandingMessages = _asyncMessageProducer.MaxOutStandingMessages;
 
-            _logger.Value.Debug($"Outbox oustanding message count is: {_outStandingCount}");
+            s_logger.LogDebug($"Outbox oustanding message count is: {_outStandingCount}");
             // Because a thread recalculates this, we may always be in a delay, so we check on entry for the next outstanding item
             bool exceedsOutstandingMessageLimit = maxOutStandingMessages != -1 && _outStandingCount > maxOutStandingMessages;
 
@@ -869,14 +870,14 @@ namespace Paramore.Brighter
 
 
             var timeSinceLastCheck = now - _lastOutStandingMessageCheckAt;
-            _logger.Value.Debug($"Time since last check is {timeSinceLastCheck.TotalSeconds} seconds ");
+            s_logger.LogDebug($"Time since last check is {timeSinceLastCheck.TotalSeconds} seconds ");
             if (timeSinceLastCheck < checkInterval)
             {
-                _logger.Value.Debug($"Check not ready to run yet");
+                s_logger.LogDebug($"Check not ready to run yet");
                 return;
             }
 
-            _logger.Value.Debug($"Running outstanding message check at {DateTime.UtcNow} after {timeSinceLastCheck.TotalSeconds} seconds wait");
+            s_logger.LogDebug($"Running outstanding message check at {DateTime.UtcNow} after {timeSinceLastCheck.TotalSeconds} seconds wait");
             //This is expensive, so use a background thread
             Task.Run(() => OutstandingMessagesCheck());
             _lastOutStandingMessageCheckAt = DateTime.UtcNow;
@@ -893,7 +894,7 @@ namespace Paramore.Brighter
                 {
                     if (success)
                     {
-                        _logger.Value.InfoFormat("Sent message: Id:{0}", id.ToString());
+                        s_logger.LogInformation("Sent message: Id:{0}", id.ToString());
                         if (_asyncOutbox != null)
                             await RetryAsync(async ct => await _asyncOutbox.MarkDispatchedAsync(id, DateTime.UtcNow));
                     }
@@ -906,16 +907,13 @@ namespace Paramore.Brighter
 
         private bool ConfigurePublisherCallbackMaybe()
         {
-            if (_messageProducer == null)
-                return false;
-
             if (_messageProducer is ISupportPublishConfirmation producer)
             {
                 producer.OnMessagePublished += delegate(bool success, Guid id)
                 {
                     if (success)
                     {
-                        _logger.Value.InfoFormat("Sent message: Id:{0}", id.ToString());
+                        s_logger.LogInformation("Sent message: Id:{0}", id.ToString());
                         if (_outBox != null)
                             Retry(() => _outBox.MarkDispatched(id, DateTime.UtcNow));
                     }
@@ -931,7 +929,7 @@ namespace Paramore.Brighter
             if (Monitor.TryEnter(_checkOutStandingMessagesObject))
             {
 
-                _logger.Value.Debug("Begin count of oustanding messages");
+                s_logger.LogDebug("Begin count of oustanding messages");
                 try
                 {
                     if ((_outBox != null) && (_outBox is IAmAnOutboxViewer<Message> outboxViewer))
@@ -959,12 +957,12 @@ namespace Paramore.Brighter
                 {
                     //if we can't talk to the outbox, we would swallow the exception on this thread
                     //by setting the _outstandingCount to -1, we force an exception
-                    _logger.Value.ErrorException("Error getting outstanding message count, reset count", ex);
+                    s_logger.LogError(ex,"Error getting outstanding message count, reset count");
                     _outStandingCount = 0;
                 }
                 finally
                 {
-                    _logger.Value.Debug($"Current outstanding count is {_outStandingCount}");
+                    s_logger.LogDebug("Current outstanding count is {OutStandingCount}", _outStandingCount);
                     Monitor.Exit(_checkOutStandingMessagesObject);
                 }
             }
@@ -978,7 +976,7 @@ namespace Paramore.Brighter
             {
                 if (result.FinalException != null)
                 {
-                    _logger.Value.ErrorException("Exception whilst trying to publish message", result.FinalException);
+                    s_logger.LogError(result.FinalException,"Exception whilst trying to publish message");
                     CheckOutstandingMessages();
                 }
 
@@ -999,7 +997,7 @@ namespace Paramore.Brighter
             {
                 if (result.FinalException != null)
                 {
-                    _logger.Value.ErrorException("Exception whilst trying to publish message", result.FinalException);
+                    s_logger.LogError(result.FinalException, "Exception whilst trying to publish message" );
                     CheckOutstandingMessages();
                 }
 

--- a/src/Paramore.Brighter/LifetimeScope.cs
+++ b/src/Paramore.Brighter/LifetimeScope.cs
@@ -1,4 +1,4 @@
-#region Licence
+﻿#region Licence
 /* The MIT License (MIT)
 Copyright © 2014 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
 
@@ -24,6 +24,7 @@ THE SOFTWARE. */
 
 using System;
 using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
 using Paramore.Brighter.Extensions;
 using Paramore.Brighter.Logging;
 
@@ -31,7 +32,7 @@ namespace Paramore.Brighter
 {
     internal class LifetimeScope : IAmALifetime
     {
-        private static readonly Lazy<ILog> _logger = new Lazy<ILog>(LogProvider.For<LifetimeScope>);
+        private static readonly ILogger s_logger= ApplicationLogging.CreateLogger<LifetimeScope>();
 
         private readonly IAmAHandlerFactory _handlerFactory;
         private readonly List<IHandleRequests> _trackedObjects = new List<IHandleRequests>();
@@ -59,7 +60,7 @@ namespace Paramore.Brighter
             if (_handlerFactory == null)
                 throw new ArgumentException("An instance of a handler can not be added without a HandlerFactory.");
             _trackedObjects.Add(instance);
-            _logger.Value.DebugFormat("Tracking instance {0} of type {1}", instance.GetHashCode(), instance.GetType());
+            s_logger.LogDebug("Tracking instance {0} of type {1}", instance.GetHashCode(), instance.GetType());
         }
 
         public void Add(IHandleRequestsAsync instance)
@@ -67,7 +68,7 @@ namespace Paramore.Brighter
             if (_asyncHandlerFactory == null)
                 throw new ArgumentException("An instance of an async handler can not be added without an AsyncHandlerFactory.");
             _trackedAsyncObjects.Add(instance);
-            _logger.Value.DebugFormat("Tracking async handler instance {0} of type {1}", instance.GetHashCode(), instance.GetType());
+            s_logger.LogDebug("Tracking async handler instance {0} of type {1}", instance.GetHashCode(), instance.GetType());
         }
 
         public void Dispose()
@@ -76,14 +77,14 @@ namespace Paramore.Brighter
             {
                 //free disposable items
                 _handlerFactory.Release(trackedItem);
-                _logger.Value.DebugFormat("Releasing handler instance {0} of type {1}", trackedItem.GetHashCode(), trackedItem.GetType());
+                s_logger.LogDebug("Releasing handler instance {0} of type {1}", trackedItem.GetHashCode(), trackedItem.GetType());
             });
 
             _trackedAsyncObjects.Each(trackedItem =>
             {
                 //free disposable items
                 _asyncHandlerFactory.Release(trackedItem);
-                _logger.Value.DebugFormat("Releasing async handler instance {0} of type {1}", trackedItem.GetHashCode(), trackedItem.GetType());
+                s_logger.LogDebug("Releasing async handler instance {0} of type {1}", trackedItem.GetHashCode(), trackedItem.GetType());
             });
 
             //clear our tracking

--- a/src/Paramore.Brighter/Logging/ApplicationLogging.cs
+++ b/src/Paramore.Brighter/Logging/ApplicationLogging.cs
@@ -1,0 +1,10 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace Paramore.Brighter.Logging
+{
+    public static class ApplicationLogging
+    {
+        public static ILoggerFactory LoggerFactory { get; set; } = new LoggerFactory();
+        public static ILogger CreateLogger<T>() => LoggerFactory.CreateLogger<T>();
+    }
+}

--- a/src/Paramore.Brighter/Logging/Handlers/RequestLoggingHandler.cs
+++ b/src/Paramore.Brighter/Logging/Handlers/RequestLoggingHandler.cs
@@ -24,6 +24,7 @@ THE SOFTWARE. */
 
 using System;
 using System.Text.Json;
+using Microsoft.Extensions.Logging;
 
 namespace Paramore.Brighter.Logging.Handlers
 {
@@ -35,7 +36,7 @@ namespace Paramore.Brighter.Logging.Handlers
     /// <typeparam name="TRequest">The type of the t request.</typeparam>
     public class RequestLoggingHandler<TRequest> : RequestHandler<TRequest> where TRequest : class, IRequest
     {
-        private static readonly Lazy<ILog> _logger = new Lazy<ILog>(LogProvider.For<RequestLoggingHandler<TRequest>>);
+        private static readonly ILogger s_logger= ApplicationLogging.CreateLogger<RequestLoggingHandler<TRequest>>();
 
         private HandlerTiming _timing;
 
@@ -86,12 +87,12 @@ namespace Paramore.Brighter.Logging.Handlers
 
         private void LogCommand(TRequest request)
         {
-            _logger.Value.InfoFormat("Logging handler pipeline call. Pipeline timing {0} target, for {1} with values of {2} at: {3}", _timing.ToString(), typeof(TRequest), JsonSerializer.Serialize(request), DateTime.UtcNow);
+            s_logger.LogInformation("Logging handler pipeline call. Pipeline timing {0} target, for {1} with values of {2} at: {3}", _timing.ToString(), typeof(TRequest), JsonSerializer.Serialize(request), DateTime.UtcNow);
         }
 
         private void LogFailure(TRequest request)
         {
-            _logger.Value.InfoFormat("Failure in pipeline call for {0} with values of {1} at: {2}", typeof(TRequest), JsonSerializer.Serialize(request), DateTime.UtcNow);
+            s_logger.LogInformation("Failure in pipeline call for {0} with values of {1} at: {2}", typeof(TRequest), JsonSerializer.Serialize(request), DateTime.UtcNow);
         }
     }
 }

--- a/src/Paramore.Brighter/Logging/Handlers/RequestLoggingHandlerAsync.cs
+++ b/src/Paramore.Brighter/Logging/Handlers/RequestLoggingHandlerAsync.cs
@@ -26,7 +26,7 @@ using System;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using Paramore.Brighter.Logging;
+using Microsoft.Extensions.Logging;
 
 namespace Paramore.Brighter.Logging.Handlers
 {
@@ -38,7 +38,7 @@ namespace Paramore.Brighter.Logging.Handlers
     /// <typeparam name="TRequest">The type of the t request.</typeparam>
     public class RequestLoggingHandlerAsync<TRequest> : RequestHandlerAsync<TRequest> where TRequest : class, IRequest
     {
-        private static readonly Lazy<ILog> _logger = new Lazy<ILog>(LogProvider.For<RequestLoggingHandlerAsync<TRequest>>);
+        private static readonly ILogger s_logger= ApplicationLogging.CreateLogger<RequestLoggingHandlerAsync<TRequest>>();
 
         private HandlerTiming _timing;
 
@@ -92,13 +92,13 @@ namespace Paramore.Brighter.Logging.Handlers
         private void LogCommand(TRequest request)
         {
             //TODO: LibLog has no async support, so remains a blocking call for now
-            _logger.Value.InfoFormat("Logging handler pipeline call. Pipeline timing {0} target, for {1} with values of {2} at: {3}", _timing.ToString(), typeof(TRequest), JsonSerializer.Serialize(request), DateTime.UtcNow);
+            s_logger.LogInformation("Logging handler pipeline call. Pipeline timing {0} target, for {1} with values of {2} at: {3}", _timing.ToString(), typeof(TRequest), JsonSerializer.Serialize(request), DateTime.UtcNow);
         }
 
         private void LogFailure(TRequest request)
         {
             //TODO: LibLog has no async support, so remains a blocking call for now
-            _logger.Value.InfoFormat("Failure in pipeline call for {0} with values of {1} at: {2}", typeof(TRequest), JsonSerializer.Serialize(request), DateTime.UtcNow);
+            s_logger.LogInformation("Failure in pipeline call for {0} with values of {1} at: {2}", typeof(TRequest), JsonSerializer.Serialize(request), DateTime.UtcNow);
         }
     }
 }

--- a/src/Paramore.Brighter/Paramore.Brighter.csproj
+++ b/src/Paramore.Brighter/Paramore.Brighter.csproj
@@ -3,10 +3,10 @@
     <Description>The Command Dispatcher pattern is an addition to the Command design pattern that decouples the dispatcher for a service from its execution. A Command Dispatcher component maps commands to handlers. A Command Processor pattern provides a  framework for handling orthogonal concerns such as logging, timeouts, or circuit breakers</Description>
     <Authors>Ian Cooper</Authors>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <DefineConstants>$(DefineConstants);LIBLOG_PUBLIC</DefineConstants>
     <PackageTags>Command;Event;Command Dispatcher;Command Processor;Request;Service;Task Queue;Work Queue;Retry;Circuit Breaker;Availability</PackageTags>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="Polly" Version="7.2.2" />
     <PackageReference Include="System.Memory" Version="4.5.4" />
     <PackageReference Include="System.Text.Json" Version="5.0.2" />

--- a/src/Paramore.Brighter/Paramore.Brighter.csproj
+++ b/src/Paramore.Brighter/Paramore.Brighter.csproj
@@ -7,10 +7,6 @@
     <PackageTags>Command;Event;Command Dispatcher;Command Processor;Request;Service;Task Queue;Work Queue;Retry;Circuit Breaker;Availability</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="LibLog" Version="5.0.8">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Polly" Version="7.2.2" />
     <PackageReference Include="System.Memory" Version="4.5.4" />
     <PackageReference Include="System.Text.Json" Version="5.0.2" />

--- a/src/Paramore.Brighter/PipelineBuilder.cs
+++ b/src/Paramore.Brighter/PipelineBuilder.cs
@@ -29,6 +29,7 @@ using System.Collections.Generic;
 using Paramore.Brighter.Extensions;
 using Paramore.Brighter.Logging;
 using System.Reflection;
+using Microsoft.Extensions.Logging;
 using Paramore.Brighter.Inbox.Attributes;
 
 namespace Paramore.Brighter
@@ -36,7 +37,7 @@ namespace Paramore.Brighter
     public class PipelineBuilder<TRequest> : IAmAPipelineBuilder<TRequest>, IAmAnAsyncPipelineBuilder<TRequest>
         where TRequest : class, IRequest
     {
-        private static readonly Lazy<ILog> _logger = new Lazy<ILog>(LogProvider.For<PipelineBuilder<TRequest>>);
+        private static readonly ILogger s_logger= ApplicationLogging.CreateLogger<PipelineBuilder<TRequest>>();
 
         private readonly IAmAHandlerFactory _handlerFactory;
         private readonly InboxConfiguration _inboxConfiguration;
@@ -142,7 +143,7 @@ namespace Paramore.Brighter
             }
 
             AppendToPipeline(postAttributes, implicitHandler, requestContext);
-            _logger.Value.DebugFormat("New handler pipeline created: {0}", TracePipeline(firstInPipeline));
+            s_logger.LogDebug("New handler pipeline created: {0}", TracePipeline(firstInPipeline));
             return firstInPipeline;
         }
 
@@ -198,7 +199,7 @@ namespace Paramore.Brighter
             }
 
             AppendToAsyncPipeline(postAttributes, implicitHandler, requestContext);
-            _logger.Value.DebugFormat("New async handler pipeline created: {0}", TracePipeline(firstInPipeline));
+            s_logger.LogDebug("New async handler pipeline created: {0}", TracePipeline(firstInPipeline));
             return firstInPipeline;
         }
 

--- a/src/Paramore.Brighter/RequestHandler.cs
+++ b/src/Paramore.Brighter/RequestHandler.cs
@@ -1,4 +1,4 @@
-#region Licence
+﻿#region Licence
 /* The MIT License (MIT)
 Copyright © 2014 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
 
@@ -25,6 +25,7 @@ THE SOFTWARE. */
 using System;
 using System.Linq;
 using System.Reflection;
+using Microsoft.Extensions.Logging;
 using Paramore.Brighter.Logging;
 using Paramore.Brighter.Policies.Attributes;
 using Paramore.Brighter.Policies.Handlers;
@@ -48,7 +49,7 @@ namespace Paramore.Brighter
     /// <typeparam name="TRequest">The type of the t request.</typeparam>
     public abstract class RequestHandler<TRequest> : IHandleRequests<TRequest> where TRequest : class, IRequest
     {
-        private static readonly Lazy<ILog> _logger = new Lazy<ILog>(LogProvider.For<RequestHandler<TRequest>>);
+        private static readonly ILogger s_logger= ApplicationLogging.CreateLogger<RequestHandler<TRequest>>();
 
         private IHandleRequests<TRequest> _successor;
 
@@ -102,7 +103,7 @@ namespace Paramore.Brighter
         {
             if (_successor != null)
             {
-                _logger.Value.DebugFormat("Passing request from {0} to {1}", Name, _successor.Name);
+                s_logger.LogDebug("Passing request from {0} to {1}", Name, _successor.Name);
                 return _successor.Handle(command);
             }
 
@@ -132,7 +133,7 @@ namespace Paramore.Brighter
         {
             if (_successor != null)
             {
-                _logger.Value.DebugFormat("Falling back from {0} to {1}", Name, _successor.Name);
+                s_logger.LogDebug("Falling back from {0} to {1}", Name, _successor.Name);
                 return _successor.Fallback(command);
             }
 

--- a/src/Paramore.Brighter/RequestHandlerAsync.cs
+++ b/src/Paramore.Brighter/RequestHandlerAsync.cs
@@ -1,4 +1,4 @@
-#region Licence
+﻿#region Licence
 /* The MIT License (MIT)
 Copyright © 2014 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
 
@@ -27,6 +27,7 @@ using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Paramore.Brighter.Logging;
 using Paramore.Brighter.Policies.Attributes;
 using Paramore.Brighter.Policies.Handlers;
@@ -50,7 +51,7 @@ namespace Paramore.Brighter
     /// <typeparam name="TRequest">The type of the t request.</typeparam>
     public abstract class RequestHandlerAsync<TRequest> : IHandleRequestsAsync<TRequest> where TRequest : class, IRequest
     {
-        private static readonly Lazy<ILog> _logger = new Lazy<ILog>(LogProvider.For<RequestHandlerAsync<TRequest>>);
+        private static readonly ILogger s_logger= ApplicationLogging.CreateLogger<RequestHandlerAsync<TRequest>>();
 
         private IHandleRequestsAsync<TRequest> _successor;
 
@@ -114,7 +115,7 @@ namespace Paramore.Brighter
         {
             if (_successor != null)
             {
-                _logger.Value.DebugFormat("Passing request from {0} to {1}", Name, _successor.Name);
+                s_logger.LogDebug("Passing request from {0} to {1}", Name, _successor.Name);
                 return await _successor.HandleAsync(command, cancellationToken).ConfigureAwait(ContinueOnCapturedContext);
             }
 
@@ -145,7 +146,7 @@ namespace Paramore.Brighter
         {
             if (_successor != null)
             {
-                _logger.Value.DebugFormat("Falling back from {0} to {1}", Name, _successor.Name);
+                s_logger.LogDebug("Falling back from {0} to {1}", Name, _successor.Name);
                 return await _successor.FallbackAsync(command, cancellationToken).ConfigureAwait(ContinueOnCapturedContext);
             }
 

--- a/tests/Paramore.Brighter.PostgresSQL.Tests/PostgresSqlTestHelper.cs
+++ b/tests/Paramore.Brighter.PostgresSQL.Tests/PostgresSqlTestHelper.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 using Npgsql;
 using Paramore.Brighter.Inbox.Postgres;
 using Paramore.Brighter.Logging;
@@ -9,7 +10,7 @@ namespace Paramore.Brighter.PostgresSQL.Tests
 {
     internal class PostgresSqlTestHelper
     {
-        private static readonly Lazy<ILog> _logger = new Lazy<ILog>(LogProvider.For<PostgresSqlTestHelper>);
+        private static readonly ILogger s_logger = ApplicationLogging.CreateLogger<PostgresSqlTestHelper>();
         private readonly PostgreSqlSettings _postgreSqlSettings;
         private string _tableName;
         private readonly object syncObject = new object();
@@ -78,7 +79,7 @@ namespace Paramore.Brighter.PostgresSQL.Tests
                     {
                         if (sqlException.SqlState == PostgresErrorCodes.UniqueViolation)
                         {
-                            _logger.Value.Warn("PostgresSQL: We tried our best with errors around already created database, but failed");
+                            s_logger.LogWarning("PostgresSQL: We tried our best with errors around already created database, but failed");
                             return;
                         }
 


### PR DESCRIPTION
This is for issue #242 and potentially #1254
LibLog has been deprecated and the new kid in town is to use Microsoft.Extensions.Logging.

As we don't support passing a logger through our app so we have to use a static instance.

```csharp
    public static class ApplicationLogging
    {
        public static ILoggerFactory LoggerFactory { get; set; } = new LoggerFactory();
        public static ILogger CreateLogger<T>() => LoggerFactory.CreateLogger<T>();
    }
```

In DI extension stuff I grab the LoggerFactory from the container 
```csharp
            var loggerFactory = provider.GetService<ILoggerFactory>();
            ApplicationLogging.LoggerFactory = loggerFactory;
```

Have not done all the work to convert the logs to do structured logging for issue #1254 

