### PR TITLE
Add initial implementation allowing multiple Db Contexts for TXNs

### DIFF
--- a/src/Paramore.Brighter.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Paramore.Brighter.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -226,7 +226,7 @@ namespace Paramore.Brighter.Extensions.DependencyInjection
 
             var outbox = provider.GetService<IAmAnOutboxSync<Message>>();
             var asyncOutbox = provider.GetService<IAmAnOutboxAsync<Message>>();
-            var overridingConnectionProvider = provider.GetService<IAmABoxTransactionConnectionProvider>();
+            var overridingConnectionProviderRegistry = provider.GetService<IAmABoxTransactionConnectionProviderRegistry>();
 
             if (outbox == null) outbox = new InMemoryOutbox();
             if (asyncOutbox == null) asyncOutbox = new InMemoryOutbox();
@@ -258,7 +258,7 @@ namespace Paramore.Brighter.Extensions.DependencyInjection
                     messageMapperRegistry, 
                     inboxConfiguration, 
                     outbox, 
-                    overridingConnectionProvider, 
+                    overridingConnectionProviderRegistry, 
                     useRequestResponse)
                 .RequestContextFactory(options.RequestContextFactory)
                 .Build();
@@ -280,7 +280,7 @@ namespace Paramore.Brighter.Extensions.DependencyInjection
             MessageMapperRegistry messageMapperRegistry, 
             InboxConfiguration inboxConfiguration, 
             IAmAnOutboxSync<Message> outbox,
