### PR TITLE
Fixes #1700 | Adds feature switch support for builders

### DIFF
--- a/src/Paramore.Brighter/CommandProcessor.cs
+++ b/src/Paramore.Brighter/CommandProcessor.cs
@@ -721,6 +721,7 @@ namespace Paramore.Brighter
             //create a reply queue via creating a consumer - we use random identifiers as we will destroy
             var channelName = Guid.NewGuid();
             var routingKey = channelName.ToString();
+            
             using (var responseChannel =
                 _responseChannelFactory.CreateChannel(
                     new Subscription(

--- a/src/Paramore.Brighter/CommandProcessorBuilder.cs
+++ b/src/Paramore.Brighter/CommandProcessorBuilder.cs
@@ -23,7 +23,6 @@ THE SOFTWARE. */
 #endregion
 
 using Paramore.Brighter.FeatureSwitch;
-using Polly.Fallback;
 using Polly.Registry;
 
 namespace Paramore.Brighter
@@ -115,6 +114,17 @@ namespace Paramore.Brighter
         }
 
         /// <summary>
+        /// Supplies the specified feature switching configuration, so we can use feature switches on user-defined request handlers
+        /// </summary>
+        /// <param name="featureSwitchRegistry">The feature switch config provider</param>
+        /// <returns>INeedPolicy</returns>
+        public INeedAHandlers ConfigureFeatureSwitches(IAmAFeatureSwitchRegistry featureSwitchRegistry)
+        {
+            _featureSwitchRegistry = featureSwitchRegistry;
+            return this;
+        }
+
+        /// <summary>
         /// Supplies the specified the policy registry, so we can use policies for Task Queues or in user-defined request handlers such as ExceptionHandler
         /// that provide quality of service concerns
         /// </summary>
@@ -189,17 +199,6 @@ namespace Paramore.Brighter
             _outboxWriteTimeout = configuration.OutboxWriteTimeout;
             _responseChannelFactory = configuration.ResponseChannelFactory;
              
-            return this;
-        }
-        
-        /// <summary>
-        /// Supplies the specified feature switching configuration, so we can use feature switches on user-defined request handlers
-        /// </summary>
-        /// <param name="featureSwitchRegistry">The feature switch config provider</param>
-        /// <returns>INeedARequestContext</returns>
-        public INeedARequestContext ConfigureFeatureSwitches(IAmAFeatureSwitchRegistry featureSwitchRegistry)
-        {
-            _featureSwitchRegistry = featureSwitchRegistry;
             return this;
         }
 
@@ -284,6 +283,13 @@ namespace Paramore.Brighter
         /// <param name="theRegistry">The registry.</param>
         /// <returns>INeedPolicy.</returns>
         INeedPolicy Handlers(HandlerConfiguration theRegistry);
+        
+        /// <summary>
+        /// Configure Feature Switches for the Handlers
+        /// </summary>
+        /// <param name="featureSwitchRegistry"></param>
+        /// <returns></returns>
+        INeedAHandlers ConfigureFeatureSwitches(IAmAFeatureSwitchRegistry featureSwitchRegistry);
     }
 
     /// <summary>
@@ -343,13 +349,6 @@ namespace Paramore.Brighter
         /// <param name="requestContextFactory">The request context factory.</param>
         /// <returns>IAmACommandProcessorBuilder.</returns>
         IAmACommandProcessorBuilder RequestContextFactory(IAmARequestContextFactory requestContextFactory);
-
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="featureSwitchRegistry"></param>
-        /// <returns></returns>
-        INeedARequestContext ConfigureFeatureSwitches(IAmAFeatureSwitchRegistry featureSwitchRegistry);
     }
     
     /// <summary>

--- a/tests/Paramore.Brighter.Core.Tests/FeatureSwitch/When_A_Handler_Is_Feature_Switch_Config_Off.cs
+++ b/tests/Paramore.Brighter.Core.Tests/FeatureSwitch/When_A_Handler_Is_Feature_Switch_Config_Off.cs
@@ -69,11 +69,15 @@ namespace Paramore.Brighter.Core.Tests.FeatureSwitch
                                 .StatusOf<MyFeatureSwitchedConfigHandler>().Is(FeatureSwitchStatus.Off)
                                 .Build();
 
-            _commandProcessor = new CommandProcessor(_registry, 
-                                                     (IAmAHandlerFactory)_handlerFactory, 
-                                                     new InMemoryRequestContextFactory(), 
-                                                     new PolicyRegistry(),
-                                                     fluentConfig);
+            _commandProcessor = CommandProcessorBuilder
+                .With()
+                .ConfigureFeatureSwitches(fluentConfig)
+                .Handlers(new HandlerConfiguration(_registry, (IAmAHandlerFactory)_handlerFactory))
+                .DefaultPolicy()
+                .NoExternalBus()
+                .RequestContextFactory(new InMemoryRequestContextFactory())
+                .Build();
+
             _commandProcessor.Send(_myCommand);
 
             _provider.GetService<MyFeatureSwitchedConfigHandler>().DidReceive(_myCommand).Should().BeFalse();

