### PR TITLE
Aligned Unit Tests with the TopicClient Async Calls

### DIFF
--- a/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusConsumer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusConsumer.cs
@@ -130,7 +130,7 @@ namespace Paramore.Brighter.MessagingGateway.AzureServiceBus
         private static int GetHandledCount(IBrokeredMessageWrapper azureServiceBusMessage)
         {
             var count = 0;
-            if (azureServiceBusMessage.UserProperties.ContainsKey("HandledCount"))
+            if (azureServiceBusMessage.UserProperties != null && azureServiceBusMessage.UserProperties.ContainsKey("HandledCount"))
             {
                 int.TryParse(azureServiceBusMessage.UserProperties["HandledCount"].ToString(), out count);
             }

--- a/tests/Paramore.Brighter.AzureServiceBus.Tests/AzureServiceBusMessageProducerTests.cs
+++ b/tests/Paramore.Brighter.AzureServiceBus.Tests/AzureServiceBusMessageProducerTests.cs
@@ -31,13 +31,13 @@ namespace Paramore.Brighter.AzureServiceBus.Tests
 
             _nameSpaceManagerWrapper.Setup(t => t.TopicExists("topic")).Returns(true);
             _topicClientProvider.Setup(f => f.Get("topic")).Returns(_topicClient.Object);
-            _topicClient.Setup(f => f.Send(It.IsAny<Microsoft.Azure.ServiceBus.Message>())).Callback((Microsoft.Azure.ServiceBus.Message g) => sentMessage = g);
+            _topicClient.Setup(f => f.SendAsync(It.IsAny<Microsoft.Azure.ServiceBus.Message>())).Callback((Microsoft.Azure.ServiceBus.Message g) => sentMessage = g);
 
             _producer.Send(new Message(new MessageHeader(Guid.NewGuid(), "topic", MessageType.MT_EVENT), new MessageBody(messageBody, "JSON")));
 
             Assert.Equal(messageBody, sentMessage.Body);
             Assert.Equal("MT_EVENT", sentMessage.UserProperties["MessageType"]);
-            _topicClient.Verify(x => x.Close(), Times.Once);
+            _topicClient.Verify(x => x.CloseAsync(), Times.Once);
         }
 
         [Fact]
@@ -48,13 +48,13 @@ namespace Paramore.Brighter.AzureServiceBus.Tests
 
             _nameSpaceManagerWrapper.Setup(t => t.TopicExists("topic")).Returns(true);
             _topicClientProvider.Setup(f => f.Get("topic")).Returns(_topicClient.Object);
-            _topicClient.Setup(f => f.Send(It.IsAny<Microsoft.Azure.ServiceBus.Message>())).Callback((Microsoft.Azure.ServiceBus.Message g) => sentMessage = g);
+            _topicClient.Setup(f => f.SendAsync(It.IsAny<Microsoft.Azure.ServiceBus.Message>())).Callback((Microsoft.Azure.ServiceBus.Message g) => sentMessage = g);
 
             _producer.Send(new Message(new MessageHeader(Guid.NewGuid(), "topic", MessageType.MT_COMMAND), new MessageBody(messageBody, "JSON")));
 
             Assert.Equal(messageBody, sentMessage.Body);
             Assert.Equal("MT_COMMAND", sentMessage.UserProperties["MessageType"]);
-            _topicClient.Verify(x => x.Close(), Times.Once);
+            _topicClient.Verify(x => x.CloseAsync(), Times.Once);
         }
 
         [Fact]
@@ -65,7 +65,7 @@ namespace Paramore.Brighter.AzureServiceBus.Tests
 
             _nameSpaceManagerWrapper.Setup(t => t.TopicExists("topic")).Returns(false);
             _topicClientProvider.Setup(f => f.Get("topic")).Returns(_topicClient.Object);
