### PR TITLE
Support Fluent Configuration of Our Inbox

### DIFF
--- a/.idea/.idea.Brighter/.idea/httpRequests/http-requests-log.http
+++ b/.idea/.idea.Brighter/.idea/httpRequests/http-requests-log.http
@@ -5,6 +5,254 @@ Content-Type: application/json
   "Greeting" : "I drink, and I know things"
 }
 
+<> 2022-02-21T191545.200.json
+
+###
+
+POST http://localhost:5000/Greetings/Tyrion/new
+Content-Type: application/json
+
+{
+  "Greeting" : "I drink, and I know things"
+}
+
+<> 2022-02-21T191543.200.json
+
+###
+
+POST http://localhost:5000/Greetings/Tyrion/new
+Content-Type: application/json
+
+{
+  "Greeting" : "I drink, and I know things"
+}
+
+<> 2022-02-21T191542.200.json
+
+###
+
+POST http://localhost:5000/Greetings/Tyrion/new
+Content-Type: application/json
+
+{
+  "Greeting" : "I drink, and I know things"
+}
+
+<> 2022-02-21T191540.200.json
+
+###
+
+POST http://localhost:5000/Greetings/Tyrion/new
+Content-Type: application/json
+
+{
+  "Greeting" : "I drink, and I know things"
+}
+
+<> 2022-02-21T191538.200.json
+
+###
+
+POST http://localhost:5000/Greetings/Tyrion/new
+Content-Type: application/json
+
+{
+  "Greeting" : "I drink, and I know things"
+}
+
+<> 2022-02-21T191537.200.json
+
+###
+
+POST http://localhost:5000/People/new
+Content-Type: application/json
+
+{
+  "Name" : "Tyrion"
+}
+
+<> 2022-02-21T191532.200.json
+
+###
+
+POST http://localhost:5000/Greetings/Tyrion/new
+Content-Type: application/json
+
+{
+  "Greeting" : "I drink, and I know things"
+}
+
+<> 2022-02-21T190227.200.json
+
+###
+
+POST http://localhost:5000/Greetings/Tyrion/new
+Content-Type: application/json
+
+{
+  "Greeting" : "I drink, and I know things"
+}
+
+<> 2022-02-21T190115.200.json
+
+###
+
+POST http://localhost:5000/Greetings/Tyrion/new
+Content-Type: application/json
+
+{
+  "Greeting" : "I drink, and I know things"
+}
+
+<> 2022-02-21T190113.200.json
+
+###
+
+POST http://localhost:5000/Greetings/Tyrion/new
+Content-Type: application/json
+
+{
+  "Greeting" : "I drink, and I know things"
+}
+
+<> 2022-02-21T190112.200.json
+
+###
+
+POST http://localhost:5000/Greetings/Tyrion/new
+Content-Type: application/json
+
+{
+  "Greeting" : "I drink, and I know things"
+}
+
+<> 2022-02-21T190109.200.json
+
+###
+
+POST http://localhost:5000/Greetings/Tyrion/new
+Content-Type: application/json
+
+{
+  "Greeting" : "I drink, and I know things"
+}
+
+<> 2022-02-21T190108.200.json
+
+###
+
+POST http://localhost:5000/People/new
+Content-Type: application/json
+
+{
+  "Name" : "Tyrion"
+}
+
+<> 2022-02-21T190103.200.json
+
+###
+
+POST http://localhost:5000/People/new
+Content-Type: application/json
+
+{
+  "Name" : "Tyrion"
+}
+
+<> 2022-02-21T185929.500.json
+
+###
+
+POST http://localhost:5000/Greetings/Tyrion/new
+Content-Type: application/json
+
+{
+  "Greeting" : "I drink, and I know things"
+}
+
+<> 2022-02-21T131223.200.json
+
+###
+
+POST http://localhost:5000/Greetings/Tyrion/new
+Content-Type: application/json
+
+{
+  "Greeting" : "I drink, and I know things"
+}
+
+<> 2022-02-21T131221.200.json
+
+###
+
+POST http://localhost:5000/Greetings/Tyrion/new
+Content-Type: application/json
+
+{
+  "Greeting" : "I drink, and I know things"
+}
+
+<> 2022-02-21T131220.200.json
+
+###
+
+POST http://localhost:5000/Greetings/Tyrion/new
+Content-Type: application/json
+
+{
+  "Greeting" : "I drink, and I know things"
+}
+
+<> 2022-02-21T131218.200.json
+
+###
+
+POST http://localhost:5000/Greetings/Tyrion/new
+Content-Type: application/json
+
+{
+  "Greeting" : "I drink, and I know things"
+}
+
+<> 2022-02-21T131215.200.json
+
+###
+
+POST http://localhost:5000/Greetings/Tyrion/new
+Content-Type: application/json
+
+{
+  "Greeting" : "I drink, and I know things"
+}
+
+<> 2022-02-21T131210.200.json
+
+###
+
+GET http://localhost:5000/People/Tyrion
+
+<> 2022-02-21T131206.200.json
+
+###
+
+POST http://localhost:5000/People/new
+Content-Type: application/json
+
+{
+  "Name" : "Tyrion"
+}
+
+<> 2022-02-21T131202.200.json
+
+###
+
+POST http://localhost:5000/Greetings/Tyrion/new
+Content-Type: application/json
+
+{
+  "Greeting" : "I drink, and I know things"
+}
+
 <> 2022-02-07T193631.200.json
 
 ###
@@ -266,203 +514,6 @@ Content-Type: application/json
 }
 
 <> 2022-02-07T090057.200.json
