### PR TITLE
fix: logger instantiation following application logging pattern

### DIFF
--- a/src/Paramore.Brighter.MessagingGateway.RedisStreams/RedisStreamsConsumerFactory.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RedisStreams/RedisStreamsConsumerFactory.cs
@@ -29,7 +29,7 @@ namespace Paramore.Brighter.MessagingGateway.RedisStreams
         private readonly RedisStreamsConfiguration _configuration;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="RmqMessageConsumerFactory"/> class.
+        /// Initializes a new instance of the <see cref="RedisStreamsConsumerFactory"/> class.
         /// </summary>
         public RedisStreamsConsumerFactory(RedisStreamsConfiguration configuration)
         {

--- a/src/Paramore.Brighter.MessagingGateway.RedisStreams/RedisStreamsGateway.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RedisStreams/RedisStreamsGateway.cs
@@ -33,14 +33,14 @@ namespace Paramore.Brighter.MessagingGateway.RedisStreams
 {
     public class RedisStreamsGateway
     {
-        private static Lazy<ConnectionMultiplexer> _redis;
+        private static Lazy<ConnectionMultiplexer> s_redis;
         private readonly RedisStreamsConfiguration _configuration;
-        private static DateTimeOffset _lastReconnect = DateTimeOffset.MinValue;
-        private static DateTimeOffset _firstError = DateTimeOffset.MinValue;
-        private static DateTimeOffset _previousError = DateTimeOffset.MinValue;
+        private static DateTimeOffset s_lastReconnect = DateTimeOffset.MinValue;
+        private static DateTimeOffset s_firstError = DateTimeOffset.MinValue;
+        private static DateTimeOffset s_previousError = DateTimeOffset.MinValue;
 
-        private static readonly object _reconnectLock = new object();
-        protected static ConnectionMultiplexer Redis { get { return _redis.Value; } }
+        private static readonly object s_reconnectLock = new object();
+        protected static ConnectionMultiplexer Redis { get { return s_redis.Value; } }
 
         protected RedisStreamsGateway(RedisStreamsConfiguration configuration)
         {
@@ -52,7 +52,7 @@ namespace Paramore.Brighter.MessagingGateway.RedisStreams
 
        private void CreateRedisClient()
        {
-           _redis = new Lazy<ConnectionMultiplexer>(() =>
+           s_redis = new Lazy<ConnectionMultiplexer>(() =>
            {
                var options = ConfigurationOptions.Parse(_configuration.ConfigurationOptions);
                options.Proxy = _configuration.UseProxy ? Proxy.Twemproxy : Proxy.None;
@@ -66,7 +66,7 @@ namespace Paramore.Brighter.MessagingGateway.RedisStreams
       
        protected void CloseRedisClient()
        {
-           if (_redis != null)
+           if (s_redis != null)
            {
                try
                {
@@ -81,31 +81,31 @@ namespace Paramore.Brighter.MessagingGateway.RedisStreams
        protected void ForceReconnect()
        {
            var now = DateTimeOffset.UtcNow;
-           var elapsedSinceLastReconnect = now - _lastReconnect;
+           var elapsedSinceLastReconnect = now - s_lastReconnect;
            var reconnectMinFrequency = TimeSpan.FromSeconds(_configuration.ReconnectMinFrequencyInSeconds);
            var reconnectWindow = TimeSpan.FromSeconds(_configuration.ReconnectErrorThresholdInSeconds);
 
            if (elapsedSinceLastReconnect > reconnectMinFrequency)
            {
-               lock (_reconnectLock)
+               lock (s_reconnectLock)
                {
                    now = DateTimeOffset.UtcNow;
                    
                    //check that we were not blocked behind another thread, that has already reconnected
-                   elapsedSinceLastReconnect = now - _lastReconnect;
+                   elapsedSinceLastReconnect = now - s_lastReconnect;
                    if (elapsedSinceLastReconnect < reconnectMinFrequency)
                        return; 
                    
-                   if (_firstError == DateTimeOffset.MinValue)
+                   if (s_firstError == DateTimeOffset.MinValue)
                    {
-                       _firstError = now;
-                       _previousError = now;
+                       s_firstError = now;
+                       s_previousError = now;
                        return;
                    }
 
-                   var elapsedSinceFirstError = now - _firstError;
-                   var elapsedSinceMostRecentError = now - _previousError;
-                   _previousError = now;
+                   var elapsedSinceFirstError = now - s_firstError;
+                   var elapsedSinceMostRecentError = now - s_previousError;
+                   s_previousError = now;
 
                    if (
                        elapsedSinceFirstError >= reconnectWindow   //Did ServiceStack fail to reconnect in the time window 
@@ -113,12 +113,12 @@ namespace Paramore.Brighter.MessagingGateway.RedisStreams
                    )
 
                    {
-                       _firstError = DateTimeOffset.MinValue;
-                       _previousError = DateTimeOffset.MinValue;
+                       s_firstError = DateTimeOffset.MinValue;
+                       s_previousError = DateTimeOffset.MinValue;
 
                        CloseRedisClient();
                        CreateRedisClient();
-                       _lastReconnect = now;
+                       s_lastReconnect = now;
                    }
                }
            }

--- a/src/Paramore.Brighter.MessagingGateway.RedisStreams/RedisStreamsPublisher.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RedisStreams/RedisStreamsPublisher.cs
@@ -23,7 +23,7 @@ THE SOFTWARE. */
 #endregion
 
 using System.Collections.Generic;
-using Newtonsoft.Json;
+using System.Text.Json;
 using StackExchange.Redis;
 
 namespace Paramore.Brighter.MessagingGateway.RedisStreams
@@ -69,7 +69,7 @@ namespace Paramore.Brighter.MessagingGateway.RedisStreams
 
         private static void WriteContentType(MessageHeader messageHeader, ICollection<NameValueEntry> entries)
         {
-            entries.Add( new NameValueEntry(MessageNames.CONTENT_TYPE, messageHeader.ContentType.ToString()));
+            entries.Add( new NameValueEntry(MessageNames.CONTENT_TYPE, messageHeader.ContentType));
         }
 
         private static void WriteCorrelationId(MessageHeader messageHeader, ICollection<NameValueEntry> entries)
@@ -89,7 +89,7 @@ namespace Paramore.Brighter.MessagingGateway.RedisStreams
 
         private static void WriteMessageBag(MessageHeader messageHeader, ICollection<NameValueEntry> entries)
         {
-            var flatBag = JsonConvert.SerializeObject(messageHeader.Bag);
+            var flatBag = JsonSerializer.Serialize(messageHeader.Bag);
             entries.Add(new NameValueEntry(MessageNames.BAG, flatBag));
         }
 
@@ -115,7 +115,7 @@ namespace Paramore.Brighter.MessagingGateway.RedisStreams
 
         private static void WriteTimeStamp(MessageHeader messageHeader, ICollection<NameValueEntry> entries)
         {
-            entries.Add(new NameValueEntry(MessageNames.TIMESTAMP, JsonConvert.SerializeObject(messageHeader.TimeStamp)));
+            entries.Add(new NameValueEntry(MessageNames.TIMESTAMP, JsonSerializer.Serialize(messageHeader.TimeStamp)));
         }
     }
 }

--- a/src/Paramore.Brighter.MessagingGateway.RedisStreams/RedisStreamsSubscription.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RedisStreams/RedisStreamsSubscription.cs
@@ -17,14 +17,8 @@ namespace Paramore.Brighter.MessagingGateway.RedisStreams
         /// <param name="requeueCount">The number of times you want to requeue a message before dropping it.</param>
         /// <param name="requeueDelayInMilliseconds">The number of milliseconds to delay the delivery of a requeue message for.</param>
         /// <param name="unacceptableMessageLimit">The number of unacceptable messages to handle, before stopping reading from the channel.</param>
-        /// <param name="isDurable">The durability of the queue definition in the broker.</param>
         /// <param name="runAsync">Is this channel read asynchronously</param>
         /// <param name="channelFactory">The channel factory to create channels for Consumer.</param>
-        /// <param name="highAvailability">Should we mirror the queue over multiple nodes</param>
-        /// <param name="lockTimeout">How long should a message remain locked for processing</param>
-        /// <param name="deadLetterChannelName">The dead letter channel </param>
-        /// <param name="deadLetterRoutingKey">The routing key for dead letters</param>
-        /// <param name="ttl">Time to live in ms of a message on a queue; null (the default) is inifinite</param>
         /// <param name="makeChannels">Should we make channels if they don't exist, defaults to creating</param>
         public RedisStreamsSubscription(
             Type dataType, 


### PR DESCRIPTION
I am sold on the idea of brighter and want to see if I can contribute where I can. For the beginning, I reviewed what is currently ongoing and as such "reviewed" the progress of the redis_streams, while addressing some ide suggestions.

I am not sure what the take on Newtonsoft is from Brighter's perspective, looking at some previous changes, I am assuming that it is moving towards System. Text's implementation.

I also noticed the ApplicationLogger being used elsewhere.

I am slowly going to try and familiarize myself with the project.