### PR TITLE
[Feature] Support different approaches to SNS Topic Validation

### DIFF
--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS/AWSMessagingGateway.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS/AWSMessagingGateway.cs
@@ -19,11 +19,11 @@ namespace Paramore.Brighter.MessagingGateway.AWSSQS
             _awsConnection = awsConnection;
         }
 
-        protected string EnsureTopic(RoutingKey topic, SnsAttributes attributes, OnMissingChannel makeTopic)
+        protected string EnsureTopic(RoutingKey topic, SnsAttributes attributes, TopicFindBy topicFindBy, OnMissingChannel makeTopic)
         {
             //on validate or assume, turn a routing key into a topicARN
             if ((makeTopic == OnMissingChannel.Assume) || (makeTopic == OnMissingChannel.Validate)) 
-                ValidateTopic(topic, attributes, makeTopic);
+                ValidateTopic(topic, topicFindBy, makeTopic);
             else if (makeTopic == OnMissingChannel.Create) CreateTopic(topic, attributes);
             return _channelTopicArn;
         }
@@ -45,6 +45,7 @@ namespace Paramore.Brighter.MessagingGateway.AWSSQS
                     Tags = new List<Tag> {new Tag {Key = "Source", Value = "Brighter"}}
                 };
                 
+                //create topic is idempotent, so safe to call even if topic already exists
                 var createTopic = snsClient.CreateTopicAsync(createTopicRequest).Result;
                 
                 if (!string.IsNullOrEmpty(createTopic.TopicArn))
@@ -54,53 +55,30 @@ namespace Paramore.Brighter.MessagingGateway.AWSSQS
             }
         }
 
-        private void ValidateTopic(RoutingKey topic, SnsAttributes attributes, OnMissingChannel onMissingChannel)
+        private void ValidateTopic(RoutingKey topic, TopicFindBy findTopicBy, OnMissingChannel onMissingChannel)
         {
-            if ((attributes != null) && (!string.IsNullOrEmpty(attributes.TopicARN)))
-            {
-                if (onMissingChannel == OnMissingChannel.Assume)
-                {
-                    _channelTopicArn = attributes.TopicARN;
-                    return;
-                }
-                else
-                {
-                    ValidateTopicByArn(attributes.TopicARN);
-                }
-            }
-
-            ValidateTopicByName(topic);
+            IValidateTopic topicValidationStrategy = GetTopicValidationStrategy(findTopicBy);
+            (bool exists, string topicArn) = topicValidationStrategy.Validate(topic);
+            if (exists)
+                _channelTopicArn = topicArn;
+            else
+                throw new BrokerUnreachableException(
+                    $"Topic validation error: could not find topic {topic}. Did you want Brighter to create infrastructure?");
         }
 
-        private bool ValidateTopicByArn(string topicArn)
+        private IValidateTopic GetTopicValidationStrategy(TopicFindBy findTopicBy)
         {
-            using (var snsClient = new AmazonSimpleNotificationServiceClient(_awsConnection.Credentials, _awsConnection.Region))
+            switch (findTopicBy)
             {
-                var response = snsClient.GetTopicAttributesAsync(new GetTopicAttributesRequest(topicArn))
-                    .GetAwaiter()
-                    .GetResult();
-                return ((response.HttpStatusCode == HttpStatusCode.OK) && (response.Attributes["TopicArn"] == topicArn));
+                case TopicFindBy.Arn:
+                    return new ValidateTopicByArn(_awsConnection.Credentials, _awsConnection.Region);
+                case TopicFindBy.Convention:
+                    return new ValidateTopicByArnConvention(_awsConnection.Credentials, _awsConnection.Region);
+                case TopicFindBy.Name:
+                    return new ValidateTopicByName(_awsConnection.Credentials, _awsConnection.Region);
+                default:
+                    throw new ConfigurationException("Unknown TopicFindBy used to determine how to read RoutingKey");
             }
-        }
-
-        private void ValidateTopicByName(RoutingKey topic)
-        {
-            using (var snsClient = new AmazonSimpleNotificationServiceClient(_awsConnection.Credentials, _awsConnection.Region))
-            {
-                var (success, arn) = FindTopicByName(topic.ToValidSNSTopicName(), snsClient);
-                if (success)
-                    _channelTopicArn = arn;
-                else
-                    throw new BrokerUnreachableException(
-                        $"Topic validation error: could not find topic {topic.ToValidSNSTopicName()}. Did you want Brighter to create infrastructure?");
-            }
-        }
-
-        //Note that we assume here that topic names are globally unique, if not provide the topic ARN directly in the SNSAttributes of the subscription
-        private static (bool success, string topicArn) FindTopicByName(RoutingKey topicName, AmazonSimpleNotificationServiceClient snsClient)
-        {
-            var topic = snsClient.FindTopicAsync(topicName.Value).GetAwaiter().GetResult();
-            return (topic != null, topic?.TopicArn);
         }
     }
 }

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS/ChannelFactory.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS/ChannelFactory.cs
@@ -61,7 +61,7 @@ namespace Paramore.Brighter.MessagingGateway.AWSSQS
                 SqsSubscription sqsSubscription = subscription as SqsSubscription;
                 _subscription = sqsSubscription ?? throw new ConfigurationException("We expect an SqsSubscription or SqsSubscription<T> as a parameter");
 
