### PR TITLE
Updated External Bus to not attempt to send MT_NONE

### DIFF
--- a/src/Paramore.Brighter.Outbox.MsSql/MsSqlOutbox.cs
+++ b/src/Paramore.Brighter.Outbox.MsSql/MsSqlOutbox.cs
@@ -690,7 +690,7 @@ namespace Paramore.Brighter.Outbox.MsSql
             }
             dr.Close();
 
-            return message;
+            return message ?? new Message();
         }
         
         private async Task<Message> MapFunctionAsync(SqlDataReader dr)
@@ -702,7 +702,7 @@ namespace Paramore.Brighter.Outbox.MsSql
             }
             dr.Close();
 
-            return message;
+            return message ?? new Message();
         }
    }
 }

--- a/src/Paramore.Brighter/ExternalBusServices.cs
+++ b/src/Paramore.Brighter/ExternalBusServices.cs
@@ -137,7 +137,7 @@ namespace Paramore.Brighter
             foreach (var messageId in posts)
             {
                 var message = OutBox.Get(messageId);
-                if (message == null)
+                if (message == null || message.Header.MessageType == MessageType.MT_NONE)
                     throw new NullReferenceException($"Message with Id {messageId} not found in the Outbox");
 
                 s_logger.LogInformation("Decoupled invocation of message: Topic:{Topic} Id:{Id}", message.Header.Topic, messageId.ToString());
@@ -173,7 +173,7 @@ namespace Paramore.Brighter
             foreach (var messageId in posts)
             {
                 var message = await AsyncOutbox.GetAsync(messageId, OutboxTimeout, cancellationToken);
-                if (message == null)
+                if (message == null || message.Header.MessageType == MessageType.MT_NONE)
                     throw new NullReferenceException($"Message with Id {messageId} not found in the Outbox");
 
                 s_logger.LogInformation("Decoupled invocation of message: Topic:{Topic} Id:{Id}", message.Header.Topic, messageId.ToString());


### PR DESCRIPTION
Following the Guidance the MSSQL Outbox new returns a message with type of MT_NONE instead of a null, and the External Bus now checks for MT_None and null when trying to Dispatch so it will no longer try to dispatch non existent messages