### PR TITLE
Pass through the args for outbox to support Dynamo and Event Store

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,14 +342,9 @@ jobs:
   
     services:
       dynamo:
-        command: "-jar DynamoDBLocal.jar -sharedDb -dbPath ./data"
-        image: "amazon/dynamodb-local:latest"
-        container_name: dynamodb-local
-        ports:
-          - "8000:8000"
-        volumes:
-          - "./docker/dynamodb:/home/dynamodblocal/data"
-        working_dir: /home/dynamodblocal
+        image: dwmkerr/dynamodb
+        ports: 
+          - 8000:8000
       
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,9 +342,14 @@ jobs:
   
     services:
       dynamo:
-        image: dwmkerr/dynamodb
-        ports: 
-          - 8000:8000
+        command: "-jar DynamoDBLocal.jar -sharedDb -dbPath ./data"
+        image: "amazon/dynamodb-local:latest"
+        container_name: dynamodb-local
+        ports:
+          - "8000:8000"
+        volumes:
+          - "./docker/dynamodb:/home/dynamodblocal/data"
+        working_dir: /home/dynamodblocal
       
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Build
         run: dotnet build --configuration Release
       - name: Core Tests
-        run: dotnet test tests/Paramore.Brighter.Core.Tests/Paramore.Brighter.Core.Tests.csproj --filter Fragile\!=CI -c Release --no-restore --no-build --verbosity d
+        run: dotnet test tests/Paramore.Brighter.Core.Tests/Paramore.Brighter.Core.Tests.csproj --filter "Fragile!=CI" -c Release --no-restore --no-build --verbosity d
       - name: Upload packages as artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/.idea/.idea.Brighter/.idea/httpRequests/http-requests-log.http
+++ b/.idea/.idea.Brighter/.idea/httpRequests/http-requests-log.http
@@ -1,3 +1,37 @@
+POST http://localhost:5000/Greetings/Tyrion/new
+Content-Type: application/json
+
+{
+  "Greeting" : "I drink, and I know things"
+}
+
+<> 2022-10-21T115924.200.json
+
+###
+
+GET http://localhost:5000/People/Tyrion
+
+<> 2022-10-21T115848.200.json
+
+###
+
+POST http://localhost:5000/People/new
+Content-Type: application/json
+
+{
+  "Name" : "Tyrion"
+}
+
+<> 2022-10-21T115844.200.json
+
+###
+
+GET http://localhost:5000/People/Tyrion
+
+<> 2022-10-21T115838.500.json
+
+###
+
 POST http://localhost:5000/People/new
 Content-Type: application/json
 
@@ -436,48 +470,6 @@ GET http://localhost:5000/People/Tyrion
 GET http://localhost:5000/People/Tyrion
 
 <> 2022-06-20T192055.500.json
-
-###
-
-POST http://localhost:5000/Greetings/Tyrion/new
-Content-Type: application/json
-
-{
-  "Greeting" : "I drink, and I know things"
-}
-
-<> 2022-06-20T134816.200.json
-
-###
-
-POST http://localhost:5000/Greetings/Tyrion/new
-Content-Type: application/json
-
-{
-  "Greeting" : "I drink, and I know things"
-}
-
-<> 2022-06-20T134716.200.json
-
-###
-
-POST http://localhost:5000/People/new
-Content-Type: application/json
-
-{
-  "Name" : "Tyrion"
-}
-
-<> 2022-06-20T134700.200.json
-
-###
-
-POST http://localhost:5000/People/new
-Content-Type: application/json
-
-{
-  "Name" : "Tyrion"
-}
 
 ###
 

--- a/docker-compose-dynamodb.yaml
+++ b/docker-compose-dynamodb.yaml
@@ -1,16 +1,13 @@
-version: '3'
+version: '3.1'
 
 services:
- dynamo:
-    image: dwmkerr/dynamodb
-    command: "-inMemory"
-    hostname: dynamo
-    volumes:
-      - dynamodb:/data
+  dynamodb-local:
+    command: "-jar DynamoDBLocal.jar -sharedDb -dbPath ./data"
+    image: "amazon/dynamodb-local:latest"
+    container_name: dynamodb-local
     ports:
       - "8000:8000"
-  
-volumes:
-  dynamodb:
-    driver: local
+    volumes:
+      - "./docker/dynamodb:/home/dynamodblocal/data"
+    working_dir: /home/dynamodblocal
   

--- a/samples/OpenTelemetry/Sweeper/Doubles/FakeMessageProducer.cs
+++ b/samples/OpenTelemetry/Sweeper/Doubles/FakeMessageProducer.cs
@@ -11,6 +11,9 @@ public class FakeMessageProducer : IAmAMessageProducerSync
 
     public int MaxOutStandingMessages { get; set; }
     public int MaxOutStandingCheckIntervalMilliSeconds { get; set; }
+
+    public Dictionary<string, object> OutBoxBag { get; set; } = new Dictionary<string, object>();
+
     public void Send(Message message)
     {
         Console.WriteLine($"Message: {message.Body}");

--- a/samples/WebAPI_Dynamo/GreetingsWeb/Startup.cs
+++ b/samples/WebAPI_Dynamo/GreetingsWeb/Startup.cs
@@ -184,6 +184,7 @@ namespace GreetingsWeb
                             MaxOutStandingMessages = 5,
                             MaxOutStandingCheckIntervalMilliSeconds = 500,
                             WaitForConfirmsTimeOutInMilliseconds = 1000,
+                            OutBoxBag = new Dictionary<string, object>(){{"Topic", "GreetingMade"}},
                             MakeChannels = OnMissingChannel.Create
                         }}
                  ).Create()

--- a/samples/WebAPI_Dynamo/GreetingsWeb/Startup.cs
+++ b/samples/WebAPI_Dynamo/GreetingsWeb/Startup.cs
@@ -17,6 +17,7 @@ using Microsoft.OpenApi.Models;
 using Paramore.Brighter;
 using Paramore.Brighter.DynamoDb;
 using Paramore.Brighter.Extensions.DependencyInjection;
+using Paramore.Brighter.Extensions.Hosting;
 using Paramore.Brighter.MessagingGateway.RMQ;
 using Paramore.Brighter.Outbox.DynamoDB;
 using Paramore.Darker.AspNetCore;
@@ -189,6 +190,7 @@ namespace GreetingsWeb
              )
              .UseDynamoDbOutbox(ServiceLifetime.Singleton)
              .UseDynamoDbTransactionConnectionProvider(typeof(DynamoDbUnitOfWork), ServiceLifetime.Scoped)
+             .UseOutboxSweeper(options => { options.Args.Add("Topic", "GreetingMade"); })
              .AutoFromAssemblies(typeof(AddPersonHandlerAsync).Assembly);
         }
 

--- a/samples/WebAPI_Dynamo/README.md
+++ b/samples/WebAPI_Dynamo/README.md
@@ -19,14 +19,9 @@ This sample shows a typical scenario when using WebAPI and Brighter/Darker. It d
 
 ## Environments
 
-*Development* - runs locally on your machine, uses Sqlite as a data store; uses RabbitMQ for messaging, can be launched individually from the docker compose file; it represents a typical setup for development.
+*All* - runs in Docker;uses RabbitMQ for messaging. We use a local dynamo db instance for this sample. The provided docker-compose file sets up both rabbit and dynamo db
 
