### PR TITLE
Outbox scoped provider

### DIFF
--- a/samples/ASBTaskQueueExamples/GreetingsReceiverConsole/Program.cs
+++ b/samples/ASBTaskQueueExamples/GreetingsReceiverConsole/Program.cs
@@ -46,7 +46,7 @@ namespace GreetingsReceiverConsole
                     };
 
                     //create the gateway
-                    var asbConfig = new AzureServiceBusConfiguration("Endpoint=sb://fim-development-bus.servicebus.windows.net/;Authentication=Managed Identity", true);
+                    var asbConfig = new AzureServiceBusConfiguration("Endpoint=sb://.servicebus.windows.net/;Authentication=Managed Identity", true);
 
                     var asbConsumerFactory = new AzureServiceBusConsumerFactory(asbConfig);
                     services.AddServiceActivator(options =>

--- a/samples/ASBTaskQueueExamples/GreetingsSender.Web/Controllers/HomeController.cs
+++ b/samples/ASBTaskQueueExamples/GreetingsSender.Web/Controllers/HomeController.cs
@@ -47,6 +47,21 @@ namespace GreetingsSender.Web.Controllers
             return View("Index");
         }
         
+        public async Task<IActionResult> DepositMessage()
+        {
+            var greetingAsync = new GreetingAsyncEvent("Deposit Hello from the web");
+            var greeting = new GreetingEvent("Deposit Hello from the web");
+
+            _context.Greetings.Add(greeting);
+            _context.GreetingsAsync.Add(greetingAsync);
+            await _context.SaveChangesAsync();
+            
+            _commandProcessor.DepositPost(greeting);
+            await _commandProcessor.DepositPostAsync(greetingAsync);
+            
+            return View("Index");
+        }
+        
         public async Task<IActionResult> SaveAndRollbackMessage()
         {
             var transaction = await _context.Database.BeginTransactionAsync();
@@ -61,8 +76,8 @@ namespace GreetingsSender.Web.Controllers
                 
                 await _context.SaveChangesAsync();
             
-                _commandProcessor.Post(greeting);
-                await _commandProcessor.PostAsync(greetingAsync);
+                _commandProcessor.DepositPost(greeting);
+                await _commandProcessor.DepositPostAsync(greetingAsync);
                 //throw new Exception("Something went wrong");
             // }
             // catch (Exception e)
@@ -81,7 +96,15 @@ namespace GreetingsSender.Web.Controllers
 
             await _context.SaveChangesAsync();
             
-            await _commandProcessor.DepositPostAsync(greetingAsync2); 
+            await _commandProcessor.DepositPostAsync(greetingAsync2);
+
+            var msgs = new List<Guid>();
+            // msgs.Add(greeting.Id);
+            // msgs.Add(greetingAsync.Id);
+            msgs.Add(greeting2.Id);
+            msgs.Add(greetingAsync2.Id);
+
+            await _commandProcessor.ClearOutboxAsync(msgs);
             
             return View("Index");
         }

--- a/samples/ASBTaskQueueExamples/GreetingsSender.Web/Startup.cs
+++ b/samples/ASBTaskQueueExamples/GreetingsSender.Web/Startup.cs
@@ -52,8 +52,9 @@ namespace GreetingsSender.Web
                     opt.CommandProcessorLifetime = ServiceLifetime.Scoped;
                 })
                 .UseExternalBus(producer)