-            _topicClient.Setup(f => f.Send(It.IsAny<Microsoft.Azure.ServiceBus.Message>())).Callback((Microsoft.Azure.ServiceBus.Message g) => sentMessage = g);
+            _topicClient.Setup(f => f.SendAsync(It.IsAny<Microsoft.Azure.ServiceBus.Message>())).Callback((Microsoft.Azure.ServiceBus.Message g) => sentMessage = g);
 
             _producer.Send(new Message(new MessageHeader(Guid.NewGuid(), "topic", MessageType.MT_NONE), new MessageBody(messageBody, "JSON")));
 
@@ -79,7 +79,7 @@ namespace Paramore.Brighter.AzureServiceBus.Tests
             _nameSpaceManagerWrapper.Setup(t => t.TopicExists("topic")).Returns(true);
             _topicClientProvider.Setup(f => f.Get("topic")).Returns(_topicClient.Object);
 
-            _topicClient.Setup(x => x.Send(It.IsAny<Microsoft.Azure.ServiceBus.Message>())).Throws(new Exception("Failed"));
+            _topicClient.Setup(x => x.SendAsync(It.IsAny<Microsoft.Azure.ServiceBus.Message>())).Throws(new Exception("Failed"));
 
             try
             {
@@ -90,7 +90,7 @@ namespace Paramore.Brighter.AzureServiceBus.Tests
                 // ignored
             }
 
-            _topicClient.Verify(x => x.Close(), Times.Once);
+            _topicClient.Verify(x => x.CloseAsync(), Times.Once);
         }
 
         [Fact]
@@ -101,13 +101,13 @@ namespace Paramore.Brighter.AzureServiceBus.Tests
 
             _nameSpaceManagerWrapper.Setup(t => t.TopicExists("topic")).Returns(true);
             _topicClientProvider.Setup(f => f.Get("topic")).Returns(_topicClient.Object);
-            _topicClient.Setup(f => f.ScheduleMessage(It.IsAny<Microsoft.Azure.ServiceBus.Message>(), It.IsAny<DateTimeOffset>())).Callback((Microsoft.Azure.ServiceBus.Message g, DateTimeOffset d) => sentMessage = g);
+            _topicClient.Setup(f => f.ScheduleMessageAsync(It.IsAny<Microsoft.Azure.ServiceBus.Message>(), It.IsAny<DateTimeOffset>())).Callback((Microsoft.Azure.ServiceBus.Message g, DateTimeOffset d) => sentMessage = g);
 
             _producer.SendWithDelay(new Message(new MessageHeader(Guid.NewGuid(), "topic", MessageType.MT_EVENT), new MessageBody(messageBody, "JSON")), 1);
 
             Assert.Equal(messageBody, sentMessage.Body);
             Assert.Equal("MT_EVENT", sentMessage.UserProperties["MessageType"]);
-            _topicClient.Verify(x => x.Close(), Times.Once);
+            _topicClient.Verify(x => x.CloseAsync(), Times.Once);
         }
 
         [Fact]
@@ -118,13 +118,13 @@ namespace Paramore.Brighter.AzureServiceBus.Tests
 
             _nameSpaceManagerWrapper.Setup(t => t.TopicExists("topic")).Returns(true);
             _topicClientProvider.Setup(f => f.Get("topic")).Returns(_topicClient.Object);
-            _topicClient.Setup(f => f.ScheduleMessage(It.IsAny<Microsoft.Azure.ServiceBus.Message>(), It.IsAny<DateTimeOffset>())).Callback((Microsoft.Azure.ServiceBus.Message g, DateTimeOffset d) => sentMessage = g);
+            _topicClient.Setup(f => f.ScheduleMessageAsync(It.IsAny<Microsoft.Azure.ServiceBus.Message>(), It.IsAny<DateTimeOffset>())).Callback((Microsoft.Azure.ServiceBus.Message g, DateTimeOffset d) => sentMessage = g);
 
             _producer.SendWithDelay(new Message(new MessageHeader(Guid.NewGuid(), "topic", MessageType.MT_COMMAND), new MessageBody(messageBody, "JSON")), 1);
 
             Assert.Equal(messageBody, sentMessage.Body);
             Assert.Equal("MT_COMMAND", sentMessage.UserProperties["MessageType"]);