-
-###
-
-POST http://localhost:5000/Greetings/Tyrion/new
-Content-Type: application/json
-
-{
-  "Greeting" : "I drink, and I know things"
-}
-
-<> 2022-02-07T084506.200.json
-
-###
-
-GET http://localhost:5000/Greetings/Tyrion
-
-<> 2022-02-07T084449.200.json
-
-###
-
-GET http://localhost:5000/People/Tyrion
-
-<> 2022-02-07T084441.200.json
-
-###
-
-POST http://localhost:5000/Greetings/Tyrion/new
-Content-Type: application/json
-
-{
-  "Greeting" : "I drink, and I know things"
-}
-
-<> 2022-02-07T083753.200.json
-
-###
-
-POST http://localhost:5000/Greetings/Tyrion/new
-Content-Type: application/json
-
-{
-  "Greeting" : "I drink, and I know things"
-}
-
-<> 2022-02-07T083705.200.json
-
-###
-
-GET http://localhost:5000/People/Tyrion
-
-<> 2022-02-07T083655.200.json
-
-###
-
-POST http://localhost:5000/Greetings/Tyrion/new
-Content-Type: application/json
-
-{
-  "Greeting" : "I drink, and I know things"
-}
-
-###
-
-POST http://localhost:5000/Greetings/Tyrion/new
-Content-Type: application/json
-
-{
-  "Greeting" : "I drink, and I know things"
-}
-
-<> 2022-02-07T082006.200.json
-
-###
-
-GET http://localhost:5000/People/Tyrion
-
-<> 2022-02-07T082000.200.json
-
-###
-
-POST http://localhost:5000/People/new
-Content-Type: application/json
-
-{
-  "Name" : "Tyrion"
-}
-
-<> 2022-02-07T081955.200.json
-
-###
-
-DELETE http://localhost:5000/People/Tyrion
-
-<> 2022-02-07T081937.500.json
-
-###
-
-POST http://localhost:5000/People/new
-Content-Type: application/json
-
-{
-  "Name" : "Tyrion"
-}
-
-<> 2022-02-07T081249.500.json
-
-###
-
-DELETE http://localhost:5000/People/Tyrion
-
-<> 2022-02-07T081239.500.json
-
-###
-
-POST http://localhost:5000/Greetings/Tyrion/new
-Content-Type: application/json
-
-{
-  "Greeting" : "I drink, and I know things"
-}
-
-<> 2021-09-21T201728.200.json
-
-###
-
-GET http://localhost:5000/Greetings/tyrion
-
-<> 2021-09-21T201723.200.json
-
-###
-
-POST http://localhost:5000/Greetings/Tyrion/new
-Content-Type: application/json
-
-{
-  "Greeting" : "I drink, and I know things"
-}
-
-<> 2021-09-21T201008.200.json
-
-###
-
-GET http://localhost:5000/Greetings/tyrion
-
-<> 2021-09-21T200947.200.json
-
-###
-
-POST http://localhost:5000/People/new
-Content-Type: application/json
-
-{
-  "Name" : "Tyrion"
-}
-
-<> 2021-09-21T200942.200.json
-
-###
-
-POST http://locahost:5000/People/new
-Content-Type: application/json
-
-{
-  "Name" : "Tyrion"
-}
-
-###
-
-GET http://localhost:5000/Greetings/tyrion
-
-<> 2021-09-21T200738.500.json
-
-###
-
-POST http://locahost:5000/People/new
-Content-Type: application/json
-
-{
-  "Name" : "Tyrion"
-}
-
-###
-
-POST http://localhost:5000/Greetings/Tyrion/new
-Content-Type: application/json
-
-{
-  "Greeting" : "I drink, and I know things"
-}
-
-<> 2021-09-21T200648.500.json
-
-###
-
-GET http://localhost:5000/People/Tyrion
-
-<> 2021-09-21T200639.500.json
 
 ###
 

--- a/samples/WebAPI_EFCore/SalutationAnalytics/Database/SchemaCreation.cs
+++ b/samples/WebAPI_EFCore/SalutationAnalytics/Database/SchemaCreation.cs
@@ -18,8 +18,8 @@ namespace SalutationAnalytics.Database
 {
     public static class SchemaCreation
     {
-        private const string INBOX_TABLE_NAME = "Inbox";
-        private const string OUTBOX_TABLE_NAME = "Outbox";
+        internal const string INBOX_TABLE_NAME = "Inbox";
+        internal const string OUTBOX_TABLE_NAME = "Outbox";
 
 
         public static IHost MigrateDatabase(this IHost host)

--- a/samples/WebAPI_EFCore/SalutationAnalytics/Program.cs
+++ b/samples/WebAPI_EFCore/SalutationAnalytics/Program.cs
@@ -7,6 +7,10 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Paramore.Brighter;
+using Paramore.Brighter.Extensions.DependencyInjection;
+using Paramore.Brighter.Inbox;
+using Paramore.Brighter.Inbox.MySql;
+using Paramore.Brighter.Inbox.Sqlite;
 using Paramore.Brighter.MessagingGateway.RMQ;
 using Paramore.Brighter.ServiceActivator.Extensions.DependencyInjection;
 using Paramore.Brighter.ServiceActivator.Extensions.Hosting;
@@ -76,7 +80,15 @@ namespace SalutationAnalytics
                             options.ChannelFactory = new ChannelFactory(rmqMessageConsumerFactory);
                             options.UseScoped = true;
                         })
-                        .AutoFromAssemblies();
+                        .AutoFromAssemblies()
+                        .UseExternalInbox(
+                            ConfigureInbox(hostContext),
+                            new InboxConfiguration(
+                                scope: InboxScope.All,
+                                onceOnly: true,
+                                actionOnExists: OnceOnlyAction.Warn
+                                )
+                            );
 
                     services.AddHostedService<ServiceActivatorHostedService>();
                 })
@@ -117,6 +129,16 @@ namespace SalutationAnalytics
                        .EnableSensitiveDataLogging();
                });
             }
+        }
+
+        private static IAmAnInbox ConfigureInbox(HostBuilderContext hostContext)
+        {
+            if (hostContext.HostingEnvironment.IsDevelopment())
+            {
+                return new SqliteInbox(new SqliteInboxConfiguration(DbConnectionString(hostContext), SchemaCreation.INBOX_TABLE_NAME));
+            }
+
+            return new MySqlInbox(new MySqlInboxConfiguration(DbConnectionString(hostContext), SchemaCreation.INBOX_TABLE_NAME));
         }
         
         private static string DbConnectionString(HostBuilderContext hostContext)

--- a/samples/WebAPI_EFCore/SalutationPorts/Handlers/GreetingMadeHandler.cs
+++ b/samples/WebAPI_EFCore/SalutationPorts/Handlers/GreetingMadeHandler.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Paramore.Brighter;
 using Paramore.Brighter.Inbox.Attributes;
+using Paramore.Brighter.Logging.Attributes;
 using SalutationEntities;
 using SalutationPorts.EntityGateway;
 using SalutationPorts.Requests;
@@ -22,6 +23,7 @@ namespace SalutationPorts.Handlers
         }
 
         [UseInboxAsync(step:0, contextKey: typeof(GreetingMadeHandlerAsync), onceOnly: true )]
+        [RequestLoggingAsync(step: 1, timing: HandlerTiming.Before)]
         public override async Task<GreetingMade> HandleAsync(GreetingMade @event, CancellationToken cancellationToken = default(CancellationToken))
         {
             var posts = new List<Guid>();
@@ -39,9 +41,13 @@ namespace SalutationPorts.Handlers
 
                 await tx.CommitAsync(cancellationToken);
             }
-            catch (Exception)
+            catch (Exception e)
             {
+                Console.WriteLine(e);
+                
                 await tx.RollbackAsync(cancellationToken);
+                
+                Console.WriteLine("Salutation analytical record not saved");
             }
 
             await _postBox.ClearOutboxAsync(posts, cancellationToken: cancellationToken);

--- a/src/Paramore.Brighter.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Paramore.Brighter.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -99,16 +99,19 @@ namespace Paramore.Brighter.Extensions.DependencyInjection
          /// <param name="inbox">The external inbox to use</param>
          /// <param name="inboxConfiguration">If this is null, configure by hand, if not, will auto-add inbox to handlers</param>
          /// <returns></returns>