-            IAmABoxTransactionConnectionProvider overridingConnectionProvider, 
+            IAmABoxTransactionConnectionProviderRegistry overridingConnectionProviderRegistry, 
             IUseRpc useRequestResponse)
         {
             ExternalBusType externalBusType = GetExternalBusType(producerRegistry, useRequestResponse);
@@ -291,7 +291,7 @@ namespace Paramore.Brighter.Extensions.DependencyInjection
                 return messagingBuilder.ExternalBus(
                     new ExternalBusConfiguration(producerRegistry, messageMapperRegistry, useInbox: inboxConfiguration),
                     outbox,
-                    overridingConnectionProvider);
+                    overridingConnectionProviderRegistry);
             else if (externalBusType == ExternalBusType.RPC)
             {
                 return messagingBuilder.ExternalRPC(

--- a/src/Paramore.Brighter/BoxTransactionConnectionProviderRegistry.cs
+++ b/src/Paramore.Brighter/BoxTransactionConnectionProviderRegistry.cs
@@ -1,0 +1,35 @@
+﻿using System.Collections.Generic;
+
+namespace Paramore.Brighter
+{
+    public class BoxTransactionConnectionProviderRegistry : IAmABoxTransactionConnectionProviderRegistry
+    {
+        private readonly Dictionary<string, IAmABoxTransactionConnectionProvider> _providers;
+        private string _defaultProvider;
+
+        public BoxTransactionConnectionProviderRegistry(string providerName, IAmABoxTransactionConnectionProvider provider)
+        {
+            _providers = new Dictionary<string, IAmABoxTransactionConnectionProvider>();
+            
+            _providers.Add(providerName, provider);
+            _defaultProvider = providerName;
+        }
+
+        public IAmABoxTransactionConnectionProviderRegistry AddProvider(string name, IAmABoxTransactionConnectionProvider provider, bool isDefault = false)
+        {
+            _providers.Add(name, provider);
+            if (isDefault) _defaultProvider = name;
+            return this;
+        }
+        
+        public IAmABoxTransactionConnectionProvider GetDefault()
+        {
+            return _providers[_defaultProvider];
+        }
+
+        public IAmABoxTransactionConnectionProvider Lookup(string name)
+        {
+            return _providers[name];
+        }
+    }
+}

--- a/src/Paramore.Brighter/CommandProcessor.cs
+++ b/src/Paramore.Brighter/CommandProcessor.cs
@@ -51,7 +51,7 @@ namespace Paramore.Brighter
         private readonly IAmARequestContextFactory _requestContextFactory;
         private readonly IPolicyRegistry<string> _policyRegistry;
         private readonly InboxConfiguration _inboxConfiguration;
-        private readonly IAmABoxTransactionConnectionProvider _boxTransactionConnectionProvider;
+        private readonly IAmABoxTransactionConnectionProviderRegistry _boxTransactionConnectionProviderRegistry;
         private readonly IAmAFeatureSwitchRegistry _featureSwitchRegistry;
         private readonly IEnumerable<Subscription> _replySubscriptions;
 
@@ -135,7 +135,7 @@ namespace Paramore.Brighter
         /// <param name="outboxTimeout">How long should we wait to write to the outbox</param>
         /// <param name="featureSwitchRegistry">The feature switch config provider.</param>
         /// <param name="inboxConfiguration">Do we want to insert an inbox handler into pipelines without the attribute. Null (default = no), yes = how to configure</param>
-        /// <param name="boxTransactionConnectionProvider">The Box Connection Provider to use when Depositing into the outbox.</param>
+        /// <param name="boxTransactionConnectionProviderRegistry">The Box Connection Provider Registry to use when Depositing into the outbox.</param>
         public CommandProcessor(
             IAmARequestContextFactory requestContextFactory,
             IPolicyRegistry<string> policyRegistry,
@@ -145,14 +145,14 @@ namespace Paramore.Brighter
             int outboxTimeout = 300,
             IAmAFeatureSwitchRegistry featureSwitchRegistry = null,
             InboxConfiguration inboxConfiguration = null,
-            IAmABoxTransactionConnectionProvider boxTransactionConnectionProvider = null)
+            IAmABoxTransactionConnectionProviderRegistry boxTransactionConnectionProviderRegistry = null)
         {
             _requestContextFactory = requestContextFactory;
             _policyRegistry = policyRegistry;
             _mapperRegistry = mapperRegistry;
             _featureSwitchRegistry = featureSwitchRegistry;
             _inboxConfiguration = inboxConfiguration;
-            _boxTransactionConnectionProvider = boxTransactionConnectionProvider;
+            _boxTransactionConnectionProviderRegistry = boxTransactionConnectionProviderRegistry;
             
             InitExtServiceBus(policyRegistry, outBox, outboxTimeout, producerRegistry);
 
@@ -175,7 +175,7 @@ namespace Paramore.Brighter
         /// <param name="outboxTimeout">How long should we wait to write to the outbox</param>
         /// <param name="featureSwitchRegistry">The feature switch config provider.</param>
         /// <param name="inboxConfiguration">Do we want to insert an inbox handler into pipelines without the attribute. Null (default = no), yes = how to configure</param>
-        /// <param name="boxTransactionConnectionProvider">The Box Connection Provider to use when Depositing into the outbox.</param>
+        /// <param name="boxTransactionConnectionProviderRegistry">The Box Connection Provider to use when Depositing into the outbox.</param>
         public CommandProcessor(
             IAmASubscriberRegistry subscriberRegistry,
             IAmAHandlerFactory handlerFactory,
@@ -189,14 +189,14 @@ namespace Paramore.Brighter
             IAmAFeatureSwitchRegistry featureSwitchRegistry = null,
             IAmAChannelFactory responseChannelFactory = null,
             InboxConfiguration inboxConfiguration = null,
-            IAmABoxTransactionConnectionProvider boxTransactionConnectionProvider = null)
+            IAmABoxTransactionConnectionProviderRegistry boxTransactionConnectionProviderRegistry = null)
             : this(subscriberRegistry, handlerFactory, requestContextFactory, policyRegistry)
         {
             _mapperRegistry = mapperRegistry;
             _featureSwitchRegistry = featureSwitchRegistry;
             _responseChannelFactory = responseChannelFactory;
             _inboxConfiguration = inboxConfiguration;
-            _boxTransactionConnectionProvider = boxTransactionConnectionProvider;
+            _boxTransactionConnectionProviderRegistry = boxTransactionConnectionProviderRegistry;
             _replySubscriptions = replySubscriptions;
 
             InitExtServiceBus(policyRegistry, outBox, outboxTimeout, producerRegistry);
@@ -230,12 +230,12 @@ namespace Paramore.Brighter
             int outboxTimeout = 300,
             IAmAFeatureSwitchRegistry featureSwitchRegistry = null,
             InboxConfiguration inboxConfiguration = null,
-            IAmABoxTransactionConnectionProvider boxTransactionConnectionProvider = null)
+            IAmABoxTransactionConnectionProviderRegistry boxTransactionConnectionProviderRegistry = null)
             : this(subscriberRegistry, handlerFactory, requestContextFactory, policyRegistry, featureSwitchRegistry)
         {
             _mapperRegistry = mapperRegistry;
             _inboxConfiguration = inboxConfiguration;
-            _boxTransactionConnectionProvider = boxTransactionConnectionProvider;
+            _boxTransactionConnectionProviderRegistry = boxTransactionConnectionProviderRegistry;
 
             InitExtServiceBus(policyRegistry, outBox, outboxTimeout, producerRegistry);
 
@@ -411,7 +411,7 @@ namespace Paramore.Brighter
         /// <exception cref="System.ArgumentOutOfRangeException"></exception>
         public void Post<T>(T request) where T : class, IRequest
         {
-            ClearOutbox(DepositPost(request, null));
+            ClearOutbox(DepositPost(request, connectionProvider: null));
         }
 
         /// <summary>
@@ -445,11 +445,12 @@ namespace Paramore.Brighter
         /// Pass deposited Guid to <see cref="ClearOutbox"/> 
         /// </summary>
         /// <param name="request">The request to save to the outbox</param>
+        /// <param name="transactionProviderName">The name of the transaction provider to use (if registered and not provided default will be used)</param>
         /// <typeparam name="T">The type of the request</typeparam>
         /// <returns>The Id of the Message that has been deposited.</returns>
-        public Guid DepositPost<T>(T request) where T : class, IRequest
+        public Guid DepositPost<T>(T request, string transactionProviderName = null) where T : class, IRequest
         {
-            return DepositPost(request, _boxTransactionConnectionProvider);
+            return DepositPost(request, GetBoxTxnProvider(transactionProviderName));
         }
         
         private Guid DepositPost<T>(T request, IAmABoxTransactionConnectionProvider connectionProvider) where T : class, IRequest
@@ -480,12 +481,13 @@ namespace Paramore.Brighter
         /// <param name="request">The request to save to the outbox</param>
         /// <param name="continueOnCapturedContext">Should we use the calling thread's synchronization context when continuing or a default thread synchronization context. Defaults to false</param>
         /// <param name="cancellationToken">The Cancellation Token.</param>
+        /// <param name="transactionProviderName">The name of the transaction provider to use (if registered and not provided default will be used)</param>
         /// <typeparam name="T">The type of the request</typeparam>
         /// <returns></returns>
         public async Task<Guid> DepositPostAsync<T>(T request, bool continueOnCapturedContext = false,
-            CancellationToken cancellationToken = default(CancellationToken)) where T : class, IRequest
+            CancellationToken cancellationToken = default(CancellationToken), string transactionProviderName = null) where T : class, IRequest
         {
-            return await DepositPostAsync(request, _boxTransactionConnectionProvider, continueOnCapturedContext, cancellationToken);
+            return await DepositPostAsync(request, GetBoxTxnProvider(transactionProviderName), continueOnCapturedContext, cancellationToken);
         }
         
         private async Task<Guid> DepositPostAsync<T>(T request, IAmABoxTransactionConnectionProvider connectionProvider,  bool continueOnCapturedContext = false,
@@ -505,6 +507,19 @@ namespace Paramore.Brighter
             await _bus.AddToOutboxAsync(request, continueOnCapturedContext, cancellationToken, message, connectionProvider);
 
             return message.Id;
+        }
+        
+        private IAmABoxTransactionConnectionProvider GetBoxTxnProvider(string name)
+        {
+            IAmABoxTransactionConnectionProvider boxTransactionConnectionProvider = null;
+            if (_boxTransactionConnectionProviderRegistry != null)
+            {
+                boxTransactionConnectionProvider = string.IsNullOrWhiteSpace(name)
+                    ? _boxTransactionConnectionProviderRegistry.GetDefault()
+                    : _boxTransactionConnectionProviderRegistry.Lookup(name);
+            }
+
+            return boxTransactionConnectionProvider;
         }
 
 