-                EnsureTopic(_subscription.RoutingKey, _subscription.SnsAttributes, _subscription.MakeChannels);
+                EnsureTopic(_subscription.RoutingKey, _subscription.SnsAttributes, _subscription.FindTopicBy, _subscription.MakeChannels);
                 EnsureQueue();
 
                 return new Channel(
@@ -269,7 +269,7 @@ namespace Paramore.Brighter.MessagingGateway.AWSSQS
                     .Result;
                 if (response.HttpStatusCode != HttpStatusCode.OK)
                 {
-                    throw new InvalidOperationException($"Unable to set subscription attribute for raw message delivery");
+                    throw new InvalidOperationException("Unable to set subscription attribute for raw message delivery");
                 }
             }
             else
@@ -360,7 +360,7 @@ namespace Paramore.Brighter.MessagingGateway.AWSSQS
                     catch (Exception)
                     {
                         //don't break on an exception here, if we can't delete, just exit
-                        s_logger.LogError($"Could not delete queue {queueExists.name}");
+                        s_logger.LogError("Could not delete queue {0}", queueExists.name);
                     }
                 }
             }
@@ -373,7 +373,7 @@ namespace Paramore.Brighter.MessagingGateway.AWSSQS
 
             using (var snsClient = new AmazonSimpleNotificationServiceClient(_awsConnection.Credentials, _awsConnection.Region))
             {
-                bool exists = FindTopicByArn(snsClient);
+                (bool exists, string topicArn) = new ValidateTopicByArn(snsClient).Validate(_channelTopicArn);
                 if (exists)
                 {
                     try
@@ -385,7 +385,7 @@ namespace Paramore.Brighter.MessagingGateway.AWSSQS
                     catch (Exception)
                     {
                         //don't break on an exception here, if we can't delete, just exit
-                        s_logger.LogError($"Could not delete topic {_channelTopicArn}");
+                        s_logger.LogError("Could not delete topic {0}", _channelTopicArn);
                     }
                 }
             }
@@ -396,19 +396,6 @@ namespace Paramore.Brighter.MessagingGateway.AWSSQS
             snsClient.DeleteTopicAsync(_channelTopicArn).GetAwaiter().GetResult();
         }
 