-         public static IBrighterBuilder UseExternalInbox(this IBrighterBuilder brighterBuilder, IAmAnInbox inbox, InboxConfiguration inboxConfiguration = null)
+         public static IBrighterBuilder UseExternalInbox(
+             this IBrighterBuilder brighterBuilder, 
+             IAmAnInbox inbox, InboxConfiguration inboxConfiguration = null, 
+             ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)
          {
              if (inbox is IAmAnInboxSync)
              {
-                 brighterBuilder.Services.Add(new ServiceDescriptor(typeof(IAmAnInboxSync), _ => inbox, ServiceLifetime.Singleton));
+                 brighterBuilder.Services.Add(new ServiceDescriptor(typeof(IAmAnInboxSync), _ => inbox, serviceLifetime));
              }
 
              if (inbox is IAmAnInboxAsync)
              {
-                 brighterBuilder.Services.Add(new ServiceDescriptor(typeof(IAmAnInboxSync), _ => inbox, ServiceLifetime.Singleton));
+                 brighterBuilder.Services.Add(new ServiceDescriptor(typeof(IAmAnInboxAsync), _ => inbox, serviceLifetime));
              }
 
              if (inboxConfiguration != null)
@@ -229,7 +232,7 @@ namespace Paramore.Brighter.Extensions.DependencyInjection
             if (asyncOutbox == null) asyncOutbox = new InMemoryOutbox();
 
             var inboxConfiguration = provider.GetService<InboxConfiguration>();
-
+            
             var producerRegistry = provider.GetService<IAmAProducerRegistry>();
 
             var needHandlers = CommandProcessorBuilder.With();

--- a/src/Paramore.Brighter.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Paramore.Brighter.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -57,16 +57,15 @@ namespace Paramore.Brighter.Extensions.DependencyInjection
         }
          
          /// <summary>
-        /// Use an external Brighter Outbox tp store messages Posted to another process (evicts based on age and size).
+        /// Use an external Brighter Outbox to store messages Posted to another process (evicts based on age and size).
         /// Advantages: By using the same Db to store both any state changes for your app, and outgoing messages you can create a transaction that spans both
         ///  your state change and writing to an outbox [use DepositPost to store]. Then a sweeper process can look for message not flagged as sent and send them.
         ///  For low latency just send after the transaction with ClearOutbox, for higher latency just let the sweeper run in the background.
         ///  The outstanding messages dispatched this way can be sent from any producer that runs a sweeper process and so it not tied to the lifetime of the
         ///  producer, offering guaranteed, at least once, delivery.
         ///  NOTE: there may be a database specific Use*OutBox available. If so, use that in preference to this generic method
-        /// Disadvantages: The Outbox will not survive restarts, so messages not published by shutdown will not be flagged as not posted
         /// If not null, registers singletons with the service collection :-
-        ///  - IAmAnOutbox - what messages have we posted
+        ///  - IAmAnOutboxSync - what messages have we posted
         ///  - ImAnOutboxAsync - what messages have we posted (async pipeline compatible)
         /// </summary>
         /// <param name="brighterBuilder">The Brighter builder to add this option to</param>
@@ -76,26 +75,56 @@ namespace Paramore.Brighter.Extensions.DependencyInjection
         {
             if (outbox is IAmAnOutboxSync<Message>)
             {
-                brighterBuilder.Services.Add(new ServiceDescriptor(typeof(IAmAnOutboxSync<Message>), _ => outbox,
-                    ServiceLifetime.Singleton));
+                brighterBuilder.Services.Add(new ServiceDescriptor(typeof(IAmAnOutboxSync<Message>), _ => outbox, ServiceLifetime.Singleton));
             }
 
             if (outbox is IAmAnOutboxAsync<Message>)
             {
-                brighterBuilder.Services.Add(new ServiceDescriptor(typeof(IAmAnOutboxAsync<Message>), _ => outbox,
-                    ServiceLifetime.Singleton));
+                brighterBuilder.Services.Add(new ServiceDescriptor(typeof(IAmAnOutboxAsync<Message>), _ => outbox, ServiceLifetime.Singleton));
             }
 
             return brighterBuilder;
              
         }
 
+         /// <summary>
+         /// Uses an external Brighter Inbox to record messages received to allow "once only" or diagnostics (how did we get here?)
+         /// Advantages: by using an external inbox then you can share "once only" across multiple threads/processes and support a competing consumer
+         /// model; an internal inbox is useful for testing but outside of single consumer scenarios won't work as intended
+         /// If not null, registers singletons with the service collecion :-
+         ///  - IAmAnInboxSync - what messages have we received
+         ///  - IAmAnInboxAsync - what messages have we received (async pipeline compatible)
+         /// </summary>
+         /// <param name="brighterBuilder">Extension method to support a fluent interface</param>
+         /// <param name="inbox">The external inbox to use</param>
+         /// <param name="inboxConfiguration">If this is null, configure by hand, if not, will auto-add inbox to handlers</param>
+         /// <returns></returns>
+         public static IBrighterBuilder UseExternalInbox(this IBrighterBuilder brighterBuilder, IAmAnInbox inbox, InboxConfiguration inboxConfiguration = null)
+         {
+             if (inbox is IAmAnInboxSync)
+             {
+                 brighterBuilder.Services.Add(new ServiceDescriptor(typeof(IAmAnInboxSync), _ => inbox, ServiceLifetime.Singleton));
+             }
+
+             if (inbox is IAmAnInboxAsync)
+             {
+                 brighterBuilder.Services.Add(new ServiceDescriptor(typeof(IAmAnInboxSync), _ => inbox, ServiceLifetime.Singleton));
+             }
+
+             if (inboxConfiguration != null)
+             {
+                 brighterBuilder.Services.AddSingleton<InboxConfiguration>(inboxConfiguration);
+             }
+
+             return brighterBuilder;
+         }
+
         /// <summary>
-        /// Use the Brighter In-Memory Outbox tp store messages Posted to another process (evicts based on age and size).
+        /// Use the Brighter In-Memory Outbox to store messages Posted to another process (evicts based on age and size).
         /// Advantages: fast and no additional infrastructure required
         /// Disadvantages: The Outbox will not survive restarts, so messages not published by shutdown will not be flagged as not posted
         /// Registers singletons with the service collection :-
-        ///  - InMemoryOutbox - what messages have we posted
+        ///  - InMemoryOutboxSync - what messages have we posted
         ///  - InMemoryOutboxAsync - what messages have we posted (async pipeline compatible)
         /// </summary>
         /// <param name="brighterBuilder">The builder we are adding this facility to</param>
@@ -104,6 +133,25 @@ namespace Paramore.Brighter.Extensions.DependencyInjection
         {
             brighterBuilder.Services.Add(new ServiceDescriptor(typeof(IAmAnOutboxSync<Message>), _ => new InMemoryOutbox(), ServiceLifetime.Singleton));
             brighterBuilder.Services.Add(new ServiceDescriptor(typeof(IAmAnOutboxAsync<Message>), _ => new InMemoryOutbox(), ServiceLifetime.Singleton));
+
+            return brighterBuilder;
+        }
+
+        /// <summary>
+        /// Uses the Brighter In-Memory Inbox to store messages received to support once-only messaging and diagnostics
+        /// Advantages: Fast and no additional infrastructure required
+        /// Disadvantages: The inbox will not survive restarts, so messages will not be de-duped if received after a restart.
+        ///                The inbox will not work across threads/processes so only works with a single performer/consumer.
+        /// Registers singletons with the service collection:
+        ///  - InMemoryInboxSync - what messages have we received
+        ///  - InMemoryInboxAsync - what messages have we recived (async pipeline compatible)
+        /// </summary>
+        /// <param name="brighterBuilder"></param>
+        /// <returns></returns>
+        public static IBrighterBuilder UseInMemoryInbox(this IBrighterBuilder brighterBuilder)
+        {
+            brighterBuilder.Services.Add(new ServiceDescriptor(typeof(IAmAnInboxSync), _ => new InMemoryInbox(), ServiceLifetime.Singleton));
+            brighterBuilder.Services.Add(new ServiceDescriptor(typeof(IAmAnInboxAsync), _ => new InMemoryInbox(), ServiceLifetime.Singleton));
 
             return brighterBuilder;
         }