--- a/src/Paramore.Brighter/CommandProcessorBuilder.cs
+++ b/src/Paramore.Brighter/CommandProcessorBuilder.cs
@@ -83,7 +83,7 @@ namespace Paramore.Brighter
         private bool _useExternalBus = false;
         private bool _useRequestReplyQueues = false;
         private IEnumerable<Subscription> _replySubscriptions;
-        private IAmABoxTransactionConnectionProvider _overridingBoxTransactionConnectionProvider = null;
+        private IAmABoxTransactionConnectionProviderRegistry _overridingBoxTransactionConnectionProviderRegistry = null;
         
         private CommandProcessorBuilder()
         {
@@ -160,14 +160,14 @@ namespace Paramore.Brighter
         /// </summary>
         /// <param name="configuration">The Task Queues configuration.</param>
         /// <param name="outbox">The Outbox.</param>
-        /// <param name="boxTransactionConnectionProvider"></param>
+        /// <param name="boxTransactionConnectionProviderRegistry"></param>
         /// <returns>INeedARequestContext.</returns>
-        public INeedARequestContext ExternalBus(ExternalBusConfiguration configuration, IAmAnOutbox<Message> outbox, IAmABoxTransactionConnectionProvider boxTransactionConnectionProvider = null)
+        public INeedARequestContext ExternalBus(ExternalBusConfiguration configuration, IAmAnOutbox<Message> outbox, IAmABoxTransactionConnectionProviderRegistry boxTransactionConnectionProviderRegistry = null)
         {
             _useExternalBus = true;
             _producers = configuration.ProducerRegistry;
             _outbox = outbox;
-            _overridingBoxTransactionConnectionProvider = boxTransactionConnectionProvider;
+            _overridingBoxTransactionConnectionProviderRegistry = boxTransactionConnectionProviderRegistry;
             _messageMapperRegistry = configuration.MessageMapperRegistry;
             _outboxWriteTimeout = configuration.OutboxWriteTimeout;
             return this;
@@ -242,7 +242,7 @@ namespace Paramore.Brighter
                     producerRegistry: _producers,
                     outboxTimeout: _outboxWriteTimeout,
                     featureSwitchRegistry: _featureSwitchRegistry,
-                    boxTransactionConnectionProvider: _overridingBoxTransactionConnectionProvider
+                    boxTransactionConnectionProviderRegistry: _overridingBoxTransactionConnectionProviderRegistry
                 );
             }
             else if (_useRequestReplyQueues)
