### PR TITLE
Fix Threading issue on Implicit Clear

### DIFF
--- a/Brighter.sln
+++ b/Brighter.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.28922.388
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.32112.339
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{235DE1F1-E71B-4817-8E27-3B34FF006E4C}"
 EndProject
@@ -223,17 +223,17 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GreetingsWorker", "samples\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Paramore.Brighter.PostgreSql", "src\Paramore.Brighter.PostgreSql\Paramore.Brighter.PostgreSql.csproj", "{08E6D0F8-B6CE-454F-8761-77731D99F743}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Paramore.Brighter.PostgreSql.EntityFrameworkCore", "src\Paramore.Brighter.PostgreSql.EntityFrameworkCore\Paramore.Brighter.PostgreSql.EntityFrameworkCore.csproj", "{AA85493A-4120-4DA0-BAA5-CBF34D238A64}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Paramore.Brighter.PostgreSql.EntityFrameworkCore", "src\Paramore.Brighter.PostgreSql.EntityFrameworkCore\Paramore.Brighter.PostgreSql.EntityFrameworkCore.csproj", "{AA85493A-4120-4DA0-BAA5-CBF34D238A64}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GreetingsWeb", "samples\WebAPI_EFCore\GreetingsWeb\GreetingsWeb.csproj", "{BC4C3DF7-52C0-41EA-98DD-70E402AD5116}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GreetingsWeb", "samples\WebAPI_EFCore\GreetingsWeb\GreetingsWeb.csproj", "{BC4C3DF7-52C0-41EA-98DD-70E402AD5116}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SalutationPorts", "samples\WebAPI_EFCore\SalutationPorts\SalutationPorts.csproj", "{5A6A95C0-F82E-49DD-B4C6-98D7A765ECFF}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SalutationPorts", "samples\WebAPI_EFCore\SalutationPorts\SalutationPorts.csproj", "{5A6A95C0-F82E-49DD-B4C6-98D7A765ECFF}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SalutationEntities", "samples\WebAPI_EFCore\SalutationEntities\SalutationEntities.csproj", "{F701369D-EDA3-4407-8655-6B81DD6EBCBA}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SalutationEntities", "samples\WebAPI_EFCore\SalutationEntities\SalutationEntities.csproj", "{F701369D-EDA3-4407-8655-6B81DD6EBCBA}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Salutations_MySqlMigrations", "samples\WebAPI_EFCore\Salutations_MySqlMigrations\Salutations_MySqlMigrations.csproj", "{82E64F30-8D74-4E01-A974-5A78EBAD916C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Salutations_MySqlMigrations", "samples\WebAPI_EFCore\Salutations_MySqlMigrations\Salutations_MySqlMigrations.csproj", "{82E64F30-8D74-4E01-A974-5A78EBAD916C}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Salutations_SqliteMigrations", "samples\WebAPI_EFCore\Salutations_SqliteMigrations\Salutations_SqliteMigrations.csproj", "{05647D1B-87A3-4440-B468-82866B206E49}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Salutations_SqliteMigrations", "samples\WebAPI_EFCore\Salutations_SqliteMigrations\Salutations_SqliteMigrations.csproj", "{05647D1B-87A3-4440-B468-82866B206E49}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -1229,6 +1229,30 @@ Global
 		{93589653-2B49-4818-BE98-FE6F16EC72EC}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{93589653-2B49-4818-BE98-FE6F16EC72EC}.Release|x86.ActiveCfg = Release|Any CPU
 		{93589653-2B49-4818-BE98-FE6F16EC72EC}.Release|x86.Build.0 = Release|Any CPU
+		{08E6D0F8-B6CE-454F-8761-77731D99F743}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{08E6D0F8-B6CE-454F-8761-77731D99F743}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{08E6D0F8-B6CE-454F-8761-77731D99F743}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{08E6D0F8-B6CE-454F-8761-77731D99F743}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{08E6D0F8-B6CE-454F-8761-77731D99F743}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{08E6D0F8-B6CE-454F-8761-77731D99F743}.Debug|x86.Build.0 = Debug|Any CPU
+		{08E6D0F8-B6CE-454F-8761-77731D99F743}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{08E6D0F8-B6CE-454F-8761-77731D99F743}.Release|Any CPU.Build.0 = Release|Any CPU
+		{08E6D0F8-B6CE-454F-8761-77731D99F743}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{08E6D0F8-B6CE-454F-8761-77731D99F743}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{08E6D0F8-B6CE-454F-8761-77731D99F743}.Release|x86.ActiveCfg = Release|Any CPU
+		{08E6D0F8-B6CE-454F-8761-77731D99F743}.Release|x86.Build.0 = Release|Any CPU
+		{AA85493A-4120-4DA0-BAA5-CBF34D238A64}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AA85493A-4120-4DA0-BAA5-CBF34D238A64}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AA85493A-4120-4DA0-BAA5-CBF34D238A64}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{AA85493A-4120-4DA0-BAA5-CBF34D238A64}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{AA85493A-4120-4DA0-BAA5-CBF34D238A64}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{AA85493A-4120-4DA0-BAA5-CBF34D238A64}.Debug|x86.Build.0 = Debug|Any CPU
+		{AA85493A-4120-4DA0-BAA5-CBF34D238A64}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AA85493A-4120-4DA0-BAA5-CBF34D238A64}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AA85493A-4120-4DA0-BAA5-CBF34D238A64}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{AA85493A-4120-4DA0-BAA5-CBF34D238A64}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{AA85493A-4120-4DA0-BAA5-CBF34D238A64}.Release|x86.ActiveCfg = Release|Any CPU
+		{AA85493A-4120-4DA0-BAA5-CBF34D238A64}.Release|x86.Build.0 = Release|Any CPU
 		{BC4C3DF7-52C0-41EA-98DD-70E402AD5116}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{BC4C3DF7-52C0-41EA-98DD-70E402AD5116}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BC4C3DF7-52C0-41EA-98DD-70E402AD5116}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU

