### PR TITLE
Issue #1634 | Adds support for async handlers when using RPC

### DIFF
--- a/src/Paramore.Brighter/CommandProcessor.cs
+++ b/src/Paramore.Brighter/CommandProcessor.cs
@@ -93,7 +93,7 @@ namespace Paramore.Brighter
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CommandProcessor"/> class.
-        /// Use this constructor when external us support is required and both sync and async handlers are needed
+        /// Use this constructor when external bus support is required and both sync and async handlers are needed
         /// </summary>
         /// <param name="subscriberRegistry">The subscriber registry.</param>
         /// <param name="handlerFactory">The handler factory.</param>
@@ -249,6 +249,7 @@ namespace Paramore.Brighter
         /// <param name="requestContextFactory">The request context factory.</param>
         /// <param name="policyRegistry">The policy registry.</param>
         /// <param name="mapperRegistry">The mapper registry.</param>
+        /// <param name="outBox">The outbox</param>
         /// <param name="messageProducer">The messaging gateway.</param>
         /// <param name="responseChannelFactory">If we are expecting a response, then we need a channel to listen on</param>
         /// <param name="outboxTimeout">How long should we wait to write to the outbox</param>
@@ -278,6 +279,47 @@ namespace Paramore.Brighter
             _bus.ConfigurePublisherCallbackMaybe();
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CommandProcessor"/> class.
+        /// Use this constructor when sync/async handlers and rpc support is required 
+        /// </summary>
+        /// <param name="subscriberRegistry">The subscriber registry.</param>
+        /// <param name="handlerFactory">The handler factory.</param>
+        /// <param name="asyncHandlerFactory">The async handler factory.</param>
+        /// <param name="requestContextFactory">The request context factory.</param>
+        /// <param name="policyRegistry">The policy registry.</param>
+        /// <param name="mapperRegistry">The mapper registry.</param>
+        /// <param name="outBox">The outbox</param>
+        /// <param name="messageProducer">The messaging gateway.</param>
+        /// <param name="responseChannelFactory">If we are expecting a response, then we need a channel to listen on</param>
+        /// <param name="outboxTimeout">How long should we wait to write to the outbox</param>
+        /// <param name="featureSwitchRegistry">The feature switch config provider.</param>
+        /// <param name="inboxConfiguration">Do we want to insert an inbox handler into pipelines without the attribute. Null (default = no), yes = how to configure</param>
+        public CommandProcessor(
+            IAmASubscriberRegistry subscriberRegistry,
+            IAmAHandlerFactory handlerFactory,
+            IAmAHandlerFactoryAsync asyncHandlerFactory,
+            IAmARequestContextFactory requestContextFactory,
+            IPolicyRegistry<string> policyRegistry,
+            IAmAMessageMapperRegistry mapperRegistry,
+            IAmAnOutbox<Message> outBox,
+            IAmAMessageProducer messageProducer,
+            int outboxTimeout = 300,
+            IAmAFeatureSwitchRegistry featureSwitchRegistry = null,
+            IAmAChannelFactory responseChannelFactory = null,
+            InboxConfiguration inboxConfiguration = null)
+            : this(subscriberRegistry, handlerFactory, asyncHandlerFactory, requestContextFactory, policyRegistry)
+        {
+            _mapperRegistry = mapperRegistry;
+            _featureSwitchRegistry = featureSwitchRegistry;
+            _responseChannelFactory = responseChannelFactory;
+            _inboxConfiguration = inboxConfiguration;
+            
+            InitExtServiceBus(policyRegistry, outBox, null, outboxTimeout, messageProducer, null);
+
+            _bus.ConfigurePublisherCallbackMaybe();
+        }
+        
         /// <summary>
         /// Initializes a new instance of the <see cref="CommandProcessor"/> class.
         /// Use this constructor when both external bus and command processor support is required

