### PR TITLE
Kafka threading issue meant offsets not being committed.

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -7,6 +7,9 @@ This section lists features in master, available by [AppVeyor](https://ci.appvey
 
 ## Master ##
 
+- Bug with Kafka Consumer failing to commit offsets fixed. Caused by Monitor being used for a lock on one thread and released on another, which does not work. Replaced with SemaphoreSlim.
+- Behavior of Kafka Consumer offset sweep changed. It now runs every x seconds, and not every x seconds since a flush. This will cause it to run more frequently, but it is easier to reason about.
+
 ## Release 9.1.14 ##
  - Fixed missing negation operator when checking for AWS resources 
 

--- a/release_notes.md
+++ b/release_notes.md
@@ -7,6 +7,7 @@ This section lists features in master, available by [AppVeyor](https://ci.appvey
 
 ## Master ##
 
+## Release 9.1.20 ##
 - Bug with Kafka Consumer failing to commit offsets fixed. Caused by Monitor being used for a lock on one thread and released on another, which does not work. Replaced with SemaphoreSlim.
 - Behavior of Kafka Consumer offset sweep changed. It now runs every x seconds, and not every x seconds since a flush. This will cause it to run more frequently, but it is easier to reason about.
 

--- a/samples/KafkaTaskQueue/GreetingsReceiverConsole/Program.cs
+++ b/samples/KafkaTaskQueue/GreetingsReceiverConsole/Program.cs
@@ -67,7 +67,7 @@ namespace GreetingsReceiverConsole
                             timeoutInMilliseconds: 100,
                             offsetDefault: AutoOffsetReset.Earliest,
                             commitBatchSize: 5,
-                            sweepUncommittedOffsetsIntervalMs: 1000)
+                            sweepUncommittedOffsetsIntervalMs: 10000)
                     };
 
                     //create the gateway

--- a/samples/KafkaTaskQueue/GreetingsReceiverConsole/appsettings.json
+++ b/samples/KafkaTaskQueue/GreetingsReceiverConsole/appsettings.json
@@ -1,7 +1,7 @@
 {
     "Logging": {
         "LogLevel": {
-            "Default": "Debug",
+            "Default": "Information",
             "System": "Warning",
             "Microsoft": "Warning"
         }

--- a/samples/KafkaTaskQueue/GreetingsSender/TimedMessageGenerator.cs
+++ b/samples/KafkaTaskQueue/GreetingsSender/TimedMessageGenerator.cs
@@ -25,7 +25,7 @@ namespace GreetingsSender
         {
             _logger.LogInformation("Kafka Message Generator is starting.");
 
-            _timer = new Timer(DoWork, null, TimeSpan.Zero, TimeSpan.FromSeconds(2));
+            _timer = new Timer(DoWork, null, TimeSpan.Zero, TimeSpan.FromMilliseconds(500));
 
             return Task.CompletedTask;
         }

--- a/samples/KafkaTaskQueue/GreetingsSender/appsettings.json
+++ b/samples/KafkaTaskQueue/GreetingsSender/appsettings.json
@@ -1,7 +1,7 @@
 {
     "Logging": {
         "LogLevel": {
-            "Default": "Debug",
+            "Default": "Information",
             "System": "Warning",
             "Microsoft": "Warning"
         }

--- a/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaMessageConsumer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaMessageConsumer.cs
@@ -471,7 +471,11 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
                     cancellationToken: CancellationToken.None,
                     creationOptions: TaskCreationOptions.DenyChildAttach,
                     scheduler: TaskScheduler.Default);
-            } 
+            }
+            else
+            {
+                s_logger.LogInformation("Skipped committing offsets, as another commit or sweep was running");
+            }
         }
 
         //If it is has been too long since we flushed, flush now to prevent offsets accumulating 
@@ -499,6 +503,10 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
                     cancellationToken: CancellationToken.None,
                     creationOptions: TaskCreationOptions.DenyChildAttach,
                     scheduler: TaskScheduler.Default);
+            }
+            else
+            {
+                s_logger.LogInformation("Skipped sweeping offsets, as another commit or sweep was running");
             }
         }
 

--- a/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaMessageConsumer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaMessageConsumer.cs
@@ -55,7 +55,7 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
         private readonly int _readCommittedOffsetsTimeoutMs;
         private DateTime _lastFlushAt = DateTime.UtcNow;
         private readonly TimeSpan _sweepUncommittedInterval;
-        private readonly object _flushLock = new object();
+        private readonly SemaphoreSlim _flushToken = new SemaphoreSlim(1, 1);
         private bool _disposedValue;
 
         /// <summary>
@@ -407,15 +407,9 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
         /// loop endlessly over the offset list as new items are added, which will trigger a commit anyway. So we limit
         /// the trigger to only commit a batch size worth
         /// </summary>