--- a/src/Paramore.Brighter.Extensions.Hosting/TimedOutboxSweeper.cs
+++ b/src/Paramore.Brighter.Extensions.Hosting/TimedOutboxSweeper.cs
@@ -36,19 +36,31 @@ namespace Paramore.Brighter.Extensions.Hosting
             s_logger.LogInformation("Outbox Sweeper looking for unsent messages");
 
             var scope = _serviceScopeFactory.CreateScope();
-            IAmACommandProcessor commandProcessor = scope.ServiceProvider.GetService<IAmACommandProcessor>();
+            try
+            {
+                IAmACommandProcessor commandProcessor = scope.ServiceProvider.GetService<IAmACommandProcessor>();
 
-            var outBoxSweeper = new OutboxSweeper(
-                milliSecondsSinceSent: _options.MinimumMessageAge,
-                commandProcessor: commandProcessor, 
-                _options.BatchSize,
-                _options.UseBulk);
+                var outBoxSweeper = new OutboxSweeper(
+                    milliSecondsSinceSent: _options.MinimumMessageAge,
+                    commandProcessor: commandProcessor,
+                    _options.BatchSize,
+                    _options.UseBulk);
 
-            if(_options.UseBulk)
-                outBoxSweeper.SweepAsync(CancellationToken.None).RunSynchronously();
-            else
-                outBoxSweeper.Sweep();
-
+                if (_options.UseBulk)
+                    outBoxSweeper.SweepAsyncOutbox();
+                else
+                    outBoxSweeper.Sweep();
+            }
+            catch (Exception e)
+            {
+                s_logger.LogError(e, "Error while sweeping the outbox.");
+                throw;
+            }
+            finally
+            {
+                scope.Dispose();
+            }
+            
             s_logger.LogInformation("Outbox Sweeper sleeping");
         }
 

--- a/src/Paramore.Brighter.Extensions.Hosting/TimedOutboxSweeper.cs
+++ b/src/Paramore.Brighter.Extensions.Hosting/TimedOutboxSweeper.cs
@@ -41,7 +41,7 @@ namespace Paramore.Brighter.Extensions.Hosting
                 IAmACommandProcessor commandProcessor = scope.ServiceProvider.GetService<IAmACommandProcessor>();
 
                 var outBoxSweeper = new OutboxSweeper(
-                    milliSecondsSinceSent: _options.MinimumMessageAge,
+                    millisecondsSinceSent: _options.MinimumMessageAge,
                     commandProcessor: commandProcessor,
                     _options.BatchSize,
                     _options.UseBulk);

--- a/src/Paramore.Brighter/OutboxSweeper.cs
+++ b/src/Paramore.Brighter/OutboxSweeper.cs
@@ -1,13 +1,8 @@
-﻿using System;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
-
-namespace Paramore.Brighter
+﻿namespace Paramore.Brighter
 {
     public class OutboxSweeper
     {
-        private readonly int _milliSecondsSinceSent;
+        private readonly int _millisecondsSinceSent;
         private readonly IAmACommandProcessor _commandProcessor;
         private readonly int _batchSize;
         private readonly bool _useBulk;
@@ -15,34 +10,33 @@ namespace Paramore.Brighter
         /// <summary>
         /// This sweeper clears an outbox of any outstanding messages within the time interval
         /// </summary>
-        /// <param name="milliSecondsSinceSent">How long can a message sit in the box before we attempt to resend</param>
+        /// <param name="millisecondsSinceSent">How long can a message sit in the box before we attempt to resend</param>
         /// <param name="commandProcessor">Who should post the messages</param>
         /// <param name="batchSize">The maximum number of messages to dispatch.</param>
         /// <param name="useBulk">Use the producers bulk dispatch functionality.</param>
-        public OutboxSweeper(int milliSecondsSinceSent, IAmACommandProcessor commandProcessor, int batchSize = 100,
+        public OutboxSweeper(int millisecondsSinceSent, IAmACommandProcessor commandProcessor, int batchSize = 100,
             bool useBulk = false)
         {
-            _milliSecondsSinceSent = milliSecondsSinceSent;
+            _millisecondsSinceSent = millisecondsSinceSent;
             _commandProcessor = commandProcessor;
             _batchSize = batchSize;
             _useBulk = useBulk;
         }
 
+        /// <summary>
+        /// Dispatches the oldest un-dispatched messages from the outbox in a background thread.
+        /// </summary>
         public void Sweep()
         {
-            _commandProcessor.ClearOutbox(_batchSize, _milliSecondsSinceSent);
+            _commandProcessor.ClearOutbox(_batchSize, _millisecondsSinceSent);
         }
 
-        public Task SweepAsync(CancellationToken cancellationToken = default)
-        {
-            _commandProcessor.ClearAsyncOutbox(_batchSize, _milliSecondsSinceSent, _useBulk);
-            
-            return Task.CompletedTask;
-        }
-
+        /// <summary>
+        /// Dispatches the oldest un-dispatched messages from the asynchronous outbox in a background thread.
+        /// </summary>
         public void SweepAsyncOutbox()
         {
-            _commandProcessor.ClearAsyncOutbox(_batchSize, _milliSecondsSinceSent, _useBulk);
+            _commandProcessor.ClearAsyncOutbox(_batchSize, _millisecondsSinceSent, _useBulk);
         }
     }
 }

--- a/src/Paramore.Brighter/OutboxSweeper.cs
+++ b/src/Paramore.Brighter/OutboxSweeper.cs
@@ -39,5 +39,10 @@ namespace Paramore.Brighter
             
             return Task.CompletedTask;
         }
