### PR TITLE
Dynamo Outbox constructor fixes

### DIFF
--- a/samples/WebAPI_Dynamo/GreetingsWeb/Startup.cs
+++ b/samples/WebAPI_Dynamo/GreetingsWeb/Startup.cs
@@ -106,7 +106,7 @@ namespace GreetingsWeb
             var dynamoDb = new AmazonDynamoDBClient(credentials, clientConfig);
             services.Add(new ServiceDescriptor(typeof(IAmazonDynamoDB), dynamoDb));
 
-            var dynamoDbConfiguration = new DynamoDbConfiguration(credentials, RegionEndpoint.EUWest1);
+            var dynamoDbConfiguration = new DynamoDbConfiguration();
             services.Add(new ServiceDescriptor(typeof(DynamoDbConfiguration), dynamoDbConfiguration));
             
             return dynamoDb;

--- a/src/Paramore.Brighter.Outbox.DynamoDB/DynamoDbConfiguration.cs
+++ b/src/Paramore.Brighter.Outbox.DynamoDB/DynamoDbConfiguration.cs
@@ -1,15 +1,20 @@
+using System;
 using Amazon;
 using Amazon.Runtime;
 
 namespace Paramore.Brighter.Outbox.DynamoDB
 {
     public class DynamoDbConfiguration
-    {
-        //What AWS Credentials to use
+    {   
+        /// <summary>
+        /// What AWS Credentials to use
+        /// </summary>
+        [Obsolete("This property is not being used")]
         public AWSCredentials Credentials { get; }
         /// <summary>
         /// Which AWS region
         /// </summary>
+        [Obsolete("This property is not being used")]
         public RegionEndpoint Region { get; }
         /// <summary>
         /// The table that forms the Outbox
@@ -27,7 +32,8 @@ namespace Paramore.Brighter.Outbox.DynamoDB
         /// Timeout in milliseconds
         /// </summary>
         public int Timeout { get; }
-
+    
+        [Obsolete("Use the DynamoDbConfiguration without AWSCredentials and without RegionEndpoint")]
         public DynamoDbConfiguration(
             AWSCredentials credentials, 
             RegionEndpoint region,

--- a/src/Paramore.Brighter.Outbox.DynamoDB/DynamoDbConfiguration.cs
+++ b/src/Paramore.Brighter.Outbox.DynamoDB/DynamoDbConfiguration.cs
@@ -41,5 +41,13 @@ namespace Paramore.Brighter.Outbox.DynamoDB
             DeliveredIndexName = "Delivered";
             Timeout = timeout;
         }
+
+        public DynamoDbConfiguration(string tableName = null, int timeout = 500)
+        {
+            TableName = tableName ?? "brighter_outbox";
+            OutstandingIndexName = "Outstanding";
+            DeliveredIndexName = "Delivered";
+            Timeout = timeout;
+        }
     }
 }


### PR DESCRIPTION
This PR makes sure that an instance of DynamoDbConfiguration can be created without an instance of AWSCredentials and RegionEndpoint. These arguments are being set as properties inside the class - however, upon review not being used. I marked the properties as obsolete as the Outbox is using the connection from the IAmazonDynamoDB.