-
-        private bool FindTopicByArn(AmazonSimpleNotificationServiceClient snsClient)
-        {
-            bool exists = false;
-            ListTopicsResponse response;
-            do
-            {
-                response = snsClient.ListTopicsAsync().GetAwaiter().GetResult();
-                exists = response.Topics.Any(topic => topic.TopicArn == _channelTopicArn);
-            } while (!exists && response.NextToken != null);
-
-            return exists;
-        }
 
         private string GetQueueARNForChannel(AmazonSQSClient sqsClient)
         {
@@ -435,7 +422,7 @@ namespace Paramore.Brighter.MessagingGateway.AWSSQS
                     var unsubscribe = snsClient.UnsubscribeAsync(new UnsubscribeRequest {SubscriptionArn = sub.SubscriptionArn}).GetAwaiter().GetResult();
                     if (unsubscribe.HttpStatusCode != HttpStatusCode.OK)
                     {
-                        s_logger.LogError($"Error unsubscribing from {_channelTopicArn} for sub {sub.SubscriptionArn}");
+                        s_logger.LogError("Error unsubscribing from {0} for sub {1}", _channelTopicArn, sub.SubscriptionArn);
                     }
                 }
             } while (response.NextToken != null);

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS/IValidateTopic.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS/IValidateTopic.cs
@@ -1,0 +1,7 @@
+﻿namespace Paramore.Brighter.MessagingGateway.AWSSQS
+{
+    internal interface IValidateTopic
+    {
+        (bool, string TopicArn) Validate(string topic);
+    }
+}

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS/Paramore.Brighter.MessagingGateway.AWSSQS.csproj
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS/Paramore.Brighter.MessagingGateway.AWSSQS.csproj
@@ -9,6 +9,7 @@
     <ProjectReference Include="..\Paramore.Brighter\Paramore.Brighter.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.3" />
     <PackageReference Include="Polly" Version="7.2.2" />
     <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
     <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.0.13" />

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS/SnsAttributes.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS/SnsAttributes.cs
@@ -6,14 +6,6 @@ namespace Paramore.Brighter.MessagingGateway.AWSSQS
     public class SnsAttributes
     {
         /// <summary>
-        /// The ARN for a topic - the routing key forms the trailing part of this
-        /// i.e. arn:aws:sns:us-east-2:123456789012:MyTopic -- the routing key is MyTopic
-        /// If the TopicARN is set we assume external creation - we will use the topic at this ARN and
-        /// ignore other fields
-        /// </summary>
-        public string TopicARN { get; set; } = null;
-
-        /// <summary>
         /// The policy that defines how Amazon SNS retries failed deliveries to HTTP/S endpoints
         /// Ignored if TopicARN is set
         /// </summary>

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS/SqsMessageProducer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS/SqsMessageProducer.cs
@@ -45,7 +45,7 @@ namespace Paramore.Brighter.MessagingGateway.AWSSQS
             : base(connection)
         {
             _connection = connection;
-            _topicArn = EnsureTopic(new RoutingKey(publication.RoutingKey), publication.SnsAttributes, publication.MakeChannels);
+            _topicArn = EnsureTopic(new RoutingKey(publication.RoutingKey), publication.SnsAttributes, publication.FindTopicBy, publication.MakeChannels);
             MaxOutStandingMessages = publication.MaxOutStandingMessages;
             MaxOutStandingCheckIntervalMilliSeconds = publication.MaxOutStandingMessages;
         }

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS/SqsPublication.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS/SqsPublication.cs
@@ -3,6 +3,14 @@
     public class SqsPublication : Publication
     {
         /// <summary>
+        /// Indicates how we should treat the routing key
+        /// TopicFindBy.Arn -> the routing key is an Arn
+        /// TopicFindBy.Convention -> The routing key is a name, but use convention to make an Arn for this account
+        /// TopicFindBy.Name -> Treat the routing key as a name & use ListTopics to find it (rate limited 30/s)
+        /// </summary>
+
+        public TopicFindBy FindTopicBy { get; set; } = TopicFindBy.Convention;
+         /// <summary>
         /// Gets or sets the routing key or topic that this channel subscribes to on the broker.
         /// Either the topic name if we are creating or validating infrastructure
         /// Or the TopicARN if we are assuming infrastructure exists
@@ -15,6 +23,6 @@
         /// need to create or validate the SNS Topic
         /// </summary>
         public SnsAttributes SnsAttributes { get; set; }
-       
-    }
+
+   }
 }

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS/SqsSubscription.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS/SqsSubscription.cs
@@ -55,6 +55,14 @@ namespace Paramore.Brighter.MessagingGateway.AWSSQS
         public int MessageRetentionPeriod { get; }
 
         /// <summary>