@@ -257,7 +257,7 @@ namespace Paramore.Brighter
                     outBox: _outbox,
                     producerRegistry: _producers,
                     responseChannelFactory: _responseChannelFactory,
-                    boxTransactionConnectionProvider: _overridingBoxTransactionConnectionProvider
+                    boxTransactionConnectionProviderRegistry: _overridingBoxTransactionConnectionProviderRegistry
                     );
             }
             else
@@ -318,9 +318,9 @@ namespace Paramore.Brighter
         /// </summary>
         /// <param name="configuration">The configuration.</param>
         /// <param name="outbox">The outbox.</param>
-        /// <param name="boxTransactionConnectionProvider">The connection provider to use when adding messages to the bus</param>
+        /// <param name="boxTransactionConnectionProviderRegistry">The connection provider registry to use when adding messages to the bus</param>
         /// <returns>INeedARequestContext.</returns>
-        INeedARequestContext ExternalBus(ExternalBusConfiguration configuration, IAmAnOutbox<Message> outbox, IAmABoxTransactionConnectionProvider boxTransactionConnectionProvider = null);
+        INeedARequestContext ExternalBus(ExternalBusConfiguration configuration, IAmAnOutbox<Message> outbox, IAmABoxTransactionConnectionProviderRegistry boxTransactionConnectionProviderRegistry = null);
         /// <summary>
         /// We don't send messages out of process
         /// </summary>

--- a/src/Paramore.Brighter/IAmABoxTransactionConnectionProviderRegistry.cs
+++ b/src/Paramore.Brighter/IAmABoxTransactionConnectionProviderRegistry.cs
@@ -1,0 +1,8 @@
+﻿namespace Paramore.Brighter
+{
+    public interface IAmABoxTransactionConnectionProviderRegistry
+    {
+        IAmABoxTransactionConnectionProvider GetDefault();
+        IAmABoxTransactionConnectionProvider Lookup(string name);
+    }
+}