+
+        public void SweepAsyncOutbox()
+        {
+            _commandProcessor.ClearAsyncOutbox(_batchSize, _milliSecondsSinceSent, _useBulk);
+        }
     }
 }

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/TestDoubles/FakeOutboxSync.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/TestDoubles/FakeOutboxSync.cs
@@ -122,10 +122,13 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles
             return tcs.Task;
         }
 
-        public Task MarkDispatchedAsync(IEnumerable<Guid> ids, DateTime? dispatchedAt = null, Dictionary<string, object> args = null,
+        public async Task MarkDispatchedAsync(IEnumerable<Guid> ids, DateTime? dispatchedAt = null, Dictionary<string, object> args = null,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            throw new NotImplementedException();
+            foreach (var id in ids)
+            {
+                await MarkDispatchedAsync(id, dispatchedAt, args, cancellationToken);
+            }
         }
 
         public Task<IEnumerable<Message>> OutstandingMessagesAsync(double millSecondsSinceSent, int pageSize = 100, int pageNumber = 1,

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Calling_A_Server_Via_The_Command_Processor_With_No_In_Mapper.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Calling_A_Server_Via_The_Command_Processor_With_No_In_Mapper.cs
@@ -54,7 +54,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
                 },
                 messageMapperRegistry,
                 new InMemoryOutbox(),
-                new ProducerRegistry(new Dictionary<string, IAmAMessageProducer>() {{"MyRequest", new FakeMessageProducer()},}),
+                new ProducerRegistry(new Dictionary<string, IAmAMessageProducer>() {{"MyRequest", new FakeMessageProducerWithPublishConfirmation()},}),
                  replySubscriptions,
                 responseChannelFactory: new InMemoryChannelFactory());
             

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Calling_A_Server_Via_The_Command_Processor_With_No_Out_Mapper.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Calling_A_Server_Via_The_Command_Processor_With_No_Out_Mapper.cs
@@ -57,7 +57,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
                 },
                 messageMapperRegistry,
                 new InMemoryOutbox(),
-                new ProducerRegistry(new Dictionary<string, IAmAMessageProducer>() {{"MyRequest", new FakeMessageProducer()},}),
+                new ProducerRegistry(new Dictionary<string, IAmAMessageProducer>() {{"MyRequest", new FakeMessageProducerWithPublishConfirmation()},}),
                 replySubs,
                 responseChannelFactory: new InMemoryChannelFactory());
             

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Calling_A_Server_Via_The_Command_Processor_With_No_Timeout.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Calling_A_Server_Via_The_Command_Processor_With_No_Timeout.cs
@@ -60,7 +60,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
                 },
                 messageMapperRegistry,
                 new InMemoryOutbox(),
-                new ProducerRegistry(new Dictionary<string, IAmAMessageProducer>() {{"MyRequest", new FakeMessageProducer()},}),
+                new ProducerRegistry(new Dictionary<string, IAmAMessageProducer>() {{"MyRequest", new FakeMessageProducerWithPublishConfirmation()},}),
                 replySubs,
                 responseChannelFactory: new InMemoryChannelFactory());
             

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Clearing_The_PostBox_On_The_Command_Processor _Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Clearing_The_PostBox_On_The_Command_Processor _Async.cs
@@ -41,14 +41,14 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
         private readonly CommandProcessor _commandProcessor;
         private readonly Message _message;
         private readonly FakeOutboxSync _fakeOutboxSync;
-        private readonly FakeMessageProducer _fakeMessageProducer;
+        private readonly FakeMessageProducerWithPublishConfirmation _fakeMessageProducerWithPublishConfirmation;
 
         public CommandProcessorPostBoxClearAsyncTests()
         {
             var myCommand = new MyCommand{ Value = "Hello World"};
 
             _fakeOutboxSync = new FakeOutboxSync();
-            _fakeMessageProducer = new FakeMessageProducer();
+            _fakeMessageProducerWithPublishConfirmation = new FakeMessageProducerWithPublishConfirmation();
 
             const string topic = "MyCommand";
             _message = new Message(
@@ -72,7 +72,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
                 new PolicyRegistry { { CommandProcessor.RETRYPOLICYASYNC, retryPolicy }, { CommandProcessor.CIRCUITBREAKERASYNC, circuitBreakerPolicy } },
                 messageMapperRegistry,
                 _fakeOutboxSync,
-                new ProducerRegistry(new Dictionary<string, IAmAMessageProducer>() {{topic, _fakeMessageProducer},}));
+                new ProducerRegistry(new Dictionary<string, IAmAMessageProducer>() {{topic, _fakeMessageProducerWithPublishConfirmation},}));
         }
 
         [Fact]