-            _topicClient.Verify(x => x.Close(), Times.Once);
+            _topicClient.Verify(x => x.CloseAsync(), Times.Once);
         }
 
         [Fact]
@@ -135,13 +135,13 @@ namespace Paramore.Brighter.AzureServiceBus.Tests
 
             _nameSpaceManagerWrapper.Setup(t => t.TopicExists("topic")).Returns(false);
             _topicClientProvider.Setup(f => f.Get("topic")).Returns(_topicClient.Object);
-            _topicClient.Setup(f => f.ScheduleMessage(It.IsAny<Microsoft.Azure.ServiceBus.Message>(), It.IsAny<DateTimeOffset>())).Callback((Microsoft.Azure.ServiceBus.Message g, DateTimeOffset d) => sentMessage = g);
+            _topicClient.Setup(f => f.ScheduleMessageAsync(It.IsAny<Microsoft.Azure.ServiceBus.Message>(), It.IsAny<DateTimeOffset>())).Callback((Microsoft.Azure.ServiceBus.Message g, DateTimeOffset d) => sentMessage = g);
 
             _producer.SendWithDelay(new Message(new MessageHeader(Guid.NewGuid(), "topic", MessageType.MT_NONE), new MessageBody(messageBody, "JSON")), 1);
 
             _nameSpaceManagerWrapper.Verify(x => x.CreateTopic("topic"), Times.Once);
             Assert.Equal(messageBody, sentMessage.Body);
-            _topicClient.Verify(x => x.Close(), Times.Once);
+            _topicClient.Verify(x => x.CloseAsync(), Times.Once);
         }
 
         [Theory]
@@ -173,7 +173,7 @@ namespace Paramore.Brighter.AzureServiceBus.Tests
 
             _nameSpaceManagerWrapper.Setup(t => t.TopicExists("topic")).Throws(new Exception());
 
-            Assert.Throws<Exception>(() => _producer.SendWithDelay(new Message(new MessageHeader(Guid.NewGuid(), "topic", MessageType.MT_NONE), new MessageBody(messageBody, "JSON")), 1));
+            Assert.ThrowsAsync<Exception>(() => _producer.SendWithDelayAsync(new Message(new MessageHeader(Guid.NewGuid(), "topic", MessageType.MT_NONE), new MessageBody(messageBody, "JSON")), 1));
             _nameSpaceManagerWrapper.Verify(managementClientWrapper => managementClientWrapper.Reset(), Times.Once);
         }
 
@@ -191,7 +191,7 @@ namespace Paramore.Brighter.AzureServiceBus.Tests
 
             _producer.SendWithDelay(new Message(new MessageHeader(Guid.NewGuid(), "topic", MessageType.MT_NONE), new MessageBody(messageBody, "JSON")));
 
-            _topicClient.Verify(topicClient => topicClient.Send(It.IsAny<Microsoft.Azure.ServiceBus.Message>()), Times.Once);
+            _topicClient.Verify(topicClient => topicClient.SendAsync(It.IsAny<Microsoft.Azure.ServiceBus.Message>()), Times.Once);
         }
 
         [Fact]
@@ -201,7 +201,7 @@ namespace Paramore.Brighter.AzureServiceBus.Tests
 
             var producerValidate = new AzureServiceBusMessageProducer(_nameSpaceManagerWrapper.Object, _topicClientProvider.Object, OnMissingChannel.Validate);
 
-            Assert.Throws<ChannelFailureException>(() => producerValidate.Send(new Message(new MessageHeader(Guid.NewGuid(), "topic", MessageType.MT_NONE), new MessageBody(messageBody, "JSON"))));
+            Assert.ThrowsAsync<ChannelFailureException>(() => producerValidate.SendAsync(new Message(new MessageHeader(Guid.NewGuid(), "topic", MessageType.MT_NONE), new MessageBody(messageBody, "JSON"))));
         }
     }
 }


### PR DESCRIPTION
@iancooper This will fix the Red Tests, looks due to the implementation of Async Producer the Moq's were relying on TopicClient sending not Sending Async