@@ -180,6 +228,8 @@ namespace Paramore.Brighter.Extensions.DependencyInjection
             if (outbox == null) outbox = new InMemoryOutbox();
             if (asyncOutbox == null) asyncOutbox = new InMemoryOutbox();
 
+            var inboxConfiguration = provider.GetService<InboxConfiguration>();
+
             var producerRegistry = provider.GetService<IAmAProducerRegistry>();
 
             var needHandlers = CommandProcessorBuilder.With();
@@ -197,36 +247,68 @@ namespace Paramore.Brighter.Extensions.DependencyInjection
 
             var loggerFactory = provider.GetService<ILoggerFactory>();
             ApplicationLogging.LoggerFactory = loggerFactory;
-            
-            INeedARequestContext externalBusBuilder;
-            if (options.ChannelFactory is null)
-            {
-                externalBusBuilder = producerRegistry == null
-                    ? messagingBuilder.NoExternalBus()
-                    : messagingBuilder.ExternalBus(new MessagingConfiguration(producerRegistry, messageMapperRegistry), outbox, overridingConnectionProvider);
-            }
-            else
-            {
-                // If Producer has been added to DI
-                if (producerRegistry == null)
-                {
-                    externalBusBuilder = messagingBuilder.NoExternalBus();
-                }
-                else
-                {
-                    externalBusBuilder = useRequestResponse.RPC
-                        ? messagingBuilder.ExternalRPC(new MessagingConfiguration(producerRegistry, messageMapperRegistry, responseChannelFactory: options.ChannelFactory), outbox, useRequestResponse.ReplyQueueSubscriptions)
-                        : messagingBuilder.ExternalBus(new MessagingConfiguration(producerRegistry, messageMapperRegistry), outbox, overridingConnectionProvider);
-                }
-            }
 
-            var commandProcessor = externalBusBuilder
+            var commandProcessor = AddExternalBusMaybe(
+                    options, 
+                    producerRegistry, 
+                    messagingBuilder, 
+                    messageMapperRegistry, 
+                    inboxConfiguration, 
+                    outbox, 
+                    overridingConnectionProvider, 
+                    useRequestResponse)
                 .RequestContextFactory(options.RequestContextFactory)
                 .Build();
 
             return commandProcessor;
         }
 
+        private enum ExternalBusType
+        {
+            None = 0,
+            FireAndForget = 1,
+            RPC = 2
+        }
+        
+        private static INeedARequestContext AddExternalBusMaybe(
+            IBrighterOptions options, 
+            IAmAProducerRegistry producerRegistry, 
+            INeedMessaging messagingBuilder,
+            MessageMapperRegistry messageMapperRegistry, 
+            InboxConfiguration inboxConfiguration, 
+            IAmAnOutboxSync<Message> outbox,
+            IAmABoxTransactionConnectionProvider overridingConnectionProvider, 
+            IUseRpc useRequestResponse)
+        {
+            ExternalBusType externalBusType = GetExternalBusType(producerRegistry, useRequestResponse);
 
+            if (externalBusType == ExternalBusType.None)
+                return messagingBuilder.NoExternalBus();
+            else if (externalBusType == ExternalBusType.FireAndForget)
+                return messagingBuilder.ExternalBus(
+                    new ExternalBusConfiguration(producerRegistry, messageMapperRegistry, useInbox: inboxConfiguration),
+                    outbox,
+                    overridingConnectionProvider);
+            else if (externalBusType == ExternalBusType.RPC)
+            {
+                return messagingBuilder.ExternalRPC(
+                    new ExternalBusConfiguration(
+                        producerRegistry,
+                        messageMapperRegistry,
+                        responseChannelFactory: options.ChannelFactory,
+                        useInbox: inboxConfiguration),
+                    outbox,
+                    useRequestResponse.ReplyQueueSubscriptions);
+            }
+
+            throw new ArgumentOutOfRangeException("The external bus type requested was not understood");
+        }
+
+        private static ExternalBusType GetExternalBusType(IAmAProducerRegistry producerRegistry, IUseRpc useRequestResponse)
+        {
+            var externalBusType = producerRegistry == null ? ExternalBusType.None : ExternalBusType.FireAndForget;
+            if (externalBusType == ExternalBusType.FireAndForget && useRequestResponse.RPC) externalBusType = ExternalBusType.RPC;
+            return externalBusType;
+        }
     }
 }