--- a/src/Paramore.Brighter/CommandProcessorBuilder.cs
+++ b/src/Paramore.Brighter/CommandProcessorBuilder.cs
@@ -251,6 +251,7 @@ namespace Paramore.Brighter
                  return new CommandProcessor(
                     subscriberRegistry: _registry,
                     handlerFactory: _handlerFactory,
+                    asyncHandlerFactory: _asyncHandlerFactory,
                     requestContextFactory: _requestContextFactory,
                     policyRegistry: _policyRegistry,
                     mapperRegistry: _messageMapperRegistry,

--- a/tests/Paramore.Brighter.Core.Tests/Monitoring/When_Monitoring_Is_On_For_A_Handler_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Monitoring/When_Monitoring_Is_On_For_A_Handler_Async.cs
@@ -92,7 +92,7 @@ namespace Paramore.Brighter.Core.Tests.Monitoring
             //_should_include_the_underlying_request_details_before
             _beforeEvent.RequestBody.Should().Be(_originalRequestAsJson);
             //should_post_the_time_of_the_request_before
-            _beforeEvent.EventTime.AsUtc().Should().BeCloseTo(_at.AsUtc(), 1000);
+            _beforeEvent.EventTime.AsUtc().Should().BeCloseTo(_at.AsUtc(), TimeSpan.FromSeconds(1));
             //_should_have_an_instance_name_after
             _afterEvent.InstanceName.Should().Be("UnitTests");
             //_should_post_the_event_type_to_the_control_bus_after

--- a/tests/Paramore.Brighter.Core.Tests/Monitoring/When_monitoring_is_on_for_a_handler.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Monitoring/When_monitoring_is_on_for_a_handler.cs
@@ -92,7 +92,7 @@ namespace Paramore.Brighter.Core.Tests.Monitoring
             //_should_include_the_underlying_request_details_before
             _beforeEvent.RequestBody.Should().Be(_originalRequestAsJson);
             //_should_post_the_time_of_the_request_before
-            _beforeEvent.EventTime.AsUtc().Should().BeCloseTo(_at.AsUtc(), 1000);
+            _beforeEvent.EventTime.AsUtc().Should().BeCloseTo(_at.AsUtc(), TimeSpan.FromSeconds(1));
             //_should_elapsed_before_as_zero
             _beforeEvent.TimeElapsedMs.Should().Be(0);
             //_should_have_an_instance_name_after

--- a/tests/Paramore.Brighter.Core.Tests/Monitoring/When_serializing_a_monitoring_event.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Monitoring/When_serializing_a_monitoring_event.cs
@@ -74,7 +74,7 @@ namespace Paramore.Brighter.Core.Tests.Monitoring
             //_should_have_the_original_request_as_json
             _monitorEvent.RequestBody.Should().Be(_originalRequestAsJson);
             //_should_have_the_correct_event_time
-            _monitorEvent.EventTime.AsUtc().Should().BeCloseTo(_at.AsUtc(), 1000);
+            _monitorEvent.EventTime.AsUtc().Should().BeCloseTo(_at.AsUtc(), TimeSpan.FromSeconds(1));
             //_should_have_the_correct_time_elapsed
             _monitorEvent.TimeElapsedMs.Should().Be(_elapsedMilliseconds);
         }

--- a/tests/Paramore.Brighter.EventStore.Tests/Outbox/When_marking_a_message_as_dispatched_async_tests.cs
+++ b/tests/Paramore.Brighter.EventStore.Tests/Outbox/When_marking_a_message_as_dispatched_async_tests.cs
@@ -73,7 +73,7 @@ namespace Paramore.Brighter.EventStore.Tests.Outbox
             Func<Task> getWithoutArgs = async () => await eventStoreOutbox.MarkDispatchedAsync(Guid.Empty, DateTime.UtcNow);
             
             // assert
-            getWithoutArgs.Should().Throw<ArgumentNullException>();
+            getWithoutArgs.Should().ThrowAsync<ArgumentNullException>();
         }
 
         [Fact]
@@ -88,7 +88,7 @@ namespace Paramore.Brighter.EventStore.Tests.Outbox
             Func<Task> getWithoutArgs = async () => await eventStoreOutbox.MarkDispatchedAsync(Guid.Empty, DateTime.UtcNow, args);
             
             // assert
-            getWithoutArgs.Should().Throw<ArgumentException>();
+            getWithoutArgs.Should().ThrowAsync<ArgumentException>();
         }
 
         [Fact]
@@ -103,7 +103,7 @@ namespace Paramore.Brighter.EventStore.Tests.Outbox
             Func<Task> getWithoutArgs = async () => await eventStoreOutbox.MarkDispatchedAsync(Guid.Empty, DateTime.UtcNow, args);
             
             // assert
-            getWithoutArgs.Should().Throw<ArgumentException>();
+            getWithoutArgs.Should().ThrowAsync<ArgumentException>();
         }
 
         [Fact]
@@ -118,7 +118,7 @@ namespace Paramore.Brighter.EventStore.Tests.Outbox
             Func<Task> getWithoutArgs = async () => await eventStoreOutbox.MarkDispatchedAsync(Guid.Empty, DateTime.UtcNow, args);
             
             // assert
-            getWithoutArgs.Should().Throw<ArgumentException>();
+            getWithoutArgs.Should().ThrowAsync<ArgumentException>();
         }
     }
 }

--- a/tests/Paramore.Brighter.EventStore.Tests/Outbox/When_there_is_an_outstanding_message_in_the_outbox.cs
+++ b/tests/Paramore.Brighter.EventStore.Tests/Outbox/When_there_is_an_outstanding_message_in_the_outbox.cs
@@ -75,7 +75,7 @@ namespace Paramore.Brighter.EventStore.Tests.Outbox
             var messages = eventStoreOutbox.OutstandingMessages(500, 100, 1, args);
 
             // assert
-            messages.Should().BeEquivalentTo(outstandingMessage);
+            messages.Should().BeEquivalentTo(new [] { outstandingMessage });
         }
         
         [Fact]


### PR DESCRIPTION
Fix for Issue #1634 

- Adds an additional constructor for supporting sync/async handlers and RPC calls
- Fixes compile errors in tests.