+        /// Indicates how we should treat the routing key
+        /// TopicFindBy.Arn -> the routing key is an Arn
+        /// TopicFindBy.Convention -> The routing key is a name, but use convention to make an Arn for this account
+        /// TopicFindBy.Name -> Treat the routing key as a name & use ListTopics to find it (rate limited 30/s)
+        /// </summary>
+        public TopicFindBy FindTopicBy { get; }
+
+        /// <summary>
         ///  The JSON serialization of the queue's access control policy.
         /// </summary>
         public string IAMPolicy { get; }
@@ -93,6 +101,7 @@ namespace Paramore.Brighter.MessagingGateway.AWSSQS
         /// <param name="lockTimeout">What is the visibility timeout for the queue</param>
         /// <param name="delaySeconds">The length of time, in seconds, for which the delivery of all messages in the queue is delayed.</param>
         /// <param name="messageRetentionPeriod">The length of time, in seconds, for which Amazon SQS retains a message</param>
+        /// <param name="findTopicBy">Is the Topic an Arn, should be treated as an Arn by convention, or a name</param>
         /// <param name="iAmPolicy">The queue's policy. A valid AWS policy.</param>
         /// <param name="redrivePolicy">The policy that controls when and where requeued messages are sent to the DLQ</param>
         /// <param name="snsAttributes">The attributes of the Topic, either ARN if created, or attributes for creation</param>
@@ -113,6 +122,7 @@ namespace Paramore.Brighter.MessagingGateway.AWSSQS
             int lockTimeout = 10,
             int delaySeconds = 0,
             int messageRetentionPeriod = 345600,
+            TopicFindBy findTopicBy = TopicFindBy.Name,
             string iAmPolicy = null,
             RedrivePolicy redrivePolicy = null,
             SnsAttributes snsAttributes = null,
@@ -125,6 +135,7 @@ namespace Paramore.Brighter.MessagingGateway.AWSSQS
             LockTimeout = lockTimeout;
             DelaySeconds = delaySeconds;
             MessageRetentionPeriod = messageRetentionPeriod;
+            FindTopicBy = findTopicBy;
             IAMPolicy = iAmPolicy;
             RedrivePolicy = redrivePolicy;
             SnsAttributes = snsAttributes;
@@ -177,6 +188,7 @@ namespace Paramore.Brighter.MessagingGateway.AWSSQS
             int lockTimeout = 10,
             int delaySeconds = 0,
             int messageRetentionPeriod = 345600,
+            TopicFindBy findTopicBy = TopicFindBy.Name,
             string iAmPolicy = null,
             RedrivePolicy redrivePolicy = null,
             SnsAttributes snsAttributes = null,
