### PR TITLE
Send Commands to the DLQ if their limit is reached #1519

### DIFF
--- a/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusMessageProducer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusMessageProducer.cs
@@ -80,6 +80,7 @@ namespace Paramore.Brighter.MessagingGateway.AzureServiceBus
 
                 var azureServiceBusMessage = new Microsoft.Azure.ServiceBus.Message(message.Body.Bytes);
                 azureServiceBusMessage.UserProperties.Add("MessageType", message.Header.MessageType.ToString());
+                azureServiceBusMessage.UserProperties.Add("HandledCount", message.Header.HandledCount);
                 if (delayMilliseconds == 0)
                 {
                     await topicClient.SendAsync(azureServiceBusMessage);

--- a/src/Paramore.Brighter.ServiceActivator/MessagePump.cs
+++ b/src/Paramore.Brighter.ServiceActivator/MessagePump.cs
@@ -126,17 +126,15 @@ namespace Paramore.Brighter.ServiceActivator
                 }
                 catch (DeferMessageAction)
                 {
-                    RequeueMessage(message);
-                    continue;
+                    if (!RequeueMessage(message)) continue;
                 }
                 catch (AggregateException aggregateException)
                 {
                     var (stop, requeue) = HandleProcessingException(aggregateException);
 
-                    if (requeue)   
+                    if (requeue)
                     {
-                        RequeueMessage(message);
-                        continue;
+                        if (!RequeueMessage(message)) continue;
                     }
 
                     if (stop)   
@@ -159,9 +157,6 @@ namespace Paramore.Brighter.ServiceActivator
                     s_logger.LogError(e,
                         "MessagePump: Failed to dispatch message '{Id}' from {ChannelName} on thread # {ManagementThreadId}",
                         message.Id, Channel.Name, Thread.CurrentThread.ManagedThreadId);
-
-                    // if Message was Rejected then go on to next Iteration, no need to ACK
-                    if(!RequeueMessage(message)) continue;
                 }
 
                 AcknowledgeMessage(message);