-*Production* - runs in Docker;uses RabbitMQ for messaging; it emulates a possible production environment. We offer support for a range of common SQL stores in this example. We determine which SQL store to use via an environment 
-variable. The process is: (1) determine we are running in a non-development environment (2) lookup the type of database we want to support (3) initialise an enum to identify that.
-
-We provide launchSetting.json files for all of these, which allows you to run Production with the appropriate db; you should launch your SQL data store and RabbitMQ from the docker compose file. 
-
-In case you are using Command Line Interface for running the project, consider adding --launch-profile:
+We provide launchSetting.json file which allows you to run the code easily from within an IDE. In case you are using Command Line Interface for running the project, consider adding --launch-profile:
 
 ```sh
 dotnet run --launch-profile XXXXXX -d
@@ -50,7 +45,7 @@ The assemblies migrations: **Greetings_MySqlMigrations** and **Greetings_SqliteM
 
 ### SalutationAnalytics
 
-This listens for a GreetingMade message and stores it. It demonstrates listening to a queue. It also demonstrates the use of scopes provided by Brighter's ServiceActivator, which work with EFCore. These support writing to an Outbox when this component raises a message in turn.
+This listens for a GreetingMade message and stores it. It demonstrates listening to a queue. It also demonstrates the use of scopes provided by Brighter's ServiceActivator. These support writing to an Outbox when this component raises a message in turn.
 
 We don't listen to that message, and without any listeners the RabbitMQ will drop the message we send, as it has no queues to give it to. We don't listen because we would just be repeating what we have shown here. If you want to see the messages produced, use the RMQ Management Console (localhost:15672) to create a queue and then bind it to the paramore.binding.exchange with the routingkey of SalutationReceived.
 
@@ -84,11 +79,6 @@ docker compose up -d mysql   # will just start mysql
 and so on.
 
 ### Possible issues
-#### Sqlite Database Read-Only Errors
-
-A Sqlite database will only have permissions for the process that created it. This can result in you receiving read-only errors between invocations of the sample. You either need to alter the permissions on your Db, or delete it between runs.
-
-Maintainers, please don't check the Sqlite files into source control.
 
 #### Queue Creation and Dropped Messages
 
@@ -122,3 +112,7 @@ In case you still struggle, consider following these steps: [RabbitMQ Troublesho
 ## Tests
 
 We provide a tests.http file (supported by both JetBrains Rider and VS Code with the REST Client plugin) to allow you to test operations.
+
+## DynamoDb UI
+
+We recommend the use of dynamodb-admin to view the contents of your local DynamoDb instance: https://medium.com/swlh/a-gui-for-local-dynamodb-dynamodb-admin-b16998323f8e

--- a/samples/WebAPI_Dynamo/docker-compose.yml
+++ b/samples/WebAPI_Dynamo/docker-compose.yml
@@ -1,14 +1,16 @@
 version: '3.1'
 services:
- dynamo:
-    image: dwmkerr/dynamodb
-    command: "-inMemory"
-    hostname: dynamo
-    volumes:
-      - dynamodb:/data
+  dynamodb-local:
+    command: "-jar DynamoDBLocal.jar -sharedDb -dbPath ./data"
+    image: "amazon/dynamodb-local:latest"
+    container_name: dynamodb-local
     ports:
       - "8000:8000"
- rabbitmq:
+    volumes:
+      - "./docker/dynamodb:/home/dynamodblocal/data"
+    working_dir: /home/dynamodblocal
+    
+  rabbitmq:
     image: brightercommand/rabbitmq:3.8-management-delay
     ports:
       - "5672:5672"
@@ -18,7 +20,5 @@ services:
 
 volumes:
     rabbitmq-home:
-      driver: local
-    dynamodb:
       driver: local
  

--- a/src/Paramore.Brighter.Extensions.Hosting/TimedOutboxSweeper.cs
+++ b/src/Paramore.Brighter.Extensions.Hosting/TimedOutboxSweeper.cs
@@ -44,7 +44,8 @@ namespace Paramore.Brighter.Extensions.Hosting
                     millisecondsSinceSent: _options.MinimumMessageAge,
                     commandProcessor: commandProcessor,
                     _options.BatchSize,
-                    _options.UseBulk);
+                    _options.UseBulk,
+                    _options.Args);
 
                 if (_options.UseBulk)
                     outBoxSweeper.SweepAsyncOutbox();

--- a/src/Paramore.Brighter.Extensions.Hosting/TimedOutboxSweeperOptions.cs
+++ b/src/Paramore.Brighter.Extensions.Hosting/TimedOutboxSweeperOptions.cs
@@ -1,4 +1,6 @@
-﻿namespace Paramore.Brighter.Extensions.Hosting
+﻿using System.Collections.Generic;
+
+namespace Paramore.Brighter.Extensions.Hosting
 {
     /// <summary>
     /// The configuration options for <see cref="TimedOutboxSweeper"/>
@@ -18,6 +20,11 @@
         /// The maximum number of messages to dispatch.
         /// </summary>
         public int BatchSize { get; set; } = 100;
+
+        /// <summary>
+        /// An optional 'bag' of arguments that the sweeper needs for a specific flavor of outbox
+        /// </summary>
+        public Dictionary<string, object> Args;
 
         /// <summary>
         /// Use bulk operations to dispatch messages.

--- a/src/Paramore.Brighter.Extensions.Hosting/TimedOutboxSweeperOptions.cs
+++ b/src/Paramore.Brighter.Extensions.Hosting/TimedOutboxSweeperOptions.cs
@@ -24,7 +24,7 @@ namespace Paramore.Brighter.Extensions.Hosting
         /// <summary>
         /// An optional 'bag' of arguments that the sweeper needs for a specific flavor of outbox
         /// </summary>
-        public Dictionary<string, object> Args;
+        public readonly Dictionary<string, object> Args = new Dictionary<string, object>();
 
         /// <summary>
         /// Use bulk operations to dispatch messages.

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS/AWSMessagingGateway.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS/AWSMessagingGateway.cs
@@ -1,4 +1,28 @@
-﻿using System;
+﻿#region Licence
+/* The MIT License (MIT)
+Copyright © 2022 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+using System;
 using System.Collections.Generic;
 using System.Net;
 using Amazon.SimpleNotificationService;

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS/AWSMessagingGatewayConfiguration.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS/AWSMessagingGatewayConfiguration.cs
@@ -1,4 +1,28 @@
-﻿using Amazon;
+﻿#region Licence
+/* The MIT License (MIT)
+Copyright © 2022 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+using Amazon;
 using Amazon.Runtime;
 
 namespace Paramore.Brighter.MessagingGateway.AWSSQS

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS/AWSNameExtensions.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS/AWSNameExtensions.cs
@@ -1,4 +1,27 @@
-﻿namespace Paramore.Brighter.MessagingGateway.AWSSQS
+﻿#region Licence
+/* The MIT License (MIT)
+Copyright © 2022 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+#endregion
+
+namespace Paramore.Brighter.MessagingGateway.AWSSQS
 {
     public static class AWSNameExtensions
     {

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS/BrokerUnreachableException.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS/BrokerUnreachableException.cs
@@ -1,4 +1,27 @@
-﻿using System;
+﻿#region Licence
+/* The MIT License (MIT)
+Copyright © 2022 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+#endregion
+
+using System;
 
 namespace Paramore.Brighter.MessagingGateway.AWSSQS
 {

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS/ChannelFactory.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS/ChannelFactory.cs
@@ -1,4 +1,27 @@
-﻿using System;
+﻿#region Licence
+/* The MIT License (MIT)
+Copyright © 2022 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+#endregion
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS/HeaderNames.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS/HeaderNames.cs
@@ -1,4 +1,25 @@
-using System.Collections.Generic;
+#region Licence
+/* The MIT License (MIT)
+Copyright © 2022 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+#endregion
 
 namespace Paramore.Brighter.MessagingGateway.AWSSQS
 {

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS/HeaderResult.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS/HeaderResult.cs
@@ -21,6 +21,28 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE. */
 
 #endregion
+#region Licence
+/* The MIT License (MIT)
+Copyright © 2022 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+#endregion
 
 using System;
 

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS/ISqsMessageCreator.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS/ISqsMessageCreator.cs
@@ -1,4 +1,27 @@
-﻿using System;
+﻿#region Licence
+/* The MIT License (MIT)
+Copyright © 2022 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+#endregion
+
+using System;
 
 namespace Paramore.Brighter.MessagingGateway.AWSSQS
 {

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS/IValidateTopic.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS/IValidateTopic.cs
@@ -1,4 +1,27 @@
-﻿namespace Paramore.Brighter.MessagingGateway.AWSSQS
+﻿#region Licence
+/* The MIT License (MIT)
+Copyright © 2022 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+#endregion
+
+namespace Paramore.Brighter.MessagingGateway.AWSSQS
 {
     internal interface IValidateTopic
     {

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS/RedrivePolicy.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS/RedrivePolicy.cs
@@ -1,4 +1,27 @@
-﻿namespace Paramore.Brighter.MessagingGateway.AWSSQS
+﻿#region Licence
+/* The MIT License (MIT)
+Copyright © 2022 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+#endregion
+
+namespace Paramore.Brighter.MessagingGateway.AWSSQS
 {
     /// <summary>
     /// Encapsulates the parameters for a redrive policy for an SQS queue

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS/SnsAttributes.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS/SnsAttributes.cs
@@ -1,4 +1,27 @@
-﻿using System.Collections.Generic;
+﻿#region Licence
+/* The MIT License (MIT)
+Copyright © 2022 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+#endregion
+
+using System.Collections.Generic;
 using Amazon.SimpleNotificationService.Model;
 
 namespace Paramore.Brighter.MessagingGateway.AWSSQS

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS/SnsMessageAttributeExtensions.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS/SnsMessageAttributeExtensions.cs
@@ -1,4 +1,27 @@
-﻿using System.Text.Json;
+﻿#region Licence
+/* The MIT License (MIT)
+Copyright © 2022 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+#endregion
+
+using System.Text.Json;
 
 namespace Paramore.Brighter.MessagingGateway.AWSSQS
 {

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS/SnsProducerRegistryFactory.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS/SnsProducerRegistryFactory.cs
@@ -1,4 +1,27 @@
-﻿using System.Collections.Generic;
+﻿#region Licence
+/* The MIT License (MIT)
+Copyright © 2022 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+#endregion
+
+using System.Collections.Generic;
 using Amazon;
 using Amazon.Runtime;
 

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS/SnsPublication.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS/SnsPublication.cs
@@ -1,4 +1,25 @@
-﻿using System.Collections.Generic;
+﻿#region Licence
+/* The MIT License (MIT)
+Copyright © 2022 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+#endregion
 
 namespace Paramore.Brighter.MessagingGateway.AWSSQS
 {

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS/SqsInlineMessageCreator.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS/SqsInlineMessageCreator.cs
@@ -1,4 +1,27 @@
-﻿using System;
+﻿#region Licence
+/* The MIT License (MIT)
+Copyright © 2022 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+#endregion
+
+using System;
 using System.Collections.Generic;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS/SqsMessage.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS/SqsMessage.cs
@@ -1,3 +1,26 @@
+#region Licence
+/* The MIT License (MIT)
+Copyright © 2022 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+#endregion
+
 using System;
 
 namespace Paramore.Brighter.MessagingGateway.AWSSQS

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS/SqsMessageConsumer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS/SqsMessageConsumer.cs
@@ -1,16 +1,25 @@
-﻿// ***********************************************************************
-// Assembly         : paramore.brighter.messaginggateway.awssqs
-// Author           : ian
-// Created          : 08-17-2015
-//
-// Last Modified By : ian
-// Last Modified On : 10-25-2015
-// ***********************************************************************
-// <copyright file="SqsMessageConsumer.cs" company="">
-//     Copyright ©  2015
-// </copyright>
-// <summary></summary>
-// ***********************************************************************
+﻿#region Licence
+/* The MIT License (MIT)
+Copyright © 2022 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+#endregion*
 
 using System;
 using System.Collections.Generic;

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS/SqsMessageConsumerFactory.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS/SqsMessageConsumerFactory.cs
@@ -1,19 +1,25 @@
-﻿// ***********************************************************************
-// Assembly         : paramore.brighter.messaginggateway.awssqs
-// Author           : ian
-// Created          : 08-17-2015
-//
-// Last Modified By : ian
-// Last Modified On : 10-25-2015
-// ***********************************************************************
-// <copyright file="SqsMessageConsumerFactory.cs" company="">
-//     Copyright ©  2015
-// </copyright>
-// <summary></summary>
-// ***********************************************************************
+﻿#region Licence
+/* The MIT License (MIT)
+Copyright © 2022 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
 
-using Amazon;
-using Amazon.Runtime;
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+#endregion
 
 namespace Paramore.Brighter.MessagingGateway.AWSSQS
 {

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS/SqsMessageCreator.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS/SqsMessageCreator.cs
@@ -1,4 +1,27 @@
-﻿using System;
+﻿#region Licence
+/* The MIT License (MIT)
+Copyright © 2022 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+#endregion
+
+using System;
 using System.Collections.Generic;
 using System.Text.Json;
 using Amazon.SQS.Model;

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS/SqsMessageCreatorFactory.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS/SqsMessageCreatorFactory.cs
@@ -1,4 +1,27 @@
-﻿namespace Paramore.Brighter.MessagingGateway.AWSSQS
+﻿#region Licence
+/* The MIT License (MIT)
+Copyright © 2022 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+#endregion
+
+namespace Paramore.Brighter.MessagingGateway.AWSSQS
 {
     internal class SqsMessageCreatorFactory
     {

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS/SqsMessageProducer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS/SqsMessageProducer.cs
@@ -1,19 +1,27 @@
-﻿// ***********************************************************************
-// Assembly         : paramore.brighter.messaginggateway.awssqs
-// Author           : ian
-// Created          : 08-17-2015
-//
-// Last Modified By : ian
-// Last Modified On : 10-25-2015
-// ***********************************************************************
-// <copyright file="SqsMessageProducer.cs" company="">
-//     Copyright ©  2015
-// </copyright>
-// <summary></summary>
-// ***********************************************************************
+﻿#region Licence
+/* The MIT License (MIT)
+Copyright © 2022 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+#endregion
 
 using System.Collections.Generic;
-using System.Linq;
 using Amazon.SimpleNotificationService;
 using Microsoft.Extensions.Logging;
 
@@ -24,8 +32,26 @@ namespace Paramore.Brighter.MessagingGateway.AWSSQS
     /// </summary>
     public class SqsMessageProducer : AWSMessagingGateway, IAmAMessageProducerSync
     {
+        /// <summary>
+        /// How many outstanding messages may the outbox have before we terminate the programme with an OutboxLimitReached exception?
+        /// -1 => No limit, although the Outbox may discard older entries which is implementation dependent
+        /// 0 => No outstanding messages, i.e. throw an error as soon as something goes into the Outbox
+        /// 1+ => Allow this number of messages to stack up in an Outbox before throwing an exception (likely to fail fast)
+        /// </summary>
         public int MaxOutStandingMessages { get; set; } = -1;
+        
+        /// <summary>
+        /// At what interval should we check the number of outstanding messages has not exceeded the limit set in MaxOutStandingMessages
+        /// We spin off a thread to check when inserting an item into the outbox, if the interval since the last insertion is greater than this threshold
+        /// If you set MaxOutStandingMessages to -1 or 0 this property is effectively ignored
+        /// </summary>
         public int MaxOutStandingCheckIntervalMilliSeconds { get; set; } = 0;
+
+        /// <summary>
+        /// An outbox may require additional arguments before it can run its checks. The DynamoDb outbox for example expects there to be a Topic in the args
+        /// This bag provides the args required
+        /// </summary>
+        public Dictionary<string, object> OutBoxBag { get; set; } = new Dictionary<string, object>();
 
         private readonly AWSMessagingGatewayConnection _connection;
         private readonly SnsPublication _publication;

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS/SqsMessagePublisher.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS/SqsMessagePublisher.cs
@@ -1,4 +1,27 @@
-﻿using System;
+﻿#region Licence
+/* The MIT License (MIT)
+Copyright © 2022 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+#endregion
+
+using System;
 using System.Collections.Generic;
 using System.Text.Json;
 using Amazon.SimpleNotificationService;

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS/TopicFindBy.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS/TopicFindBy.cs
@@ -1,4 +1,27 @@
-﻿namespace Paramore.Brighter.MessagingGateway.AWSSQS
+﻿#region Licence
+/* The MIT License (MIT)
+Copyright © 2022 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+#endregion
+
+namespace Paramore.Brighter.MessagingGateway.AWSSQS
 {
     /// <summary>
     /// How do we validate the topic - when we opt to validate or create (already exists) infrastructure

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS/ValidateTopicByArn.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS/ValidateTopicByArn.cs
@@ -1,4 +1,27 @@
-﻿using System;
+﻿#region Licence
+/* The MIT License (MIT)
+Copyright © 2022 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+#endregion
+
+using System;
 using System.Net;
 using Amazon;
 using Amazon.Runtime;

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS/ValidateTopicByArnConvention.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS/ValidateTopicByArnConvention.cs
@@ -1,4 +1,27 @@
-﻿using System;
+﻿#region Licence
+/* The MIT License (MIT)
+Copyright © 2022 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+#endregion
+
+using System;
 using System.Net;
 using Amazon;
 using Amazon.Runtime;

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS/ValidateTopicByName.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS/ValidateTopicByName.cs
@@ -1,4 +1,27 @@
-﻿using Amazon;
+﻿#region Licence
+/* The MIT License (MIT)
+Copyright © 2022 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+#endregion
+
+using Amazon;
 using Amazon.Runtime;
 using Amazon.SimpleNotificationService;
 

--- a/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusMessageProducer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusMessageProducer.cs
@@ -1,4 +1,29 @@
-﻿using System;
+﻿#region Licence
+
+/* The MIT License (MIT)
+Copyright © 2014 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -18,8 +43,26 @@ namespace Paramore.Brighter.MessagingGateway.AzureServiceBus
     /// </summary>
     public class AzureServiceBusMessageProducer : IAmAMessageProducerSync, IAmAMessageProducerAsync, IAmABulkMessageProducerAsync
     {
+        /// <summary>
+        /// How many outstanding messages may the outbox have before we terminate the programme with an OutboxLimitReached exception?
+        /// -1 => No limit, although the Outbox may discard older entries which is implementation dependent
+        /// 0 => No outstanding messages, i.e. throw an error as soon as something goes into the Outbox
+        /// 1+ => Allow this number of messages to stack up in an Outbox before throwing an exception (likely to fail fast)
+        /// </summary>
         public int MaxOutStandingMessages { get; set; } = -1;
+  
+        /// <summary>
+        /// At what interval should we check the number of outstanding messages has not exceeded the limit set in MaxOutStandingMessages
+        /// We spin off a thread to check when inserting an item into the outbox, if the interval since the last insertion is greater than this threshold
+        /// If you set MaxOutStandingMessages to -1 or 0 this property is effectively ignored
+        /// </summary>
         public int MaxOutStandingCheckIntervalMilliSeconds { get; set; } = 0;
+
+        /// <summary>
+        /// An outbox may require additional arguments before it can run its checks. The DynamoDb outbox for example expects there to be a Topic in the args
+        /// This bag provides the args required
+        /// </summary>
+        public Dictionary<string, object> OutBoxBag { get; set; } = new Dictionary<string, object>();
 
         private readonly IAdministrationClientWrapper _administrationClientWrapper;
         private readonly IServiceBusSenderProvider _serviceBusSenderProvider;

--- a/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaMessageProducer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaMessageProducer.cs
@@ -107,6 +107,7 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
             TopicFindTimeoutMs = publication.TopicFindTimeoutMs;
             MaxOutStandingMessages = publication.MaxOutStandingMessages;
             MaxOutStandingCheckIntervalMilliSeconds = publication.MaxOutStandingCheckIntervalMilliSeconds;
+            OutBoxBag = publication.OutBoxBag;
         }
         
         /// <summary>

--- a/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaMessageProducer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaMessageProducer.cs
@@ -22,6 +22,7 @@ THE SOFTWARE. */
 #endregion
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Confluent.Kafka;
@@ -33,8 +34,26 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
     internal class KafkaMessageProducer : KafkaMessagingGateway, IAmAMessageProducerSync, IAmAMessageProducerAsync, ISupportPublishConfirmation
     {
         public event Action<bool, Guid> OnMessagePublished;
+        /// <summary>
+        /// How many outstanding messages may the outbox have before we terminate the programme with an OutboxLimitReached exception?
+        /// -1 => No limit, although the Outbox may discard older entries which is implementation dependent
+        /// 0 => No outstanding messages, i.e. throw an error as soon as something goes into the Outbox
+        /// 1+ => Allow this number of messages to stack up in an Outbox before throwing an exception (likely to fail fast)
+        /// </summary>
         public int MaxOutStandingMessages { get; set; } = -1;
+        
+        /// <summary>
+        /// At what interval should we check the number of outstanding messages has not exceeded the limit set in MaxOutStandingMessages
+        /// We spin off a thread to check when inserting an item into the outbox, if the interval since the last insertion is greater than this threshold
+        /// If you set MaxOutStandingMessages to -1 or 0 this property is effectively ignored
+        /// </summary>
         public int MaxOutStandingCheckIntervalMilliSeconds { get; set; } = 0;
+
+        /// <summary>
+        /// An outbox may require additional arguments before it can run its checks. The DynamoDb outbox for example expects there to be a Topic in the args
+        /// This bag provides the args required
+        /// </summary>
+        public Dictionary<string, object> OutBoxBag { get; set; } = new Dictionary<string, object>();
 
         private IProducer<string, string> _producer;
         private readonly ProducerConfig _producerConfig;

--- a/src/Paramore.Brighter.MessagingGateway.MsSql/MsSqlMessageProducer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.MsSql/MsSqlMessageProducer.cs
@@ -66,6 +66,7 @@ namespace Paramore.Brighter.MessagingGateway.MsSql
             _publication = publication ?? new Publication() {MakeChannels = OnMissingChannel.Create};
             MaxOutStandingMessages = _publication.MaxOutStandingMessages;
             MaxOutStandingCheckIntervalMilliSeconds = _publication.MaxOutStandingCheckIntervalMilliSeconds;
+            OutBoxBag = publication.OutBoxBag;
         }
 
         public MsSqlMessageProducer(

--- a/src/Paramore.Brighter.MessagingGateway.MsSql/MsSqlMessageProducer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.MsSql/MsSqlMessageProducer.cs
@@ -1,4 +1,28 @@
-﻿using System.Threading.Tasks;
+﻿#region Licence
+/* The MIT License (MIT)
+Copyright © 2022 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+#endregion
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Paramore.Brighter.Logging;
 using Paramore.Brighter.MessagingGateway.MsSql.SqlQueues;
@@ -8,9 +32,27 @@ namespace Paramore.Brighter.MessagingGateway.MsSql
 {
     public class MsSqlMessageProducer : IAmAMessageProducerSync, IAmAMessageProducerAsync
     {
+        /// <summary>
+        /// How many outstanding messages may the outbox have before we terminate the programme with an OutboxLimitReached exception?
+        /// -1 => No limit, although the Outbox may discard older entries which is implementation dependent
+        /// 0 => No outstanding messages, i.e. throw an error as soon as something goes into the Outbox
+        /// 1+ => Allow this number of messages to stack up in an Outbox before throwing an exception (likely to fail fast)
+        /// </summary>
         public int MaxOutStandingMessages { get; set; } = -1;
+  
+        /// <summary>
+        /// At what interval should we check the number of outstanding messages has not exceeded the limit set in MaxOutStandingMessages
+        /// We spin off a thread to check when inserting an item into the outbox, if the interval since the last insertion is greater than this threshold
+        /// If you set MaxOutStandingMessages to -1 or 0 this property is effectively ignored
+        /// </summary>
         public int MaxOutStandingCheckIntervalMilliSeconds { get; set; } = 0;
-        
+
+        /// <summary>
+        /// An outbox may require additional arguments before it can run its checks. The DynamoDb outbox for example expects there to be a Topic in the args
+        /// This bag provides the args required
+        /// </summary>
+        public Dictionary<string, object> OutBoxBag { get; set; } = new Dictionary<string, object>();
+
         private static readonly ILogger s_logger = ApplicationLogging.CreateLogger<MsSqlMessageProducer>();
         private readonly MsSqlMessageQueue<Message> _sqlQ;
         private Publication _publication; // -- placeholder for future use

--- a/src/Paramore.Brighter.MessagingGateway.RESTMS/RestMsMessageProducer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RESTMS/RestMsMessageProducer.cs
@@ -41,9 +41,27 @@ namespace Paramore.Brighter.MessagingGateway.RESTMS
     /// </summary>
     public class RestMsMessageProducer : RestMSMessageGateway, IAmAMessageProducerSync
     {
+        /// <summary>
+        /// How many outstanding messages may the outbox have before we terminate the programme with an OutboxLimitReached exception?
+        /// -1 => No limit, although the Outbox may discard older entries which is implementation dependent
+        /// 0 => No outstanding messages, i.e. throw an error as soon as something goes into the Outbox
+        /// 1+ => Allow this number of messages to stack up in an Outbox before throwing an exception (likely to fail fast)
+        /// </summary>
         public int MaxOutStandingMessages { get; set; } = -1;
+        
+        /// <summary>
+        /// At what interval should we check the number of outstanding messages has not exceeded the limit set in MaxOutStandingMessages
+        /// We spin off a thread to check when inserting an item into the outbox, if the interval since the last insertion is greater than this threshold
+        /// If you set MaxOutStandingMessages to -1 or 0 this property is effectively ignored
+        /// </summary>
         public int MaxOutStandingCheckIntervalMilliSeconds { get; set; } = 0;
-         
+
+        /// <summary>
+        /// An outbox may require additional arguments before it can run its checks. The DynamoDb outbox for example expects there to be a Topic in the args
+        /// This bag provides the args required
+        /// </summary>
+        public Dictionary<string, object> OutBoxBag { get; set; } = new Dictionary<string, object>();
+
         private static readonly ILogger s_logger = ApplicationLogging.CreateLogger<RestMsMessageProducer>();
 
         private readonly Feed _feed;

--- a/src/Paramore.Brighter.MessagingGateway.RMQ/RmqMessageProducer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ/RmqMessageProducer.cs
@@ -98,6 +98,7 @@ namespace Paramore.Brighter.MessagingGateway.RMQ
             MaxOutStandingMessages = _publication.MaxOutStandingMessages;
             MaxOutStandingCheckIntervalMilliSeconds = _publication.MaxOutStandingCheckIntervalMilliSeconds;
             _waitForConfirmsTimeOutInMilliseconds = _publication.WaitForConfirmsTimeOutInMilliseconds;
+            OutBoxBag = _publication.OutBoxBag;
         }
 
         /// <summary>

--- a/src/Paramore.Brighter.MessagingGateway.Redis/RedisMessageProducer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.Redis/RedisMessageProducer.cs
@@ -85,6 +85,7 @@ namespace Paramore.Brighter.MessagingGateway.Redis
              _publication = publication;
              MaxOutStandingMessages = _publication.MaxOutStandingMessages;
              MaxOutStandingCheckIntervalMilliSeconds = _publication.MaxOutStandingCheckIntervalMilliSeconds;
+             OutBoxBag = publication.OutBoxBag;
          }
 
         public void Dispose()

--- a/src/Paramore.Brighter.MessagingGateway.Redis/RedisMessageProducer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.Redis/RedisMessageProducer.cs
@@ -51,9 +51,26 @@ namespace Paramore.Brighter.MessagingGateway.Redis
 
     public class RedisMessageProducer : RedisMessageGateway, IAmAMessageProducerSync
     {
+        /// <summary>
+        /// How many outstanding messages may the outbox have before we terminate the programme with an OutboxLimitReached exception?
+        /// -1 => No limit, although the Outbox may discard older entries which is implementation dependent
+        /// 0 => No outstanding messages, i.e. throw an error as soon as something goes into the Outbox
+        /// 1+ => Allow this number of messages to stack up in an Outbox before throwing an exception (likely to fail fast)
+        /// </summary>
         public int MaxOutStandingMessages { get; set;  } = -1;
+        /// <summary>
+        /// At what interval should we check the number of outstanding messages has not exceeded the limit set in MaxOutStandingMessages
+        /// We spin off a thread to check when inserting an item into the outbox, if the interval since the last insertion is greater than this threshold
+        /// If you set MaxOutStandingMessages to -1 or 0 this property is effectively ignored
+        /// </summary>
         public int MaxOutStandingCheckIntervalMilliSeconds { get; set; } = 0;
-    
+
+        /// <summary>
+        /// An outbox may require additional arguments before it can run its checks. The DynamoDb outbox for example expects there to be a Topic in the args
+        /// This bag provides the args required
+        /// </summary>
+        public Dictionary<string, object> OutBoxBag { get; set; } = new Dictionary<string, object>();
+
         private static readonly ILogger s_logger = ApplicationLogging.CreateLogger<RedisMessageProducer>();
         private readonly Publication _publication; 
         private const string NEXT_ID = "nextid";

--- a/src/Paramore.Brighter.Outbox.DynamoDB/DynamoDbOutbox.cs
+++ b/src/Paramore.Brighter.Outbox.DynamoDB/DynamoDbOutbox.cs
@@ -267,12 +267,14 @@ namespace Paramore.Brighter.Outbox.DynamoDB
          int pageNumber = 1, 
          Dictionary<string, object> args = null)
         {
+            var now = DateTime.UtcNow;
+            
             if (args == null)
             {
                 throw new ArgumentException("Missing required argument", nameof(args));
             }
-            
-            var createdTime = DateTime.UtcNow.Subtract(TimeSpan.FromMilliseconds(millisecondsDispatchedSince));
+
+            var dispatchedTime = now.Subtract(TimeSpan.FromMilliseconds(millisecondsDispatchedSince));
             var topic = (string)args["Topic"];
 
             // We get all the messages for topic, added within a time range
@@ -281,7 +283,7 @@ namespace Paramore.Brighter.Outbox.DynamoDB
             var queryConfig = new QueryOperationConfig
             {
                 IndexName = _configuration.OutstandingIndexName,
-                KeyExpression = new KeyTopicCreatedTimeExpression().Generate(topic, createdTime),
+                KeyExpression = new KeyTopicCreatedTimeExpression().Generate(topic, dispatchedTime),
                 FilterExpression = new NoDispatchTimeExpression().Generate(),
                 ConsistentRead = false
             };
@@ -313,7 +315,7 @@ namespace Paramore.Brighter.Outbox.DynamoDB
                 throw new ArgumentException("Missing required argument", nameof(args));
             }
 
-            var createdTime = DateTime.UtcNow.Subtract(TimeSpan.FromMilliseconds(millisecondsDispatchedSince));
+            var dispatchedTime = DateTime.UtcNow.Subtract(TimeSpan.FromMilliseconds(millisecondsDispatchedSince));
             var topic = (string)args["Topic"];
 
             // We get all the messages for topic, added within a time range
@@ -322,7 +324,7 @@ namespace Paramore.Brighter.Outbox.DynamoDB
             var queryConfig = new QueryOperationConfig
             {
                 IndexName = _configuration.OutstandingIndexName,
-                KeyExpression = new KeyTopicCreatedTimeExpression().Generate(topic, createdTime),
+                KeyExpression = new KeyTopicCreatedTimeExpression().Generate(topic, dispatchedTime),
                 FilterExpression = new NoDispatchTimeExpression().Generate(),
                 ConsistentRead = false
             };

--- a/src/Paramore.Brighter.Outbox.DynamoDB/DynamoDbOutbox.cs
+++ b/src/Paramore.Brighter.Outbox.DynamoDB/DynamoDbOutbox.cs
@@ -339,7 +339,7 @@ namespace Paramore.Brighter.Outbox.DynamoDB
             return messages.Select(msg => msg.ConvertToMessage());
         }
         
-       private async Task<TransactWriteItemsRequest> AddToTransactionWrite(MessageItem messageToStore, DynamoDbUnitOfWork dynamoDbUnitOfWork)
+       private Task<TransactWriteItemsRequest> AddToTransactionWrite(MessageItem messageToStore, DynamoDbUnitOfWork dynamoDbUnitOfWork)
        {
            var tcs = new TaskCompletionSource<TransactWriteItemsRequest>();
            var attributes = _context.ToDocument(messageToStore).ToAttributeMap();
@@ -347,7 +347,7 @@ namespace Paramore.Brighter.Outbox.DynamoDB
            var transaction = dynamoDbUnitOfWork.BeginOrGetTransaction();
            transaction.TransactItems.Add(new TransactWriteItem{Put = new Put{TableName = _configuration.TableName, Item = attributes}});
            tcs.SetResult(transaction);
-           return tcs.Task.Result;
+           return tcs.Task;
        }
        
        private async Task<Message> GetMessage(Guid id, CancellationToken cancellationToken = default(CancellationToken))

--- a/src/Paramore.Brighter.Outbox.DynamoDB/DynamoDbOutbox.cs
+++ b/src/Paramore.Brighter.Outbox.DynamoDB/DynamoDbOutbox.cs
@@ -320,7 +320,7 @@ namespace Paramore.Brighter.Outbox.DynamoDB
                 throw new ArgumentException("Missing required argument", nameof(args));
             }
 
-            var dispatchedTime = DateTime.UtcNow.Subtract(TimeSpan.FromMilliseconds(millisecondsDispatchedSince));
+            var minimumAge = DateTime.UtcNow.Subtract(TimeSpan.FromMilliseconds(millisecondsDispatchedSince));
             var topic = (string)args["Topic"];
 
             // We get all the messages for topic, added within a time range
@@ -329,7 +329,7 @@ namespace Paramore.Brighter.Outbox.DynamoDB
             var queryConfig = new QueryOperationConfig
             {
                 IndexName = _configuration.OutstandingIndexName,
-                KeyExpression = new KeyTopicCreatedTimeExpression().Generate(topic, dispatchedTime),
+                KeyExpression = new KeyTopicCreatedTimeExpression().Generate(topic, minimumAge),
                 FilterExpression = new NoDispatchTimeExpression().Generate(),
                 ConsistentRead = false
             };

--- a/src/Paramore.Brighter.Outbox.DynamoDB/DynamoDbOutbox.cs
+++ b/src/Paramore.Brighter.Outbox.DynamoDB/DynamoDbOutbox.cs
@@ -244,7 +244,8 @@ namespace Paramore.Brighter.Outbox.DynamoDB
         public void MarkDispatched(Guid id, DateTime? dispatchedAt = null, Dictionary<string, object> args = null)
         {
             var message = _context.LoadAsync<MessageItem>(id.ToString()).Result;
-            message.DeliveryTime = $"{dispatchedAt:yyyy-MM-dd}";
+            message.DeliveryTime = dispatchedAt.Value.Ticks;
+            message.DeliveredAt = $"{dispatchedAt:yyyy-MM-dd}";
 
             _context.SaveAsync(
                 message, 
@@ -320,7 +321,7 @@ namespace Paramore.Brighter.Outbox.DynamoDB
             {
                 IndexName = _configuration.OutstandingIndexName,
                 KeyExpression = new KeyTopicCreatedTimeExpression().Generate(topic, sinceTime),
-                FilterExpression = new NoDispatchTimeExpression().Generate(),
+                //FilterExpression = new NoDispatchTimeExpression().Generate(),
                 ConsistentRead = false
             };
            

--- a/src/Paramore.Brighter.Outbox.DynamoDB/KeyTopicCreatedTimeExpression.cs
+++ b/src/Paramore.Brighter.Outbox.DynamoDB/KeyTopicCreatedTimeExpression.cs
@@ -10,7 +10,7 @@ namespace Paramore.Brighter.Outbox.DynamoDB
 
         public KeyTopicCreatedTimeExpression()
         {
-            _expression = new Expression { ExpressionStatement = "Topic = :v_Topic and CreatedTime >= :v_CreatedTime" };
+            _expression = new Expression { ExpressionStatement = "Topic = :v_Topic and CreatedTime < :v_CreatedTime" };
         }
 
         public override string ToString()

--- a/src/Paramore.Brighter.Outbox.DynamoDB/KeyTopicCreatedTimeExpression.cs
+++ b/src/Paramore.Brighter.Outbox.DynamoDB/KeyTopicCreatedTimeExpression.cs
@@ -6,13 +6,11 @@ namespace Paramore.Brighter.Outbox.DynamoDB
 {
     internal class KeyTopicCreatedTimeExpression
     {
-        private Expression _expression;
+        private readonly Expression _expression;
 
         public KeyTopicCreatedTimeExpression()
         {
-            _expression = new Expression();
-            _expression.ExpressionStatement = "Topic = :v_Topic and CreatedTime >= :v_SinceTime";
- 
+            _expression = new Expression { ExpressionStatement = "Topic = :v_Topic and CreatedTime >= :v_CreatedTime" };
         }
 
         public override string ToString()
@@ -20,11 +18,11 @@ namespace Paramore.Brighter.Outbox.DynamoDB
             return _expression.ExpressionStatement;
         }
 
-        public Expression Generate(string topicName, DateTime sinceTime)
+        public Expression Generate(string topicName, DateTime createdTime)
         {
             var values = new Dictionary<string, DynamoDBEntry>();
             values.Add(":v_Topic", topicName);
-            values.Add(":v_SinceTime", sinceTime.Ticks);
+            values.Add(":v_CreatedTime", createdTime.Ticks);
 
             _expression.ExpressionAttributeValues = values;
 

--- a/src/Paramore.Brighter.Outbox.DynamoDB/KeyTopicDeliveredTimeExpression.cs
+++ b/src/Paramore.Brighter.Outbox.DynamoDB/KeyTopicDeliveredTimeExpression.cs
@@ -6,13 +6,11 @@ namespace Paramore.Brighter.Outbox.DynamoDB
 {
     internal class KeyTopicDeliveredTimeExpression
     {
-        private Expression _expression;
+        private readonly Expression _expression;
 
         public KeyTopicDeliveredTimeExpression()
         {
-            _expression = new Expression();
-            _expression.ExpressionStatement = "Topic = :v_Topic and DeliveryTime >= :v_SinceTime";
- 
+            _expression = new Expression { ExpressionStatement = "Topic = :v_Topic and DeliveryTime < :v_SinceTime" };
         }
 
         public override string ToString()

--- a/src/Paramore.Brighter.Outbox.DynamoDB/MessageItem.cs
+++ b/src/Paramore.Brighter.Outbox.DynamoDB/MessageItem.cs
@@ -23,11 +23,12 @@ namespace Paramore.Brighter.Outbox.DynamoDB
         /// </summary>
         [DynamoDBGlobalSecondaryIndexRangeKey(indexName: "Outstanding")]
         [DynamoDBProperty]
-        public string CreatedTime { get; set; }
+        public long CreatedTime { get; set; }
 
         /// <summary>
         /// The time at which the message was delivered, formatted as a string yyyy-MM-dd
         /// </summary>
+        [DynamoDBProperty]
         public string DeliveredAt { get; set; }
 
         /// <summary>
@@ -35,7 +36,7 @@ namespace Paramore.Brighter.Outbox.DynamoDB
         /// </summary>
         [DynamoDBGlobalSecondaryIndexRangeKey(indexName: "Delivered")]
         [DynamoDBProperty]
-        public string DeliveryTime { get; set; }
+        public long DeliveryTime { get; set; }
 
         /// <summary>
         /// A JSON object representing a dictionary of additional properties set on the message
@@ -88,7 +89,7 @@ namespace Paramore.Brighter.Outbox.DynamoDB
         {
             var date = message.Header.TimeStamp == DateTime.MinValue ? DateTime.UtcNow : message.Header.TimeStamp;
 
-            CreatedTime = $"{date.Ticks}";
+            CreatedTime = date.Ticks;
             MessageId = message.Id.ToString();
             Topic = message.Header.Topic;
             MessageType = message.Header.MessageType.ToString();
@@ -98,6 +99,7 @@ namespace Paramore.Brighter.Outbox.DynamoDB
             CreatedAt = $"{date}";
             HeaderBag = JsonSerializer.Serialize(message.Header.Bag, JsonSerialisationOptions.Options);
             Body = message.Body.Value;
+            DeliveryTime = 0;
         }
 
         public Message ConvertToMessage()
@@ -129,7 +131,7 @@ namespace Paramore.Brighter.Outbox.DynamoDB
 
         public void MarkMessageDelivered(DateTime deliveredAt)
         {
-            DeliveryTime = $"{deliveredAt.Ticks}";
+            DeliveryTime = deliveredAt.Ticks;
             DeliveredAt = $"{deliveredAt:yyyy-MM-dd}";
         }
     }

--- a/src/Paramore.Brighter.Outbox.DynamoDB/NoDispatchTimeExpression.cs
+++ b/src/Paramore.Brighter.Outbox.DynamoDB/NoDispatchTimeExpression.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Amazon.DynamoDBv2.DocumentModel;
 
 namespace Paramore.Brighter.Outbox.DynamoDB
@@ -10,7 +11,10 @@ namespace Paramore.Brighter.Outbox.DynamoDB
         public NoDispatchTimeExpression()
         {
             _expression = new Expression();
-            _expression.ExpressionStatement = "Delivery = NULL";
+            _expression.ExpressionStatement = "DeliveryTime = :null";
+            var values = new Dictionary<string, DynamoDBEntry>();
+            values.Add(":null", "0");
+            _expression.ExpressionAttributeValues = values;
         }
 
 

--- a/src/Paramore.Brighter.Outbox.DynamoDB/NoDispatchTimeExpression.cs
+++ b/src/Paramore.Brighter.Outbox.DynamoDB/NoDispatchTimeExpression.cs
@@ -13,7 +13,7 @@ namespace Paramore.Brighter.Outbox.DynamoDB
             _expression = new Expression();
             _expression.ExpressionStatement = "DeliveryTime = :null";
             var values = new Dictionary<string, DynamoDBEntry>();
-            values.Add(":null", "0");
+            values.Add(":null", 0L);
             _expression.ExpressionAttributeValues = values;
         }
 

--- a/src/Paramore.Brighter/CommandProcessor.cs
+++ b/src/Paramore.Brighter/CommandProcessor.cs
@@ -718,9 +718,10 @@ namespace Paramore.Brighter
         /// </summary>
         /// <param name="amountToClear">The maximum number to clear.</param>
         /// <param name="minimumAge">The minimum age to clear in milliseconds.</param>
-        public void ClearOutbox( int amountToClear = 100, int minimumAge = 5000)
+        /// <param name="args">Optional bag of arguments required by an outbox implementation to sweep</param>
+        public void ClearOutbox( int amountToClear = 100, int minimumAge = 5000, Dictionary<string, object> args = null)
         {
-            _bus.ClearOutbox(amountToClear, minimumAge, false, false); 
+            _bus.ClearOutbox(amountToClear, minimumAge, false, false, args); 
         }
 
         /// <summary>
@@ -744,12 +745,15 @@ namespace Paramore.Brighter
         /// <param name="amountToClear">The maximum number to clear.</param>
         /// <param name="minimumAge">The minimum age to clear in milliseconds.</param>
         /// <param name="useBulk">Use the bulk send on the producer.</param>
+        /// <param name="args">Optional bag of arguments required by an outbox implementation to sweep</param>
         public void ClearAsyncOutbox(
             int amountToClear = 100,
             int minimumAge = 5000,
-            bool useBulk = false)
+            bool useBulk = false,
+            Dictionary<string, object> args = null
+            )
         {
-            _bus.ClearOutbox(amountToClear, minimumAge, true, useBulk); 
+            _bus.ClearOutbox(amountToClear, minimumAge, true, useBulk, args); 
         }
 
         /// <summary>

--- a/src/Paramore.Brighter/ExternalBusServices.cs
+++ b/src/Paramore.Brighter/ExternalBusServices.cs
@@ -532,11 +532,14 @@ namespace Paramore.Brighter
                 s_logger.LogDebug("Begin count of outstanding messages");
                 try
                 {
+                    var producer = ProducerRegistry.GetDefaultProducer();
                     if (OutBox != null)
                     {
                         _outStandingCount = OutBox
-                            .OutstandingMessages(ProducerRegistry.GetDefaultProducer()
-                                .MaxOutStandingCheckIntervalMilliSeconds)
+                            .OutstandingMessages(
+                                producer.MaxOutStandingCheckIntervalMilliSeconds,
+                                args:producer.OutBoxBag 
+                                )
                             .Count();
                         return;
                     }
@@ -544,7 +547,10 @@ namespace Paramore.Brighter
                     // {
                     //     //TODO: There is no async version of this call at present; the thread here means that won't hurt if implemented
                     //     _outStandingCount = AsyncOutbox
-                    //         .OutstandingMessages(ProducerRegistry.GetDefaultProducer().MaxOutStandingCheckIntervalMilliSeconds)
+                    //          .OutstandingMessages(
+                    //           producer.MaxOutStandingCheckIntervalMilliSeconds,
+                    //          args:producer.OutBoxBag 
+                    //          )
                     //         .Count();
                     //     return;
                     // }

--- a/src/Paramore.Brighter/IAmACommandProcessor.cs
+++ b/src/Paramore.Brighter/IAmACommandProcessor.cs
@@ -154,7 +154,8 @@ namespace Paramore.Brighter
         /// </summary>
         /// <param name="amountToClear">The maximum number to clear.</param>
         /// <param name="minimumAge">The minimum age to clear in milliseconds.</param>
-        public void ClearOutbox(int amountToClear = 100, int minimumAge = 5000);
+        /// <param name="args">Optional bag of arguments required by an outbox implementation to sweep</param>
+        public void ClearOutbox(int amountToClear = 100, int minimumAge = 5000, Dictionary<string, object> args = null);
 
         /// <summary>
         /// Flushes the message box message given by <param name="posts"> to the broker.
@@ -170,7 +171,8 @@ namespace Paramore.Brighter
         /// <param name="amountToClear">The maximum number to clear.</param>
         /// <param name="minimumAge">The minimum age to clear in milliseconds.</param>
         /// <param name="useBulk">Use the bulk send on the producer.</param>
-        public void ClearAsyncOutbox(int amountToClear = 100, int minimumAge = 5000, bool useBulk = false);
+        /// <param name="args">Optional bag of arguments required by an outbox implementation to sweep</param>
+        public void ClearAsyncOutbox(int amountToClear = 100, int minimumAge = 5000, bool useBulk = false, Dictionary<string, object> args = null);
 
         /// <summary>
         /// Uses the Request-Reply messaging approach to send a message to another server and block awaiting a reply.

--- a/src/Paramore.Brighter/IAmAMessageProducer.cs
+++ b/src/Paramore.Brighter/IAmAMessageProducer.cs
@@ -1,4 +1,28 @@
-﻿using System;
+﻿#region Licence
+/* The MIT License (MIT)
+Copyright © 2022 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+#endregion
+
+using System;
+using System.Collections.Generic;
 
 namespace Paramore.Brighter
 {
@@ -18,6 +42,12 @@ namespace Paramore.Brighter
         /// If you set MaxOutStandingMessages to -1 or 0 this property is effectively ignored
         /// </summary>
         int MaxOutStandingCheckIntervalMilliSeconds { get; set; }
+        
+        /// <summary>
+        /// An outbox may require additional arguments before it can run its checks. The DynamoDb outbox for example expects there to be a Topic in the args
+        /// This bag provides the args required
+        /// </summary>
+        Dictionary<string, object> OutBoxBag { get; set; }
 
     }
 }

--- a/src/Paramore.Brighter/IAmAMessageProducerSync.cs
+++ b/src/Paramore.Brighter/IAmAMessageProducerSync.cs
@@ -22,8 +22,6 @@ THE SOFTWARE. */
 
 #endregion
 
-using System;
-
 namespace Paramore.Brighter
 {
     /// <summary>

--- a/src/Paramore.Brighter/IAmAnOutboxAsync.cs
+++ b/src/Paramore.Brighter/IAmAnOutboxAsync.cs
@@ -74,6 +74,7 @@ namespace Paramore.Brighter
         /// <param name="args">Additional parameters required for search, if any</param>
         /// <param name="cancellationToken">Cancellation Token, if any</param>
         /// <returns></returns>
+        [Obsolete("Removed in v10, Please use OutstandingMessagesAsync instead.")]
         Task<IList<Message>> GetAsync(
             int pageSize = 100, 
             int pageNumber = 1, 

--- a/src/Paramore.Brighter/IAmAnOutboxSync.cs
+++ b/src/Paramore.Brighter/IAmAnOutboxSync.cs
@@ -83,6 +83,7 @@ namespace Paramore.Brighter
         /// <param name="pageNumber">Page number of results to return, default is first</param>
         /// <param name="args">Additional parameters required for the search, if any</param>
         /// <returns></returns>
+        [Obsolete("Removed in v10, Please use OutstandingMessages instead.")]
         IList<Message> Get(int pageSize = 100, int pageNumber = 1, Dictionary<string, object> args = null);
         
         /// <summary>

--- a/src/Paramore.Brighter/InMemoryOutbox.cs
+++ b/src/Paramore.Brighter/InMemoryOutbox.cs
@@ -322,9 +322,10 @@ namespace Paramore.Brighter
             ClearExpiredMessages();
             
             DateTime sentBefore = DateTime.UtcNow.AddMilliseconds( -1 * millSecondsSinceSent);
-            return _requests.Values.Where(oe =>  (oe.TimeFlushed == DateTime.MinValue) && (oe.WriteTime <= sentBefore))
+            var outstandingMessages = _requests.Values.Where(oe =>  (oe.TimeFlushed == DateTime.MinValue) && (oe.WriteTime <= sentBefore))
                 .Take(pageSize)
                 .Select(oe => oe.Message).ToArray();
+            return outstandingMessages;
         }
 
         public Task<IList<Message>> GetAsync(int pageSize = 100, int pageNumber = 1, Dictionary<string, object> args = null, CancellationToken cancellationToken = default)

--- a/src/Paramore.Brighter/OutboxSweeper.cs
+++ b/src/Paramore.Brighter/OutboxSweeper.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace Paramore.Brighter
 {
@@ -8,9 +9,10 @@ namespace Paramore.Brighter
         private readonly IAmACommandProcessor _commandProcessor;
         private readonly int _batchSize;
         private readonly bool _useBulk;
+        private readonly Dictionary<string, object> _args;
 
         private const string IMPLICITCLEAROUTBOX = "Implicit Clear Outbox";
-        
+
         /// <summary>
         /// This sweeper clears an outbox of any outstanding messages within the time interval
         /// </summary>
@@ -18,13 +20,19 @@ namespace Paramore.Brighter
         /// <param name="commandProcessor">Who should post the messages</param>
         /// <param name="batchSize">The maximum number of messages to dispatch.</param>
         /// <param name="useBulk">Use the producers bulk dispatch functionality.</param>
-        public OutboxSweeper(int millisecondsSinceSent, IAmACommandProcessor commandProcessor, int batchSize = 100,
-            bool useBulk = false)
+        /// <param name="args">Optional bag of parameters to pass to the Outbox</param>
+        public OutboxSweeper(
+            int millisecondsSinceSent, 
+            IAmACommandProcessor commandProcessor, 
+            int batchSize = 100,
+            bool useBulk = false,
+            Dictionary<string, object> args = null)
         {
             _millisecondsSinceSent = millisecondsSinceSent;
             _commandProcessor = commandProcessor;
             _batchSize = batchSize;
             _useBulk = useBulk;
+            _args = args;
         }
 
         /// <summary>

--- a/src/Paramore.Brighter/OutboxSweeper.cs
+++ b/src/Paramore.Brighter/OutboxSweeper.cs
@@ -41,7 +41,7 @@ namespace Paramore.Brighter
         public void Sweep()
         {
             ApplicationTelemetry.ActivitySource.StartActivity(IMPLICITCLEAROUTBOX, ActivityKind.Server);
-            _commandProcessor.ClearOutbox(_batchSize, _millisecondsSinceSent);
+            _commandProcessor.ClearOutbox(_batchSize, _millisecondsSinceSent, _args);
         }
 
         /// <summary>
@@ -50,7 +50,7 @@ namespace Paramore.Brighter
         public void SweepAsyncOutbox()
         {
             ApplicationTelemetry.ActivitySource.StartActivity(IMPLICITCLEAROUTBOX, ActivityKind.Server);
-            _commandProcessor.ClearAsyncOutbox(_batchSize, _millisecondsSinceSent, _useBulk);
+            _commandProcessor.ClearAsyncOutbox(_batchSize, _millisecondsSinceSent, _useBulk, _args);
         }
     }
 }

--- a/src/Paramore.Brighter/Publication.cs
+++ b/src/Paramore.Brighter/Publication.cs
@@ -22,6 +22,8 @@ THE SOFTWARE. */
 
 #endregion
 
+using System.Collections.Generic;
+
 namespace Paramore.Brighter
 {
     /// <summary>
@@ -52,9 +54,17 @@ namespace Paramore.Brighter
         /// </summary>
         public int MaxOutStandingCheckIntervalMilliSeconds { get; set; } = 0;
         
+        /// <summary>
+        /// An outbox may require additional arguments before it can run its checks. The DynamoDb outbox for example expects there to be a Topic in the args
+        /// This bag provides the args required
+        /// </summary>
+        public Dictionary<string, object> OutBoxBag { get; set; }
+        
          /// <summary>
         /// The topic this publication is for
         /// </summary>
         public RoutingKey Topic { get; set; }
+         
+         
     }
 }

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/TestDoubles/FakeErroringMessageProducerSync.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/TestDoubles/FakeErroringMessageProducerSync.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles
 {
@@ -6,6 +7,8 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles
     {
         public int MaxOutStandingMessages { get; set; } = -1;
         public int MaxOutStandingCheckIntervalMilliSeconds { get; set; } = 0;
+
+        public Dictionary<string, object> OutBoxBag { get; set; } = new Dictionary<string, object>();
         public int SentCalledCount { get; set; }
         public void Dispose() { }
 

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/TestDoubles/FakeMessageProducer.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/TestDoubles/FakeMessageProducer.cs
@@ -35,6 +35,8 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles
         public int MaxOutStandingMessages { get; set; } = -1;
         public int MaxOutStandingCheckIntervalMilliSeconds { get; set; } = 0;
 
+        public Dictionary<string, object> OutBoxBag { get; set; } = new Dictionary<string, object>();  
+
         public List<Message> SentMessages = new List<Message>();
         public bool MessageWasSent { get; set; }
 

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Posting_Fails_Limit_Total_Writes_To_OutBox_In_Window.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Posting_Fails_Limit_Total_Writes_To_OutBox_In_Window.cs
@@ -64,8 +64,8 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
         public void When_Posting_Fails_Limit_Total_Writes_To_OutBox_In_Window()
         {
             //We are only going to allow 50 erroring messages
-            _fakeMessageProducer.MaxOutStandingMessages = 5;
-            _fakeMessageProducer.MaxOutStandingCheckIntervalMilliSeconds = 1000;
+            _fakeMessageProducer.MaxOutStandingMessages = 3;
+            _fakeMessageProducer.MaxOutStandingCheckIntervalMilliSeconds = 250;
 
             var sentList = new List<Guid>(); 
             bool shouldThrowException = false;

--- a/tests/Paramore.Brighter.Core.Tests/MessageDispatch/TestDoubles/SpyCommandProcessor.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageDispatch/TestDoubles/SpyCommandProcessor.cs
@@ -157,7 +157,7 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch.TestDoubles
             }
         }
 
-        public void ClearOutbox(int amountToClear = 100, int minimumAge = 5000)
+        public void ClearOutbox(int amountToClear = 100, int minimumAge = 5000, Dictionary<string, object> args = null)
         {
             throw new NotImplementedException();
         }
@@ -172,7 +172,7 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch.TestDoubles
             await completionSource.Task;
         }
 
-        public void ClearAsyncOutbox(int amountToClear = 100, int minimumAge = 5000, bool useBulk = false)
+        public void ClearAsyncOutbox(int amountToClear = 100, int minimumAge = 5000, bool useBulk = false, Dictionary<string, object> args = null)
         {
             throw new NotImplementedException();
         }

--- a/tests/Paramore.Brighter.Core.Tests/MessageDispatch/TestDoubles/SpyCommandProcessor.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageDispatch/TestDoubles/SpyCommandProcessor.cs
@@ -46,12 +46,20 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch.TestDoubles
         Call
     }
 
+    public class ClearParams
+    {
+        public int AmountToClear;
+        public int MinimumAge;
+        public Dictionary<string, object> Args;
+    }
+
     internal class SpyCommandProcessor : Paramore.Brighter.IAmACommandProcessor
     {
         private readonly Queue<IRequest> _requests = new Queue<IRequest>();
         private readonly Dictionary<Guid, IRequest> _postBox = new Dictionary<Guid, IRequest>();
 
         public IList<CommandType> Commands { get; } = new List<CommandType>();
+        public List<ClearParams> ClearParamsList { get; } = new List<ClearParams>();
 
         public virtual void Send<T>(T command) where T : class, IRequest
         {
@@ -159,7 +167,8 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch.TestDoubles
 
         public void ClearOutbox(int amountToClear = 100, int minimumAge = 5000, Dictionary<string, object> args = null)
         {
-            throw new NotImplementedException();
+            Commands.Add(CommandType.Clear);
+            ClearParamsList.Add(new ClearParams { AmountToClear = amountToClear, MinimumAge = minimumAge, Args = args });
         }
 
         public async Task ClearOutboxAsync(IEnumerable<Guid> posts, bool continueOnCapturedContext = false,
@@ -174,7 +183,8 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch.TestDoubles
 
         public void ClearAsyncOutbox(int amountToClear = 100, int minimumAge = 5000, bool useBulk = false, Dictionary<string, object> args = null)
         {
-            throw new NotImplementedException();
+            Commands.Add(CommandType.Clear);
+            ClearParamsList.Add(new ClearParams { AmountToClear = amountToClear, MinimumAge = minimumAge, Args = args });
         }
 
         public Task BulkClearOutboxAsync(IEnumerable<Guid> posts, bool continueOnCapturedContext = false,

--- a/tests/Paramore.Brighter.Core.Tests/Observability/TestDoubles/FakeMessageProducer.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Observability/TestDoubles/FakeMessageProducer.cs
@@ -1,4 +1,6 @@
-﻿namespace Paramore.Brighter.Core.Tests.Observability.TestDoubles;
+﻿using System.Collections.Generic;
+
+namespace Paramore.Brighter.Core.Tests.Observability.TestDoubles;
 
 public class FakeMessageProducer : IAmAMessageProducer
 {
@@ -9,4 +11,6 @@ public class FakeMessageProducer : IAmAMessageProducer
 
     public int MaxOutStandingMessages { get; set; }
     public int MaxOutStandingCheckIntervalMilliSeconds { get; set; }
+    
+    public Dictionary<string, object> OutBoxBag { get; set; }
 }

--- a/tests/Paramore.Brighter.DynamoDB.Tests/Outbox/When_marking_a_message_as_dispatched_in_the_outbox.cs
+++ b/tests/Paramore.Brighter.DynamoDB.Tests/Outbox/When_marking_a_message_as_dispatched_in_the_outbox.cs
@@ -9,6 +9,7 @@ using Xunit;
 
 namespace Paramore.Brighter.DynamoDB.Tests.Outbox;
 
+[Trait("Category", "DynamoDB")]
 public class DynamoDbOutboxMessageDispatchTests : DynamoDBOutboxBaseTest 
 {
    private readonly Message _message;

--- a/tests/Paramore.Brighter.DynamoDB.Tests/Outbox/When_marking_a_message_as_dispatched_in_the_outbox.cs
+++ b/tests/Paramore.Brighter.DynamoDB.Tests/Outbox/When_marking_a_message_as_dispatched_in_the_outbox.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Amazon;
+using FluentAssertions;
+using Paramore.Brighter.Outbox.DynamoDB;
+using Xunit;
+
+namespace Paramore.Brighter.DynamoDB.Tests.Outbox;
+
+public class DynamoDbOutboxMessageDispatchTests : DynamoDBOutboxBaseTest 
+{
+   private readonly Message _message;
+   private readonly DynamoDbOutbox _dynamoDbOutbox;
+
+   public DynamoDbOutboxMessageDispatchTests()
+   {
+          _message = new Message(new MessageHeader(Guid.NewGuid(), "test_topic", MessageType.MT_DOCUMENT), new MessageBody("message body"));
+          _dynamoDbOutbox = new DynamoDbOutbox(Client, new DynamoDbConfiguration(Credentials, RegionEndpoint.EUWest1, OutboxTableName));
+   }
+    
+    [Fact]
+    public async Task When_Marking_A_Message_As_Dispatched_In_The_Outbox_Async()
+    {
+        await _dynamoDbOutbox.AddAsync(_message);
+        await _dynamoDbOutbox.MarkDispatchedAsync(_message.Id, DateTime.UtcNow);
+        
+        var args = new Dictionary<string, object>(); 
+        args.Add("Topic", "test_topic");
+
+        var messages = _dynamoDbOutbox.DispatchedMessages(0, 100, 1, args:args);
+        var message = messages.Single(m => m.Id == _message.Id);
+        message.Should().NotBeNull();
+        message.Body.Should().Be(_message.Body);
+
+
+    }
+    
+    [Fact]
+    public void When_Marking_A_Message_As_Dispatched_In_The_Outbox()
+    {
+        _dynamoDbOutbox.Add(_message);  
+        _dynamoDbOutbox.MarkDispatched(_message.Id, DateTime.UtcNow);
+        
+        var args = new Dictionary<string, object>(); 
+        args.Add("Topic", "test_topic");
+
+        var messages = _dynamoDbOutbox.DispatchedMessages(0, 100, 1, args:args);
+        var message = messages.Single(m => m.Id == _message.Id);
+        message.Should().NotBeNull();
+        message.Body.Should().Be(_message.Body);
+
+
+    }
+}

--- a/tests/Paramore.Brighter.DynamoDB.Tests/Outbox/When_there_are_outstanding_messages_in_the_outbox.cs
+++ b/tests/Paramore.Brighter.DynamoDB.Tests/Outbox/When_there_are_outstanding_messages_in_the_outbox.cs
@@ -22,21 +22,38 @@ public class DynamoDbOutboxOutstandingMessageTests : DynamoDBOutboxBaseTest
     }
 
     [Fact]
-    public async Task When_there_are_outstanding_messages_in_the_outbox()
+    public async Task When_there_are_outstanding_messages_in_the_outbox_async()
     {
         await _dynamoDbOutbox.AddAsync(_message);
 
         var args = new Dictionary<string, object>(); 
         args.Add("Topic", "test_topic");
 
-        var messages = await _dynamoDbOutbox.OutstandingMessagesAsync(5000, 100, 1, args);
+        var messages = await _dynamoDbOutbox.OutstandingMessagesAsync(10000, 100, 1, args);
 
-        messages.Count().Should().Be(1);
-        var message = messages.Single();
+        ///Other tests may leave messages, so make sure that we grab ours
+        var message = messages.Single(m => m.Id == _message.Id);
         message.Should().NotBeNull();
-        message.Id.Should().Be(_message.Id);
-        messages.Single().Body.Should().Be(_message.Body);
+        message.Body.Should().Be(_message.Body);
 
+                     
+    }
+    
+    [Fact]
+    public void When_there_are_outstanding_messages_in_the_outbox()
+    {
+        _dynamoDbOutbox.Add(_message);
 
+        var args = new Dictionary<string, object>(); 
+        args.Add("Topic", "test_topic");
+
+        var messages =_dynamoDbOutbox.OutstandingMessages(10000, 100, 1, args);
+
+        ///Other tests may leave messages, so make sure that we grab ours
+        var message = messages.Single(m => m.Id == _message.Id);
+        message.Should().NotBeNull();
+        message.Body.Should().Be(_message.Body);
+
+                     
     }
 }

--- a/tests/Paramore.Brighter.DynamoDB.Tests/Outbox/When_there_are_outstanding_messages_in_the_outbox.cs
+++ b/tests/Paramore.Brighter.DynamoDB.Tests/Outbox/When_there_are_outstanding_messages_in_the_outbox.cs
@@ -26,10 +26,12 @@ public class DynamoDbOutboxOutstandingMessageTests : DynamoDBOutboxBaseTest
     {
         await _dynamoDbOutbox.AddAsync(_message);
 
+        await Task.Delay(1000);
+
         var args = new Dictionary<string, object>(); 
         args.Add("Topic", "test_topic");
 
-        var messages = await _dynamoDbOutbox.OutstandingMessagesAsync(10000, 100, 1, args);
+        var messages = await _dynamoDbOutbox.OutstandingMessagesAsync(0, 100, 1, args);
 
         ///Other tests may leave messages, so make sure that we grab ours
         var message = messages.Single(m => m.Id == _message.Id);
@@ -44,10 +46,12 @@ public class DynamoDbOutboxOutstandingMessageTests : DynamoDBOutboxBaseTest
     {
         _dynamoDbOutbox.Add(_message);
 
+        Task.Delay(1000).Wait();
+
         var args = new Dictionary<string, object>(); 
         args.Add("Topic", "test_topic");
 
-        var messages =_dynamoDbOutbox.OutstandingMessages(10000, 100, 1, args);
+        var messages =_dynamoDbOutbox.OutstandingMessages(0, 100, 1, args);
 
         ///Other tests may leave messages, so make sure that we grab ours
         var message = messages.Single(m => m.Id == _message.Id);

--- a/tests/Paramore.Brighter.DynamoDB.Tests/Outbox/When_there_are_outstanding_messages_in_the_outbox.cs
+++ b/tests/Paramore.Brighter.DynamoDB.Tests/Outbox/When_there_are_outstanding_messages_in_the_outbox.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Amazon;
+using FluentAssertions;
+using Paramore.Brighter.Outbox.DynamoDB;
+using Xunit;
+
+namespace Paramore.Brighter.DynamoDB.Tests.Outbox;
+
+[Trait("Category", "DynamoDB")]
+public class DynamoDbOutboxOutstandingMessageTests : DynamoDBOutboxBaseTest 
+{
+    private readonly Message _message;
+    private readonly DynamoDbOutbox _dynamoDbOutbox;
+
+    public DynamoDbOutboxOutstandingMessageTests()
+    {                                  
+        _message = new Message(new MessageHeader(Guid.NewGuid(), "test_topic", MessageType.MT_DOCUMENT), new MessageBody("message body"));
+        _dynamoDbOutbox = new DynamoDbOutbox(Client, new DynamoDbConfiguration(Credentials, RegionEndpoint.EUWest1, OutboxTableName));
+    }
+
+    [Fact]
+    public async Task When_there_are_outstanding_messages_in_the_outbox()
+    {
+        await _dynamoDbOutbox.AddAsync(_message);
+
+        var args = new Dictionary<string, object>(); 
+        args.Add("Topic", "test_topic");
+
+        var messages = await _dynamoDbOutbox.OutstandingMessagesAsync(5000, 100, 1, args);
+
+        messages.Count().Should().Be(1);
+        var message = messages.Single();
+        message.Should().NotBeNull();
+        message.Id.Should().Be(_message.Id);
+        messages.Single().Body.Should().Be(_message.Body);
+
+
+    }
+}

--- a/tests/Paramore.Brighter.Extensions.Tests/TestDifferentSetups.cs
+++ b/tests/Paramore.Brighter.Extensions.Tests/TestDifferentSetups.cs
@@ -99,7 +99,9 @@ namespace Tests
     {
         public int MaxOutStandingMessages { get; set; } = -1;
         public int MaxOutStandingCheckIntervalMilliSeconds { get; set; } = 0;
- 
+
+        public Dictionary<string, object> OutBoxBag { get; set; } = new Dictionary<string, object>();
+
         public void Dispose()
         {
             throw new NotImplementedException();

--- a/tests/Paramore.Brighter.InMemory.Tests/TestDoubles/FakeCommandProcessor.cs
+++ b/tests/Paramore.Brighter.InMemory.Tests/TestDoubles/FakeCommandProcessor.cs
@@ -125,7 +125,7 @@ namespace Paramore.Brighter.InMemory.Tests.TestDoubles
             }
         }
 
-        public void ClearOutbox(int amountToClear = 100, int minimumAge = 5000)
+        public void ClearOutbox(int amountToClear = 100, int minimumAge = 5000, Dictionary<string, object> args = null)
         {
             var depositedMessages = Deposited.Where(m =>
                 m.EnqueuedTime < DateTime.Now.AddMilliseconds(-1 * minimumAge) &&
@@ -151,7 +151,7 @@ namespace Paramore.Brighter.InMemory.Tests.TestDoubles
             return tcs.Task;
         }
 
-        public void ClearAsyncOutbox(int amountToClear = 100, int minimumAge = 5000, bool useBulk = false)
+        public void ClearAsyncOutbox(int amountToClear = 100, int minimumAge = 5000, bool useBulk = false, Dictionary<string, object> args = null)
         {
             ClearOutbox(amountToClear, minimumAge);
         }


### PR DESCRIPTION
We don't pass through the args required by Dynamo or Event Store to manage an Outbox. This adds the option to pass these through. Should be non-breaking as it is an optional argument (unless you are implementing your own CommandProcessor).

This makes non-breaking changes to interfaces:

* CommandProcessor -> The Outbox Sweeper methods (they need a rename still) now take the args dictionary needed to pass through to these outboxes
* Producer -> The Producer now has an OutboxBag for these arguments
* Publication -> The Publication now has an OutboxBag, which is passed to the Producer on creation.

We may want to review how this is done in V10, when we can make breaking changes to these interfaces.