@@ -184,7 +196,7 @@ namespace Paramore.Brighter.MessagingGateway.AWSSQS
             OnMissingChannel makeChannels = OnMissingChannel.Create
         )
             : base(typeof(T), name, channelName, routingKey, noOfPerformers, bufferSize, timeoutInMilliseconds, requeueCount, requeueDelayInMilliseconds,
-                unacceptableMessageLimit, runAsync, channelFactory, lockTimeout, delaySeconds, messageRetentionPeriod, iAmPolicy,redrivePolicy,
+                unacceptableMessageLimit, runAsync, channelFactory, lockTimeout, delaySeconds, messageRetentionPeriod,findTopicBy, iAmPolicy,redrivePolicy,
                 snsAttributes, tags, makeChannels)
         {
         }

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS/TopicFindBy.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS/TopicFindBy.cs
@@ -1,0 +1,16 @@
+﻿namespace Paramore.Brighter.MessagingGateway.AWSSQS
+{
+    /// <summary>
+    /// How do we validate the topic - when we opt to validate or create (already exists) infrastructure
+    /// Relates to how we interpret the RoutingKey. Is it an Arn (0 or 1) or a name (2)
+    /// 0 - The topic is supplied as an Arn, and should be checked with a GetTopicAttributes call. May be any account.
+    /// 1 - The topic is supplied as a name, and should be turned into an Arn and checked via a GetTopicAttributes call. Must be in caller's account.
+    /// 2 - The topic is supplies as a name, and should be checked by a ListTopics call. Must be in caller's account. Rate limited at 30 calls per second
+    /// </summary>
+    public enum TopicFindBy
+    {
+        Arn,
+        Convention,
+        Name,
+    }
+}

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS/ValidateTopicByArn.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS/ValidateTopicByArn.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Net;
+using Amazon;
+using Amazon.Runtime;
+using Amazon.SimpleNotificationService;
+using Amazon.SimpleNotificationService.Model;
+
+namespace Paramore.Brighter.MessagingGateway.AWSSQS
+{
+    public class ValidateTopicByArn : IDisposable, IValidateTopic
+    {
+        private AmazonSimpleNotificationServiceClient _snsClient;
+
+        public ValidateTopicByArn(AWSCredentials credentials, RegionEndpoint region)
+        {
+            _snsClient = new AmazonSimpleNotificationServiceClient(credentials, region);
+        }
+
+        public ValidateTopicByArn(AmazonSimpleNotificationServiceClient snsClient)
+        {
+            _snsClient = snsClient;
+        }
+
+        public virtual (bool, string TopicArn) Validate(string topicArn)
+        {
+            //List topics does not work across accounts - GetTopicAttributesRequest works within the region
+            //List Topics is rate limited to 30 ListTopic transactions per second, and can be rate limited
+            //So where we can, we validate a topic using GetTopicAttributesRequest
+            
+            bool exists = false;
+
+            try
+            {
+                var topicAttributes = _snsClient.GetTopicAttributesAsync(
+                    new GetTopicAttributesRequest(topicArn)
+                ).GetAwaiter().GetResult();
+
+                exists = ((topicAttributes.HttpStatusCode == HttpStatusCode.OK)  && (topicAttributes.Attributes["TopicArn"] == topicArn));
+            }
+            catch (InternalErrorException)
+            {
+                exists = false;
+            }
+            catch (NotFoundException)
+            {
+                exists = false;
+            }
+            catch (AuthorizationErrorException)
+            {
+                exists = false;
+            }
+
+            return (exists, topicArn);
+        }
+
+        public void Dispose()
+        {
+            _snsClient?.Dispose();
+        }
+    }
+}

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS/ValidateTopicByArnConvention.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS/ValidateTopicByArnConvention.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Net;
+using Amazon;
+using Amazon.Runtime;
+using Amazon.SecurityToken;
+using Amazon.SecurityToken.Model;
+
+namespace Paramore.Brighter.MessagingGateway.AWSSQS
+{
+    public class ValidateTopicByArnConvention : ValidateTopicByArn, IValidateTopic
+    {
+        private readonly RegionEndpoint _region;
+        private AmazonSecurityTokenServiceClient _stsClient;
+
+        public ValidateTopicByArnConvention(AWSCredentials credentials, RegionEndpoint region) : base(credentials, region)
+        {
+            _region = region;
+
+            _stsClient = new AmazonSecurityTokenServiceClient(credentials, region);
+        }
+
+        public override (bool, string TopicArn) Validate(string topic)
+        {
+            var topicArn = GetArnFromTopic(topic);
+            return base.Validate(topicArn);
+        }
+
+        private string GetArnFromTopic(string topicName)
+        {
+            var callerIdentityResponse = _stsClient.GetCallerIdentityAsync(
+                    new GetCallerIdentityRequest()
+                )
+                .GetAwaiter().GetResult();
+
+            if (callerIdentityResponse.HttpStatusCode != HttpStatusCode.OK) throw new InvalidCastException("Could not find identity of AWS account"); 
+
+            return new Arn
+            {
+                Partition = _region.PartitionName,
+                Service = "sns",
+                Region = _region.SystemName,
+                AccountId = callerIdentityResponse.Account,
+                Resource = topicName
+            }.ToString();
+        }
+    }
+}

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS/ValidateTopicByName.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS/ValidateTopicByName.cs
@@ -1,0 +1,30 @@
+﻿using Amazon;
+using Amazon.Runtime;
+using Amazon.SimpleNotificationService;
+
+namespace Paramore.Brighter.MessagingGateway.AWSSQS
+{
+    internal class ValidateTopicByName : IValidateTopic
+    {
+        private readonly AmazonSimpleNotificationServiceClient _snsClient;
+
+        public ValidateTopicByName(AWSCredentials credentials, RegionEndpoint region)
+        {
+            _snsClient = new AmazonSimpleNotificationServiceClient(credentials, region);
+        }
+        
+        public ValidateTopicByName(AmazonSimpleNotificationServiceClient snsClient)
+        {
+            _snsClient = snsClient;
+        }
+        
+        //Note that we assume here that topic names are globally unique, if not provide the topic ARN directly in the SNSAttributes of the subscription
+        //This approach can have be rate throttled at scale. AWS limits to 30 ListTopics calls per second, so it you have a lot of clients starting
+        //you may run into issues
+        public (bool, string TopicArn) Validate(string topicName)
+        {
+            var topic = _snsClient.FindTopicAsync(topicName).GetAwaiter().GetResult();
+            return (topic != null, topic?.TopicArn);
+        }
+    }
+}