--- a/src/Paramore.Brighter.ServiceActivator/TestHelpers/FakeChannel.cs
+++ b/src/Paramore.Brighter.ServiceActivator/TestHelpers/FakeChannel.cs
@@ -1,4 +1,4 @@
-#region Licence
+﻿#region Licence
 /* The MIT License (MIT)
 Copyright © 2014 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
 
@@ -35,6 +35,7 @@ namespace Paramore.Brighter.ServiceActivator.TestHelpers
         public bool AcknowledgeHappened { get; set; }
         public int AcknowledgeCount { get; set; }
         public int RejectCount { get; set; }
+        public int RequeueCount { get; set; }
         public virtual ChannelName Name { get; }
         public virtual int Length => _messageQueue.Count;
 
@@ -76,6 +77,7 @@ namespace Paramore.Brighter.ServiceActivator.TestHelpers
 
         public virtual void Requeue(Message message, int delayMilliseconds = 0)
         {
+            RequeueCount++;
             _messageQueue.Enqueue(message);
         }
 

--- a/src/Paramore.Brighter/MessageHeader.cs
+++ b/src/Paramore.Brighter/MessageHeader.cs
@@ -286,9 +286,6 @@ namespace Paramore.Brighter
                 var hashCode = Id.GetHashCode();
                 hashCode = (hashCode * 397) ^ (Topic != null ? Topic.GetHashCode() : 0);
                 hashCode = (hashCode * 397) ^ (int)MessageType;
-                hashCode = (hashCode * 397) ^ TimeStamp.GetHashCode();
-                hashCode = (hashCode * 397) ^ HandledCount.GetHashCode();
-                hashCode = (hashCode * 397) ^ DelayedMilliseconds.GetHashCode();
                 return hashCode;
             }
         }

--- a/tests/Paramore.Brighter.Core.Tests/MessageDispatch/TestDoubles/SpyCommandProcessor.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageDispatch/TestDoubles/SpyCommandProcessor.cs
@@ -190,4 +190,50 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch.TestDoubles
             throw new AggregateException("Failed to publish to one more handlers successfully, see inner exceptions for details", exceptions);
         }
     }
+
+    internal class SpyThrowingCommandProcessor : SpyCommandProcessor
+    {
+        public int SendCount { get; set; }
+        public int PublishCount { get; set; }
+
+        public SpyThrowingCommandProcessor()
+        {
+            SendCount = 0;
+            PublishCount = 0;
+        }
+
+        public override void Send<T>(T command)
+        {
+            base.Send(command);
+            SendCount++;
+            throw new Exception("Something went wrong");
+        }
+
+        public override void Publish<T>(T @event)
+        {
+            base.Publish(@event);
+            PublishCount++;
+
+            var exceptions = new List<Exception> { new Exception("Something went wrong.") };
+
+            throw new AggregateException("Failed to publish to one more handlers successfully, see inner exceptions for details", exceptions);
+        }
+
+        public override async Task SendAsync<T>(T command, bool continueOnCapturedContext = false, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            await base.SendAsync(command, continueOnCapturedContext, cancellationToken);
+            SendCount++;
+            throw new Exception("Something went wrong");
+        }
+
+        public override async Task PublishAsync<T>(T @event, bool continueOnCapturedContext = false, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            await base.PublishAsync(@event, continueOnCapturedContext, cancellationToken);
+            PublishCount++;
+
+            var exceptions = new List<Exception> { new Exception("Something went wrong.") };
+
+            throw new AggregateException("Failed to publish to one more handlers successfully, see inner exceptions for details", exceptions);
+        }
+    }
 }

--- a/tests/Paramore.Brighter.Core.Tests/MessageDispatch/TestDoubles/SpyCommandProcessor.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageDispatch/TestDoubles/SpyCommandProcessor.cs
@@ -189,41 +189,11 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch.TestDoubles
 
             throw new AggregateException("Failed to publish to one more handlers successfully, see inner exceptions for details", exceptions);
         }
-    }
-
-    internal class SpyThrowingCommandProcessor : SpyCommandProcessor
-    {
-        public int SendCount { get; set; }
-        public int PublishCount { get; set; }
-
-        public SpyThrowingCommandProcessor()
-        {
-            SendCount = 0;
-            PublishCount = 0;
-        }
-
-        public override void Send<T>(T command)
-        {
-            base.Send(command);
-            SendCount++;
-            throw new Exception("Something went wrong");
-        }
-
-        public override void Publish<T>(T @event)
-        {
-            base.Publish(@event);
-            PublishCount++;
-
-            var exceptions = new List<Exception> { new Exception("Something went wrong.") };
-
-            throw new AggregateException("Failed to publish to one more handlers successfully, see inner exceptions for details", exceptions);
-        }
-
         public override async Task SendAsync<T>(T command, bool continueOnCapturedContext = false, CancellationToken cancellationToken = default(CancellationToken))
         {
             await base.SendAsync(command, continueOnCapturedContext, cancellationToken);
             SendCount++;
-            throw new Exception("Something went wrong");
+            throw new DeferMessageAction();
         }
 
         public override async Task PublishAsync<T>(T @event, bool continueOnCapturedContext = false, CancellationToken cancellationToken = default(CancellationToken))
@@ -231,9 +201,10 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch.TestDoubles
             await base.PublishAsync(@event, continueOnCapturedContext, cancellationToken);
             PublishCount++;
 
-            var exceptions = new List<Exception> { new Exception("Something went wrong.") };
+            var exceptions = new List<Exception> { new DeferMessageAction() };
 
             throw new AggregateException("Failed to publish to one more handlers successfully, see inner exceptions for details", exceptions);
         }
+
     }
 }

--- a/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_a_command_handler_throws_Then_message_is_requeued_until_rejected.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_a_command_handler_throws_Then_message_is_requeued_until_rejected.cs
@@ -23,7 +23,6 @@ THE SOFTWARE. */
 #endregion
 
 using System;
