### PR TITLE
Use topic from message header, allow send to multiple topics

### DIFF
--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS/SqsPublication.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS/SqsPublication.cs
@@ -10,13 +10,6 @@
         /// </summary>
 
         public TopicFindBy FindTopicBy { get; set; } = TopicFindBy.Convention;
-         /// <summary>
-        /// Gets or sets the routing key or topic that this channel subscribes to on the broker.
-        /// Either the topic name if we are creating or validating infrastructure
-        /// Or the TopicARN if we are assuming infrastructure exists
-        /// </summary>
-        /// <value>The name.</value>
-        public RoutingKey RoutingKey { get; set; } 
         
         /// <summary>
         /// The attributes of the topic. If TopicARN is set we will always assume that we do not

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS/SqsPublication.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS/SqsPublication.cs
@@ -1,4 +1,6 @@
-﻿namespace Paramore.Brighter.MessagingGateway.AWSSQS
+﻿using System.Collections.Generic;
+
+namespace Paramore.Brighter.MessagingGateway.AWSSQS
 {
     public class SqsPublication : Publication
     {
@@ -12,10 +14,17 @@
         public TopicFindBy FindTopicBy { get; set; } = TopicFindBy.Convention;
         
         /// <summary>
-        /// The attributes of the topic. If TopicARN is set we will always assume that we do not
+        /// The attributes of the topic. If TopicARNs is set we will always assume that we do not
         /// need to create or validate the SNS Topic
         /// </summary>
         public SnsAttributes SnsAttributes { get; set; }
 
-   }
+        /// <summary>
+        /// If we want to use topic Arns and not topics you need to supply a mapping file that tells us
+        /// the Arn to use for any message that you send to us, as we use the topic from the header to dispatch to
+        /// an Arn.
+        /// Internally we construct this routing table when creating on other paths
+        /// </summary>
+        public Dictionary<string,string> TopicArns { get; set; }
+    }
 }

--- a/tests/Paramore.Brighter.AWSSQS.Tests/MessagingGateway/When_a_message_consumer_reads_multiple_messages.cs
+++ b/tests/Paramore.Brighter.AWSSQS.Tests/MessagingGateway/When_a_message_consumer_reads_multiple_messages.cs
@@ -50,8 +50,7 @@ namespace Paramore.Brighter.AWSSQS.Tests.MessagingGateway
             _messageProducer = new SqsMessageProducer(awsConnection, 
                 new SqsPublication
                 {
-                    MakeChannels = OnMissingChannel.Create, 
-                    RoutingKey = routingKey
+                    MakeChannels = OnMissingChannel.Create 
                 });
         }
             

--- a/tests/Paramore.Brighter.AWSSQS.Tests/MessagingGateway/When_infastructure_exists_can_assume.cs
+++ b/tests/Paramore.Brighter.AWSSQS.Tests/MessagingGateway/When_infastructure_exists_can_assume.cs
@@ -59,7 +59,7 @@ namespace Paramore.Brighter.AWSSQS.Tests.MessagingGateway
                 makeChannels: OnMissingChannel.Assume
             );
             
-            _messageProducer = new SqsMessageProducer(awsConnection, new SqsPublication{MakeChannels = OnMissingChannel.Assume, RoutingKey = routingKey});
+            _messageProducer = new SqsMessageProducer(awsConnection, new SqsPublication{MakeChannels = OnMissingChannel.Assume});
 
             _consumer = new SqsMessageConsumer(awsConnection, channel.Name.ToValidSQSQueueName(), routingKey);
         }

--- a/tests/Paramore.Brighter.AWSSQS.Tests/MessagingGateway/When_infastructure_exists_can_verify.cs
+++ b/tests/Paramore.Brighter.AWSSQS.Tests/MessagingGateway/When_infastructure_exists_can_verify.cs
@@ -66,8 +66,7 @@ namespace Paramore.Brighter.AWSSQS.Tests.MessagingGateway
                 new SqsPublication
                 {
                     FindTopicBy = TopicFindBy.Name,
-                    MakeChannels = OnMissingChannel.Validate, 
-                    RoutingKey = routingKey
+                    MakeChannels = OnMissingChannel.Validate
                 }
                 );
 

--- a/tests/Paramore.Brighter.AWSSQS.Tests/MessagingGateway/When_infastructure_exists_can_verify_by_arn.cs
+++ b/tests/Paramore.Brighter.AWSSQS.Tests/MessagingGateway/When_infastructure_exists_can_verify_by_arn.cs
@@ -70,8 +70,7 @@ namespace Paramore.Brighter.AWSSQS.Tests.MessagingGateway
                 new SqsPublication
                 {
                     FindTopicBy = TopicFindBy.Arn,
-                    MakeChannels = OnMissingChannel.Validate, 
-                    RoutingKey = routingKeyArn
+                    MakeChannels = OnMissingChannel.Validate
                 });
 
             _consumer = new SqsMessageConsumerFactory(awsConnection).Create(subscription);

