### PR TITLE
Updated POST on Command Processor to no participate on TXNs #1757

### DIFF
--- a/tests/Paramore.Brighter.MSSQL.Tests/Outbox/When_there_is_an_outstanding_message_in_the_outbox.cs
+++ b/tests/Paramore.Brighter.MSSQL.Tests/Outbox/When_there_is_an_outstanding_message_in_the_outbox.cs
@@ -31,7 +31,7 @@ namespace Paramore.Brighter.MSSQL.Tests.Outbox
         [Fact]
         public void When_there_is_an_outstanding_message_in_the_outbox()
         {
-            var outstandingMessage = _sqlOutboxSync.OutstandingMessages(500).SingleOrDefault();
+            var outstandingMessage = _sqlOutboxSync.OutstandingMessages(100).SingleOrDefault();
 
             outstandingMessage.Should().NotBeNull();
             outstandingMessage.Id.Should().Be(_dispatchedMessage.Id);
@@ -40,7 +40,7 @@ namespace Paramore.Brighter.MSSQL.Tests.Outbox
         [Fact]
         public async Task When_there_is_an_outstanding_message_in_the_outbox_async()
         {
-            var outstandingMessage = (await _sqlOutboxSync.OutstandingMessagesAsync(500)).SingleOrDefault();
+            var outstandingMessage = (await _sqlOutboxSync.OutstandingMessagesAsync(100)).SingleOrDefault();
 
             outstandingMessage.Should().NotBeNull();
             outstandingMessage.Id.Should().Be(_dispatchedMessage.Id);


### PR DESCRIPTION
This PR modifies the Behaviour of Post and PostAsync so that they explicitly do not Participate in a Transaction if a TransactionConnectionProvider is configured