-using System.Text.Json;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
@@ -34,27 +33,26 @@ using Paramore.Brighter.ServiceActivator.TestHelpers;
 
 namespace Paramore.Brighter.Core.Tests.MessageDispatch
 {
-    public class MessagePumpUnacceptableMessageTests
+    public class MessagePumpCommandProcessingExceptionTests
     {
         private readonly IAmAMessagePump _messagePump;
         private readonly FakeChannel _channel;
-        private readonly SpyRequeueCommandProcessor _commandProcessor;
+        private readonly SpyThrowingCommandProcessor _commandProcessor;
+        private readonly int _requeueCount = 5;
 
-        public MessagePumpUnacceptableMessageTests()
+        public MessagePumpCommandProcessingExceptionTests()
         {
-            _commandProcessor = new SpyRequeueCommandProcessor();
+            _commandProcessor = new SpyThrowingCommandProcessor();
             _channel = new FakeChannel();
-            var mapper = new MyEventMessageMapper();
-            _messagePump = new MessagePumpBlocking<MyEvent>(_commandProcessor, mapper) { Channel = _channel, TimeoutInMilliseconds = 5000, RequeueCount = 3 };
+            var mapper = new MyCommandMessageMapper();
+            _messagePump = new MessagePumpBlocking<MyCommand>(_commandProcessor, mapper) { Channel = _channel, TimeoutInMilliseconds = 5000, RequeueCount = _requeueCount };
 
-            var myMessage = JsonSerializer.Serialize(new MyEvent());
-            var unacceptableMessage = new Message(new MessageHeader(Guid.NewGuid(), "MyTopic", MessageType.MT_UNACCEPTABLE), new MessageBody(myMessage));
-
-            _channel.Enqueue(unacceptableMessage);
+            var msg = mapper.MapToMessage(new MyCommand());
+            _channel.Enqueue(msg);
         }
 
         [Fact]
-        public void When_An_Unacceptable_Message_Is_Recieved()
+        public void When_a_command_handler_throws_Then_message_is_requeued_until_rejected()
         {
             var task = Task.Factory.StartNew(() => _messagePump.Run(), TaskCreationOptions.LongRunning);
             Task.Delay(1000).Wait();
@@ -64,8 +62,8 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch
 
             Task.WaitAll(new[] { task });
 
-            //should_acknowledge_the_message
-            _channel.AcknowledgeHappened.Should().BeTrue();
+            _channel.RequeueCount.Should().Be(_requeueCount-1);
+            _channel.RejectCount.Should().Be(1);
         }
     }
 }