--- a/tests/Paramore.Brighter.Core.Tests/FeatureSwitch/When_A_Handler_Is_Feature_Switch_Config_On.cs
+++ b/tests/Paramore.Brighter.Core.Tests/FeatureSwitch/When_A_Handler_Is_Feature_Switch_Config_On.cs
@@ -68,12 +68,16 @@ namespace Paramore.Brighter.Core.Tests.FeatureSwitch
                                     .With()                
                                     .StatusOf<MyFeatureSwitchedConfigHandler>().Is(FeatureSwitchStatus.On)
                                     .Build();
-
-            _commandProcessor = new CommandProcessor(_registry, 
-                                                     (IAmAHandlerFactory)_handlerFactory, 
-                                                     new InMemoryRequestContextFactory(), 
-                                                     new PolicyRegistry(),
-                                                     fluentConfig);
+            
+            _commandProcessor = CommandProcessorBuilder
+                .With()
+                .ConfigureFeatureSwitches(fluentConfig)
+                .Handlers(new HandlerConfiguration(_registry, (IAmAHandlerFactory)_handlerFactory))
+                .DefaultPolicy()
+                .NoExternalBus()
+                .RequestContextFactory(new InMemoryRequestContextFactory())
+                .Build();
+            
             _commandProcessor.Send(_myCommand);
 
             _provider.GetService<MyFeatureSwitchedConfigHandler>().DidReceive(_myCommand).Should().BeTrue();

