### PR TITLE
Fix to ensure check is done for Error.Code.NoError if Error is not null

### DIFF
--- a/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaMessagingGateway.cs
+++ b/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaMessagingGateway.cs
@@ -74,7 +74,6 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
                     {
                         var matchingTopic = matchingTopics[0];
                         if (matchingTopic.Error == null) return true;
-                        // TODO : Still trying to work out how to test this
                         if (matchingTopic.Error.Code == ErrorCode.NoError) return true;
                         if (matchingTopic.Error.Code == ErrorCode.UnknownTopicOrPart)
                             return false;


### PR DESCRIPTION
Fix for #1763

Upon discussion with @iancooper this fix won't come with any code tests as it's quite difficult to test. The only consequence of this bug, is an unnecessary call to create a topic, and the handling of a CreateTopicException - which is to just log a message.

## The output before the fix
![image](https://user-images.githubusercontent.com/10956881/138568312-d660758e-aa3c-4ca2-bc51-3034cc1ea29b.png)

## The output after the fix
![image](https://user-images.githubusercontent.com/10956881/138568298-7dc2ba75-68b3-4d4d-a80d-7555862739d4.png)

You can see from the output that after the fix, there are no longer the following message in the output:
`Topic xxx is in error with code : NoError and reason : Success`
and
`Topic xxx already exists`