--- a/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_a_command_handler_throws_Then_message_is_requeued_until_rejected.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_a_command_handler_throws_Then_message_is_requeued_until_rejected.cs
@@ -37,12 +37,12 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch
     {
         private readonly IAmAMessagePump _messagePump;
         private readonly FakeChannel _channel;
-        private readonly SpyThrowingCommandProcessor _commandProcessor;
+        private readonly SpyRequeueCommandProcessor _commandProcessor;
         private readonly int _requeueCount = 5;
 
         public MessagePumpCommandProcessingExceptionTests()
         {
-            _commandProcessor = new SpyThrowingCommandProcessor();
+            _commandProcessor = new SpyRequeueCommandProcessor();
             _channel = new FakeChannel();
             var mapper = new MyCommandMessageMapper();
             _messagePump = new MessagePumpBlocking<MyCommand>(_commandProcessor, mapper) { Channel = _channel, TimeoutInMilliseconds = 5000, RequeueCount = _requeueCount };

--- a/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_a_command_handler_throws_Then_message_is_requeued_until_rejectedAsync.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_a_command_handler_throws_Then_message_is_requeued_until_rejectedAsync.cs
@@ -23,7 +23,6 @@ THE SOFTWARE. */
 #endregion
 
 using System;
-using System.Text.Json;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
@@ -34,27 +33,26 @@ using Paramore.Brighter.ServiceActivator.TestHelpers;
 
 namespace Paramore.Brighter.Core.Tests.MessageDispatch
 {
-    public class MessagePumpUnacceptableMessageTests
+    public class MessagePumpCommandProcessingExceptionTestsAsync
     {
         private readonly IAmAMessagePump _messagePump;
         private readonly FakeChannel _channel;
-        private readonly SpyRequeueCommandProcessor _commandProcessor;
+        private readonly SpyThrowingCommandProcessor _commandProcessor;
+        private readonly int _requeueCount = 5;
 
-        public MessagePumpUnacceptableMessageTests()
+        public MessagePumpCommandProcessingExceptionTestsAsync()
         {
-            _commandProcessor = new SpyRequeueCommandProcessor();
+            _commandProcessor = new SpyThrowingCommandProcessor();
             _channel = new FakeChannel();
-            var mapper = new MyEventMessageMapper();
-            _messagePump = new MessagePumpBlocking<MyEvent>(_commandProcessor, mapper) { Channel = _channel, TimeoutInMilliseconds = 5000, RequeueCount = 3 };
+            var mapper = new MyCommandMessageMapper();
+            _messagePump = new MessagePumpAsync<MyCommand>(_commandProcessor, mapper) { Channel = _channel, TimeoutInMilliseconds = 5000, RequeueCount = _requeueCount };
 
-            var myMessage = JsonSerializer.Serialize(new MyEvent());
-            var unacceptableMessage = new Message(new MessageHeader(Guid.NewGuid(), "MyTopic", MessageType.MT_UNACCEPTABLE), new MessageBody(myMessage));
-
-            _channel.Enqueue(unacceptableMessage);
+            var msg = mapper.MapToMessage(new MyCommand());
+            _channel.Enqueue(msg);
         }
 
         [Fact]
-        public void When_An_Unacceptable_Message_Is_Recieved()
+        public void When_a_command_handler_throws_Then_message_is_requeued_until_rejectedAsync()
         {
             var task = Task.Factory.StartNew(() => _messagePump.Run(), TaskCreationOptions.LongRunning);
             Task.Delay(1000).Wait();
@@ -64,8 +62,8 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch
 
             Task.WaitAll(new[] { task });
 
-            //should_acknowledge_the_message
-            _channel.AcknowledgeHappened.Should().BeTrue();
+            _channel.RequeueCount.Should().Be(_requeueCount-1);
+            _channel.RejectCount.Should().Be(1);
         }
     }
 }

--- a/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_an_event_handler_throws_Then_message_is_requeued_until_rejected.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_an_event_handler_throws_Then_message_is_requeued_until_rejected.cs
@@ -33,26 +33,26 @@ using Paramore.Brighter.ServiceActivator.TestHelpers;
 
 namespace Paramore.Brighter.Core.Tests.MessageDispatch
 {
-    public class MessagePumpCommandProcessingExceptionTestsAsync
+    public class MessagePumpEventProcessingExceptionTests
     {
         private readonly IAmAMessagePump _messagePump;
         private readonly FakeChannel _channel;
         private readonly SpyRequeueCommandProcessor _commandProcessor;
         private readonly int _requeueCount = 5;
 
-        public MessagePumpCommandProcessingExceptionTestsAsync()
+        public MessagePumpEventProcessingExceptionTests()
         {
             _commandProcessor = new SpyRequeueCommandProcessor();
             _channel = new FakeChannel();
-            var mapper = new MyCommandMessageMapper();
-            _messagePump = new MessagePumpAsync<MyCommand>(_commandProcessor, mapper) { Channel = _channel, TimeoutInMilliseconds = 5000, RequeueCount = _requeueCount };
+            var mapper = new MyEventMessageMapper();
+            _messagePump = new MessagePumpBlocking<MyEvent>(_commandProcessor, mapper) { Channel = _channel, TimeoutInMilliseconds = 5000, RequeueCount = _requeueCount };
 
-            var msg = mapper.MapToMessage(new MyCommand());
+            var msg = mapper.MapToMessage(new MyEvent());
             _channel.Enqueue(msg);
         }
 
         [Fact]
-        public void When_a_command_handler_throws_Then_message_is_requeued_until_rejectedAsync()
+        public void When_an_event_handler_throws_Then_message_is_requeued_until_rejected()
         {
             var task = Task.Factory.StartNew(() => _messagePump.Run(), TaskCreationOptions.LongRunning);
             Task.Delay(1000).Wait();

--- a/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_an_event_handler_throws_Then_message_is_requeued_until_rejectedAsync.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_an_event_handler_throws_Then_message_is_requeued_until_rejectedAsync.cs
@@ -33,26 +33,26 @@ using Paramore.Brighter.ServiceActivator.TestHelpers;
 
 namespace Paramore.Brighter.Core.Tests.MessageDispatch
 {
-    public class MessagePumpCommandProcessingExceptionTestsAsync
+    public class MessagePumpEventProcessingExceptionTestsAsync
     {
         private readonly IAmAMessagePump _messagePump;
         private readonly FakeChannel _channel;
         private readonly SpyRequeueCommandProcessor _commandProcessor;
         private readonly int _requeueCount = 5;
 
-        public MessagePumpCommandProcessingExceptionTestsAsync()
+        public MessagePumpEventProcessingExceptionTestsAsync()
         {
             _commandProcessor = new SpyRequeueCommandProcessor();
             _channel = new FakeChannel();
-            var mapper = new MyCommandMessageMapper();
-            _messagePump = new MessagePumpAsync<MyCommand>(_commandProcessor, mapper) { Channel = _channel, TimeoutInMilliseconds = 5000, RequeueCount = _requeueCount };
+            var mapper = new MyEventMessageMapper();
+            _messagePump = new MessagePumpAsync<MyEvent>(_commandProcessor, mapper) { Channel = _channel, TimeoutInMilliseconds = 5000, RequeueCount = _requeueCount };
 
-            var msg = mapper.MapToMessage(new MyCommand());
+            var msg = mapper.MapToMessage(new MyEvent());
             _channel.Enqueue(msg);
         }
 
         [Fact]
-        public void When_a_command_handler_throws_Then_message_is_requeued_until_rejectedAsync()
+        public void When_an_event_handler_throws_Then_message_is_requeued_until_rejectedAsync()
         {
             var task = Task.Factory.StartNew(() => _messagePump.Run(), TaskCreationOptions.LongRunning);
             Task.Delay(1000).Wait();


### PR DESCRIPTION
The Code so Far works (Based on my Unit Tests, will run sample app against them soon) for Commands (not events at this stage, I've got a few Questions there 😊

Anyway, I have set the Pump to Requeue on Generic Error as this will mean that if you set the Retry count to 0 it will Automatically Reject the Message.

The next Change I have made is to have RequeueMessage return a Bool to denote Weather the Message was Requeue or Rejected, This is because if we have Rejected we shouldn't still need to Acknowledge The Message, also we had it set to ACK the Message if Disposal was Turned on and the Count was exceeded, I feel this should be where we do our Reject of the Message

In Terms of Action of Transports in our System they Have the following Actions

ASB
	-> Reject : Currently Nothing, Proposed DLQ if Non Destructive read enabled (Peek Lock / AckOnRead)
	-> Requeue : Producer.Send
	
Kafka
	-> Reject: ACK
	-> Requeue: Nothing
	
MSSQL
	-> Reject: Not Implemented
	-> Requeue : Send

Redis
	-> Reject: Remove
	-> Requeue: Add new, Remove Existing

RestMS
	-> Reject: Nothing
	-> Requeue: Nothing

RMQ
	-> Reject: Reject
	-> Requeue: Basic Publish

SQS
	-> Reject: DLQ\Delete
	-> Requeue: Change Visibility