@@ -83,9 +83,9 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
             await _commandProcessor.ClearOutboxAsync(new []{_message.Id});
 
             //_should_send_a_message_via_the_messaging_gateway
-            _fakeMessageProducer.MessageWasSent.Should().BeTrue();
+            _fakeMessageProducerWithPublishConfirmation.MessageWasSent.Should().BeTrue();
 
-            var sentMessage = _fakeMessageProducer.SentMessages.FirstOrDefault();
+            var sentMessage = _fakeMessageProducerWithPublishConfirmation.SentMessages.FirstOrDefault();
             sentMessage.Should().NotBeNull();
             sentMessage.Id.Should().Be(_message.Id);
             sentMessage.Header.Topic.Should().Be(_message.Header.Topic);

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Clearing_The_PostBox_On_The_Command_Processor.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Clearing_The_PostBox_On_The_Command_Processor.cs
@@ -40,14 +40,14 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
         private readonly CommandProcessor _commandProcessor;
         private readonly Message _message;
         private readonly FakeOutboxSync _fakeOutbox;
-        private readonly FakeMessageProducer _fakeMessageProducer;
+        private readonly FakeMessageProducerWithPublishConfirmation _fakeMessageProducerWithPublishConfirmation;
 
         public CommandProcessorPostBoxClearTests()
         {
             var myCommand = new MyCommand{ Value = "Hello World"};
 
             _fakeOutbox = new FakeOutboxSync();
-            _fakeMessageProducer = new FakeMessageProducer();
+            _fakeMessageProducerWithPublishConfirmation = new FakeMessageProducerWithPublishConfirmation();
 
             var topic = "MyCommand";
             _message = new Message(
@@ -71,7 +71,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
                 new PolicyRegistry { { CommandProcessor.RETRYPOLICY, retryPolicy }, { CommandProcessor.CIRCUITBREAKER, circuitBreakerPolicy } },
                 messageMapperRegistry,
                 _fakeOutbox,
-                new ProducerRegistry(new Dictionary<string, IAmAMessageProducer>() {{topic, _fakeMessageProducer},}));
+                new ProducerRegistry(new Dictionary<string, IAmAMessageProducer>() {{topic, _fakeMessageProducerWithPublishConfirmation},}));
         }
 
         [Fact]
@@ -82,9 +82,9 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
             _commandProcessor.ClearOutbox(_message.Id);
 
             //_should_send_a_message_via_the_messaging_gateway
-            _fakeMessageProducer.MessageWasSent.Should().BeTrue();
+            _fakeMessageProducerWithPublishConfirmation.MessageWasSent.Should().BeTrue();
 
-            var sentMessage = _fakeMessageProducer.SentMessages.FirstOrDefault();
+            var sentMessage = _fakeMessageProducerWithPublishConfirmation.SentMessages.FirstOrDefault();
             sentMessage.Should().NotBeNull();
             sentMessage.Id.Should().Be(_message.Id);
             sentMessage.Header.Topic.Should().Be(_message.Header.Topic);

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Depositing_A_Message_In_The_Message_Store.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Depositing_A_Message_In_The_Message_Store.cs
@@ -20,14 +20,14 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
         private readonly MyCommand _myCommand = new MyCommand();
         private readonly Message _message;
         private readonly FakeOutboxSync _fakeOutbox;
-        private readonly FakeMessageProducer _fakeMessageProducer;
+        private readonly FakeMessageProducerWithPublishConfirmation _fakeMessageProducerWithPublishConfirmation;
 
         public CommandProcessorDepositPostTests()
         {
             _myCommand.Value = "Hello World";
 
             _fakeOutbox = new FakeOutboxSync();
-            _fakeMessageProducer = new FakeMessageProducer();
+            _fakeMessageProducerWithPublishConfirmation = new FakeMessageProducerWithPublishConfirmation();
 
             const string topic = "MyCommand";
             _message = new Message(
@@ -51,7 +51,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
                 new PolicyRegistry { { CommandProcessor.RETRYPOLICY, retryPolicy }, { CommandProcessor.CIRCUITBREAKER, circuitBreakerPolicy } },
                 messageMapperRegistry,
                 _fakeOutbox,
-                new ProducerRegistry(new Dictionary<string, IAmAMessageProducer>() {{topic, _fakeMessageProducer},}));
+                new ProducerRegistry(new Dictionary<string, IAmAMessageProducer>() {{topic, _fakeMessageProducerWithPublishConfirmation},}));
         }
 
 
@@ -64,7 +64,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
             //assert
             
             //message should not be posted