--- a/src/Paramore.Brighter/IAmACommandProcessor.cs
+++ b/src/Paramore.Brighter/IAmACommandProcessor.cs
@@ -98,9 +98,10 @@ namespace Paramore.Brighter
         /// Pass deposited Guid to <see cref="CommandProcessor.ClearOutbox"/> 
         /// </summary>
         /// <param name="request">The request to save to the outbox</param>
+        /// <param name="transactionProviderName">The name of the transaction provider to use (if registered and not provided default will be used)</param>
         /// <typeparam name="T">The type of the request</typeparam>
         /// <returns></returns>
-        Guid DepositPost<T>(T request) where T : class, IRequest;
+        Guid DepositPost<T>(T request, string transactionProviderName = null) where T : class, IRequest;
 
         /// <summary>
         /// Adds a message into the outbox, and returns the id of the saved message.
@@ -110,9 +111,10 @@ namespace Paramore.Brighter
         /// Pass deposited Guid to <see cref="CommandProcessor.ClearOutboxAsync"/> 
         /// </summary>
         /// <param name="request">The request to save to the outbox</param>
+        /// <param name="transactionProviderName">The name of the transaction provider to use (if registered and not provided default will be used)</param>
         /// <typeparam name="T">The type of the request</typeparam>
         /// <returns></returns>