-        private void CommitOffsets(DateTime flushTime)
+        private void CommitOffsets()
         {
-           if (s_logger.IsEnabled(LogLevel.Debug))
-           {
-               var offsets = _offsetStorage.Select(tpo => $"Topic: {tpo.Topic} Partition: {tpo.Partition.Value} Offset: {tpo.Offset.Value}");
-               var offsetAsString = string.Join(Environment.NewLine, offsets);
-               s_logger.LogDebug("Commiting all offsets: {0} {Offset}", Environment.NewLine, offsetAsString);
-           }
-            
+           
            var listOffsets = new List<TopicPartitionOffset>();
            for (int i = 0; i < _maxBatchSize; i++)
            {
@@ -426,20 +420,53 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
                    break;
 
            }
+           
+           if (s_logger.IsEnabled(LogLevel.Information))
+           {
+               var offsets = listOffsets.Select(tpo => $"Topic: {tpo.Topic} Partition: {tpo.Partition.Value} Offset: {tpo.Offset.Value}");
+               var offsetAsString = string.Join(Environment.NewLine, offsets);
+               s_logger.LogInformation("Commiting offsets: {0} {Offset}", Environment.NewLine, offsetAsString);
+           }
+           
            _consumer.Commit(listOffsets);
-           _lastFlushAt = flushTime;
-           Monitor.Exit(_flushLock);
+           _flushToken.Release(1);
+        }
+        
+        private void CommitAllOffsets(DateTime flushTime)
+        {
+            var listOffsets = new List<TopicPartitionOffset>();
+            var currentOffsetsInBag = _offsetStorage.Count; 
+            for (int i = 0; i < currentOffsetsInBag; i++)
+            {
+                bool hasOffsets = _offsetStorage.TryTake(out var offset);
+                if (hasOffsets)
+                    listOffsets.Add(offset);
+                else
+                    break;
+
+            }
+           
+            if (s_logger.IsEnabled(LogLevel.Information))
+            {
+                var offsets = listOffsets.Select(tpo => $"Topic: {tpo.Topic} Partition: {tpo.Partition.Value} Offset: {tpo.Offset.Value}");
+                var offsetAsString = string.Join(Environment.NewLine, offsets);
+                s_logger.LogInformation("Sweeping offsets: {0} {Offset}", Environment.NewLine, offsetAsString);
+            }
+           
+            _consumer.Commit(listOffsets);
+            _lastFlushAt = flushTime;
+            _flushToken.Release(1);
         }
 
         // The batch size has been exceeded, so flush our offsets
         private void FlushOffsets()
         {
             var now = DateTime.UtcNow;
-            if (Monitor.TryEnter(_flushLock))
+            if (_flushToken.Wait(TimeSpan.Zero))
             {
                 //This is expensive, so use a background thread
                 Task.Factory.StartNew(
-                    action: state => CommitOffsets((DateTime)state),
+                    action: state => CommitOffsets(),
                     state: now,
                     cancellationToken: CancellationToken.None,
                     creationOptions: TaskCreationOptions.DenyChildAttach,
@@ -452,15 +479,22 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
         {
             var now = DateTime.UtcNow;
 
-            if (Monitor.TryEnter(_flushLock))
+            if (now - _lastFlushAt < _sweepUncommittedInterval)
             {
-
+                return;
+            }
+                
+            if (_flushToken.Wait(TimeSpan.Zero))
+            {
                 if (now - _lastFlushAt < _sweepUncommittedInterval)
+                {
+                    _flushToken.Release(1);
                     return;
-
+                }
+                
                 //This is expensive, so use a background thread
                 Task.Factory.StartNew(
-                    action: state => CommitOffsets((DateTime)state),
+                    action: state => CommitAllOffsets((DateTime)state),
                     state: now,
                     cancellationToken: CancellationToken.None,
                     creationOptions: TaskCreationOptions.DenyChildAttach,

--- a/tests/Paramore.Brighter.RMQ.Tests/MessageDispatch/When_building_a_dispatcher_with_named_gateway.cs
+++ b/tests/Paramore.Brighter.RMQ.Tests/MessageDispatch/When_building_a_dispatcher_with_named_gateway.cs
@@ -79,7 +79,7 @@ namespace Paramore.Brighter.RMQ.Tests.MessageDispatch
                 .CommandProcessorFactory(() => new CommandProcessorProvider(commandProcessor))
                 .MessageMappers(messageMapperRegistry)
                 .DefaultChannelFactory(new ChannelFactory(rmqMessageConsumerFactory))
-                .Connections(new []
+                .Subscriptions(new []
                 {
                     new RmqSubscription<MyEvent>(
                         new SubscriptionName("foo"),


### PR DESCRIPTION
Failing to commit offsets #2269 

The KakfaConsumer was using a Monitor to protect us against concurrent attempts to flush. The strategy was:

- Enter the monitor
- Run the flush in a new thread, and exit the monitor when the flush completes

However, a monitor does not work across threads, so this was failing. For a cross-thread lock we need to use a Semaphore (in this case we can use the lightweight SemaphoreSlim).

In addition, when we did a sweep we were sweeping up to batch size of items. We have changed that, and now sweep the current length of offset storage (obviously this will only be up to the point of the sweep, new items will be arriving).