### PR TITLE
Ensured a new CommandProcessorProvider for each Message Pump

### DIFF
--- a/samples/ASBTaskQueue/GreetingsWorker/Program.cs
+++ b/samples/ASBTaskQueue/GreetingsWorker/Program.cs
@@ -89,6 +89,7 @@ namespace GreetingsWorker
                             options.Subscriptions = subscriptions;
                             options.ChannelFactory = new AzureServiceBusChannelFactory(asbConsumerFactory);
                             options.UseScoped = true;
+                            
                         }).UseMsSqlOutbox(outboxConfig, typeof(MsSqlSqlAuthConnectionProvider))
                         .UseMsSqlTransactionConnectionProvider(typeof(MsSqlEntityFrameworkCoreConnectionProvider<GreetingsDataContext>))
                         .UseExternalBus(AzureServiceBusMessageProducerFactory.Get(clientProvider))

--- a/src/Paramore.Brighter.Inbox.MsSql/Paramore.Brighter.Inbox.MsSql.csproj
+++ b/src/Paramore.Brighter.Inbox.MsSql/Paramore.Brighter.Inbox.MsSql.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.5.0" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="4.0.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="3.0.1" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.3" />
   </ItemGroup>
 </Project>

--- a/src/Paramore.Brighter.MessagingGateway.MsSql/Paramore.Brighter.MessagingGateway.MsSql.csproj
+++ b/src/Paramore.Brighter.MessagingGateway.MsSql/Paramore.Brighter.MessagingGateway.MsSql.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.5.0" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="4.0.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="3.0.1" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.3" />
   </ItemGroup>
 </Project>

--- a/src/Paramore.Brighter.MsSql/Paramore.Brighter.MsSql.csproj
+++ b/src/Paramore.Brighter.MsSql/Paramore.Brighter.MsSql.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Data.SqlClient" Version="4.0.0" />
+      <PackageReference Include="Microsoft.Data.SqlClient" Version="3.0.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Paramore.Brighter.Outbox.MsSql/Paramore.Brighter.Outbox.MsSql.csproj
+++ b/src/Paramore.Brighter.Outbox.MsSql/Paramore.Brighter.Outbox.MsSql.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.5.0" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="4.0.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="3.0.1" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.3" />
   </ItemGroup>
 </Project>

--- a/src/Paramore.Brighter.ServiceActivator/ControlBusReceiverBuilder.cs
+++ b/src/Paramore.Brighter.ServiceActivator/ControlBusReceiverBuilder.cs
@@ -161,9 +161,7 @@ namespace Paramore.Brighter.ServiceActivator.ControlBus
                 .ExternalBus(new MessagingConfiguration(producer, outgoingMessageMapperRegistry), outbox)
                 .RequestContextFactory(new InMemoryRequestContextFactory())
                 .Build();
-
-            var commandProcessorProvider = new CommandProcessorProvider(commandProcessor);
-
+            
             // These are the control bus channels, we hardcode them because we want to know they exist, but we use
             // a base naming scheme to allow centralized management.
             var connectionsConfiguration = new Subscription[]
@@ -179,7 +177,7 @@ namespace Paramore.Brighter.ServiceActivator.ControlBus
             };
 
             return DispatchBuilder.With()
-                .CommandProcessorProvider(commandProcessorProvider)
+                .CommandProcessorFactory(() => new CommandProcessorProvider(commandProcessor))
                 .MessageMappers(incomingMessageMapperRegistry)
                 .DefaultChannelFactory(_channelFactory)
                 .Connections(connectionsConfiguration)

--- a/src/Paramore.Brighter.ServiceActivator/DispatchBuilder.cs
+++ b/src/Paramore.Brighter.ServiceActivator/DispatchBuilder.cs
@@ -1,4 +1,4 @@
-#region Licence
+﻿#region Licence
 /* The MIT License (MIT)
 Copyright © 2014 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
 
@@ -22,6 +22,7 @@ THE SOFTWARE. */
 
 #endregion
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -33,9 +34,9 @@ namespace Paramore.Brighter.ServiceActivator
     /// progressive interfaces to manage the requirements for a complete Dispatcher via Intellisense in the IDE. The intent is to make it easier to
     /// recognize those dependencies that you need to configure
     /// </summary>