-        Task<Guid> DepositPostAsync<T>(T request, bool continueOnCapturedContext = false, CancellationToken cancellationToken = default(CancellationToken)) where T : class, IRequest;
+        Task<Guid> DepositPostAsync<T>(T request, bool continueOnCapturedContext = false, CancellationToken cancellationToken = default(CancellationToken), string transactionProviderName = null) where T : class, IRequest;
 
         /// <summary>
         /// Flushes the message box message given by <param name="posts"> to the broker.

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/TestDoubles/FakeOutboxSync.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/TestDoubles/FakeOutboxSync.cs
@@ -35,11 +35,15 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles
     {
         private readonly List<OutboxEntry> _posts = new List<OutboxEntry>();
 
+        public Dictionary<Guid, Type> TransactionProviderUsedForPost { get; } = new Dictionary<Guid, Type>();
+
         public bool ContinueOnCapturedContext { get; set; }
 
         public void Add(Message message, int outBoxTimeout = -1, IAmABoxTransactionConnectionProvider transactionConnectionProvider = null)
         {
             _posts.Add(new OutboxEntry {Message = message, TimeDeposited = DateTime.UtcNow});
+            if (transactionConnectionProvider != null)
+                TransactionProviderUsedForPost.Add(message.Id, transactionConnectionProvider.GetType());
         }
 
         public Task AddAsync(Message message, int outBoxTimeout = -1, CancellationToken cancellationToken = default(CancellationToken), IAmABoxTransactionConnectionProvider transactionConnectionProvider = null)
@@ -47,7 +51,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles
             if (cancellationToken.IsCancellationRequested)
                 return Task.FromCanceled(cancellationToken);
 
-            Add(message, outBoxTimeout);
+            Add(message, outBoxTimeout, transactionConnectionProvider);
 
             return Task.FromResult(0);
         }

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Depositing_A_Message_In_a_Transaction_to_the_Message_StoreAsync.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Depositing_A_Message_In_a_Transaction_to_the_Message_StoreAsync.cs
@@ -1,0 +1,140 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
+using Polly;
+using Polly.Registry;
+using Xunit;
+
+namespace Paramore.Brighter.Core.Tests.CommandProcessors
+{
+    
+    [Collection("CommandProcessor")]
+    public class CommandProcessorDepositPostTransactionTestsAsync: IDisposable
+    {
+        
+        private readonly CommandProcessor _commandProcessor;
+        private readonly MyCommand _myCommand = new MyCommand();
+        private readonly Message _message1;
+        private readonly MyCommand _myCommand2 = new MyCommand();
+        private readonly Message _message2;
+        private readonly FakeOutboxSync _fakeOutboxSync;
+        private readonly FakeMessageProducerWithPublishConfirmation _fakeMessageProducerWithPublishConfirmation;
+
+        private readonly IAmABoxTransactionConnectionProvider txnProvider1 = new TxnProvider1();
+        private readonly string txnProvider1Name = "provider1";
+        private readonly IAmABoxTransactionConnectionProvider txnProvider2 = new TxnProvider2();
+        private readonly string txnProvider2Name = "provider2";
+
+        public CommandProcessorDepositPostTransactionTestsAsync()
+        {
+            _myCommand.Value = "Hello World";
+            _myCommand2.Value = "Hello again.";
+
+            _fakeOutboxSync = new FakeOutboxSync();
+            _fakeMessageProducerWithPublishConfirmation = new FakeMessageProducerWithPublishConfirmation();
+
+            var topic = "MyCommand";
+            _message1 = new Message(
+                new MessageHeader(_myCommand.Id, topic, MessageType.MT_COMMAND),
+                new MessageBody(JsonSerializer.Serialize(_myCommand, JsonSerialisationOptions.Options))
+                );
+            
+            _message2 = new Message(
+                new MessageHeader(_myCommand2.Id, topic, MessageType.MT_COMMAND),
+                new MessageBody(JsonSerializer.Serialize(_myCommand2, JsonSerialisationOptions.Options))
+            );
+
+            var messageMapperRegistry = new MessageMapperRegistry(new SimpleMessageMapperFactory((_) => new MyCommandMessageMapper()));
+            messageMapperRegistry.Register<MyCommand, MyCommandMessageMapper>();
+
+            var retryPolicy = Policy
+                .Handle<Exception>()
+                .RetryAsync();
+
+            var circuitBreakerPolicy = Policy
+                .Handle<Exception>()
+                .CircuitBreakerAsync(1, TimeSpan.FromMilliseconds(1));
+
+            var boxTxnProviderRegistry =
+                new BoxTransactionConnectionProviderRegistry(txnProvider1Name, txnProvider1).AddProvider(
+                    txnProvider2Name, txnProvider2);
+            
+            PolicyRegistry policyRegistry = new PolicyRegistry { { CommandProcessor.RETRYPOLICYASYNC, retryPolicy }, { CommandProcessor.CIRCUITBREAKERASYNC, circuitBreakerPolicy } };
+            _commandProcessor = new CommandProcessor(
+                new InMemoryRequestContextFactory(),
+                policyRegistry,
+                messageMapperRegistry,
+                _fakeOutboxSync,
+                new ProducerRegistry(new Dictionary<string, IAmAMessageProducer>() {{topic, _fakeMessageProducerWithPublishConfirmation},}),
+                boxTransactionConnectionProviderRegistry: boxTxnProviderRegistry);
+        }
+
+
+        [Fact]
+        public async Task When_depositing_a_message_in_the_outbox()
+        {
+            //act
+            var postedMessageId = await _commandProcessor.DepositPostAsync(_myCommand);
+            var postedMessage2Id =
+                await _commandProcessor.DepositPostAsync(_myCommand2, transactionProviderName: txnProvider2Name);
+            
+            //assert
+            //message should not be posted
+            _fakeMessageProducerWithPublishConfirmation.MessageWasSent.Should().BeFalse();
+            
+            //message should be in the store
+            var depositedPost = _fakeOutboxSync
+                .OutstandingMessages(0)
+                .SingleOrDefault(msg => msg.Id == _message1.Id);
+            
+            var depositedPost2 = _fakeOutboxSync
+                .OutstandingMessages(0)
+                .SingleOrDefault(msg => msg.Id == _message2.Id);
+
+            depositedPost.Should().NotBeNull();
+           
+            //message should correspond to the command
+            depositedPost.Id.Should().Be(_message1.Id);
+            depositedPost.Body.Value.Should().Be(_message1.Body.Value);
+            depositedPost.Header.Topic.Should().Be(_message1.Header.Topic);
+            depositedPost.Header.MessageType.Should().Be(_message1.Header.MessageType);
+            
+            depositedPost2.Id.Should().Be(_message2.Id);
+            depositedPost2.Body.Value.Should().Be(_message2.Body.Value);
+            depositedPost2.Header.Topic.Should().Be(_message2.Header.Topic);
+            depositedPost2.Header.MessageType.Should().Be(_message2.Header.MessageType);
+            
+            //message should be marked as outstanding if not sent
+            var outstandingMessages = await _fakeOutboxSync.OutstandingMessagesAsync(0);
+            var outstandingMessage = outstandingMessages.First(m => m.Id == postedMessageId);
+            var outstandingMessage2 = outstandingMessages.First(m => m.Id == postedMessage2Id);
+            outstandingMessage.Id.Should().Be(_message1.Id);
+            outstandingMessage2.Id.Should().Be(_message2.Id);
+
+            var depositedPostProvider1 = _fakeOutboxSync.TransactionProviderUsedForPost[postedMessageId];
+            var depositedPostProvider2 = _fakeOutboxSync.TransactionProviderUsedForPost[postedMessage2Id];
+            
+            Assert.Equal(typeof(TxnProvider1), depositedPostProvider1);
+            Assert.Equal(typeof(TxnProvider2), depositedPostProvider2);
+        }
+        
+        public void Dispose()
+        {
+            CommandProcessor.ClearExtServiceBus();
+        }
+     }
+
+    public class TxnProvider1 : IAmABoxTransactionConnectionProvider
+    {
+        
+    }
+    
+    public class TxnProvider2 : IAmABoxTransactionConnectionProvider
+    {
+        
+    }
+}