--- a/tests/Paramore.Brighter.Core.Tests/FeatureSwitch/When_A_Handler_Is_Feature_Switch_Missing_Config_Exception.cs
+++ b/tests/Paramore.Brighter.Core.Tests/FeatureSwitch/When_A_Handler_Is_Feature_Switch_Missing_Config_Exception.cs
@@ -68,11 +68,14 @@ namespace Paramore.Brighter.Core.Tests.FeatureSwitch
         {
             _featureSwitchRegistry.MissingConfigStrategy = MissingConfigStrategy.Exception;
 
-            _commandProcessor = new CommandProcessor(_registry, 
-                                                     (IAmAHandlerFactory)_handlerFactory, 
-                                                     new InMemoryRequestContextFactory(), 
-                                                     new PolicyRegistry(),
-                                                     _featureSwitchRegistry);
+            _commandProcessor = CommandProcessorBuilder
+                .With()
+                .ConfigureFeatureSwitches(_featureSwitchRegistry)
+                .Handlers(new HandlerConfiguration(_registry, (IAmAHandlerFactory)_handlerFactory))
+                .DefaultPolicy()
+                .NoExternalBus()
+                .RequestContextFactory(new InMemoryRequestContextFactory())
+                .Build();
 
             _exception = Catch.Exception(() => _commandProcessor.Send(_myCommand));
 

--- a/tests/Paramore.Brighter.Core.Tests/FeatureSwitch/When_A_Handler_Is_Feature_Switch_Missing_Config_SilentOff.cs
+++ b/tests/Paramore.Brighter.Core.Tests/FeatureSwitch/When_A_Handler_Is_Feature_Switch_Missing_Config_SilentOff.cs
@@ -67,11 +67,15 @@ namespace Paramore.Brighter.Core.Tests.FeatureSwitch
         {
             _featureSwitchRegistry.MissingConfigStrategy = MissingConfigStrategy.SilentOff;
 
-            _commandProcessor = new CommandProcessor(_registry, 
-                                                     (IAmAHandlerFactory)_handlerFactory, 
-                                                     new InMemoryRequestContextFactory(), 
-                                                     new PolicyRegistry(),
-                                                     _featureSwitchRegistry);
+          _commandProcessor = CommandProcessorBuilder
+                .With()
+                .ConfigureFeatureSwitches(_featureSwitchRegistry)
+                .Handlers(new HandlerConfiguration(_registry, (IAmAHandlerFactory)_handlerFactory))
+                .DefaultPolicy()
+                .NoExternalBus()
+                .RequestContextFactory(new InMemoryRequestContextFactory())
+                .Build();
+            
             _commandProcessor.Send(_myCommand);
 
             _provider.GetService<MyFeatureSwitchedConfigHandler>().DidReceive(_myCommand).Should().BeFalse();

--- a/tests/Paramore.Brighter.Core.Tests/FeatureSwitch/When_A_Handler_Is_Feature_Switch_Missing_Config_SilentOn.cs
+++ b/tests/Paramore.Brighter.Core.Tests/FeatureSwitch/When_A_Handler_Is_Feature_Switch_Missing_Config_SilentOn.cs
@@ -68,11 +68,15 @@ namespace Paramore.Brighter.Core.Tests.FeatureSwitch
         {
             _featureSwitchRegistry.MissingConfigStrategy = MissingConfigStrategy.SilentOn;
 
-            _commandProcessor = new CommandProcessor(_registry, 
-                                                     (IAmAHandlerFactory)_handlerFactory, 
-                                                     new InMemoryRequestContextFactory(), 
-                                                     new PolicyRegistry(),
-                                                     _featureSwitchRegistry);
+            _commandProcessor = CommandProcessorBuilder
+                .With()
+                .ConfigureFeatureSwitches(_featureSwitchRegistry)
+                .Handlers(new HandlerConfiguration(_registry, (IAmAHandlerFactory)_handlerFactory))
+                .DefaultPolicy()
+                .NoExternalBus()
+                .RequestContextFactory(new InMemoryRequestContextFactory())
+                .Build();
+            
             _commandProcessor.Send(_myCommand);
 
             _provider.GetService<MyFeatureSwitchedConfigHandler>().DidReceive(_myCommand).Should().BeTrue();

--- a/tests/Paramore.Brighter.Core.Tests/FeatureSwitch/When_A_Handler_Is_Feature_Switch_Off.cs
+++ b/tests/Paramore.Brighter.Core.Tests/FeatureSwitch/When_A_Handler_Is_Feature_Switch_Off.cs
@@ -59,7 +59,14 @@ namespace Paramore.Brighter.Core.Tests.FeatureSwitch
         [Fact]
         public void When_Sending_A_Command_To_The_Processor_When_A_Feature_Switch_Is_Off()
         {
-            _commandProcessor = new CommandProcessor(_registry, (IAmAHandlerFactory)_handlerFactory, new InMemoryRequestContextFactory(), new PolicyRegistry());
+            _commandProcessor = CommandProcessorBuilder
+                .With()
+                .Handlers(new HandlerConfiguration(_registry, (IAmAHandlerFactory)_handlerFactory))
+                .DefaultPolicy()
+                .NoExternalBus()
+                .RequestContextFactory(new InMemoryRequestContextFactory())
+                .Build();
+            
             _commandProcessor.Send(_myCommand);
 
             MyFeatureSwitchedOffHandler.DidReceive(_myCommand).Should().BeFalse();

--- a/tests/Paramore.Brighter.Core.Tests/FeatureSwitch/When_A_Handler_Is_Feature_Switch_On.cs
+++ b/tests/Paramore.Brighter.Core.Tests/FeatureSwitch/When_A_Handler_Is_Feature_Switch_On.cs
@@ -59,7 +59,14 @@ namespace Paramore.Brighter.Core.Tests.FeatureSwitch
         [Fact]
         public void When_Sending_A_Command_To_The_Processor_When_A_Feature_Switch_Is_On()
         {
-            _commandProcessor = new CommandProcessor(_registry, (IAmAHandlerFactory)_handlerFactory, new InMemoryRequestContextFactory(), new PolicyRegistry());
+            _commandProcessor = CommandProcessorBuilder
+                .With()
+                .Handlers(new HandlerConfiguration(_registry, (IAmAHandlerFactory)_handlerFactory))
+                .DefaultPolicy()
+                .NoExternalBus()
+                .RequestContextFactory(new InMemoryRequestContextFactory())
+                .Build();
+
             _commandProcessor.Send(_myCommand);
 
             MyFeatureSwitchedOnHandler.DidReceive(_myCommand).Should().BeTrue();

--- a/tests/Paramore.Brighter.Core.Tests/FeatureSwitch/When_No_Feature_Switch_Config.cs
+++ b/tests/Paramore.Brighter.Core.Tests/FeatureSwitch/When_No_Feature_Switch_Config.cs
@@ -61,10 +61,13 @@ namespace Paramore.Brighter.Core.Tests.FeatureSwitch
         [Fact]
         public void When_a_sending_a_command_to_the_processor_when_null_feature_switch_config()
         {
-            _commandProcessor = new CommandProcessor(_registry, 
-                                                     (IAmAHandlerFactory)_handlerFactory, 
-                                                     new InMemoryRequestContextFactory(), 
-                                                     new PolicyRegistry());
+            _commandProcessor = CommandProcessorBuilder
+                .With()
+                .Handlers(new HandlerConfiguration(_registry, (IAmAHandlerFactory)_handlerFactory))
+                .DefaultPolicy()
+                .NoExternalBus()
+                .RequestContextFactory(new InMemoryRequestContextFactory())
+                .Build();
 
             _commandProcessor.Send(_myCommand);
 


### PR DESCRIPTION
- Adds configuring of Feature Switches to CommandProcessorBuilder and ServiceCollectionExtensions
- Updates the feature switch tests to use the CommandProcessorBuilder