-            _fakeMessageProducer.MessageWasSent.Should().BeFalse();
+            _fakeMessageProducerWithPublishConfirmation.MessageWasSent.Should().BeFalse();
             
             //message should correspond to the command
             var depositedPost = _fakeOutbox.Get(postedMessageId);

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Depositing_A_Message_In_The_Message_StoreAsync.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Depositing_A_Message_In_The_Message_StoreAsync.cs
@@ -20,14 +20,14 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
         private readonly MyCommand _myCommand = new MyCommand();
         private readonly Message _message;
         private readonly FakeOutboxSync _fakeOutboxSync;
-        private readonly FakeMessageProducer _fakeMessageProducer;
+        private readonly FakeMessageProducerWithPublishConfirmation _fakeMessageProducerWithPublishConfirmation;
 
         public CommandProcessorDepositPostTestsAsync()
         {
             _myCommand.Value = "Hello World";
 
             _fakeOutboxSync = new FakeOutboxSync();
-            _fakeMessageProducer = new FakeMessageProducer();
+            _fakeMessageProducerWithPublishConfirmation = new FakeMessageProducerWithPublishConfirmation();
 
             var topic = "MyCommand";
             _message = new Message(
@@ -52,7 +52,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
                 policyRegistry,
                 messageMapperRegistry,
                 _fakeOutboxSync,
-                new ProducerRegistry(new Dictionary<string, IAmAMessageProducer>() {{topic, _fakeMessageProducer},}));
+                new ProducerRegistry(new Dictionary<string, IAmAMessageProducer>() {{topic, _fakeMessageProducerWithPublishConfirmation},}));
         }
 
 
@@ -64,7 +64,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
             
             //assert
             //message should not be posted
-            _fakeMessageProducer.MessageWasSent.Should().BeFalse();
+            _fakeMessageProducerWithPublishConfirmation.MessageWasSent.Should().BeFalse();
             
             //message should be in the store
             var depositedPost = _fakeOutboxSync

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Posting_A_Message_And_There_Is_No_Message_Mapper_Registry.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Posting_A_Message_And_There_Is_No_Message_Mapper_Registry.cs
@@ -40,7 +40,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
         private readonly MyCommand _myCommand = new MyCommand();
         private Message _message;
         private readonly FakeOutboxSync _fakeOutbox;
-        private readonly FakeMessageProducer _fakeMessageProducer;
+        private readonly FakeMessageProducerWithPublishConfirmation _fakeMessageProducerWithPublishConfirmation;
         private Exception _exception;
 
         public CommandProcessorNoMessageMapperTests()
@@ -48,7 +48,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
             _myCommand.Value = "Hello World";
 
             _fakeOutbox = new FakeOutboxSync();
-            _fakeMessageProducer = new FakeMessageProducer();
+            _fakeMessageProducerWithPublishConfirmation = new FakeMessageProducerWithPublishConfirmation();
 
             const string topic = "MyCommand";
             _message = new Message(
@@ -71,7 +71,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
                 new PolicyRegistry { { CommandProcessor.RETRYPOLICY, retryPolicy }, { CommandProcessor.CIRCUITBREAKER, circuitBreakerPolicy } },
                 messageMapperRegistry,
                 _fakeOutbox,
-                new ProducerRegistry(new Dictionary<string, IAmAMessageProducer>() {{topic, _fakeMessageProducer},}));
+                new ProducerRegistry(new Dictionary<string, IAmAMessageProducer>() {{topic, _fakeMessageProducerWithPublishConfirmation},}));
         }
 
         public void When_Posting_A_Message_And_There_Is_No_Message_Mapper_Registry()

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Posting_A_Message_And_There_Is_No_Message_Mapper_Registry_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Posting_A_Message_And_There_Is_No_Message_Mapper_Registry_Async.cs
@@ -41,7 +41,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
         private readonly MyCommand _myCommand = new MyCommand();
         private Message _message;
         private readonly FakeOutboxSync _fakeOutboxSync;
-        private readonly FakeMessageProducer _fakeMessageProducer;
+        private readonly FakeMessageProducerWithPublishConfirmation _fakeMessageProducerWithPublishConfirmation;
         private Exception _exception;
 
         public CommandProcessorNoMessageMapperAsyncTests()
@@ -49,7 +49,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
             _myCommand.Value = "Hello World";
 
             _fakeOutboxSync = new FakeOutboxSync();