--- a/tests/Paramore.Brighter.Core.Tests/MessageDispatch/TestDoubles/SpyCommandProcessor.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageDispatch/TestDoubles/SpyCommandProcessor.cs
@@ -107,14 +107,14 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch.TestDoubles
             await completionSource.Task;
         }
 
-        public Guid DepositPost<T>(T request) where T : class, IRequest
+        public Guid DepositPost<T>(T request, string transactionName = null) where T : class, IRequest
         {
             _postBox.Add(request.Id, request);
             return request.Id;
         }
 
         public async Task<Guid> DepositPostAsync<T>(T request, bool continueOnCapturedContext = false,
-            CancellationToken cancellationToken = default(CancellationToken)) where T : class, IRequest
+            CancellationToken cancellationToken = default(CancellationToken), string transactionProviderName = null) where T : class, IRequest
         {
             _postBox.Add(request.Id, request);
 

--- a/tests/Paramore.Brighter.InMemory.Tests/TestDoubles/FakeCommandProcessor.cs
+++ b/tests/Paramore.Brighter.InMemory.Tests/TestDoubles/FakeCommandProcessor.cs
@@ -72,13 +72,13 @@ namespace Paramore.Brighter.InMemory.Tests.TestDoubles
               return tcs.Task;
         }
 
-        public Guid DepositPost<T>(T request) where T : class, IRequest
+        public Guid DepositPost<T>(T request, string transactionProviderName = null) where T : class, IRequest
         {
             Deposited.Enqueue(new DepositedMessage(request));
             return request.Id;
         }
 
-        public Task<Guid> DepositPostAsync<T>(T request, bool continueOnCapturedContext = false, CancellationToken cancellationToken = default(CancellationToken)) where T : class, IRequest
+        public Task<Guid> DepositPostAsync<T>(T request, bool continueOnCapturedContext = false, CancellationToken cancellationToken = default(CancellationToken), string transactionProviderName = null) where T : class, IRequest
         {
             var tcs = new TaskCompletionSource<Guid>(TaskCreationOptions.RunContinuationsAsynchronously);
             


### PR DESCRIPTION
@IlSocio Here is my implementation for #2104

This requires a small change to the ctor of CommandProvider / the DI stuff around it, instead of passing a IAmABoxTransactionConnectionProvider there is now a IAmABoxTransactionConnectionProviderRegistry

The BoxTransactionConnectionProvider that you pass in the ctor becomes the default and from there you can add more as follows

```c#
var boxTxnProviderRegistry =
                new BoxTransactionConnectionProviderRegistry(txnProvider1Name, txnProvider1).AddProvider(
                    txnProvider2Name, txnProvider2);
```

From here when you go to Deposit Post you can do the following to use the default

```c#
await _commandProcessor.DepositPostAsync(_myCommand);
```

or to be specific

```c#
await _commandProcessor.DepositPostAsync(_myCommand2, transactionProviderName: txnProvider2Name);
```

this is still a rough draft (I feel we should maybe default the default txn Provider name and there are no tests on the non async Path (however it should be identical)


@iancooper , @holytshirt , @DevJonny Please let me know your thoughts