-                //.UseMsSqlOutbox(outboxConfig, typeof(MsSqlOutboxSqlAuthConnectionFactory))
-                .UseMsSqlOutbox(outboxConfig, typeof(MsSqlEntityFrameworkCoreConnectionProvider<GreetingsDataContext>), ServiceLifetime.Scoped)
+                .UseMsSqlOutbox(outboxConfig, typeof(MsSqlSqlAuthConnectionProvider))
+                //.UseMsSqlOutbox(outboxConfig, typeof(MsSqlEntityFrameworkCoreConnectionProvider<GreetingsDataContext>), ServiceLifetime.Scoped)
+                .UseOverridingMsSqlConnectionProvider(typeof(MsSqlEntityFrameworkCoreConnectionProvider<GreetingsDataContext>))
                 .MapperRegistry(r =>
                 {
                     r.Add(typeof(GreetingEvent), typeof(GreetingEventMessageMapper));

--- a/samples/ASBTaskQueueExamples/GreetingsSender.Web/Startup.cs
+++ b/samples/ASBTaskQueueExamples/GreetingsSender.Web/Startup.cs
@@ -54,7 +54,7 @@ namespace GreetingsSender.Web
                 .UseExternalBus(producer)
                 .UseMsSqlOutbox(outboxConfig, typeof(MsSqlSqlAuthConnectionProvider))
                 //.UseMsSqlOutbox(outboxConfig, typeof(MsSqlEntityFrameworkCoreConnectionProvider<GreetingsDataContext>), ServiceLifetime.Scoped)
-                .UseOverridingMsSqlConnectionProvider(typeof(MsSqlEntityFrameworkCoreConnectionProvider<GreetingsDataContext>))
+                .UseMsSqlTransactionConnectionProvider(typeof(MsSqlEntityFrameworkCoreConnectionProvider<GreetingsDataContext>))
                 .MapperRegistry(r =>
                 {
                     r.Add(typeof(GreetingEvent), typeof(GreetingEventMessageMapper));

--- a/samples/ASBTaskQueueExamples/GreetingsSender.Web/Views/Home/Index.cshtml
+++ b/samples/ASBTaskQueueExamples/GreetingsSender.Web/Views/Home/Index.cshtml
@@ -6,5 +6,6 @@
     <h1 class="display-4">Welcome</h1>
     <p>Learn about <a href="https://docs.microsoft.com/aspnet/core">building Web apps with ASP.NET Core</a>.</p>
     <a class="btn btn-secondary" asp-action="SendMessage">Send Message</a>
+    <a class="btn btn-secondary" asp-action="DepositMessage">Deposit Message</a>
     <a class="btn btn-secondary" asp-action="SaveAndRollbackMessage">Send and Rollback Message</a>
 </div>

--- a/samples/ASBTaskQueueExamples/GreetingsSender/Program.cs
+++ b/samples/ASBTaskQueueExamples/GreetingsSender/Program.cs
@@ -15,7 +15,7 @@ namespace GreetingsSender
 
             serviceCollection.AddLogging();
 
-            var asbConnection = new AzureServiceBusConfiguration("Endpoint=sb://fim-development-bus.servicebus.windows.net/;Authentication=Managed Identity", true);
+            var asbConnection = new AzureServiceBusConfiguration("Endpoint=sb://.servicebus.windows.net/;Authentication=Managed Identity", true);
 
             var producer = AzureServiceBusMessageProducerFactory.Get(asbConnection);
             serviceCollection.AddBrighter()
@@ -32,10 +32,14 @@ namespace GreetingsSender
             while (run)
             {
                 Console.WriteLine("Sending....");
-
+                var distroGreeting = new GreetingEvent("Paul - Distributed");
+                commandProcessor.DepositPost(distroGreeting);
+                
                 commandProcessor.Post(new GreetingEvent("Paul"));
                 commandProcessor.Post(new GreetingAsyncEvent("Paul - Async"));
 
+                commandProcessor.ClearOutbox(distroGreeting.Id);
+                
                 Console.WriteLine("Press q to Quit or any other key to continue");
 
                 var keyPress = Console.ReadKey();

--- a/src/Paramore.Brighter.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Paramore.Brighter.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -126,7 +126,7 @@ namespace Paramore.Brighter.Extensions.DependencyInjection
 
             var outbox = provider.GetService<IAmAnOutbox<Message>>();
             var asyncOutbox = provider.GetService<IAmAnOutboxAsync<Message>>();
-            var overridingConnectionProvider = provider.GetService<IAmABoxConnectionProvider>();
+            var overridingConnectionProvider = provider.GetService<IAmABoxTransactionConnectionProvider>();
 
             if (outbox == null) outbox = new InMemoryOutbox();
             if (asyncOutbox == null) asyncOutbox = new InMemoryOutbox();

--- a/src/Paramore.Brighter.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Paramore.Brighter.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -126,10 +126,11 @@ namespace Paramore.Brighter.Extensions.DependencyInjection
 
             var outbox = provider.GetService<IAmAnOutbox<Message>>();
             var asyncOutbox = provider.GetService<IAmAnOutboxAsync<Message>>();
+            var overridingConnectionProvider = provider.GetService<IAmABoxConnectionProvider>();
 
             if (outbox == null) outbox = new InMemoryOutbox();
             if (asyncOutbox == null) asyncOutbox = new InMemoryOutbox();
-            
+
             var producer = provider.GetService<IAmAMessageProducer>();
             var asyncProducer = provider.GetService<IAmAMessageProducerAsync>();
 
@@ -148,7 +149,7 @@ namespace Paramore.Brighter.Extensions.DependencyInjection
             {
                 externalBusBuilder = producer == null
                     ? messagingBuilder.NoExternalBus()
-                    : messagingBuilder.ExternalBus(new MessagingConfiguration(producer, asyncProducer, messageMapperRegistry), outbox);
+                    : messagingBuilder.ExternalBus(new MessagingConfiguration(producer, asyncProducer, messageMapperRegistry), outbox, overridingConnectionProvider);
             }
             else
             {
@@ -163,7 +164,7 @@ namespace Paramore.Brighter.Extensions.DependencyInjection
                         ? messagingBuilder.ExternalRPC(new MessagingConfiguration(
                             producer, messageMapperRegistry,
                             responseChannelFactory: options.ChannelFactory))
-                        : messagingBuilder.ExternalBus(new MessagingConfiguration(producer, asyncProducer, messageMapperRegistry), outbox);
+                        : messagingBuilder.ExternalBus(new MessagingConfiguration(producer, asyncProducer, messageMapperRegistry), outbox, overridingConnectionProvider);
                 }
             }
 

--- a/src/Paramore.Brighter.MsSql.Azure/MsSqlAzureConnectionProviderBase.cs
+++ b/src/Paramore.Brighter.MsSql.Azure/MsSqlAzureConnectionProviderBase.cs
@@ -7,7 +7,7 @@ using Microsoft.Data.SqlClient;
 
 namespace Paramore.Brighter.MsSql.Azure
 {
-    public abstract class MsSqlAzureConnectionProviderBase
+    public abstract class MsSqlAzureConnectionProviderBase : IMsSqlConnectionProvider
     {
         private readonly bool _cacheTokens;
         private const string _azureScope = "https://database.windows.net/.default";

--- a/src/Paramore.Brighter.MsSql.EntityFrameworkCore/MsSqlEntityFrameworkCoreConnectionProvider.cs
+++ b/src/Paramore.Brighter.MsSql.EntityFrameworkCore/MsSqlEntityFrameworkCoreConnectionProvider.cs
@@ -6,7 +6,7 @@ using Microsoft.EntityFrameworkCore.Storage;
 
 namespace Paramore.Brighter.MsSql.EntityFrameworkCore
 {
-    public class MsSqlEntityFrameworkCoreConnectionProvider<T> : IMsSqlConnectionProvider where T : DbContext
+    public class MsSqlEntityFrameworkCoreConnectionProvider<T> : IMsSqlTransactionConnectionProvider where T : DbContext
     {
         private readonly T _context;
         

--- a/src/Paramore.Brighter.MsSql.EntityFrameworkCore/Paramore.Brighter.MsSql.EntityFrameworkCore.csproj
+++ b/src/Paramore.Brighter.MsSql.EntityFrameworkCore/Paramore.Brighter.MsSql.EntityFrameworkCore.csproj
@@ -9,6 +9,7 @@
 
     <ItemGroup>
       <ProjectReference Include="..\Paramore.Brighter.MsSql\Paramore.Brighter.MsSql.csproj" />
+      <ProjectReference Include="..\Paramore.Brighter\Paramore.Brighter.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Paramore.Brighter.MsSql/IMsSqlConnectionProvider.cs
+++ b/src/Paramore.Brighter.MsSql/IMsSqlConnectionProvider.cs
@@ -4,7 +4,7 @@ using Microsoft.Data.SqlClient;
 
 namespace Paramore.Brighter.MsSql
 {
-    public interface IMsSqlConnectionProvider : IAmABoxConnectionProvider
+    public interface IMsSqlConnectionProvider
     {
         SqlConnection GetConnection();
         Task<SqlConnection> GetConnectionAsync(CancellationToken cancellationToken = default(CancellationToken));

--- a/src/Paramore.Brighter.MsSql/IMsSqlConnectionProvider.cs
+++ b/src/Paramore.Brighter.MsSql/IMsSqlConnectionProvider.cs
@@ -4,7 +4,7 @@ using Microsoft.Data.SqlClient;
 
 namespace Paramore.Brighter.MsSql
 {
-    public interface IMsSqlConnectionProvider
+    public interface IMsSqlConnectionProvider : IAmABoxConnectionProvider
     {
         SqlConnection GetConnection();
         Task<SqlConnection> GetConnectionAsync(CancellationToken cancellationToken = default(CancellationToken));

--- a/src/Paramore.Brighter.MsSql/IMsSqlTransactionConnectionProvider.cs
+++ b/src/Paramore.Brighter.MsSql/IMsSqlTransactionConnectionProvider.cs
@@ -1,0 +1,9 @@
+﻿using Microsoft.Data.SqlClient;
+
+namespace Paramore.Brighter.MsSql
+{
+    public interface IMsSqlTransactionConnectionProvider : IMsSqlConnectionProvider, IAmABoxTransactionConnectionProvider
+    {
+        
+    }
+}

--- a/src/Paramore.Brighter.MsSql/Paramore.Brighter.MsSql.csproj
+++ b/src/Paramore.Brighter.MsSql/Paramore.Brighter.MsSql.csproj
@@ -11,4 +11,8 @@
       <PackageReference Include="Microsoft.Data.SqlClient" Version="3.0.0" />
     </ItemGroup>
 
+    <ItemGroup>
+      <ProjectReference Include="..\Paramore.Brighter\Paramore.Brighter.csproj" />
+    </ItemGroup>
+
 </Project>

--- a/src/Paramore.Brighter.Outbox.DynamoDB/DynamoDbOutbox.cs
+++ b/src/Paramore.Brighter.Outbox.DynamoDB/DynamoDbOutbox.cs
@@ -62,7 +62,7 @@ namespace Paramore.Brighter.Outbox.DynamoDB
         /// </summary>       
         /// <param name="message">The message to be stored</param>
         /// <param name="outBoxTimeout">Timeout in milliseconds; -1 for default timeout</param>
-        public void Add(Message message, int outBoxTimeout = -1)
+        public void Add(Message message, int outBoxTimeout = -1, IAmABoxTransactionConnectionProvider transactionConnectionProvider = null)
         {
             AddAsync(message, outBoxTimeout).ConfigureAwait(ContinueOnCapturedContext).GetAwaiter().GetResult();
         }
@@ -74,7 +74,7 @@ namespace Paramore.Brighter.Outbox.DynamoDB
         /// <param name="message">The message to be stored</param>
         /// <param name="outBoxTimeout">Timeout in milliseconds; -1 for default timeout</param>
         /// <param name="cancellationToken">Allows the sender to cancel the request pipeline. Optional</param>        
-        public async Task AddAsync(Message message, int outBoxTimeout = -1, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task AddAsync(Message message, int outBoxTimeout = -1, CancellationToken cancellationToken = default(CancellationToken), IAmABoxTransactionConnectionProvider transactionConnectionProvider = null)
         {
             var messageToStore = new MessageItem(message);
 

--- a/src/Paramore.Brighter.Outbox.EventStore/EventStoreOutbox.cs
+++ b/src/Paramore.Brighter.Outbox.EventStore/EventStoreOutbox.cs
@@ -76,7 +76,7 @@ namespace Paramore.Brighter.Outbox.EventStore
         /// <param name="message">The message.</param>
         /// <param name="outBoxTimeout">The outBoxTimeout.</param>
         /// <returns>Task.</returns>
-        public void Add(Message message, int outBoxTimeout = -1)
+        public void Add(Message message, int outBoxTimeout = -1, IAmABoxTransactionConnectionProvider transactionConnectionProvider = null)
         {
             s_logger.LogDebug("Adding message to Event Store Outbox: {Request}", JsonSerializer.Serialize(message, JsonSerialisationOptions.Options));
 
@@ -98,7 +98,7 @@ namespace Paramore.Brighter.Outbox.EventStore
         /// <param name="cancellationToken">Allows the sender to cancel the request pipeline. Optional</param>
         /// <returns><see cref="Task"/>.</returns>
         public async Task AddAsync(Message message, int outBoxTimeout = -1,
-            CancellationToken cancellationToken = default(CancellationToken))
+            CancellationToken cancellationToken = default(CancellationToken), IAmABoxTransactionConnectionProvider transactionConnectionProvider = null)
         {
             s_logger.LogDebug("Adding message to Event Store Outbox: {Request}", JsonSerializer.Serialize(message, JsonSerialisationOptions.Options));
 

--- a/src/Paramore.Brighter.Outbox.MsSql/MsSqlOutbox.cs
+++ b/src/Paramore.Brighter.Outbox.MsSql/MsSqlOutbox.cs
@@ -86,14 +86,14 @@ namespace Paramore.Brighter.Outbox.MsSql
         /// </summary>
         /// <param name="message">The message.</param>
         /// <param name="outBoxTimeout"></param>
-        /// <param name="overridingConnectionProvider">Connection Provider to use for this call</param>
+        /// <param name="transactionConnectionProvider">Connection Provider to use for this call</param>
         /// <returns>Task.</returns>
-        public void Add(Message message, int outBoxTimeout = -1, IAmABoxConnectionProvider overridingConnectionProvider = null)
+        public void Add(Message message, int outBoxTimeout = -1, IAmABoxTransactionConnectionProvider transactionConnectionProvider = null)
         {
             var parameters = InitAddDbParameters(message);
             
             var connectionProvider = _connectionProvider;
-            if (overridingConnectionProvider != null && overridingConnectionProvider is IMsSqlConnectionProvider provider)
+            if (transactionConnectionProvider != null && transactionConnectionProvider is IMsSqlTransactionConnectionProvider provider)
                 connectionProvider = provider;
             
             var connection = connectionProvider.GetConnection();
@@ -133,14 +133,14 @@ namespace Paramore.Brighter.Outbox.MsSql
         /// <param name="message">The message.</param>
         /// <param name="outBoxTimeout"></param>
         /// <param name="cancellationToken">Cancellation Token</param>
-        /// <param name="overridingConnectionProvider">Connection Provider to use for this call</param>
+        /// <param name="transactionConnectionProvider">Connection Provider to use for this call</param>
         /// <returns>Task&lt;Message&gt;.</returns>
-        public async Task AddAsync(Message message, int outBoxTimeout = -1, CancellationToken cancellationToken = default(CancellationToken), IAmABoxConnectionProvider overridingConnectionProvider = null)
+        public async Task AddAsync(Message message, int outBoxTimeout = -1, CancellationToken cancellationToken = default(CancellationToken), IAmABoxTransactionConnectionProvider transactionConnectionProvider = null)
         {
             var parameters = InitAddDbParameters(message);
             
             var connectionProvider = _connectionProvider;
-            if (overridingConnectionProvider != null && overridingConnectionProvider is IMsSqlConnectionProvider provider)
+            if (transactionConnectionProvider != null && transactionConnectionProvider is IMsSqlConnectionProvider provider)
                 connectionProvider = provider;
 
             var connection = await connectionProvider.GetConnectionAsync(cancellationToken);
@@ -198,7 +198,7 @@ namespace Paramore.Brighter.Outbox.MsSql
 
                 if(connection.State!= ConnectionState.Open) connection.Open();
 
-                if (_connectionProvider.HasOpenTransaction) command.Transaction = _connectionProvider.GetTransaction(); 
+                //if (_connectionProvider.HasOpenTransaction) command.Transaction = _connectionProvider.GetTransaction(); 
                 var dbDataReader = command.ExecuteReader();
 
                 var messages = new List<Message>();
@@ -494,7 +494,7 @@ namespace Paramore.Brighter.Outbox.MsSql
                 command.Parameters.AddRange(parameters);
 
                 if(connection.State!= ConnectionState.Open) await connection.OpenAsync(cancellationToken).ConfigureAwait(ContinueOnCapturedContext);
-                if (_connectionProvider.HasOpenTransaction) command.Transaction = _connectionProvider.GetTransaction(); 
+                //if (_connectionProvider.HasOpenTransaction) command.Transaction = _connectionProvider.GetTransaction(); 
                 var response =  await execute(command).ConfigureAwait(ContinueOnCapturedContext);
                 
                 if(!_connectionProvider.IsSharedConnection) connection.Dispose();

--- a/src/Paramore.Brighter.Outbox.MsSql/MsSqlOutbox.cs
+++ b/src/Paramore.Brighter.Outbox.MsSql/MsSqlOutbox.cs
@@ -86,19 +86,24 @@ namespace Paramore.Brighter.Outbox.MsSql
         /// </summary>
         /// <param name="message">The message.</param>
         /// <param name="outBoxTimeout"></param>
+        /// <param name="overridingConnectionProvider">Connection Provider to use for this call</param>
         /// <returns>Task.</returns>
-        public void Add(Message message, int outBoxTimeout = -1)
+        public void Add(Message message, int outBoxTimeout = -1, IAmABoxConnectionProvider overridingConnectionProvider = null)
         {
             var parameters = InitAddDbParameters(message);
-
-            var connection = _connectionProvider.GetConnection();
+            
+            var connectionProvider = _connectionProvider;
+            if (overridingConnectionProvider != null && overridingConnectionProvider is IMsSqlConnectionProvider provider)
+                connectionProvider = provider;
+            
+            var connection = connectionProvider.GetConnection();
             
             if(connection.State!= ConnectionState.Open) connection.Open();
             using (var command = InitAddDbCommand(connection, parameters))
             {
                 try
                 {
-                    if (_connectionProvider.HasOpenTransaction) command.Transaction = _connectionProvider.GetTransaction(); 
+                    if (connectionProvider.HasOpenTransaction) command.Transaction = connectionProvider.GetTransaction(); 
                     command.ExecuteNonQuery();
                 }
                 catch (SqlException sqlException)
@@ -116,8 +121,8 @@ namespace Paramore.Brighter.Outbox.MsSql
                 }
                 finally
                 {
-                    if(!_connectionProvider.IsSharedConnection) connection.Dispose();
-                    else if (!_connectionProvider.HasOpenTransaction) connection.Close();
+                    if(!connectionProvider.IsSharedConnection) connection.Dispose();
+                    else if (!connectionProvider.HasOpenTransaction) connection.Close();
                 }
             }
         }
@@ -125,21 +130,27 @@ namespace Paramore.Brighter.Outbox.MsSql
         /// <summary>
         ///     Gets the specified message identifier.
         /// </summary>
-        /// <param name="messageId">The message identifier.</param>
+        /// <param name="message">The message.</param>
         /// <param name="outBoxTimeout"></param>
+        /// <param name="cancellationToken">Cancellation Token</param>
+        /// <param name="overridingConnectionProvider">Connection Provider to use for this call</param>
         /// <returns>Task&lt;Message&gt;.</returns>
-        public async Task AddAsync(Message message, int outBoxTimeout = -1, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task AddAsync(Message message, int outBoxTimeout = -1, CancellationToken cancellationToken = default(CancellationToken), IAmABoxConnectionProvider overridingConnectionProvider = null)
         {
             var parameters = InitAddDbParameters(message);
+            
+            var connectionProvider = _connectionProvider;
+            if (overridingConnectionProvider != null && overridingConnectionProvider is IMsSqlConnectionProvider provider)
+                connectionProvider = provider;
 
-            var connection = await _connectionProvider.GetConnectionAsync(cancellationToken);
+            var connection = await connectionProvider.GetConnectionAsync(cancellationToken);
             
             if(connection.State!= ConnectionState.Open) await connection.OpenAsync(cancellationToken).ConfigureAwait(ContinueOnCapturedContext);
             using (var command = InitAddDbCommand(connection, parameters))
             {
                 try
                 {
-                    if (_connectionProvider.IsSharedConnection) command.Transaction = _connectionProvider.GetTransaction();
+                    if (connectionProvider.IsSharedConnection) command.Transaction = connectionProvider.GetTransaction();
                     await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(ContinueOnCapturedContext);
                 }
                 catch (SqlException sqlException)
@@ -157,8 +168,8 @@ namespace Paramore.Brighter.Outbox.MsSql
                 }
                 finally
                 {
-                    if(!_connectionProvider.IsSharedConnection) connection.Dispose();
-                    else if (!_connectionProvider.HasOpenTransaction) connection.Close();
+                    if(!connectionProvider.IsSharedConnection) connection.Dispose();
+                    else if (!connectionProvider.HasOpenTransaction) connection.Close();
                 }
             }
             
@@ -634,7 +645,7 @@ namespace Paramore.Brighter.Outbox.MsSql
 
         private Message MapFunction(SqlDataReader dr)
         {
-            var message = new Message();
+            Message message = null;
             if (dr.Read())
             {
                 message = MapAMessage(dr);

--- a/src/Paramore.Brighter.Outbox.MsSql/ServiceCollectionExtensions.cs
+++ b/src/Paramore.Brighter.Outbox.MsSql/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 using Microsoft.Extensions.DependencyInjection;
 using Paramore.Brighter.Extensions.DependencyInjection;
 using Paramore.Brighter.MsSql;
@@ -15,8 +16,17 @@ namespace Paramore.Brighter.Outbox.MsSql
             
             brighterBuilder.Services.Add(new ServiceDescriptor(typeof(IAmAnOutbox<Message>), BuildMsSqlOutbox, serviceLifetime));
             brighterBuilder.Services.Add(new ServiceDescriptor(typeof(IAmAnOutboxAsync<Message>), BuildMsSqlOutbox, serviceLifetime));
-            
+
             return brighterBuilder;
+        }
+
+        public static IBrighterHandlerBuilder UseOverridingMsSqlConnectionProvider(
+            this IBrighterHandlerBuilder brighterHandlerBuilder, Type connectionProvider,
+            ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)
+        {
+            brighterHandlerBuilder.Services.Add(new ServiceDescriptor(typeof(IAmABoxConnectionProvider), connectionProvider, serviceLifetime));
+
+            return brighterHandlerBuilder;
         }
 
         private static MsSqlOutbox BuildMsSqlOutbox(IServiceProvider provider)

--- a/src/Paramore.Brighter.Outbox.MsSql/ServiceCollectionExtensions.cs
+++ b/src/Paramore.Brighter.Outbox.MsSql/ServiceCollectionExtensions.cs
@@ -20,11 +20,11 @@ namespace Paramore.Brighter.Outbox.MsSql
             return brighterBuilder;
         }
 
-        public static IBrighterHandlerBuilder UseOverridingMsSqlConnectionProvider(
+        public static IBrighterHandlerBuilder UseMsSqlTransactionConnectionProvider(
             this IBrighterHandlerBuilder brighterHandlerBuilder, Type connectionProvider,
             ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)
         {
-            brighterHandlerBuilder.Services.Add(new ServiceDescriptor(typeof(IAmABoxConnectionProvider), connectionProvider, serviceLifetime));
+            brighterHandlerBuilder.Services.Add(new ServiceDescriptor(typeof(IAmABoxTransactionConnectionProvider), connectionProvider, serviceLifetime));
 
             return brighterHandlerBuilder;
         }

--- a/src/Paramore.Brighter.Outbox.MySql/MySqlOutbox.cs
+++ b/src/Paramore.Brighter.Outbox.MySql/MySqlOutbox.cs
@@ -79,7 +79,7 @@ namespace Paramore.Brighter.Outbox.MySql
         /// <param name="message">The message.</param>
         /// <param name="outBoxTimeout"></param>
         /// <returns>Task.</returns>
-        public void Add(Message message, int outBoxTimeout = -1)
+        public void Add(Message message, int outBoxTimeout = -1, IAmABoxTransactionConnectionProvider transactionConnectionProvider = null)
         {
             var parameters = InitAddDbParameters(message);
 
@@ -111,7 +111,7 @@ namespace Paramore.Brighter.Outbox.MySql
             }
         }
 
-        public async Task AddAsync(Message message, int outBoxTimeout = -1, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task AddAsync(Message message, int outBoxTimeout = -1, CancellationToken cancellationToken = default(CancellationToken), IAmABoxTransactionConnectionProvider transactionConnectionProvider = null)
         {
             var parameters = InitAddDbParameters(message);
 

--- a/src/Paramore.Brighter.Outbox.PostgreSql/PostgreSqlOutbox.cs
+++ b/src/Paramore.Brighter.Outbox.PostgreSql/PostgreSqlOutbox.cs
@@ -59,7 +59,7 @@ namespace Paramore.Brighter.Outbox.PostgreSql
         /// </summary>
         /// <param name="message">The message.</param>
         /// <param name="outBoxTimeout">The time allowed for the write in milliseconds; on a -1 default</param>
-        public void Add(Message message, int outBoxTimeout = -1)
+        public void Add(Message message, int outBoxTimeout = -1, IAmABoxTransactionConnectionProvider transactionConnectionProvider = null)
         {
             var parameters = InitAddDbParameters(message);
             using (var connection = GetConnection())

--- a/src/Paramore.Brighter.Outbox.Sqlite/SqliteOutbox.cs
+++ b/src/Paramore.Brighter.Outbox.Sqlite/SqliteOutbox.cs
@@ -77,7 +77,7 @@ namespace Paramore.Brighter.Outbox.Sqlite
         /// <param name="message">The message.</param>
         /// <param name="outBoxTimeout"></param>
         /// <returns>Task.</returns>
-        public void Add(Message message, int outBoxTimeout = -1)
+        public void Add(Message message, int outBoxTimeout = -1, IAmABoxTransactionConnectionProvider transactionConnectionProvider = null)
         {
             var parameters = InitAddDbParameters(message);
 
@@ -110,7 +110,7 @@ namespace Paramore.Brighter.Outbox.Sqlite
             }
         }
 
-        public async Task AddAsync(Message message, int outBoxTimeout = -1, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task AddAsync(Message message, int outBoxTimeout = -1, CancellationToken cancellationToken = default(CancellationToken), IAmABoxTransactionConnectionProvider transactionConnectionProvider = null)
         {
             var parameters = InitAddDbParameters(message);
 

--- a/src/Paramore.Brighter.ServiceActivator/ControlBusReceiverBuilder.cs
+++ b/src/Paramore.Brighter.ServiceActivator/ControlBusReceiverBuilder.cs
@@ -190,7 +190,7 @@ namespace Paramore.Brighter.ServiceActivator.ControlBus
         /// </summary>
         private class SinkOutbox : IAmAnOutbox<Message>
         {
-            public void Add(Message message, int outBoxTimeout = -1)
+            public void Add(Message message, int outBoxTimeout = -1, IAmABoxConnectionProvider overrideConnectionProvider = null)
             {
                 //discard message
             }

--- a/src/Paramore.Brighter.ServiceActivator/ControlBusReceiverBuilder.cs
+++ b/src/Paramore.Brighter.ServiceActivator/ControlBusReceiverBuilder.cs
@@ -190,7 +190,7 @@ namespace Paramore.Brighter.ServiceActivator.ControlBus
         /// </summary>
         private class SinkOutbox : IAmAnOutbox<Message>
         {
-            public void Add(Message message, int outBoxTimeout = -1, IAmABoxConnectionProvider overrideConnectionProvider = null)
+            public void Add(Message message, int outBoxTimeout = -1, IAmABoxTransactionConnectionProvider transactionConnectionProvider = null)
             {
                 //discard message
             }

--- a/src/Paramore.Brighter/CommandProcessor.cs
+++ b/src/Paramore.Brighter/CommandProcessor.cs
@@ -51,6 +51,7 @@ namespace Paramore.Brighter
         private readonly IAmARequestContextFactory _requestContextFactory;
         private readonly IPolicyRegistry<string> _policyRegistry;
         private readonly InboxConfiguration _inboxConfiguration;
+        private readonly IAmABoxConnectionProvider _overridingConnectionProvider;
         private readonly IAmAFeatureSwitchRegistry _featureSwitchRegistry;
 
         //Uses -1 to indicate no outbox and will thus force a throw on a failed publish
@@ -185,6 +186,7 @@ namespace Paramore.Brighter
         /// <param name="outboxTimeout">How long should we wait to write to the outbox</param>
         /// <param name="featureSwitchRegistry">The feature switch config provider.</param>
         /// <param name="inboxConfiguration">Do we want to insert an inbox handler into pipelines without the attribute. Null (default = no), yes = how to configure</param>
+        /// <param name="overridingConnectionProvider">The Box Connection Provider to use when Depositing into the outbox.</param>
         public CommandProcessor(
             IAmARequestContextFactory requestContextFactory,
             IPolicyRegistry<string> policyRegistry,
@@ -193,14 +195,16 @@ namespace Paramore.Brighter
             IAmAMessageProducer messageProducer,
             int outboxTimeout = 300,
             IAmAFeatureSwitchRegistry featureSwitchRegistry = null,
-            InboxConfiguration inboxConfiguration = null)
+            InboxConfiguration inboxConfiguration = null,
+            IAmABoxConnectionProvider overridingConnectionProvider = null)
         {
             _requestContextFactory = requestContextFactory;
             _policyRegistry = policyRegistry;
             _mapperRegistry = mapperRegistry;
             _featureSwitchRegistry = featureSwitchRegistry;
             _inboxConfiguration = inboxConfiguration;
-            
+            _overridingConnectionProvider = overridingConnectionProvider;
+
             InitExtServiceBus(policyRegistry, outBox, null, outboxTimeout, messageProducer, null);
 
             _bus.ConfigurePublisherCallbackMaybe();
@@ -219,6 +223,7 @@ namespace Paramore.Brighter
         /// <param name="outboxTimeout">How long should we wait to write to the outbox</param>
         /// <param name="featureSwitchRegistry">The feature switch config provider.</param>
         /// <param name="inboxConfiguration">Do we want to insert an inbox handler into pipelines without the attribute. Null (default = no), yes = how to configure</param>
+        /// <param name="overridingConnectionProvider">The Box Connection Provider to use when Depositing into the outbox.</param>
         public CommandProcessor(
             IAmARequestContextFactory requestContextFactory,
             IPolicyRegistry<string> policyRegistry,
@@ -227,14 +232,16 @@ namespace Paramore.Brighter
             IAmAMessageProducerAsync asyncMessageProducer,
             int outboxTimeout = 300,
             IAmAFeatureSwitchRegistry featureSwitchRegistry = null,
-            InboxConfiguration inboxConfiguration = null)
+            InboxConfiguration inboxConfiguration = null,
+            IAmABoxConnectionProvider overridingConnectionProvider = null)
         {
             _requestContextFactory = requestContextFactory;
             _policyRegistry = policyRegistry;
             _mapperRegistry = mapperRegistry;
             _featureSwitchRegistry = featureSwitchRegistry;
             _inboxConfiguration = inboxConfiguration;
-            
+            _overridingConnectionProvider = overridingConnectionProvider;
+
             InitExtServiceBus(policyRegistry, null, asyncOutbox, outboxTimeout, null, asyncMessageProducer);
 
             _bus.ConfigureAsyncPublisherCallbackMaybe();
@@ -249,11 +256,13 @@ namespace Paramore.Brighter
         /// <param name="requestContextFactory">The request context factory.</param>
         /// <param name="policyRegistry">The policy registry.</param>
         /// <param name="mapperRegistry">The mapper registry.</param>
+        /// <param name="outBox"></param>
         /// <param name="messageProducer">The messaging gateway.</param>
         /// <param name="responseChannelFactory">If we are expecting a response, then we need a channel to listen on</param>
         /// <param name="outboxTimeout">How long should we wait to write to the outbox</param>
         /// <param name="featureSwitchRegistry">The feature switch config provider.</param>
         /// <param name="inboxConfiguration">Do we want to insert an inbox handler into pipelines without the attribute. Null (default = no), yes = how to configure</param>
+        /// <param name="overridingConnectionProvider">The Box Connection Provider to use when Depositing into the outbox.</param>
         public CommandProcessor(
             IAmASubscriberRegistry subscriberRegistry,
             IAmAHandlerFactory handlerFactory,
@@ -265,14 +274,16 @@ namespace Paramore.Brighter
             int outboxTimeout = 300,
             IAmAFeatureSwitchRegistry featureSwitchRegistry = null,
             IAmAChannelFactory responseChannelFactory = null,
-            InboxConfiguration inboxConfiguration = null)
+            InboxConfiguration inboxConfiguration = null,
+            IAmABoxConnectionProvider overridingConnectionProvider = null)
             : this(subscriberRegistry, handlerFactory, requestContextFactory, policyRegistry)
         {
             _mapperRegistry = mapperRegistry;
             _featureSwitchRegistry = featureSwitchRegistry;
             _responseChannelFactory = responseChannelFactory;
             _inboxConfiguration = inboxConfiguration;
-            
+            _overridingConnectionProvider = overridingConnectionProvider;
+
             InitExtServiceBus(policyRegistry, outBox, null, outboxTimeout, messageProducer, null);
 
             _bus.ConfigurePublisherCallbackMaybe();
@@ -292,6 +303,7 @@ namespace Paramore.Brighter
         /// <param name="outboxTimeout">How long should we wait to write to the outbox</param>
         /// <param name="featureSwitchRegistry">The feature switch config provider.</param>
         /// <param name="inboxConfiguration">Do we want to insert an inbox handler into pipelines without the attribute. Null (default = no), yes = how to configure</param>
+        /// <param name="overridingConnectionProvider">The Box Connection Provider to use when Depositing into the outbox.</param>
         public CommandProcessor(
             IAmASubscriberRegistry subscriberRegistry,
             IAmAHandlerFactoryAsync asyncHandlerFactory,
@@ -302,13 +314,15 @@ namespace Paramore.Brighter
             IAmAMessageProducerAsync asyncMessageProducer,
             int outboxTimeout = 300,
             IAmAFeatureSwitchRegistry featureSwitchRegistry = null,
-            InboxConfiguration inboxConfiguration = null)
+            InboxConfiguration inboxConfiguration = null,
+            IAmABoxConnectionProvider overridingConnectionProvider = null)
             : this(subscriberRegistry, asyncHandlerFactory, requestContextFactory, policyRegistry, featureSwitchRegistry)
         {
             _mapperRegistry = mapperRegistry;
             _featureSwitchRegistry = featureSwitchRegistry;
             _inboxConfiguration = inboxConfiguration;
-            
+            _overridingConnectionProvider = overridingConnectionProvider;
+
             InitExtServiceBus(policyRegistry, null, asyncOutbox, outboxTimeout, null, asyncMessageProducer);
 
             _bus.ConfigurePublisherCallbackMaybe();
@@ -331,6 +345,7 @@ namespace Paramore.Brighter
         /// <param name="outboxTimeout">How long should we wait to write to the outbox</param>
         /// <param name="featureSwitchRegistry">The feature switch config provider.</param>
         /// <param name="inboxConfiguration">Do we want to insert an inbox handler into pipelines without the attribute. Null (default = no), yes = how to configure</param>
+        /// <param name="overridingConnectionProvider">The Box Connection Provider to use when Depositing into the outbox.</param>
         public CommandProcessor(
             IAmASubscriberRegistry subscriberRegistry,
             IAmAHandlerFactory handlerFactory,
@@ -344,12 +359,14 @@ namespace Paramore.Brighter
             IAmAMessageProducerAsync asyncMessageProducer,
             int outboxTimeout = 300,
             IAmAFeatureSwitchRegistry featureSwitchRegistry = null,
-            InboxConfiguration inboxConfiguration = null)
+            InboxConfiguration inboxConfiguration = null,
+            IAmABoxConnectionProvider overridingConnectionProvider = null)
             : this(subscriberRegistry, handlerFactory, asyncHandlerFactory, requestContextFactory, policyRegistry, featureSwitchRegistry)
         {
             _mapperRegistry = mapperRegistry;
             _inboxConfiguration = inboxConfiguration;
-            
+            _overridingConnectionProvider = overridingConnectionProvider;
+
             InitExtServiceBus(policyRegistry, outBox, asyncOutbox, outboxTimeout, messageProducer, asyncMessageProducer);
 
             //Only register one, to avoid two callbacks where we support both interfaces on a producer
@@ -570,7 +587,7 @@ namespace Paramore.Brighter
 
             var message = messageMapper.MapToMessage(request);
 
-            _bus.AddToOutbox(request, message);
+            _bus.AddToOutbox(request, message, _overridingConnectionProvider);
 
             return message.Id;
         }
@@ -599,7 +616,7 @@ namespace Paramore.Brighter
 
             var message = messageMapper.MapToMessage(request);
 
-            await _bus.AddToOutboxAsync(request, continueOnCapturedContext, cancellationToken, message);
+            await _bus.AddToOutboxAsync(request, continueOnCapturedContext, cancellationToken, message, _overridingConnectionProvider);
 
             return message.Id;
         }

--- a/src/Paramore.Brighter/CommandProcessor.cs
+++ b/src/Paramore.Brighter/CommandProcessor.cs
@@ -51,7 +51,7 @@ namespace Paramore.Brighter
         private readonly IAmARequestContextFactory _requestContextFactory;
         private readonly IPolicyRegistry<string> _policyRegistry;
         private readonly InboxConfiguration _inboxConfiguration;
-        private readonly IAmABoxConnectionProvider _overridingConnectionProvider;
+        private readonly IAmABoxTransactionConnectionProvider _boxTransactionConnectionProvider;
         private readonly IAmAFeatureSwitchRegistry _featureSwitchRegistry;
 
         //Uses -1 to indicate no outbox and will thus force a throw on a failed publish
@@ -186,7 +186,7 @@ namespace Paramore.Brighter
         /// <param name="outboxTimeout">How long should we wait to write to the outbox</param>
         /// <param name="featureSwitchRegistry">The feature switch config provider.</param>
         /// <param name="inboxConfiguration">Do we want to insert an inbox handler into pipelines without the attribute. Null (default = no), yes = how to configure</param>
-        /// <param name="overridingConnectionProvider">The Box Connection Provider to use when Depositing into the outbox.</param>
+        /// <param name="boxTransactionConnectionProvider">The Box Connection Provider to use when Depositing into the outbox.</param>
         public CommandProcessor(
             IAmARequestContextFactory requestContextFactory,
             IPolicyRegistry<string> policyRegistry,
@@ -196,14 +196,14 @@ namespace Paramore.Brighter
             int outboxTimeout = 300,
             IAmAFeatureSwitchRegistry featureSwitchRegistry = null,
             InboxConfiguration inboxConfiguration = null,
-            IAmABoxConnectionProvider overridingConnectionProvider = null)
+            IAmABoxTransactionConnectionProvider boxTransactionConnectionProvider = null)
         {
             _requestContextFactory = requestContextFactory;
             _policyRegistry = policyRegistry;
             _mapperRegistry = mapperRegistry;
             _featureSwitchRegistry = featureSwitchRegistry;
             _inboxConfiguration = inboxConfiguration;
-            _overridingConnectionProvider = overridingConnectionProvider;
+            _boxTransactionConnectionProvider = boxTransactionConnectionProvider;
 
             InitExtServiceBus(policyRegistry, outBox, null, outboxTimeout, messageProducer, null);
 
@@ -223,7 +223,7 @@ namespace Paramore.Brighter
         /// <param name="outboxTimeout">How long should we wait to write to the outbox</param>
         /// <param name="featureSwitchRegistry">The feature switch config provider.</param>
         /// <param name="inboxConfiguration">Do we want to insert an inbox handler into pipelines without the attribute. Null (default = no), yes = how to configure</param>
-        /// <param name="overridingConnectionProvider">The Box Connection Provider to use when Depositing into the outbox.</param>
+        /// <param name="boxTransactionConnectionProvider">The Box Connection Provider to use when Depositing into the outbox.</param>
         public CommandProcessor(
             IAmARequestContextFactory requestContextFactory,
             IPolicyRegistry<string> policyRegistry,
@@ -233,14 +233,14 @@ namespace Paramore.Brighter
             int outboxTimeout = 300,
             IAmAFeatureSwitchRegistry featureSwitchRegistry = null,
             InboxConfiguration inboxConfiguration = null,
-            IAmABoxConnectionProvider overridingConnectionProvider = null)
+            IAmABoxTransactionConnectionProvider boxTransactionConnectionProvider = null)
         {
             _requestContextFactory = requestContextFactory;
             _policyRegistry = policyRegistry;
             _mapperRegistry = mapperRegistry;
             _featureSwitchRegistry = featureSwitchRegistry;
             _inboxConfiguration = inboxConfiguration;
-            _overridingConnectionProvider = overridingConnectionProvider;
+            _boxTransactionConnectionProvider = boxTransactionConnectionProvider;
 
             InitExtServiceBus(policyRegistry, null, asyncOutbox, outboxTimeout, null, asyncMessageProducer);
 
@@ -262,7 +262,7 @@ namespace Paramore.Brighter
         /// <param name="outboxTimeout">How long should we wait to write to the outbox</param>
         /// <param name="featureSwitchRegistry">The feature switch config provider.</param>
         /// <param name="inboxConfiguration">Do we want to insert an inbox handler into pipelines without the attribute. Null (default = no), yes = how to configure</param>
-        /// <param name="overridingConnectionProvider">The Box Connection Provider to use when Depositing into the outbox.</param>
+        /// <param name="boxTransactionConnectionProvider">The Box Connection Provider to use when Depositing into the outbox.</param>
         public CommandProcessor(
             IAmASubscriberRegistry subscriberRegistry,
             IAmAHandlerFactory handlerFactory,
@@ -275,14 +275,14 @@ namespace Paramore.Brighter
             IAmAFeatureSwitchRegistry featureSwitchRegistry = null,
             IAmAChannelFactory responseChannelFactory = null,
             InboxConfiguration inboxConfiguration = null,
-            IAmABoxConnectionProvider overridingConnectionProvider = null)
+            IAmABoxTransactionConnectionProvider boxTransactionConnectionProvider = null)
             : this(subscriberRegistry, handlerFactory, requestContextFactory, policyRegistry)
         {
             _mapperRegistry = mapperRegistry;
             _featureSwitchRegistry = featureSwitchRegistry;
             _responseChannelFactory = responseChannelFactory;
             _inboxConfiguration = inboxConfiguration;
-            _overridingConnectionProvider = overridingConnectionProvider;
+            _boxTransactionConnectionProvider = boxTransactionConnectionProvider;
 
             InitExtServiceBus(policyRegistry, outBox, null, outboxTimeout, messageProducer, null);
 
@@ -303,7 +303,7 @@ namespace Paramore.Brighter
         /// <param name="outboxTimeout">How long should we wait to write to the outbox</param>
         /// <param name="featureSwitchRegistry">The feature switch config provider.</param>
         /// <param name="inboxConfiguration">Do we want to insert an inbox handler into pipelines without the attribute. Null (default = no), yes = how to configure</param>
-        /// <param name="overridingConnectionProvider">The Box Connection Provider to use when Depositing into the outbox.</param>
+        /// <param name="boxTransactionConnectionProvider">The Box Connection Provider to use when Depositing into the outbox.</param>
         public CommandProcessor(
             IAmASubscriberRegistry subscriberRegistry,
             IAmAHandlerFactoryAsync asyncHandlerFactory,
@@ -315,13 +315,13 @@ namespace Paramore.Brighter
             int outboxTimeout = 300,
             IAmAFeatureSwitchRegistry featureSwitchRegistry = null,
             InboxConfiguration inboxConfiguration = null,
-            IAmABoxConnectionProvider overridingConnectionProvider = null)
+            IAmABoxTransactionConnectionProvider boxTransactionConnectionProvider = null)
             : this(subscriberRegistry, asyncHandlerFactory, requestContextFactory, policyRegistry, featureSwitchRegistry)
         {
             _mapperRegistry = mapperRegistry;
             _featureSwitchRegistry = featureSwitchRegistry;
             _inboxConfiguration = inboxConfiguration;
-            _overridingConnectionProvider = overridingConnectionProvider;
+            _boxTransactionConnectionProvider = boxTransactionConnectionProvider;
 
             InitExtServiceBus(policyRegistry, null, asyncOutbox, outboxTimeout, null, asyncMessageProducer);
 
@@ -345,7 +345,7 @@ namespace Paramore.Brighter
         /// <param name="outboxTimeout">How long should we wait to write to the outbox</param>
         /// <param name="featureSwitchRegistry">The feature switch config provider.</param>
         /// <param name="inboxConfiguration">Do we want to insert an inbox handler into pipelines without the attribute. Null (default = no), yes = how to configure</param>
-        /// <param name="overridingConnectionProvider">The Box Connection Provider to use when Depositing into the outbox.</param>
+        /// <param name="boxTransactionConnectionProvider">The Box Connection Provider to use when Depositing into the outbox.</param>
         public CommandProcessor(
             IAmASubscriberRegistry subscriberRegistry,
             IAmAHandlerFactory handlerFactory,
@@ -360,12 +360,12 @@ namespace Paramore.Brighter
             int outboxTimeout = 300,
             IAmAFeatureSwitchRegistry featureSwitchRegistry = null,
             InboxConfiguration inboxConfiguration = null,
-            IAmABoxConnectionProvider overridingConnectionProvider = null)
+            IAmABoxTransactionConnectionProvider boxTransactionConnectionProvider = null)
             : this(subscriberRegistry, handlerFactory, asyncHandlerFactory, requestContextFactory, policyRegistry, featureSwitchRegistry)
         {
             _mapperRegistry = mapperRegistry;
             _inboxConfiguration = inboxConfiguration;
-            _overridingConnectionProvider = overridingConnectionProvider;
+            _boxTransactionConnectionProvider = boxTransactionConnectionProvider;
 
             InitExtServiceBus(policyRegistry, outBox, asyncOutbox, outboxTimeout, messageProducer, asyncMessageProducer);
 
@@ -587,7 +587,7 @@ namespace Paramore.Brighter
 
             var message = messageMapper.MapToMessage(request);
 
-            _bus.AddToOutbox(request, message, _overridingConnectionProvider);
+            _bus.AddToOutbox(request, message, _boxTransactionConnectionProvider);
 
             return message.Id;
         }
@@ -616,7 +616,7 @@ namespace Paramore.Brighter
 
             var message = messageMapper.MapToMessage(request);
 
-            await _bus.AddToOutboxAsync(request, continueOnCapturedContext, cancellationToken, message, _overridingConnectionProvider);
+            await _bus.AddToOutboxAsync(request, continueOnCapturedContext, cancellationToken, message, _boxTransactionConnectionProvider);
 
             return message.Id;
         }

--- a/src/Paramore.Brighter/CommandProcessorBuilder.cs
+++ b/src/Paramore.Brighter/CommandProcessorBuilder.cs
@@ -85,7 +85,7 @@ namespace Paramore.Brighter
         private int _outboxWriteTimeout;
         private bool _useExternalBus = false;
         private bool _useRequestReplyQueues = false;
-        private IAmABoxConnectionProvider _overridingBoxConnectionProvider = null;
+        private IAmABoxTransactionConnectionProvider _overridingBoxTransactionConnectionProvider = null;
         
         private CommandProcessorBuilder()
         {
@@ -151,15 +151,15 @@ namespace Paramore.Brighter
         /// 
         /// </summary>
         /// <param name="configuration">The Task Queues configuration.</param>
-        /// <param name="overridingConnectionProvider"></param>
+        /// <param name="boxTransactionConnectionProvider"></param>
         /// <returns>INeedARequestContext.</returns>
-        public INeedARequestContext ExternalBus(MessagingConfiguration configuration, IAmAnOutbox<Message> outbox, IAmABoxConnectionProvider overridingConnectionProvider = null)
+        public INeedARequestContext ExternalBus(MessagingConfiguration configuration, IAmAnOutbox<Message> outbox, IAmABoxTransactionConnectionProvider boxTransactionConnectionProvider = null)
         {
             _useExternalBus = true;
             _messagingGateway = configuration.MessageProducer;
             _outbox = outbox;
             if(outbox is IAmAnOutboxAsync<Message>) _asyncOutbox = (IAmAnOutboxAsync<Message>)outbox;
-            _overridingBoxConnectionProvider = overridingConnectionProvider;
+            _overridingBoxTransactionConnectionProvider = boxTransactionConnectionProvider;
             _asyncMessagingGateway = configuration.MessageProducerAsync;
             _messageMapperRegistry = configuration.MessageMapperRegistry;
             _outboxWriteTimeout = configuration.OutboxWriteTimeout;
@@ -247,7 +247,7 @@ namespace Paramore.Brighter
                     asyncMessageProducer: _asyncMessagingGateway,
                     outboxTimeout: _outboxWriteTimeout,
                     featureSwitchRegistry: _featureSwitchRegistry,
-                    overridingConnectionProvider: _overridingBoxConnectionProvider
+                    boxTransactionConnectionProvider: _overridingBoxTransactionConnectionProvider
                 );
             }
             else if (_useRequestReplyQueues)
@@ -261,7 +261,7 @@ namespace Paramore.Brighter
                     outBox: _outbox,
                     messageProducer: _messagingGateway,
                     responseChannelFactory: _responseChannelFactory,
-                    overridingConnectionProvider: _overridingBoxConnectionProvider
+                    boxTransactionConnectionProvider: _overridingBoxTransactionConnectionProvider
                     );
             }
             else
@@ -315,9 +315,9 @@ namespace Paramore.Brighter
         /// </summary>
         /// <param name="configuration">The configuration.</param>
         /// <param name="outbox">The outbox.</param>
-        /// <param name="overridingConnectionProvider">The connection provider to use when adding messages to the bus</param>
+        /// <param name="boxTransactionConnectionProvider">The connection provider to use when adding messages to the bus</param>
         /// <returns>INeedARequestContext.</returns>
-        INeedARequestContext ExternalBus(MessagingConfiguration configuration, IAmAnOutbox<Message> outbox, IAmABoxConnectionProvider overridingConnectionProvider = null);
+        INeedARequestContext ExternalBus(MessagingConfiguration configuration, IAmAnOutbox<Message> outbox, IAmABoxTransactionConnectionProvider boxTransactionConnectionProvider = null);
         /// <summary>
         /// We don't send messages out of process
         /// </summary>

--- a/src/Paramore.Brighter/CommandProcessorBuilder.cs
+++ b/src/Paramore.Brighter/CommandProcessorBuilder.cs
@@ -85,6 +85,7 @@ namespace Paramore.Brighter
         private int _outboxWriteTimeout;
         private bool _useExternalBus = false;
         private bool _useRequestReplyQueues = false;
+        private IAmABoxConnectionProvider _overridingBoxConnectionProvider = null;
         
         private CommandProcessorBuilder()
         {
@@ -150,13 +151,15 @@ namespace Paramore.Brighter
         /// 
         /// </summary>
         /// <param name="configuration">The Task Queues configuration.</param>
+        /// <param name="overridingConnectionProvider"></param>
         /// <returns>INeedARequestContext.</returns>
-        public INeedARequestContext ExternalBus(MessagingConfiguration configuration, IAmAnOutbox<Message> outbox)
+        public INeedARequestContext ExternalBus(MessagingConfiguration configuration, IAmAnOutbox<Message> outbox, IAmABoxConnectionProvider overridingConnectionProvider = null)
         {
             _useExternalBus = true;
             _messagingGateway = configuration.MessageProducer;
             _outbox = outbox;
             if(outbox is IAmAnOutboxAsync<Message>) _asyncOutbox = (IAmAnOutboxAsync<Message>)outbox;
+            _overridingBoxConnectionProvider = overridingConnectionProvider;
             _asyncMessagingGateway = configuration.MessageProducerAsync;
             _messageMapperRegistry = configuration.MessageMapperRegistry;
             _outboxWriteTimeout = configuration.OutboxWriteTimeout;
@@ -243,7 +246,8 @@ namespace Paramore.Brighter
                     messageProducer: _messagingGateway,
                     asyncMessageProducer: _asyncMessagingGateway,
                     outboxTimeout: _outboxWriteTimeout,
-                    featureSwitchRegistry: _featureSwitchRegistry
+                    featureSwitchRegistry: _featureSwitchRegistry,
+                    overridingConnectionProvider: _overridingBoxConnectionProvider
                 );
             }
             else if (_useRequestReplyQueues)
@@ -256,7 +260,8 @@ namespace Paramore.Brighter
                     mapperRegistry: _messageMapperRegistry,
                     outBox: _outbox,
                     messageProducer: _messagingGateway,
-                    responseChannelFactory: _responseChannelFactory 
+                    responseChannelFactory: _responseChannelFactory,
+                    overridingConnectionProvider: _overridingBoxConnectionProvider
                     );
             }
             else
@@ -310,9 +315,9 @@ namespace Paramore.Brighter
         /// </summary>
         /// <param name="configuration">The configuration.</param>
         /// <param name="outbox">The outbox.</param>
+        /// <param name="overridingConnectionProvider">The connection provider to use when adding messages to the bus</param>
         /// <returns>INeedARequestContext.</returns>
-        INeedARequestContext ExternalBus(MessagingConfiguration configuration, IAmAnOutbox<Message> outbox);
-        
+        INeedARequestContext ExternalBus(MessagingConfiguration configuration, IAmAnOutbox<Message> outbox, IAmABoxConnectionProvider overridingConnectionProvider = null);
         /// <summary>
         /// We don't send messages out of process
         /// </summary>

--- a/src/Paramore.Brighter/ExternalBusServices.cs
+++ b/src/Paramore.Brighter/ExternalBusServices.cs
@@ -62,10 +62,10 @@ namespace Paramore.Brighter
             _disposed = true;
         }
 
-        internal async Task AddToOutboxAsync<T>(T request, bool continueOnCapturedContext, CancellationToken cancellationToken, Message message, IAmABoxConnectionProvider overridingConnectionProvider = null)
+        internal async Task AddToOutboxAsync<T>(T request, bool continueOnCapturedContext, CancellationToken cancellationToken, Message message, IAmABoxTransactionConnectionProvider overridingTransactionConnectionProvider = null)
             where T : class, IRequest
         {
-            var written = await RetryAsync(async ct => { await AsyncOutbox.AddAsync(message, OutboxTimeout, ct, overridingConnectionProvider).ConfigureAwait(continueOnCapturedContext); },
+            var written = await RetryAsync(async ct => { await AsyncOutbox.AddAsync(message, OutboxTimeout, ct, overridingTransactionConnectionProvider).ConfigureAwait(continueOnCapturedContext); },
                     continueOnCapturedContext, cancellationToken).ConfigureAwait(continueOnCapturedContext);
 
             if (!written)
@@ -73,9 +73,9 @@ namespace Paramore.Brighter
         }            
             
             
-        internal void AddToOutbox<T>(T request, Message message, IAmABoxConnectionProvider overridingConnectionProvider = null) where T : class, IRequest
+        internal void AddToOutbox<T>(T request, Message message, IAmABoxTransactionConnectionProvider overridingTransactionConnectionProvider = null) where T : class, IRequest
         {
-            var written = Retry(() => { OutBox.Add(message, OutboxTimeout, overridingConnectionProvider); });
+            var written = Retry(() => { OutBox.Add(message, OutboxTimeout, overridingTransactionConnectionProvider); });
 
             if (!written)
                 throw new ChannelFailureException($"Could not write request {request.Id} to the outbox");

--- a/src/Paramore.Brighter/ExternalBusServices.cs
+++ b/src/Paramore.Brighter/ExternalBusServices.cs
@@ -62,10 +62,10 @@ namespace Paramore.Brighter
             _disposed = true;
         }
 
-        internal async Task AddToOutboxAsync<T>(T request, bool continueOnCapturedContext, CancellationToken cancellationToken, Message message)
+        internal async Task AddToOutboxAsync<T>(T request, bool continueOnCapturedContext, CancellationToken cancellationToken, Message message, IAmABoxConnectionProvider overridingConnectionProvider = null)
             where T : class, IRequest
         {
-            var written = await RetryAsync(async ct => { await AsyncOutbox.AddAsync(message, OutboxTimeout, ct).ConfigureAwait(continueOnCapturedContext); },
+            var written = await RetryAsync(async ct => { await AsyncOutbox.AddAsync(message, OutboxTimeout, ct, overridingConnectionProvider).ConfigureAwait(continueOnCapturedContext); },
                     continueOnCapturedContext, cancellationToken).ConfigureAwait(continueOnCapturedContext);
 
             if (!written)
@@ -73,9 +73,9 @@ namespace Paramore.Brighter
         }            
             
             
-        internal void AddToOutbox<T>(T request, Message message) where T : class, IRequest
+        internal void AddToOutbox<T>(T request, Message message, IAmABoxConnectionProvider overridingConnectionProvider = null) where T : class, IRequest
         {
-            var written = Retry(() => { OutBox.Add(message, OutboxTimeout); });
+            var written = Retry(() => { OutBox.Add(message, OutboxTimeout, overridingConnectionProvider); });
 
             if (!written)
                 throw new ChannelFailureException($"Could not write request {request.Id} to the outbox");

--- a/src/Paramore.Brighter/IAmABoxConnectionProvider.cs
+++ b/src/Paramore.Brighter/IAmABoxConnectionProvider.cs
@@ -1,7 +1,0 @@
-﻿namespace Paramore.Brighter
-{
-    public interface IAmABoxConnectionProvider
-    {
-        
-    }
-}

--- a/src/Paramore.Brighter/IAmABoxConnectionProvider.cs
+++ b/src/Paramore.Brighter/IAmABoxConnectionProvider.cs
@@ -1,0 +1,7 @@
+﻿namespace Paramore.Brighter
+{
+    public interface IAmABoxConnectionProvider
+    {
+        
+    }
+}

--- a/src/Paramore.Brighter/IAmABoxTransactionConnectionProvider.cs
+++ b/src/Paramore.Brighter/IAmABoxTransactionConnectionProvider.cs
@@ -1,0 +1,7 @@
+﻿namespace Paramore.Brighter
+{
+    public interface IAmABoxTransactionConnectionProvider
+    {
+        
+    }
+}

--- a/src/Paramore.Brighter/IAmAnOutbox.cs
+++ b/src/Paramore.Brighter/IAmAnOutbox.cs
@@ -41,7 +41,8 @@ namespace Paramore.Brighter
         /// </summary>
         /// <param name="message">The message.</param>
         /// <param name="outBoxTimeout">The time allowed for the write in milliseconds; on a -1 default</param>
-        void Add(T message, int outBoxTimeout = -1);
+        /// <param name="overridingConnectionProvider">The Connection Provider to use for this call</param>
+        void Add(T message, int outBoxTimeout = -1, IAmABoxConnectionProvider overridingConnectionProvider = null);
 
         /// <summary>
         /// Gets the specified message identifier.

--- a/src/Paramore.Brighter/IAmAnOutbox.cs
+++ b/src/Paramore.Brighter/IAmAnOutbox.cs
@@ -41,8 +41,8 @@ namespace Paramore.Brighter
         /// </summary>
         /// <param name="message">The message.</param>
         /// <param name="outBoxTimeout">The time allowed for the write in milliseconds; on a -1 default</param>
-        /// <param name="overridingConnectionProvider">The Connection Provider to use for this call</param>
-        void Add(T message, int outBoxTimeout = -1, IAmABoxConnectionProvider overridingConnectionProvider = null);
+        /// <param name="transactionConnectionProvider">The Connection Provider to use for this call</param>
+        void Add(T message, int outBoxTimeout = -1, IAmABoxTransactionConnectionProvider transactionConnectionProvider = null);
 
         /// <summary>
         /// Gets the specified message identifier.

--- a/src/Paramore.Brighter/IAmAnOutboxAsync.cs
+++ b/src/Paramore.Brighter/IAmAnOutboxAsync.cs
@@ -46,15 +46,16 @@ namespace Paramore.Brighter
         /// such as HTTPContext 
         /// </summary>
         bool ContinueOnCapturedContext { get; set; }
-         
+
         /// <summary>
         /// Awaitable add the specified message.
         /// </summary>
         /// <param name="message">The message.</param>
         /// <param name="outBoxTimeout">The time allowed for the write in milliseconds; on a -1 default</param>
         /// <param name="cancellationToken">Allows the sender to cancel the request pipeline. Optional</param>
+        /// <param name="overridingConnectionProvider">The Connection Provider to use for this call</param>
         /// <returns><see cref="Task"/>.</returns>
-        Task AddAsync(T message, int outBoxTimeout = -1, CancellationToken cancellationToken = default(CancellationToken));
+        Task AddAsync(T message, int outBoxTimeout = -1, CancellationToken cancellationToken = default(CancellationToken), IAmABoxConnectionProvider overridingConnectionProvider = null);
 
         /// <summary>
         /// Awaitable Get the specified message identifier.

--- a/src/Paramore.Brighter/IAmAnOutboxAsync.cs
+++ b/src/Paramore.Brighter/IAmAnOutboxAsync.cs
@@ -53,9 +53,9 @@ namespace Paramore.Brighter
         /// <param name="message">The message.</param>
         /// <param name="outBoxTimeout">The time allowed for the write in milliseconds; on a -1 default</param>
         /// <param name="cancellationToken">Allows the sender to cancel the request pipeline. Optional</param>
-        /// <param name="overridingConnectionProvider">The Connection Provider to use for this call</param>
+        /// <param name="transactionConnectionProvider">The Connection Provider to use for this call</param>
         /// <returns><see cref="Task"/>.</returns>
-        Task AddAsync(T message, int outBoxTimeout = -1, CancellationToken cancellationToken = default(CancellationToken), IAmABoxConnectionProvider overridingConnectionProvider = null);
+        Task AddAsync(T message, int outBoxTimeout = -1, CancellationToken cancellationToken = default(CancellationToken), IAmABoxTransactionConnectionProvider transactionConnectionProvider = null);
 
         /// <summary>
         /// Awaitable Get the specified message identifier.

--- a/src/Paramore.Brighter/InMemoryOutbox.cs
+++ b/src/Paramore.Brighter/InMemoryOutbox.cs
@@ -91,12 +91,13 @@ namespace Paramore.Brighter
         /// <value><c>true</c> if [continue on captured context]; otherwise, <c>false</c>.</value>
         public bool ContinueOnCapturedContext { get; set; }
 
-       /// <summary>
+        /// <summary>
         /// Adds the specified message
         /// </summary>
         /// <param name="message"></param>
         /// <param name="outBoxTimeout"></param>
-        public void Add(Message message, int outBoxTimeout = -1)
+        /// <param name="overridingConnectionProvider">This is not used for the In Memory Outbox.</param>
+        public void Add(Message message, int outBoxTimeout = -1, IAmABoxConnectionProvider overridingConnectionProvider = null)
         {
             ClearExpiredMessages();
             EnforceCapacityLimit();
@@ -117,8 +118,9 @@ namespace Paramore.Brighter
         /// <param name="message"></param>
         /// <param name="outBoxTimeout"></param>
         /// <param name="cancellationToken"></param>
+        /// <param name="overridingConnectionProvider">This is not used for the In Memory Outbox.</param>
         /// <returns></returns>
-        public Task AddAsync(Message message, int outBoxTimeout = -1, CancellationToken cancellationToken = default(CancellationToken))
+        public Task AddAsync(Message message, int outBoxTimeout = -1, CancellationToken cancellationToken = default(CancellationToken), IAmABoxConnectionProvider overridingConnectionProvider = null)
         {
             var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
 

--- a/src/Paramore.Brighter/InMemoryOutbox.cs
+++ b/src/Paramore.Brighter/InMemoryOutbox.cs
@@ -96,8 +96,8 @@ namespace Paramore.Brighter
         /// </summary>
         /// <param name="message"></param>
         /// <param name="outBoxTimeout"></param>
-        /// <param name="overridingConnectionProvider">This is not used for the In Memory Outbox.</param>
-        public void Add(Message message, int outBoxTimeout = -1, IAmABoxConnectionProvider overridingConnectionProvider = null)
+        /// <param name="transactionConnectionProvider">This is not used for the In Memory Outbox.</param>
+        public void Add(Message message, int outBoxTimeout = -1, IAmABoxTransactionConnectionProvider transactionConnectionProvider = null)
         {
             ClearExpiredMessages();
             EnforceCapacityLimit();
@@ -118,9 +118,9 @@ namespace Paramore.Brighter
         /// <param name="message"></param>
         /// <param name="outBoxTimeout"></param>
         /// <param name="cancellationToken"></param>
-        /// <param name="overridingConnectionProvider">This is not used for the In Memory Outbox.</param>
+        /// <param name="transactionConnectionProvider">This is not used for the In Memory Outbox.</param>
         /// <returns></returns>
-        public Task AddAsync(Message message, int outBoxTimeout = -1, CancellationToken cancellationToken = default(CancellationToken), IAmABoxConnectionProvider overridingConnectionProvider = null)
+        public Task AddAsync(Message message, int outBoxTimeout = -1, CancellationToken cancellationToken = default(CancellationToken), IAmABoxTransactionConnectionProvider transactionConnectionProvider = null)
         {
             var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
 

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/TestDoubles/FakeOutbox.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/TestDoubles/FakeOutbox.cs
@@ -37,12 +37,12 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles
 
         public bool ContinueOnCapturedContext { get; set; }
 
-        public void Add(Message message, int outBoxTimeout = -1)
+        public void Add(Message message, int outBoxTimeout = -1, IAmABoxTransactionConnectionProvider transactionConnectionProvider = null)
         {
             _posts.Add(new OutboxEntry {Message = message, TimeDeposited = DateTime.UtcNow});
         }
 
-        public Task AddAsync(Message message, int outBoxTimeout = -1, CancellationToken cancellationToken = default(CancellationToken))
+        public Task AddAsync(Message message, int outBoxTimeout = -1, CancellationToken cancellationToken = default(CancellationToken), IAmABoxTransactionConnectionProvider transactionConnectionProvider = null)
         {
             if (cancellationToken.IsCancellationRequested)
                 return Task.FromCanceled(cancellationToken);


### PR DESCRIPTION
@iancooper this is the new draft PR, spent some time re acquainting myself with what was going on here.

I propose IAmABoxTransactionConnectionProvider as the name (as it deals with Inbox and outbox)

There are a couple of things going on here that I've had to remind myself

1. The Ability to specify a Different Connection on Adding (so that you can share in a Transaction)
2. The Idea of a "Shared" connection so that you don't dispose the object between calls (At the minute a single Post will dispose and Re Open the connection multiple times)

I have also added the update to the Interface to the Other providers even though they do not yet do anything with them (Will need to look into this)

What are your thoughts on the two use cases above, this was previously done and in main before we split out the external bus, I see some value in here as we will probably want to use this optimisation later on but it does leave me thinking about  splitting the connection provider interfaces into 2 (Standard and Transaction) I suppose I should probably try to get something similar working for MySql and see how it shakes down.