-            _fakeMessageProducer = new FakeMessageProducer();
+            _fakeMessageProducerWithPublishConfirmation = new FakeMessageProducerWithPublishConfirmation();
 
             const string topic = "MyCommand";
             _message = new Message(
@@ -72,7 +72,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
                 new PolicyRegistry { { CommandProcessor.RETRYPOLICY, retryPolicy }, { CommandProcessor.CIRCUITBREAKER, circuitBreakerPolicy } },
                 messageMapperRegistry,
                 _fakeOutboxSync,
-                new ProducerRegistry(new Dictionary<string, IAmAMessageProducer>() {{topic, _fakeMessageProducer},}));
+                new ProducerRegistry(new Dictionary<string, IAmAMessageProducer>() {{topic, _fakeMessageProducerWithPublishConfirmation},}));
         }
 
         [Fact]

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Posting_A_Message_And_There_Is_No_Message_Store.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Posting_A_Message_And_There_Is_No_Message_Store.cs
@@ -37,14 +37,14 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
     {
         private readonly CommandProcessor _commandProcessor;
         private readonly MyCommand _myCommand = new MyCommand();
-        private readonly FakeMessageProducer _fakeMessageProducer;
+        private readonly FakeMessageProducerWithPublishConfirmation _fakeMessageProducerWithPublishConfirmation;
         private Exception _exception;
 
         public CommandProcessorNoOutboxTests()
         {
             _myCommand.Value = "Hello World";
 
-            _fakeMessageProducer = new FakeMessageProducer();
+            _fakeMessageProducerWithPublishConfirmation = new FakeMessageProducerWithPublishConfirmation();
 
             var messageMapperRegistry = new MessageMapperRegistry(new SimpleMessageMapperFactory((_) => new MyCommandMessageMapper()));
             messageMapperRegistry.Register<MyCommand, MyCommandMessageMapper>();
@@ -62,7 +62,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
                 new PolicyRegistry { { CommandProcessor.RETRYPOLICY, retryPolicy }, { CommandProcessor.CIRCUITBREAKER, circuitBreakerPolicy } },
                 messageMapperRegistry,
                 null,
-                new ProducerRegistry(new Dictionary<string, IAmAMessageProducer>() {{"MyCommand", _fakeMessageProducer},}));
+                new ProducerRegistry(new Dictionary<string, IAmAMessageProducer>() {{"MyCommand", _fakeMessageProducerWithPublishConfirmation},}));
         }
 
         [Fact]

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Posting_A_Message_And_There_Is_No_Message_Store_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Posting_A_Message_And_There_Is_No_Message_Store_Async.cs
@@ -38,14 +38,14 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
     {
         private readonly CommandProcessor _commandProcessor;
         private readonly MyCommand _myCommand = new MyCommand();
-        private readonly FakeMessageProducer _fakeMessageProducer;
+        private readonly FakeMessageProducerWithPublishConfirmation _fakeMessageProducerWithPublishConfirmation;
         private Exception _exception;
 
         public CommandProcessorNoOutboxAsyncTests()
         {
             _myCommand.Value = "Hello World";
 
-            _fakeMessageProducer = new FakeMessageProducer();
+            _fakeMessageProducerWithPublishConfirmation = new FakeMessageProducerWithPublishConfirmation();
 
             var messageMapperRegistry = new MessageMapperRegistry(new SimpleMessageMapperFactory((_) => new MyCommandMessageMapper()));
             messageMapperRegistry.Register<MyCommand, MyCommandMessageMapper>();
@@ -63,7 +63,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
                 new PolicyRegistry { { CommandProcessor.RETRYPOLICY, retryPolicy }, { CommandProcessor.CIRCUITBREAKER, circuitBreakerPolicy } },
                 messageMapperRegistry,
                 null,
-                new ProducerRegistry(new Dictionary<string, IAmAMessageProducer>() {{"MyCommand", _fakeMessageProducer},}));
+                new ProducerRegistry(new Dictionary<string, IAmAMessageProducer>() {{"MyCommand", _fakeMessageProducerWithPublishConfirmation},}));
         }
 
         [Fact]

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Posting_A_Message_To_The_Command_Processor.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Posting_A_Message_To_The_Command_Processor.cs
@@ -41,14 +41,14 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
         private readonly MyCommand _myCommand = new MyCommand();
         private readonly Message _message;
         private readonly FakeOutboxSync _fakeOutbox;
-        private readonly FakeMessageProducer _fakeMessageProducer;
+        private readonly FakeMessageProducerWithPublishConfirmation _fakeMessageProducerWithPublishConfirmation;
 
         public CommandProcessorPostCommandTests()
         {
             _myCommand.Value = "Hello World";
 
             _fakeOutbox = new FakeOutboxSync();
-            _fakeMessageProducer = new FakeMessageProducer();
+            _fakeMessageProducerWithPublishConfirmation = new FakeMessageProducerWithPublishConfirmation();
 
             const string topic = "MyCommand";
             _message = new Message(
@@ -72,7 +72,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
                 new PolicyRegistry { { CommandProcessor.RETRYPOLICY, retryPolicy }, { CommandProcessor.CIRCUITBREAKER, circuitBreakerPolicy } },
                 messageMapperRegistry,
                 _fakeOutbox,
-                new ProducerRegistry(new Dictionary<string, IAmAMessageProducer>() {{topic, _fakeMessageProducer},}));
+                new ProducerRegistry(new Dictionary<string, IAmAMessageProducer>() {{topic, _fakeMessageProducerWithPublishConfirmation},}));
         }
 
         [Fact]
@@ -86,7 +86,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
                 .SingleOrDefault(msg => msg.Id == _message.Id)
                 .Should().NotBeNull();
             //_should_send_a_message_via_the_messaging_gateway
-            _fakeMessageProducer.MessageWasSent.Should().BeTrue();
+            _fakeMessageProducerWithPublishConfirmation.MessageWasSent.Should().BeTrue();
             //_should_convert_the_command_into_a_message
             _fakeOutbox.Get().First().Should().Be(_message);
         }

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Posting_A_Message_To_The_Command_Processor_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Posting_A_Message_To_The_Command_Processor_Async.cs
@@ -42,14 +42,14 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
         private readonly MyCommand _myCommand = new MyCommand();
         private Message _message;
         private readonly FakeOutboxSync _fakeOutboxSync;