--- a/src/Paramore.Brighter.Inbox.DynamoDB/DynamoDbInbox.cs
+++ b/src/Paramore.Brighter.Inbox.DynamoDB/DynamoDbInbox.cs
@@ -35,7 +35,7 @@ using Paramore.Brighter.Inbox.Exceptions;
 
 namespace Paramore.Brighter.Inbox.DynamoDB
 {
-    public class DynamoDbInbox : IAmAnInbox, IAmAnInboxAsync
+    public class DynamoDbInbox : IAmAnInboxSync, IAmAnInboxAsync
     {
        
         private readonly DynamoDBContext _context;

--- a/src/Paramore.Brighter.Inbox.MsSql/MsSqlInbox.cs
+++ b/src/Paramore.Brighter.Inbox.MsSql/MsSqlInbox.cs
@@ -38,7 +38,7 @@ namespace Paramore.Brighter.Inbox.MsSql
     /// <summary>
     ///     Class MsSqlInbox.
     /// </summary>
-    public class MsSqlInbox : IAmAnInbox, IAmAnInboxAsync
+    public class MsSqlInbox : IAmAnInboxSync, IAmAnInboxAsync
     {
         private static readonly ILogger s_logger = ApplicationLogging.CreateLogger<MsSqlInbox>();
 

--- a/src/Paramore.Brighter.Inbox.MySql/MySqlInbox.cs
+++ b/src/Paramore.Brighter.Inbox.MySql/MySqlInbox.cs
@@ -39,7 +39,7 @@ namespace Paramore.Brighter.Inbox.MySql
     /// <summary>
     ///     Class MySqlInbox.
     /// </summary>
-    public class MySqlInbox : IAmAnInbox, IAmAnInboxAsync
+    public class MySqlInbox : IAmAnInboxSync, IAmAnInboxAsync
     {
         private static readonly ILogger s_logger = ApplicationLogging.CreateLogger<MySqlInbox>();
 

--- a/src/Paramore.Brighter.Inbox.Postgres/PostgresSqlInbox.cs
+++ b/src/Paramore.Brighter.Inbox.Postgres/PostgresSqlInbox.cs
@@ -38,7 +38,7 @@ using Paramore.Brighter.PostgreSql;
 
 namespace Paramore.Brighter.Inbox.Postgres
 {
-    public class PostgresSqlInbox : IAmAnInbox, IAmAnInboxAsync
+    public class PostgresSqlInbox : IAmAnInboxSync, IAmAnInboxAsync
     {
         private readonly PostgresSqlInboxConfiguration _configuration;
         private readonly IPostgreSqlConnectionProvider _connectionProvider;

--- a/src/Paramore.Brighter.Inbox.Sqlite/SqliteInbox.cs
+++ b/src/Paramore.Brighter.Inbox.Sqlite/SqliteInbox.cs
@@ -39,7 +39,7 @@ namespace Paramore.Brighter.Inbox.Sqlite
     /// <summary>
     ///     Class SqliteInbox.
     /// </summary>
-    public class SqliteInbox : IAmAnInbox, IAmAnInboxAsync
+    public class SqliteInbox : IAmAnInboxSync, IAmAnInboxAsync
     {
         private static readonly ILogger s_logger = ApplicationLogging.CreateLogger<SqliteInbox>();
 

--- a/src/Paramore.Brighter.ServiceActivator/ControlBusReceiverBuilder.cs
+++ b/src/Paramore.Brighter.ServiceActivator/ControlBusReceiverBuilder.cs
@@ -153,7 +153,7 @@ namespace Paramore.Brighter.ServiceActivator.ControlBus
             commandProcessor = CommandProcessorBuilder.With()
                 .Handlers(new HandlerConfiguration(subscriberRegistry, new ControlBusHandlerFactorySync(_dispatcher, () => commandProcessor)))
                 .Policies(policyRegistry)
-                .ExternalBus(new MessagingConfiguration(producerRegistry, outgoingMessageMapperRegistry), outbox)
+                .ExternalBus(new ExternalBusConfiguration(producerRegistry, outgoingMessageMapperRegistry), outbox)
                 .RequestContextFactory(new InMemoryRequestContextFactory())
                 .Build();
             

--- a/src/Paramore.Brighter/CommandProcessorBuilder.cs
+++ b/src/Paramore.Brighter/CommandProcessorBuilder.cs
@@ -50,7 +50,7 @@ namespace Paramore.Brighter
     ///      </item>
     ///     <item>
     ///         <description>
-    ///             A <see cref="MessagingConfiguration"/> describing how you want to configure Task Queues for the <see cref="CommandProcessor"/>. We store messages in a <see cref="IAmAnOutbox{T}"/>
+    ///             A <see cref="ExternalBusConfiguration"/> describing how you want to configure Task Queues for the <see cref="CommandProcessor"/>. We store messages in a <see cref="IAmAnOutbox{T}"/>
     ///             for later replay (in case we need to compensate by trying a message again). We send messages to a Task Queue via a <see cref="IAmAMessageProducer"/> and we  want to know how
     ///             to map the <see cref="IRequest"/> (<see cref="Command"/> or <see cref="Event"/>) to a <see cref="Message"/> using a <see cref="IAmAMessageMapper"/> using 
     ///             an <see cref="IAmAMessageMapperRegistry"/>. You can use the default <see cref="MessageMapperRegistry"/> to register the association. You need to 
@@ -162,7 +162,7 @@ namespace Paramore.Brighter
         /// <param name="outbox">The Outbox.</param>
         /// <param name="boxTransactionConnectionProvider"></param>
         /// <returns>INeedARequestContext.</returns>
-        public INeedARequestContext ExternalBus(MessagingConfiguration configuration, IAmAnOutbox<Message> outbox, IAmABoxTransactionConnectionProvider boxTransactionConnectionProvider = null)
+        public INeedARequestContext ExternalBus(ExternalBusConfiguration configuration, IAmAnOutbox<Message> outbox, IAmABoxTransactionConnectionProvider boxTransactionConnectionProvider = null)
         {
             _useExternalBus = true;
             _producers = configuration.ProducerRegistry;
@@ -189,7 +189,7 @@ namespace Paramore.Brighter
         /// <param name="outbox">The outbox</param>
         /// <param name="subscriptions">Subscriptions for creating reply queues</param>
         /// <returns></returns>
-        public INeedARequestContext ExternalRPC(MessagingConfiguration configuration, IAmAnOutbox<Message> outbox, IEnumerable<Subscription> subscriptions)
+        public INeedARequestContext ExternalRPC(ExternalBusConfiguration configuration, IAmAnOutbox<Message> outbox, IEnumerable<Subscription> subscriptions)
         {
             _useRequestReplyQueues = true;
             _replySubscriptions = subscriptions;
@@ -320,7 +320,7 @@ namespace Paramore.Brighter
         /// <param name="outbox">The outbox.</param>
         /// <param name="boxTransactionConnectionProvider">The connection provider to use when adding messages to the bus</param>
         /// <returns>INeedARequestContext.</returns>
-        INeedARequestContext ExternalBus(MessagingConfiguration configuration, IAmAnOutbox<Message> outbox, IAmABoxTransactionConnectionProvider boxTransactionConnectionProvider = null);
+        INeedARequestContext ExternalBus(ExternalBusConfiguration configuration, IAmAnOutbox<Message> outbox, IAmABoxTransactionConnectionProvider boxTransactionConnectionProvider = null);
         /// <summary>
         /// We don't send messages out of process
         /// </summary>
@@ -330,10 +330,10 @@ namespace Paramore.Brighter
         /// <summary>
         ///  We want to use RPC to send messages to another process
         /// </summary>
-        /// <param name="messagingConfiguration"></param>
+        /// <param name="externalBusConfiguration"></param>
         /// <param name="outboxSync">The outbox</param>
         /// <param name="subscriptions">Subscriptions for creating Reply queues</param>
-        INeedARequestContext ExternalRPC(MessagingConfiguration messagingConfiguration, IAmAnOutbox<Message> outboxSync, IEnumerable<Subscription> subscriptions);
+        INeedARequestContext ExternalRPC(ExternalBusConfiguration externalBusConfiguration, IAmAnOutbox<Message> outboxSync, IEnumerable<Subscription> subscriptions);
     }
 
     /// <summary>

--- a/src/Paramore.Brighter/ControlBusSenderFactory.cs
+++ b/src/Paramore.Brighter/ControlBusSenderFactory.cs
@@ -48,7 +48,7 @@ namespace Paramore.Brighter
             return new ControlBusSender(CommandProcessorBuilder.With()
                     .Handlers(new HandlerConfiguration())
                     .DefaultPolicy()
-                    .ExternalBus(new MessagingConfiguration(producerRegistry, mapper),outbox)
+                    .ExternalBus(new ExternalBusConfiguration(producerRegistry, mapper),outbox)
                     .RequestContextFactory(new InMemoryRequestContextFactory())
                     .Build()
                 );

--- a/src/Paramore.Brighter/ExternalBusConfiguration.cs
+++ b/src/Paramore.Brighter/ExternalBusConfiguration.cs
@@ -28,15 +28,14 @@ using System.Linq;
 namespace Paramore.Brighter
 {
     /// <summary>
-    /// Class MessagingConfiguration.
-    /// Used to set the components of a work queue solution
+    /// Used to configure the Event Bus
     /// </summary>
-    public class MessagingConfiguration
+    public class ExternalBusConfiguration
     {
         /// <summary>
-        /// Gets the message producer.
+        /// The registry is a collection of producers 
         /// </summary>
-        /// <value>The message producer.</value>
+        /// <value>The registry of producers</value>
         public IAmAProducerRegistry ProducerRegistry { get; }
 
         /// <summary>
@@ -63,14 +62,14 @@ namespace Paramore.Brighter
         
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="MessagingConfiguration"/> class.
+        /// Initializes a new instance of the <see cref="ExternalBusConfiguration"/> class.
         /// </summary>
         /// <param name="producerRegistry">Clients for the external bus by topic they send to. The client details are specialised by transport</param>
         /// <param name="messageMapperRegistry">The message mapper registry.</param>
         /// <param name="outboxWriteTimeout">How long to wait when writing to the outbox</param>
         /// <param name="responseChannelFactory">in a request-response scenario how do we build response pipelie</param>
         /// <param name="useInbox">Do we want to create an inbox globally i.e. on every handler (as opposed to by hand). Defaults to null, ,by hand</param>
-        public MessagingConfiguration(
+        public ExternalBusConfiguration(
             IAmAProducerRegistry producerRegistry,
             IAmAMessageMapperRegistry messageMapperRegistry,
             int outboxWriteTimeout = 300,

--- a/src/Paramore.Brighter/IAmAnInbox.cs
+++ b/src/Paramore.Brighter/IAmAnInbox.cs
@@ -1,64 +1,7 @@
-﻿#region Licence
-/* The MIT License (MIT)
-Copyright © 2015 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the “Software”), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE. */
-
-#endregion
-
-using System;
-
-namespace Paramore.Brighter
+﻿namespace Paramore.Brighter
 {
-    /// <summary>
-    /// Interface IAmAnInbox
-    /// A Inbox stores <see cref="Command"/>s for diagnostics or replay.
-    /// </summary>
     public interface IAmAnInbox
     {
-        /// <summary>
-        /// Adds the specified identifier.
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="command">The command.</param>
-        /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
-        /// <param name="timeoutInMilliseconds"></param>
-        void Add<T>(T command, string contextKey, int timeoutInMilliseconds = -1) where T : class, IRequest;
-
-        /// <summary>
-        /// Finds the specified identifier.
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="id">The identifier.</param>
-        /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
-        /// <param name="timeoutInMilliseconds"></param>
-        /// <returns>T.</returns>
-        T Get<T>(Guid id, string contextKey, int timeoutInMilliseconds = -1) where T : class, IRequest;
-
-        /// <summary>
-        /// Checks whether a command with the specified identifier exists in the store
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="id">The identifier.</param>
-        /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
-        /// <param name="timeoutInMilliseconds"></param>
-        /// <returns>True if it exists, False otherwise</returns>
-        bool Exists<T>(Guid id, string contextKey, int timeoutInMilliseconds = -1) where T : class, IRequest;
+        
     }
 }

--- a/src/Paramore.Brighter/IAmAnInboxSync.cs
+++ b/src/Paramore.Brighter/IAmAnInboxSync.cs
@@ -23,53 +23,42 @@ THE SOFTWARE. */
 #endregion
 
 using System;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Paramore.Brighter
 {
     /// <summary>
-    /// Interface IAmAnInboxAsync
-    /// An Inbox stores <see cref="Request"/>s for diagnostics or de-duplication.
+    /// Interface IAmAnInbox
+    /// A Inbox stores <see cref="Command"/>s for diagnostics or replay.
     /// </summary>
-    public interface IAmAnInboxAsync : IAmAnInbox
+    public interface IAmAnInboxSync : IAmAnInbox
     {
         /// <summary>
-        /// Awaitably adds the specified identifier.
+        /// Adds the specified identifier.
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="command">The command.</param>
+        /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
         /// <param name="timeoutInMilliseconds"></param>
-        /// <param name="cancellationToken">Allow the sender to cancel the operation, if the parameter is supplied</param>
-        /// <returns><see cref="Task"/>.</returns>
-        Task AddAsync<T>(T command, string contextKey, int timeoutInMilliseconds = -1, CancellationToken cancellationToken = default(CancellationToken)) where T : class, IRequest;
+        void Add<T>(T command, string contextKey, int timeoutInMilliseconds = -1) where T : class, IRequest;
 
         /// <summary>
-        /// Awaitably finds the specified identifier.
+        /// Finds the specified identifier.
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="id">The identifier.</param>
+        /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
         /// <param name="timeoutInMilliseconds"></param>
-        /// <param name="cancellationToken">Allow the sender to cancel the operation, if the parameter is supplied</param>
-        /// <returns><see cref="Task{T}"/>.</returns>
-        Task<T> GetAsync<T>(Guid id, string contextKey, int timeoutInMilliseconds = -1, CancellationToken cancellationToken = default(CancellationToken)) where T : class, IRequest;
+        /// <returns>T.</returns>
+        T Get<T>(Guid id, string contextKey, int timeoutInMilliseconds = -1) where T : class, IRequest;
 
         /// <summary>
         /// Checks whether a command with the specified identifier exists in the store
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="id">The identifier.</param>
+        /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
         /// <param name="timeoutInMilliseconds"></param>
-        /// <param name="cancellationToken">Allow the sender to cancel the operation, if the parameter is supplied</param>
         /// <returns>True if it exists, False otherwise</returns>
-        Task<bool> ExistsAsync<T>(Guid id, string contextKey, int timeoutInMilliseconds = -1, CancellationToken cancellationToken = default(CancellationToken)) where T : class, IRequest;
-
-        /// <summary>
-        /// If false we the default thread synchronization context to run any continuation, if true we re-use the original synchronization context.
-        /// Default to false unless you know that you need true, as you risk deadlocks with the originating thread if you Wait 
-        /// or access the Result or otherwise block. You may need the orginating synchronization context if you need to access thread specific storage
-        /// such as HTTPContext 
-        /// </summary>
-        bool ContinueOnCapturedContext { get; set; }
+        bool Exists<T>(Guid id, string contextKey, int timeoutInMilliseconds = -1) where T : class, IRequest;
     }
 }

--- a/src/Paramore.Brighter/InMemoryInbox.cs
+++ b/src/Paramore.Brighter/InMemoryInbox.cs
@@ -108,7 +108,7 @@ namespace Paramore.Brighter
     /// It is possible to use multiple performers within one process as competing consumers, and if you want to use an InMemoryInbox this is the most
     /// viable strategy - otherwise use an out-of-process inbox that provides shared state to all consumers
     /// </summary>
-    public class InMemoryInbox : InMemoryBox<InboxItem>, IAmAnInbox, IAmAnInboxAsync
+    public class InMemoryInbox : InMemoryBox<InboxItem>, IAmAnInboxSync, IAmAnInboxAsync
     {
         /// <summary>
         /// If false we the default thread synchronization context to run any continuation, if true we re-use the original synchronization context.

--- a/src/Paramore.Brighter/Inbox/Handlers/UseInboxHandler.cs
+++ b/src/Paramore.Brighter/Inbox/Handlers/UseInboxHandler.cs
@@ -43,7 +43,7 @@ namespace Paramore.Brighter.Inbox.Handlers
     {
         private static readonly ILogger s_logger= ApplicationLogging.CreateLogger<UseInboxHandler<T>>();
 
-        private readonly IAmAnInbox _inbox;
+        private readonly IAmAnInboxSync _inbox;
         private bool _onceOnly;
         private string _contextKey;
         private OnceOnlyAction _onceOnlyAction;
@@ -52,7 +52,7 @@ namespace Paramore.Brighter.Inbox.Handlers
         /// Initializes a new instance of the <see cref="RequestHandler{TRequest}" /> class.
         /// </summary>
         /// <param name="inbox">The store for commands that pass into the system</param>
-        public UseInboxHandler(IAmAnInbox inbox)
+        public UseInboxHandler(IAmAnInboxSync inbox)
         {
             _inbox = inbox;
         }

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Building_A_Pipeline_With_Global_Inbox.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Building_A_Pipeline_With_Global_Inbox.cs
@@ -18,14 +18,14 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
 
         public PipelineGlobalInboxTests()
         {
-            IAmAnInbox inbox = new InMemoryInbox();
+            IAmAnInboxSync inbox = new InMemoryInbox();
             
             var registry = new SubscriberRegistry();
             registry.Register<MyCommand, MyCommandHandler>();
             
             var container = new ServiceCollection();
             container.AddTransient<MyCommandHandler>();
-            container.AddSingleton<IAmAnInbox>(inbox);
+            container.AddSingleton<IAmAnInboxSync>(inbox);
             container.AddTransient<UseInboxHandler<MyCommand>>();
             container.AddSingleton<IBrighterOptions>(new BrighterOptions() {HandlerLifetime = ServiceLifetime.Transient});
  

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Building_A_Pipeline_With_Global_Inbox_And_NoInbox_Attribute.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Building_A_Pipeline_With_Global_Inbox_And_NoInbox_Attribute.cs
@@ -15,7 +15,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
         private Pipelines<MyCommand> _chainOfResponsibility;
         private readonly RequestContext _requestContext;
         private readonly InboxConfiguration _inboxConfiguration;
-        private IAmAnInbox _inbox;
+        private IAmAnInboxSync _inbox;
 
 
         public PipelineGlobalInboxNoInboxAttributeTests()
@@ -27,7 +27,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
             
             var container = new ServiceCollection();
             container.AddTransient<MyNoInboxCommandHandler>();
-            container.AddSingleton<IAmAnInbox>(_inbox);
+            container.AddSingleton<IAmAnInboxSync>(_inbox);
             container.AddSingleton<IBrighterOptions>(new BrighterOptions() {HandlerLifetime = ServiceLifetime.Transient});
  
             var handlerFactory = new ServiceProviderHandlerFactory(container.BuildServiceProvider());

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Building_A_Pipeline_With_Global_Inbox_And_NoInbox_Attribute_Async .cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Building_A_Pipeline_With_Global_Inbox_And_NoInbox_Attribute_Async .cs
@@ -15,7 +15,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
         private AsyncPipelines<MyCommand> _chainOfResponsibility;
         private readonly RequestContext _requestContext;
         private readonly InboxConfiguration _inboxConfiguration;
-        private IAmAnInbox _inbox;
+        private IAmAnInboxSync _inbox;
 
 
         public PipelineGlobalInboxNoInboxAttributeAsyncTests()
@@ -27,7 +27,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
             
             var container = new ServiceCollection();
             container.AddTransient<MyNoInboxCommandHandlerAsync>();
-            container.AddSingleton<IAmAnInbox>(_inbox);
+            container.AddSingleton<IAmAnInboxSync>(_inbox);
             container.AddSingleton<IBrighterOptions>(new BrighterOptions() {HandlerLifetime = ServiceLifetime.Transient});
  
             var handlerFactory = new ServiceProviderHandlerFactory(container.BuildServiceProvider());

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Building_A_Pipeline_With_Global_Inbox_And_Use_Inbox.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Building_A_Pipeline_With_Global_Inbox_And_Use_Inbox.cs
@@ -18,7 +18,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
         private Pipelines<MyCommand> _chainOfResponsibility;
         private readonly RequestContext _requestContext;
         private readonly InboxConfiguration _inboxConfiguration;
-        private IAmAnInbox _inbox;
+        private IAmAnInboxSync _inbox;
 
 
         public PipelineGlobalInboxWhenUseInboxTests()
@@ -30,7 +30,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
             
             var container = new ServiceCollection();
             container.AddTransient<MyCommandInboxedHandler>();
-            container.AddSingleton<IAmAnInbox>(_inbox);
+            container.AddSingleton<IAmAnInboxSync>(_inbox);
             container.AddTransient<UseInboxHandler<MyCommand>>();
             container.AddSingleton<IBrighterOptions>(new BrighterOptions() {HandlerLifetime = ServiceLifetime.Transient});
  

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Building_A_Pipeline_With_Global_Inbox_And_Use_Inbox_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Building_A_Pipeline_With_Global_Inbox_And_Use_Inbox_Async.cs
@@ -19,7 +19,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
         private AsyncPipelines<MyCommand> _chainOfResponsibility;
         private readonly RequestContext _requestContext;
         private readonly InboxConfiguration _inboxConfiguration;
-        private IAmAnInbox _inbox;
+        private IAmAnInboxSync _inbox;
 
 
         public PipelineGlobalInboxWhenUseInboxAsyncTests()

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Building_A_Pipeline_With_Global_Inbox_Override_Context.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Building_A_Pipeline_With_Global_Inbox_Override_Context.cs
@@ -17,7 +17,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
         private Pipelines<MyCommand> _chainOfResponsibility;
         private readonly RequestContext _requestContext;
         private readonly InboxConfiguration _inboxConfiguration;
-        private IAmAnInbox _inbox;
+        private IAmAnInboxSync _inbox;
 
 
         public PipelineGlobalInboxContextTests()
@@ -29,7 +29,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
             
             var container = new ServiceCollection();
             container.AddTransient<MyGlobalInboxCommandHandler>();
-            container.AddSingleton<IAmAnInbox>(_inbox);
+            container.AddSingleton<IAmAnInboxSync>(_inbox);
             container.AddTransient<UseInboxHandler<MyCommand>>();
             container.AddSingleton<IBrighterOptions>(new BrighterOptions() {HandlerLifetime = ServiceLifetime.Transient});
  

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Inserting_A_Default_Inbox_Into_The_Publish_Pipeline.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Inserting_A_Default_Inbox_Into_The_Publish_Pipeline.cs
@@ -28,7 +28,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
 
             var container = new ServiceCollection();
             container.AddSingleton<MyGlobalInboxEventHandler>(handler);
-            container.AddSingleton<IAmAnInbox>(_inbox);
+            container.AddSingleton<IAmAnInboxSync>(_inbox);
             container.AddSingleton<UseInboxHandler<MyEvent>>();
             container.AddSingleton<IBrighterOptions>(new BrighterOptions() {HandlerLifetime = ServiceLifetime.Transient});
 

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Inserting_A_Default_Inbox_Into_The_Send_Pipeline.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Inserting_A_Default_Inbox_Into_The_Send_Pipeline.cs
@@ -25,7 +25,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
 
             var container = new ServiceCollection();
             container.AddTransient<MyCommandHandler>();
-            container.AddSingleton<IAmAnInbox, InMemoryInbox>();
+            container.AddSingleton<IAmAnInboxSync, InMemoryInbox>();
             container.AddTransient<UseInboxHandler<MyCommand>>();
             container.AddSingleton<IBrighterOptions>(new BrighterOptions() {HandlerLifetime = ServiceLifetime.Transient});
 
@@ -67,7 +67,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
             _commandProcessor.Send(command);
 
             //assert we are in, and auto-context added us under our name
-            var inbox = _provider.GetService<IAmAnInbox>();
+            var inbox = _provider.GetService<IAmAnInboxSync>();
             inbox.Should().NotBeNull();
             var boxed = inbox.Exists<MyCommand>(command.Id, typeof(MyCommandHandler).FullName, 100);
             boxed.Should().BeTrue();

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Posting_Fails_Limit_Total_Writes_To_OutBox_In_Window.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Posting_Fails_Limit_Total_Writes_To_OutBox_In_Window.cs
@@ -51,7 +51,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
             _commandProcessor = CommandProcessorBuilder.With()
                 .Handlers(new HandlerConfiguration(new SubscriberRegistry(), new EmptyHandlerFactorySync()))
                 .DefaultPolicy()
-                .ExternalBus(new MessagingConfiguration(
+                .ExternalBus(new ExternalBusConfiguration(
                     new ProducerRegistry(new Dictionary<string, IAmAMessageProducer>() {{"MyCommand", _fakeMessageProducer},}), 
                     messageMapperRegistry), 
                     _outbox

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Posting_With_A_Default_Policy.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Posting_With_A_Default_Policy.cs
@@ -61,7 +61,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
             _commandProcessor = CommandProcessorBuilder.With()
                 .Handlers(new HandlerConfiguration(new SubscriberRegistry(), new EmptyHandlerFactorySync()))
                 .DefaultPolicy()
-                .ExternalBus(new MessagingConfiguration(
+                .ExternalBus(new ExternalBusConfiguration(
                     new ProducerRegistry(new Dictionary<string, IAmAMessageProducer>() {{topic, _fakeMessageProducerWithPublishConfirmation},}), 
                     messageMapperRegistry), 
                     _fakeOutboxSync)

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Posting_With_A_Default_Policy.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Posting_With_A_Default_Policy.cs
@@ -61,7 +61,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
             _commandProcessor = CommandProcessorBuilder.With()
                 .Handlers(new HandlerConfiguration(new SubscriberRegistry(), new EmptyHandlerFactorySync()))
                 .DefaultPolicy()
-                .ExternalBus(new MessagingConfiguration(
+                .ExternalBus(new ExternalBusConfiguration(
                     new ProducerRegistry(new Dictionary<string, IAmAMessageProducer>() {{topic, _fakeMessageProducer},}), 
                     messageMapperRegistry), 
                     _fakeOutboxSync)

--- a/tests/Paramore.Brighter.Core.Tests/OnceOnly/When_Handling_A_Command_Once_Only_With_Inbox_Enabled.cs
+++ b/tests/Paramore.Brighter.Core.Tests/OnceOnly/When_Handling_A_Command_Once_Only_With_Inbox_Enabled.cs
@@ -14,7 +14,7 @@ namespace Paramore.Brighter.Core.Tests.OnceOnly
      public class OnceOnlyAttributeTests 
     {
         private readonly MyCommand _command;
-        private readonly IAmAnInbox _inbox;
+        private readonly IAmAnInboxSync _inbox;
         private readonly IAmACommandProcessor _commandProcessor;
         
         public OnceOnlyAttributeTests()

--- a/tests/Paramore.Brighter.Core.Tests/OnceOnly/When_Handling_A_Command_Once_Only_With_Throw_Enabled.cs
+++ b/tests/Paramore.Brighter.Core.Tests/OnceOnly/When_Handling_A_Command_Once_Only_With_Throw_Enabled.cs
@@ -38,7 +38,7 @@ namespace Paramore.Brighter.Core.Tests.OnceOnly
     public class OnceOnlyAttributeWithThrowExceptionTests
     {
         private readonly MyCommand _command;
-        private readonly IAmAnInbox _inbox;
+        private readonly IAmAnInboxSync _inbox;
         private readonly IAmACommandProcessor _commandProcessor;
 
         public OnceOnlyAttributeWithThrowExceptionTests()

--- a/tests/Paramore.Brighter.Core.Tests/OnceOnly/When_Handling_A_Command_Once_Only_With_Warn_Enabled.cs
+++ b/tests/Paramore.Brighter.Core.Tests/OnceOnly/When_Handling_A_Command_Once_Only_With_Warn_Enabled.cs
@@ -37,7 +37,7 @@ namespace Paramore.Brighter.Core.Tests.OnceOnly
     public class OnceOnlyAttributeWithWarnExceptionTests
     {
         private readonly MyCommand _command;
-        private readonly IAmAnInbox _inbox;
+        private readonly IAmAnInboxSync _inbox;
         private readonly IAmACommandProcessor _commandProcessor;
 
         public OnceOnlyAttributeWithWarnExceptionTests()

--- a/tests/Paramore.Brighter.Core.Tests/OnceOnly/When_Handling_A_Command_With_A_Inbox_Enabled.cs
+++ b/tests/Paramore.Brighter.Core.Tests/OnceOnly/When_Handling_A_Command_With_A_Inbox_Enabled.cs
@@ -38,7 +38,7 @@ namespace Paramore.Brighter.Core.Tests.OnceOnly
     public class CommandProcessorUsingInboxTests
     {
         private readonly MyCommand _command;
-        private readonly IAmAnInbox _inbox;
+        private readonly IAmAnInboxSync _inbox;
         private readonly IAmACommandProcessor _commandProcessor;
         private readonly string _contextKey;
 


### PR DESCRIPTION
The improvements to MessageStore - now Outbox - have really helped to surface this important tool. But when we use an Outbox we may also need an Inbox, to remove duplication (an outbox is guaranteed **at least once**). However, our Inbox configuration has lagged the Outbox.

This PR makes Inbox feel more first class by adding an Use***Inbox set of methods (internal and external). It also surfaces the global inbox settings better, so folks know how to turn it on for all their handlers.

Finally, it does a little refactoring to make some of the code clearer where it deals with multiple configuration options and has to decide how to build the external bus.
 
It alters the IAmAnInbox interface, breaking out IAmAnInboxSync and IAmAnInboxAsync to mirror the approach used by Outbox. This results in a breaking change to that interface.