--- a/tests/Paramore.Brighter.AWSSQS.Tests/MessagingGateway/When_infastructure_exists_can_verify_by_arn.cs
+++ b/tests/Paramore.Brighter.AWSSQS.Tests/MessagingGateway/When_infastructure_exists_can_verify_by_arn.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
@@ -69,6 +70,7 @@ namespace Paramore.Brighter.AWSSQS.Tests.MessagingGateway
                 awsConnection, 
                 new SqsPublication
                 {
+                    TopicArns = new Dictionary<string, string>(){{topicName, topicArn}},
                     FindTopicBy = TopicFindBy.Arn,
                     MakeChannels = OnMissingChannel.Validate
                 });

--- a/tests/Paramore.Brighter.AWSSQS.Tests/MessagingGateway/When_infastructure_exists_can_verify_by_convention.cs
+++ b/tests/Paramore.Brighter.AWSSQS.Tests/MessagingGateway/When_infastructure_exists_can_verify_by_convention.cs
@@ -65,8 +65,8 @@ namespace Paramore.Brighter.AWSSQS.Tests.MessagingGateway
                 awsConnection, 
                 new SqsPublication{
                     FindTopicBy = TopicFindBy.Convention,
-                    MakeChannels = OnMissingChannel.Validate, 
-                    RoutingKey = routingKey}
+                    MakeChannels = OnMissingChannel.Validate 
+                    }
                 );
 
             _consumer = new SqsMessageConsumerFactory(awsConnection).Create(subscription);

--- a/tests/Paramore.Brighter.AWSSQS.Tests/MessagingGateway/When_posting_a_message_via_the_messaging_gateway.cs
+++ b/tests/Paramore.Brighter.AWSSQS.Tests/MessagingGateway/When_posting_a_message_via_the_messaging_gateway.cs
@@ -51,7 +51,7 @@ namespace Paramore.Brighter.AWSSQS.Tests.MessagingGateway
             _channelFactory = new ChannelFactory(awsConnection);
             _channel = _channelFactory.CreateChannel(subscription);
             
-            _messageProducer = new SqsMessageProducer(awsConnection, new SqsPublication{MakeChannels = OnMissingChannel.Create, RoutingKey = routingKey});
+            _messageProducer = new SqsMessageProducer(awsConnection, new SqsPublication{MakeChannels = OnMissingChannel.Create});
         }
 
 

--- a/tests/Paramore.Brighter.AWSSQS.Tests/MessagingGateway/When_queues_missing_assume_throws.cs
+++ b/tests/Paramore.Brighter.AWSSQS.Tests/MessagingGateway/When_queues_missing_assume_throws.cs
@@ -34,8 +34,7 @@ namespace Paramore.Brighter.AWSSQS.Tests.MessagingGateway
             var _ = new SqsMessageProducer(awsConnection, 
                 new SqsPublication
                 {
-                    MakeChannels = OnMissingChannel.Create, 
-                    RoutingKey = routingKey
+                    MakeChannels = OnMissingChannel.Create 
                 });
             
             _channelFactory = new ChannelFactory(awsConnection);

--- a/tests/Paramore.Brighter.AWSSQS.Tests/MessagingGateway/When_queues_missing_assume_throws.cs
+++ b/tests/Paramore.Brighter.AWSSQS.Tests/MessagingGateway/When_queues_missing_assume_throws.cs
@@ -31,11 +31,14 @@ namespace Paramore.Brighter.AWSSQS.Tests.MessagingGateway
             var awsConnection = new AWSMessagingGatewayConnection(credentials, region);
             
             //create the topic, we want the queue to be the issue
-            var _ = new SqsMessageProducer(awsConnection, 
+            //We need to create the topic at least, to check the queues
+            var producer = new SqsMessageProducer(awsConnection, 
                 new SqsPublication
                 {
                     MakeChannels = OnMissingChannel.Create 
                 });
+            
+           producer.ConfirmTopicExists(topicName); 
             
             _channelFactory = new ChannelFactory(awsConnection);
             var channel = _channelFactory.CreateChannel(subscription);

--- a/tests/Paramore.Brighter.AWSSQS.Tests/MessagingGateway/When_queues_missing_verify_throws.cs
+++ b/tests/Paramore.Brighter.AWSSQS.Tests/MessagingGateway/When_queues_missing_verify_throws.cs
@@ -35,8 +35,7 @@ namespace Paramore.Brighter.AWSSQS.Tests.MessagingGateway
             var _ = new SqsMessageProducer(_awsConnection, 
                 new SqsPublication
                 {
-                    MakeChannels = OnMissingChannel.Create, 
-                    RoutingKey = routingKey
+                    MakeChannels = OnMissingChannel.Create 
                 });
         }
 

--- a/tests/Paramore.Brighter.AWSSQS.Tests/MessagingGateway/When_queues_missing_verify_throws.cs
+++ b/tests/Paramore.Brighter.AWSSQS.Tests/MessagingGateway/When_queues_missing_verify_throws.cs
@@ -32,11 +32,13 @@ namespace Paramore.Brighter.AWSSQS.Tests.MessagingGateway
             _awsConnection = new AWSMessagingGatewayConnection(credentials, region);
             
             //We need to create the topic at least, to check the queues