-        private readonly FakeMessageProducer _fakeMessageProducer;
+        private readonly FakeMessageProducerWithPublishConfirmation _fakeMessageProducerWithPublishConfirmation;
 
         public CommandProcessorPostCommandAsyncTests()
         {
             _myCommand.Value = "Hello World";
 
             _fakeOutboxSync = new FakeOutboxSync();
-            _fakeMessageProducer = new FakeMessageProducer();
+            _fakeMessageProducerWithPublishConfirmation = new FakeMessageProducerWithPublishConfirmation();
 
             const string topic = "MyCommand";
             _message = new Message(
@@ -73,7 +73,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
                 new PolicyRegistry { { CommandProcessor.RETRYPOLICYASYNC, retryPolicy }, { CommandProcessor.CIRCUITBREAKERASYNC, circuitBreakerPolicy } },
                 messageMapperRegistry,
                 _fakeOutboxSync,
-                new ProducerRegistry(new Dictionary<string, IAmAMessageProducer>() {{topic, _fakeMessageProducer},}));
+                new ProducerRegistry(new Dictionary<string, IAmAMessageProducer>() {{topic, _fakeMessageProducerWithPublishConfirmation},}));
         }
 
         [Fact]
@@ -87,7 +87,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
                 .SingleOrDefault(msg => msg.Id == _message.Id)
                 .Should().NotBeNull();
             //_should_send_a_message_via_the_messaging_gateway
-            _fakeMessageProducer.MessageWasSent.Should().BeTrue();
+            _fakeMessageProducerWithPublishConfirmation.MessageWasSent.Should().BeTrue();
             //_should_convert_the_command_into_a_message
         }
 

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Posting_Via_A_Control_Bus_Sender_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Posting_Via_A_Control_Bus_Sender_Async.cs
@@ -43,14 +43,14 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
         private readonly MyCommand _myCommand = new MyCommand();
         private readonly Message _message;
         private readonly IAmAnOutboxSync<Message> _outbox;
-        private readonly FakeMessageProducer _fakeMessageProducer;
+        private readonly FakeMessageProducerWithPublishConfirmation _fakeMessageProducerWithPublishConfirmation;
 
         public ControlBusSenderPostMessageAsyncTests()
         {
             _myCommand.Value = "Hello World";
 
             _outbox = new InMemoryOutbox();
-            _fakeMessageProducer = new FakeMessageProducer();
+            _fakeMessageProducerWithPublishConfirmation = new FakeMessageProducerWithPublishConfirmation();
 
             const string topic = "MyCommand";
             _message = new Message(
@@ -74,7 +74,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
                 new PolicyRegistry { { CommandProcessor.RETRYPOLICYASYNC, retryPolicy }, { CommandProcessor.CIRCUITBREAKERASYNC, circuitBreakerPolicy } },
                 messageMapperRegistry,
                 _outbox,
-                new ProducerRegistry(new Dictionary<string, IAmAMessageProducer>() {{topic, _fakeMessageProducer},}));
+                new ProducerRegistry(new Dictionary<string, IAmAMessageProducer>() {{topic, _fakeMessageProducerWithPublishConfirmation},}));
 
             _controlBusSender = new ControlBusSender(_commandProcessor);
         }
@@ -85,7 +85,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
             await _controlBusSender.PostAsync(_myCommand);
 
             //_should_send_a_message_via_the_messaging_gateway
-            _fakeMessageProducer.MessageWasSent.Should().BeTrue();
+            _fakeMessageProducerWithPublishConfirmation.MessageWasSent.Should().BeTrue();
             
             //_should_store_the_message_in_the_sent_command_message_repository
             var message = _outbox

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Posting_With_A_Default_Policy.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Posting_With_A_Default_Policy.cs
@@ -39,14 +39,14 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
         private readonly MyCommand _myCommand = new MyCommand();
         private readonly Message _message;
         private readonly FakeOutboxSync _fakeOutboxSync;