--- a/tests/Paramore.Brighter.AWSSQS.Tests/MessagingGateway/When_infastructure_exists_can_verify_by_convention.cs
+++ b/tests/Paramore.Brighter.AWSSQS.Tests/MessagingGateway/When_infastructure_exists_can_verify_by_convention.cs
@@ -11,14 +11,14 @@ using Xunit;
 
 namespace Paramore.Brighter.AWSSQS.Tests.MessagingGateway
 {
-    public class AWSValidateInfrastructureTests  : IDisposable
+    public class AWSValidateInfrastructureByConventionTests  : IDisposable
     {     private readonly Message _message;
         private readonly IAmAMessageConsumer _consumer;
         private readonly SqsMessageProducer _messageProducer;
         private readonly ChannelFactory _channelFactory;
         private readonly MyCommand _myCommand;
 
-        public AWSValidateInfrastructureTests()
+        public AWSValidateInfrastructureByConventionTests()
         {
             _myCommand = new MyCommand{Value = "Test"};
             Guid correlationId = Guid.NewGuid();
@@ -50,23 +50,21 @@ namespace Paramore.Brighter.AWSSQS.Tests.MessagingGateway
             _channelFactory = new ChannelFactory(awsConnection);
             var channel = _channelFactory.CreateChannel(subscription);
             
-            //Now change the subscription to validate, just check what we made
+            //Now change the subscription to validate, just check what we made - will make the SNS Arn to prevent ListTopics call
             subscription = new(
                 name: new SubscriptionName(channelName),
                 channelName: channel.Name,
                 routingKey: routingKey,
-                findTopicBy: TopicFindBy.Name,
+                findTopicBy: TopicFindBy.Convention,
                 makeChannels: OnMissingChannel.Validate
             );
             
             _messageProducer = new SqsMessageProducer(
                 awsConnection, 
-                new SqsPublication
-                {
-                    FindTopicBy = TopicFindBy.Name,
+                new SqsPublication{
+                    FindTopicBy = TopicFindBy.Convention,
                     MakeChannels = OnMissingChannel.Validate, 
-                    RoutingKey = routingKey
-                }
+                    RoutingKey = routingKey}
                 );
 
             _consumer = new SqsMessageConsumerFactory(awsConnection).Create(subscription);


### PR DESCRIPTION
ListTopics is rate limited at 30 calls per second.  In a large deployment that can mean the strategy of clients validating an Arn or TopicName will be rate limited. it is better to use GetTopicAttributes via Arn where possible. This also allows validation of an Arn outside of the caller's account i.e. the publisher and subscriber are in different accounts. ListTopics only list topics for the account, but GetTopicAttributes works anywhere. 

GetTopicAttributes requires an SNS Arn. You either set the routing key to an arn, or we can infer the sns arn from the name by convention. Names inferred by convention will be assumed to be in the executing code's account - so the only way to get a cross-account Arn is to pass the Arn in directly, we can't infer from the executing code.

Find by name still works for the current account, it will make a List Topic call, which is rate limited to 30 per second