-    public class DispatchBuilder : INeedACommandProcessorProvider, INeedAChannelFactory, INeedAMessageMapper, INeedAListOfConnections, IAmADispatchBuilder
+    public class DispatchBuilder : INeedACommandProcessorFactory, INeedAChannelFactory, INeedAMessageMapper, INeedAListOfConnections, IAmADispatchBuilder
     {
-        private IAmACommandProcessorProvider _commandProcessorProvider;
+        private Func<IAmACommandProcessorProvider> _commandProcessorFactory;
         private IAmAMessageMapperRegistry _messageMapperRegistry;
         private IAmAChannelFactory _defaultChannelFactory;
         private IEnumerable<Subscription> _connections;
@@ -46,7 +47,7 @@ namespace Paramore.Brighter.ServiceActivator
         /// Begins the fluent interface 
         /// </summary>
         /// <returns>INeedALogger.</returns>
-        public static INeedACommandProcessorProvider With()
+        public static INeedACommandProcessorFactory With()
         {
             return new DispatchBuilder();
         }
@@ -54,11 +55,11 @@ namespace Paramore.Brighter.ServiceActivator
         /// <summary>
         /// The command processor used to send and publish messages to handlers by the service activator.
         /// </summary>
-        /// <param name="theCommandProcessorProvider">The command processor provider.</param>
+        /// <param name="commandProcessorFactory">The command processor Factory.</param>
         /// <returns>INeedAMessageMapper.</returns>
-        public INeedAMessageMapper CommandProcessorProvider(IAmACommandProcessorProvider theCommandProcessorProvider)
+        public INeedAMessageMapper CommandProcessorFactory(Func<IAmACommandProcessorProvider> commandProcessorFactory)
         {
-            _commandProcessorProvider = theCommandProcessorProvider;
+            _commandProcessorFactory = commandProcessorFactory;
             return this;
         }
 
@@ -109,7 +110,7 @@ namespace Paramore.Brighter.ServiceActivator
         /// <returns>Dispatcher.</returns>
         public Dispatcher Build()
         {
-            return new Dispatcher(_commandProcessorProvider, _messageMapperRegistry, _connections);
+            return new Dispatcher(_commandProcessorFactory.Invoke(), _messageMapperRegistry, _connections);
         }
     }
 
@@ -118,14 +119,14 @@ namespace Paramore.Brighter.ServiceActivator
     /// <summary>
     /// Interface INeedACommandProcessor
     /// </summary>
-    public interface INeedACommandProcessorProvider
+    public interface INeedACommandProcessorFactory
     {
         /// <summary>
         /// The command processor used to send and publish messages to handlers by the service activator.
         /// </summary>
-        /// <param name="commandProcessorProvider">The command processor provider.</param>
+        /// <param name="commandProcessorFactory">The command processor provider Factory.</param>
         /// <returns>INeedAMessageMapper.</returns>
-        INeedAMessageMapper CommandProcessorProvider(IAmACommandProcessorProvider commandProcessorProvider);
+        INeedAMessageMapper CommandProcessorFactory(Func<IAmACommandProcessorProvider> commandProcessorFactory);
     }
 
     /// <summary>

--- a/src/Paramore.Brighter.ServiceActivator/DispatchBuilder.cs
+++ b/src/Paramore.Brighter.ServiceActivator/DispatchBuilder.cs
@@ -110,7 +110,7 @@ namespace Paramore.Brighter.ServiceActivator
         /// <returns>Dispatcher.</returns>
         public Dispatcher Build()
         {
-            return new Dispatcher(_commandProcessorFactory.Invoke(), _messageMapperRegistry, _connections);
+            return new Dispatcher(_commandProcessorFactory, _messageMapperRegistry, _connections);
         }
     }
 

--- a/tests/Paramore.Brighter.RMQ.Tests/MessageDispatch/When_building_a_dispatcher.cs
+++ b/tests/Paramore.Brighter.RMQ.Tests/MessageDispatch/When_building_a_dispatcher.cs
@@ -81,7 +81,7 @@ namespace Paramore.Brighter.RMQ.Tests.MessageDispatch
                 .Build();
 
             _builder = DispatchBuilder.With()
-                .CommandProcessorProvider(new CommandProcessorProvider(commandProcessor))
+                .CommandProcessorFactory(() =>new CommandProcessorProvider(commandProcessor))
                 .MessageMappers(messageMapperRegistry)
                 .DefaultChannelFactory(new ChannelFactory(rmqMessageConsumerFactory))
                 .Connections(new []

--- a/tests/Paramore.Brighter.RMQ.Tests/MessageDispatch/When_building_a_dispatcher_with_named_gateway.cs
+++ b/tests/Paramore.Brighter.RMQ.Tests/MessageDispatch/When_building_a_dispatcher_with_named_gateway.cs
@@ -76,7 +76,7 @@ namespace Paramore.Brighter.RMQ.Tests.MessageDispatch
                 .Build();
 
             _builder = DispatchBuilder.With()
-                .CommandProcessorProvider(new CommandProcessorProvider(commandProcessor))
+                .CommandProcessorFactory(() => new CommandProcessorProvider(commandProcessor))
                 .MessageMappers(messageMapperRegistry)
                 .DefaultChannelFactory(new ChannelFactory(rmqMessageConsumerFactory))
                 .Connections(new []


### PR DESCRIPTION
Fixed Issue where the same instance of Command Processor Provider was Passed to each instance of the Dispatcher/Message pump resulting in a "Shared Scoped" across instances.