-            var _ = new SqsMessageProducer(_awsConnection, 
+            var producer = new SqsMessageProducer(_awsConnection, 
                 new SqsPublication
                 {
                     MakeChannels = OnMissingChannel.Create 
                 });
+           producer.ConfirmTopicExists(topicName); 
+            
         }
 
         [Fact]

--- a/tests/Paramore.Brighter.AWSSQS.Tests/MessagingGateway/When_rejecting_a_message_through_gateway_with_requeue.cs
+++ b/tests/Paramore.Brighter.AWSSQS.Tests/MessagingGateway/When_rejecting_a_message_through_gateway_with_requeue.cs
@@ -49,7 +49,7 @@ namespace Paramore.Brighter.AWSSQS.Tests.MessagingGateway
             _channelFactory = new ChannelFactory(awsConnection);
             _channel = _channelFactory.CreateChannel(subscription);
             
-            _messageProducer = new SqsMessageProducer(awsConnection, new SqsPublication{MakeChannels = OnMissingChannel.Create, RoutingKey = routingKey});
+            _messageProducer = new SqsMessageProducer(awsConnection, new SqsPublication{MakeChannels = OnMissingChannel.Create});
         }
 
         [Fact]

--- a/tests/Paramore.Brighter.AWSSQS.Tests/MessagingGateway/When_requeueing_a_message.cs
+++ b/tests/Paramore.Brighter.AWSSQS.Tests/MessagingGateway/When_requeueing_a_message.cs
@@ -47,7 +47,7 @@ namespace Paramore.Brighter.AWSSQS.Tests.MessagingGateway
             (AWSCredentials credentials, RegionEndpoint region) = CredentialsChain.GetAwsCredentials();
             var awsConnection = new AWSMessagingGatewayConnection(credentials, region);
             
-            _sender = new SqsMessageProducer(awsConnection, new SqsPublication{MakeChannels = OnMissingChannel.Create, RoutingKey = routingKey});
+            _sender = new SqsMessageProducer(awsConnection, new SqsPublication{MakeChannels = OnMissingChannel.Create});
             
             //We need to do this manually in a test - will create the channel from subscriber parameters
             _channelFactory = new ChannelFactory(awsConnection);

--- a/tests/Paramore.Brighter.AWSSQS.Tests/MessagingGateway/When_requeueing_redrives_to_the_dlq.cs
+++ b/tests/Paramore.Brighter.AWSSQS.Tests/MessagingGateway/When_requeueing_redrives_to_the_dlq.cs
@@ -55,7 +55,7 @@ namespace Paramore.Brighter.AWSSQS.Tests.MessagingGateway
             (AWSCredentials credentials, RegionEndpoint region) = CredentialsChain.GetAwsCredentials();
             _awsConnection = new AWSMessagingGatewayConnection(credentials, region);
             
-            _sender = new SqsMessageProducer(_awsConnection, new SqsPublication{MakeChannels = OnMissingChannel.Create, RoutingKey = routingKey});
+            _sender = new SqsMessageProducer(_awsConnection, new SqsPublication{MakeChannels = OnMissingChannel.Create});
             
             //We need to do this manually in a test - will create the channel from subscriber parameters
             _channelFactory = new ChannelFactory(_awsConnection);

--- a/tests/Paramore.Brighter.AWSSQS.Tests/MessagingGateway/When_topic_missing_verify_throws.cs
+++ b/tests/Paramore.Brighter.AWSSQS.Tests/MessagingGateway/When_topic_missing_verify_throws.cs
@@ -33,8 +33,7 @@ namespace Paramore.Brighter.AWSSQS.Tests.MessagingGateway
                     _awsConnection, 
                     new SqsPublication
                     {
-                        MakeChannels = OnMissingChannel.Validate, 
-                        RoutingKey = _routingKey
+                        MakeChannels = OnMissingChannel.Validate 
                     }));
         }
    }

--- a/tests/Paramore.Brighter.AWSSQS.Tests/MessagingGateway/When_topic_missing_verify_throws.cs
+++ b/tests/Paramore.Brighter.AWSSQS.Tests/MessagingGateway/When_topic_missing_verify_throws.cs
@@ -28,13 +28,16 @@ namespace Paramore.Brighter.AWSSQS.Tests.MessagingGateway
         public void When_topic_missing_verify_throws()
         {
             //arrange
-            Assert.Throws<BrokerUnreachableException>(() => 
-                new SqsMessageProducer(
-                    _awsConnection, 
-                    new SqsPublication
-                    {
-                        MakeChannels = OnMissingChannel.Validate 
-                    }));
+            var producer = new SqsMessageProducer(_awsConnection, 
+                new SqsPublication
+                {
+                    MakeChannels = OnMissingChannel.Validate
+                });
+            
+            //act && assert
+            Assert.Throws<BrokerUnreachableException>(() => producer.Send(new Message(
+                new MessageHeader{Topic = _routingKey, ContentType = "plain/text"},
+                new MessageBody("Test"))));
         }
    }
 }


### PR DESCRIPTION
This follows the pattern elsewhere of taking the topic from the message header so as to allow re-use of a producer across topics. Will only check the first time that a given topic exists, acting as per publication on create/find