-        private readonly FakeMessageProducer _fakeMessageProducer;
+        private readonly FakeMessageProducerWithPublishConfirmation _fakeMessageProducerWithPublishConfirmation;
 
         public PostCommandTests()
         {
             _myCommand.Value = "Hello World";
 
             _fakeOutboxSync = new FakeOutboxSync();
-            _fakeMessageProducer = new FakeMessageProducer();
+            _fakeMessageProducerWithPublishConfirmation = new FakeMessageProducerWithPublishConfirmation();
 
             const string topic = "MyCommand";
             _message = new Message(
@@ -62,7 +62,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
                 .Handlers(new HandlerConfiguration(new SubscriberRegistry(), new EmptyHandlerFactorySync()))
                 .DefaultPolicy()
                 .ExternalBus(new MessagingConfiguration(
-                    new ProducerRegistry(new Dictionary<string, IAmAMessageProducer>() {{topic, _fakeMessageProducer},}), 
+                    new ProducerRegistry(new Dictionary<string, IAmAMessageProducer>() {{topic, _fakeMessageProducerWithPublishConfirmation},}), 
                     messageMapperRegistry), 
                     _fakeOutboxSync)
                 .RequestContextFactory(new InMemoryRequestContextFactory())
@@ -80,7 +80,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
                 .SingleOrDefault(msg => msg.Id == _message.Id)
                 .Should().NotBeNull();
             //should send a message via the messaging gateway
-            _fakeMessageProducer.MessageWasSent.Should().BeTrue();
+            _fakeMessageProducerWithPublishConfirmation.MessageWasSent.Should().BeTrue();
             // should convert the command into a message
             _fakeOutboxSync.Get().First().Should().Be(_message);
         }

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Posting_With_An_In_Memory_Message_Store.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Posting_With_An_In_Memory_Message_Store.cs
@@ -40,7 +40,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
         private readonly MyCommand _myCommand = new MyCommand();
         private readonly Message _message;
         private readonly InMemoryOutbox _outbox = new InMemoryOutbox();
-        private readonly FakeMessageProducer _fakeMessageProducer = new FakeMessageProducer();
+        private readonly FakeMessageProducerWithPublishConfirmation _fakeMessageProducerWithPublishConfirmation = new FakeMessageProducerWithPublishConfirmation();
 
         public CommandProcessorWithInMemoryOutboxTests()
         {
@@ -68,7 +68,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
                 new PolicyRegistry { { CommandProcessor.RETRYPOLICY, retryPolicy }, { CommandProcessor.CIRCUITBREAKER, circuitBreakerPolicy } },
                 messageMapperRegistry,
                 _outbox,
-                new ProducerRegistry(new Dictionary<string, IAmAMessageProducer>() {{topic, _fakeMessageProducer},}));
+                new ProducerRegistry(new Dictionary<string, IAmAMessageProducer>() {{topic, _fakeMessageProducerWithPublishConfirmation},}));
         }
 
         [Fact]
@@ -79,7 +79,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
             //_should_store_the_message_in_the_sent_command_message_repository
             _outbox.Get(_myCommand.Id).Should().NotBeNull();
             //_should_send_a_message_via_the_messaging_gateway
-            _fakeMessageProducer.MessageWasSent.Should().BeTrue();
+            _fakeMessageProducerWithPublishConfirmation.MessageWasSent.Should().BeTrue();
             // _should_convert_the_command_into_a_message
             _outbox.Get(_myCommand.Id).Should().Be(_message);
         }

--- a/tests/Paramore.Brighter.Core.Tests/ControlBus/When_configuring_a_control_bus.cs
+++ b/tests/Paramore.Brighter.Core.Tests/ControlBus/When_configuring_a_control_bus.cs
@@ -45,7 +45,7 @@ namespace Paramore.Brighter.Core.Tests.ControlBus
             var messageProducerFactory = A.Fake<IAmAProducerRegistryFactory>();
 
             A.CallTo(() => messageProducerFactory.Create())
-                .Returns(new ProducerRegistry(new Dictionary<string, IAmAMessageProducer>() {{"MyTopic", new FakeMessageProducer()},}));
+                .Returns(new ProducerRegistry(new Dictionary<string, IAmAMessageProducer>() {{"MyTopic", new FakeMessageProducerWithPublishConfirmation()},}));
 
             _busReceiverBuilder = ControlBusReceiverBuilder
                 .With()

--- a/tests/Paramore.Brighter.InMemory.Tests/Sweeper/When_sweeping_the_outbox.cs
+++ b/tests/Paramore.Brighter.InMemory.Tests/Sweeper/When_sweeping_the_outbox.cs
@@ -35,6 +35,8 @@ namespace Paramore.Brighter.InMemory.Tests.Sweeper
             
             sweeper.Sweep();
 
+            Thread.Sleep(200);
+
             //Assert
             outbox.EntryCount.Should().Be(3);
             commandProcessor.Dispatched.Count.Should().Be(3);
@@ -63,7 +65,9 @@ namespace Paramore.Brighter.InMemory.Tests.Sweeper
             //Act
             await Task.Delay(milliSecondsSinceSent * 2); // -- let the messages expire
             
-            await sweeper.SweepAsync();
+            sweeper.SweepAsyncOutbox();
+
+            await Task.Delay(200);
 
             //Assert
             outbox.EntryCount.Should().Be(3);
@@ -96,8 +100,10 @@ namespace Paramore.Brighter.InMemory.Tests.Sweeper
              //Act
              sweeper.Sweep();
 
-             //Assert
-             commandProcessor.Dispatched.Count.Should().Be(1);
+             Thread.Sleep(200);
+
+            //Assert
+            commandProcessor.Dispatched.Count.Should().Be(1);
              commandProcessor.Deposited.Count.Should().Be(4);
            
         }
@@ -124,7 +130,9 @@ namespace Paramore.Brighter.InMemory.Tests.Sweeper
             }
  
             //Act
-            await sweeper.SweepAsync();
+            sweeper.SweepAsyncOutbox();
+
+            await Task.Delay(200);
 
             //Assert
             commandProcessor.Deposited.Count.Should().Be(4);


### PR DESCRIPTION
This change fixes the following
  - Bulk Clear was using ProducerRegistry.LookupBy not LookupByDefailt
  - In the Implicit clearing Threads the Monitor was never releasing so it would never allow entry after the first run
  - TimedOutboxSweeper would Fail on Async as it can't be RunSynchronously ad the thread was usually already exited