### PR TITLE
feat: Adds FeatureSwitchAsync attribute and handler

### DIFF
--- a/src/Paramore.Brighter/FeatureSwitch/Attributes/FeatureSwitchAsyncAttribute.cs
+++ b/src/Paramore.Brighter/FeatureSwitch/Attributes/FeatureSwitchAsyncAttribute.cs
@@ -1,0 +1,71 @@
+﻿#region Licence
+/* The MIT License (MIT)
+Copyright © 2014 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+using System;
+using Paramore.Brighter.FeatureSwitch.Handlers;
+
+namespace Paramore.Brighter.FeatureSwitch.Attributes
+{
+    /// <summary>
+    /// Class FeatureSwitchAttribute.
+    /// This attribute supports adding feature switches on a handler. It is intended to allow control over which handlers can be used at
+    /// run-time using <see cref="FeatureSwitchStatus.Config"/> or compile time using <see cref="FeatureSwitchStatus.On"/> and <see cref="FeatureSwitchStatus.Off"/>.
+    /// </summary>
+    public class FeatureSwitchAsyncAttribute : RequestHandlerAttribute
+    {
+        private readonly Type _handler;
+        private readonly FeatureSwitchStatus _status;
+
+        /// <summary>
+        /// Initialises a new instance of the <see cref="FeatureSwitchAttribute"/> class.
+        /// </summary>
+        /// <param name="handler">The handler to feature switch</param>
+        /// <param name="status">The status of the feature switch</param>
+        /// <param name="step">The step.</param>
+        /// <param name="timing">The timing.</param>
+        public FeatureSwitchAsyncAttribute(Type handler, FeatureSwitchStatus status, int step, HandlerTiming timing = HandlerTiming.Before) : base(step, timing)
+        {
+            _handler = handler;
+            _status = status;
+        }
+
+        /// <summary>
+        /// Initialises the paramers
+        /// </summary>
+        /// <returns>System.Object[]</returns>
+        public override object[] InitializerParams()
+        {           
+            return new object[] { _handler, _status };
+        }
+
+        /// <summary>
+        /// Gets the type of the handler
+        /// </summary>
+        /// <returns></returns>
+        public override Type GetHandlerType()
+        {
+            return typeof(FeatureSwitchHandlerAsync<>);
+        }
+    }
+}

--- a/src/Paramore.Brighter/FeatureSwitch/Handlers/FeatureSwitchHandlerAsync.cs
+++ b/src/Paramore.Brighter/FeatureSwitch/Handlers/FeatureSwitchHandlerAsync.cs
@@ -1,0 +1,72 @@
+﻿#region Licence
+/* The MIT License (MIT)
+Copyright © 2014 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Paramore.Brighter.FeatureSwitch.Attributes;
+
+namespace Paramore.Brighter.FeatureSwitch.Handlers
+{
+    /// <summary>
+    /// Class FeatureSwitchHandler.
+    /// The handler is injected into the pipeline if the <see cref="FeatureSwitchAttribute"/> is applied
+    /// </summary>
+    /// <typeparam name="TRequest">The type of the request</typeparam>
+    public class FeatureSwitchHandlerAsync<TRequest> : RequestHandlerAsync<TRequest> where TRequest : class, IRequest
+    {
+        private Type _handler;
+        private FeatureSwitchStatus _status;
+
+        /// <summary>
+        /// Initializes from attribute parameters.
+        /// </summary>
+        /// <param name="initializerList">The initializer list.</param>
+        public override void InitializeFromAttributeParams(params object[] initializerList)
+        {
+            _handler = (Type) initializerList[0];
+            _status = (FeatureSwitchStatus) initializerList[1];
+        }
+
+        /// <summary>
+        /// Checks the status of the feature switch and either stops passes the command on to the next handler
+        /// or stops execution of the feature switched handler.
+        /// </summary>
+        /// <param name="command">The command.</param>
+        /// <returns>TRequest.</returns>
+        public override async Task<TRequest> HandleAsync(TRequest command, CancellationToken cancellationToken = default)
+        {
+            var featureEnabled = _status;
+
+            if (featureEnabled is FeatureSwitchStatus.Config)
+            {              
+                featureEnabled = Context.FeatureSwitches?.StatusOf(_handler) ?? FeatureSwitchStatus.On;
+            }
+
+            return featureEnabled is FeatureSwitchStatus.Off 
+                        ? command 
+                        : await base.HandleAsync(command, cancellationToken);
+        }
+    }
+}

--- a/tests/Paramore.Brighter.Core.Tests/FeatureSwitch/TestDoubles/MyCommandAsync.cs
+++ b/tests/Paramore.Brighter.Core.Tests/FeatureSwitch/TestDoubles/MyCommandAsync.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace Paramore.Brighter.Core.Tests.FeatureSwitch.TestDoubles;
+
+public class MyCommandAsync : Command
+{
+    public MyCommandAsync() : base(Guid.NewGuid())
+    {
+    }
+}

--- a/tests/Paramore.Brighter.Core.Tests/FeatureSwitch/TestDoubles/MyFeatureSwitchedConfigHandler.cs
+++ b/tests/Paramore.Brighter.Core.Tests/FeatureSwitch/TestDoubles/MyFeatureSwitchedConfigHandler.cs
@@ -22,6 +22,8 @@ THE SOFTWARE. */
 
 #endregion
 
+using System.Threading;
+using System.Threading.Tasks;
 using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
 using Paramore.Brighter.FeatureSwitch;
 using Paramore.Brighter.FeatureSwitch.Attributes;
@@ -32,15 +34,33 @@ namespace Paramore.Brighter.Core.Tests.FeatureSwitch.TestDoubles
     {
         public bool CommandReceived { get; set; }
 
-        [FeatureSwitch(typeof(MyFeatureSwitchedConfigHandler), FeatureSwitchStatus.Config, 1, HandlerTiming.Before)]
-        public override MyCommand Handle(MyCommand comand)
+        [FeatureSwitch(typeof(MyFeatureSwitchedConfigHandler), FeatureSwitchStatus.Config, 1)]
+        public override MyCommand Handle(MyCommand command)
         {
             CommandReceived = true;
 
-            return base.Handle(comand);
+            return base.Handle(command);
         }
 
-        public bool DidReceive(MyCommand command)
+        public bool DidReceive()
+        {
+            return CommandReceived;
+        }
+    }
+
+    class MyFeatureSwitchedConfigHandlerAsync : RequestHandlerAsync<MyCommandAsync>
+    {
+        public bool CommandReceived { get; set; }
+
+        [FeatureSwitchAsync(typeof(MyFeatureSwitchedConfigHandlerAsync), FeatureSwitchStatus.Config, 1)]
+        public override async Task<MyCommandAsync> HandleAsync(MyCommandAsync command, CancellationToken cancellationToken = default)
+        {
+            CommandReceived = true;
+
+            return await base.HandleAsync(command, cancellationToken);
+        }
+
+        public bool DidReceive()
         {
             return CommandReceived;
         }

--- a/tests/Paramore.Brighter.Core.Tests/FeatureSwitch/TestDoubles/MyFeatureSwitchedOffHandler.cs
+++ b/tests/Paramore.Brighter.Core.Tests/FeatureSwitch/TestDoubles/MyFeatureSwitchedOffHandler.cs
@@ -22,6 +22,8 @@ THE SOFTWARE. */
 
 #endregion
 
+using System.Threading;
+using System.Threading.Tasks;
 using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
 using Paramore.Brighter.FeatureSwitch;
 using Paramore.Brighter.FeatureSwitch.Attributes;
@@ -32,15 +34,33 @@ namespace Paramore.Brighter.Core.Tests.FeatureSwitch.TestDoubles
     {
         public static bool CommandReceived { get; set; }
 
-        [FeatureSwitch(typeof(MyFeatureSwitchedOffHandler), FeatureSwitchStatus.Off, 1, HandlerTiming.Before)]
-        public override MyCommand Handle(MyCommand comand)
+        [FeatureSwitch(typeof(MyFeatureSwitchedOffHandler), FeatureSwitchStatus.Off, 1)]
+        public override MyCommand Handle(MyCommand command)
         {
             CommandReceived = true;
 
-            return base.Handle(comand);
+            return base.Handle(command);
         }
 
-        public static bool DidReceive(MyCommand command)
+        public static bool DidReceive()
+        {
+            return CommandReceived;
+        }
+    }
+    
+    class MyFeatureSwitchedOffHandlerAsync : RequestHandlerAsync<MyCommandAsync>
+    {
+        public static bool CommandReceived { get; set; }
+
+        [FeatureSwitchAsync(typeof(MyFeatureSwitchedOffHandlerAsync), FeatureSwitchStatus.Off, 1)]
+        public override async Task<MyCommandAsync> HandleAsync(MyCommandAsync command, CancellationToken cancellationToken = default)
+        {
+            CommandReceived = true;
+
+            return await base.HandleAsync(command, cancellationToken);
+        }
+
+        public static bool DidReceive()
         {
             return CommandReceived;
         }

--- a/tests/Paramore.Brighter.Core.Tests/FeatureSwitch/TestDoubles/MyFeatureSwitchedOnHandler.cs
+++ b/tests/Paramore.Brighter.Core.Tests/FeatureSwitch/TestDoubles/MyFeatureSwitchedOnHandler.cs
@@ -22,6 +22,8 @@ THE SOFTWARE. */
 
 #endregion
 
+using System.Threading;
+using System.Threading.Tasks;
 using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
 using Paramore.Brighter.FeatureSwitch;
 using Paramore.Brighter.FeatureSwitch.Attributes;
@@ -32,7 +34,7 @@ namespace Paramore.Brighter.Core.Tests.FeatureSwitch.TestDoubles
     {
         public static bool CommandReceived { get; set; }
 
-        [FeatureSwitch(typeof(MyFeatureSwitchedOnHandler), FeatureSwitchStatus.On, 1, HandlerTiming.Before)]
+        [FeatureSwitch(typeof(MyFeatureSwitchedOnHandler), FeatureSwitchStatus.On, 1)]
         public override MyCommand Handle(MyCommand comand)
         {
             CommandReceived = true;
@@ -41,6 +43,23 @@ namespace Paramore.Brighter.Core.Tests.FeatureSwitch.TestDoubles
         }
 
         public static bool DidReceive(MyCommand command)
+        {
+            return CommandReceived;
+        }
+    }
+    class MyFeatureSwitchedOnHandlerAsync : RequestHandlerAsync<MyCommandAsync>
+    {
+        public static bool CommandReceived { get; set; }
+
+        [FeatureSwitchAsync(typeof(MyFeatureSwitchedOnHandlerAsync), FeatureSwitchStatus.On, 1)]
+        public override async Task<MyCommandAsync> HandleAsync(MyCommandAsync command, CancellationToken cancellationToken = default)
+        {
+            CommandReceived = true;
+
+            return await base.HandleAsync(command, cancellationToken);
+        }
+
+        public static bool DidReceive()
         {
             return CommandReceived;
         }

--- a/tests/Paramore.Brighter.Core.Tests/FeatureSwitch/When_A_Handler_Is_Feature_Switch_Config_On.cs
+++ b/tests/Paramore.Brighter.Core.Tests/FeatureSwitch/When_A_Handler_Is_Feature_Switch_Config_On.cs
@@ -23,12 +23,12 @@ THE SOFTWARE. */
 #endregion
 
 using System;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
 using Paramore.Brighter.Core.Tests.FeatureSwitch.TestDoubles;
 using Paramore.Brighter.FeatureSwitch;
 using Paramore.Brighter.FeatureSwitch.Providers;
-using Polly.Registry;
 using Microsoft.Extensions.DependencyInjection;
 using Paramore.Brighter.Extensions.DependencyInjection;
 using Xunit;
@@ -39,48 +39,58 @@ namespace Paramore.Brighter.Core.Tests.FeatureSwitch
     [Collection("CommandProcessor")]
     public class CommandProcessorWithFeatureSwitchOnByConfigInPipelineTests : IDisposable
     {
-        private readonly MyCommand _myCommand = new MyCommand();
-        private readonly SubscriberRegistry _registry;
-        private readonly ServiceProviderHandlerFactory _handlerFactory;
+        private readonly MyCommand _myCommand = new();
+        private readonly MyCommandAsync _myAsyncCommand = new();
 
-        private CommandProcessor _commandProcessor;
-        ServiceProvider _provider;
+        private readonly CommandProcessor _commandProcessor;
+        readonly ServiceProvider _provider;
 
         public CommandProcessorWithFeatureSwitchOnByConfigInPipelineTests()
         {
-            _registry = new SubscriberRegistry();
-            _registry.Register<MyCommand, MyFeatureSwitchedConfigHandler>();
+            SubscriberRegistry registry = new();
+            registry.Register<MyCommand, MyFeatureSwitchedConfigHandler>();
+            registry.RegisterAsync<MyCommandAsync, MyFeatureSwitchedConfigHandlerAsync>();
 
             var container = new ServiceCollection();
             container.AddSingleton<MyFeatureSwitchedConfigHandler>();
+            container.AddSingleton<MyFeatureSwitchedConfigHandlerAsync>();
             container.AddTransient<FeatureSwitchHandler<MyCommand>>();
-            container.AddSingleton<IBrighterOptions>(new BrighterOptions() {HandlerLifetime = ServiceLifetime.Transient});
-
-
+            container.AddTransient<FeatureSwitchHandlerAsync<MyCommandAsync>>();
+            container.AddSingleton<IBrighterOptions>(new BrighterOptions {HandlerLifetime = ServiceLifetime.Transient});
+            
             _provider = container.BuildServiceProvider();
-            _handlerFactory = new ServiceProviderHandlerFactory(_provider);
+            ServiceProviderHandlerFactory handlerFactory = new(_provider);
+            
+            IAmAFeatureSwitchRegistry fluentConfig = FluentConfigRegistryBuilder
+                .With()                
+                .StatusOf<MyFeatureSwitchedConfigHandler>().Is(FeatureSwitchStatus.On)
+                .StatusOf<MyFeatureSwitchedConfigHandlerAsync>().Is(FeatureSwitchStatus.On)
+                .Build();
+            
+            _commandProcessor = CommandProcessorBuilder
+                .With()
+                .ConfigureFeatureSwitches(fluentConfig)
+                .Handlers(new HandlerConfiguration(registry, handlerFactory))
+                .DefaultPolicy()
+                .NoExternalBus()
+                .RequestContextFactory(new InMemoryRequestContextFactory())
+                .Build();
         }
 
         [Fact]
         public void When_Sending_A_Command_To_The_Processor_When_A_Feature_Switch_Is_On_By_Fluent_Config()
         {
-            var fluentConfig = FluentConfigRegistryBuilder
-                                    .With()                
-                                    .StatusOf<MyFeatureSwitchedConfigHandler>().Is(FeatureSwitchStatus.On)
-                                    .Build();
-            
-            _commandProcessor = CommandProcessorBuilder
-                .With()
-                .ConfigureFeatureSwitches(fluentConfig)
-                .Handlers(new HandlerConfiguration(_registry, _handlerFactory))
-                .DefaultPolicy()
-                .NoExternalBus()
-                .RequestContextFactory(new InMemoryRequestContextFactory())
-                .Build();
-            
             _commandProcessor.Send(_myCommand);
 
-            _provider.GetService<MyFeatureSwitchedConfigHandler>().DidReceive(_myCommand).Should().BeTrue();
+            _provider.GetService<MyFeatureSwitchedConfigHandler>().DidReceive().Should().BeTrue();
+        }
+        
+        [Fact]
+        public async Task When_Sending_A_Async_Command_To_The_Processor_When_A_Feature_Switch_Is_On_By_Fluent_Config()
+        {
+            await _commandProcessor.SendAsync(_myAsyncCommand);
+
+            _provider.GetService<MyFeatureSwitchedConfigHandlerAsync>().DidReceive().Should().BeTrue();
         }
 
         public void Dispose()

--- a/tests/Paramore.Brighter.Core.Tests/FeatureSwitch/When_A_Handler_Is_Feature_Switch_Missing_Config_Exception.cs
+++ b/tests/Paramore.Brighter.Core.Tests/FeatureSwitch/When_A_Handler_Is_Feature_Switch_Missing_Config_Exception.cs
@@ -27,7 +27,6 @@ using FluentAssertions;
 using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
 using Paramore.Brighter.Core.Tests.FeatureSwitch.TestDoubles;
 using Paramore.Brighter.FeatureSwitch;
-using Polly.Registry;
 using Microsoft.Extensions.DependencyInjection;
 using Paramore.Brighter.Extensions.DependencyInjection;
 using Xunit;
@@ -38,52 +37,65 @@ namespace Paramore.Brighter.Core.Tests.FeatureSwitch
     [Collection("CommandProcessor")] 
     public class FeatureSwitchByConfigMissingConfigStrategyExceptionTests : IDisposable
     {
-        private readonly MyCommand _myCommand = new MyCommand();
-        private readonly SubscriberRegistry _registry;
-        private readonly ServiceProviderHandlerFactory _handlerFactory;
-        private readonly IAmAFeatureSwitchRegistry _featureSwitchRegistry;
+        private readonly MyCommand _myCommand = new();
+        private readonly MyCommand _myAsyncCommand = new();
 
-        private CommandProcessor _commandProcessor;
+        private readonly CommandProcessor _commandProcessor;
+        private readonly ServiceProvider _provider;
         private Exception _exception;
-        ServiceProvider _provider;
 
         public FeatureSwitchByConfigMissingConfigStrategyExceptionTests()
         {
-            _registry = new SubscriberRegistry();
-            _registry.Register<MyCommand, MyFeatureSwitchedConfigHandler>();
+            SubscriberRegistry registry = new();
+            registry.Register<MyCommand, MyFeatureSwitchedConfigHandler>();
+            registry.RegisterAsync<MyCommandAsync, MyFeatureSwitchedConfigHandlerAsync>();
 
             var container = new ServiceCollection();
             container.AddSingleton<MyFeatureSwitchedConfigHandler>();
+            container.AddSingleton<MyFeatureSwitchedConfigHandlerAsync>();
             container.AddTransient<FeatureSwitchHandler<MyCommand>>();
-            container.AddSingleton<IBrighterOptions>(new BrighterOptions() {HandlerLifetime = ServiceLifetime.Transient});
+            container.AddTransient<FeatureSwitchHandlerAsync<MyCommandAsync>>();
+            container.AddSingleton<IBrighterOptions>(new BrighterOptions {HandlerLifetime = ServiceLifetime.Transient});
 
             _provider = container.BuildServiceProvider();
-            _handlerFactory = new ServiceProviderHandlerFactory(_provider);
+            ServiceProviderHandlerFactory handlerFactory = new(_provider);
             
-            _featureSwitchRegistry = new FakeConfigRegistry();
+            IAmAFeatureSwitchRegistry featureSwitchRegistry = new FakeConfigRegistry();
+            
+            featureSwitchRegistry.MissingConfigStrategy = MissingConfigStrategy.Exception;
+
+            _commandProcessor = CommandProcessorBuilder
+                .With()
+                .ConfigureFeatureSwitches(featureSwitchRegistry)
+                .Handlers(new HandlerConfiguration(registry, handlerFactory))
+                .DefaultPolicy()
+                .NoExternalBus()
+                .RequestContextFactory(new InMemoryRequestContextFactory())
+                .Build();
         }        
 
         [Fact]
         public void When_Sending_A_Command_To_The_Processor_When_A_Feature_Switch_Has_No_Config_And_Strategy_Is_Exception()
         {
-            _featureSwitchRegistry.MissingConfigStrategy = MissingConfigStrategy.Exception;
-
-            _commandProcessor = CommandProcessorBuilder
-                .With()
-                .ConfigureFeatureSwitches(_featureSwitchRegistry)
-                .Handlers(new HandlerConfiguration(_registry, _handlerFactory))
-                .DefaultPolicy()
-                .NoExternalBus()
-                .RequestContextFactory(new InMemoryRequestContextFactory())
-                .Build();
-
             _exception = Catch.Exception(() => _commandProcessor.Send(_myCommand));
 
             _exception.Should().BeOfType<ConfigurationException>();
             _exception.Should().NotBeNull();
             _exception.Message.Should().Contain($"Handler of type {nameof(MyFeatureSwitchedConfigHandler)} does not have a Feature Switch configuration!");
 
-            _provider.GetService<MyFeatureSwitchedConfigHandler>().DidReceive(_myCommand).Should().BeFalse(); 
+            _provider.GetService<MyFeatureSwitchedConfigHandler>().DidReceive().Should().BeFalse(); 
+        }        
+
+        [Fact]
+        public void When_Sending_A_Async_Command_To_The_Processor_When_A_Feature_Switch_Has_No_Config_And_Strategy_Is_Exception()
+        {
+            var sendAsync = async () => await _commandProcessor.SendAsync(_myAsyncCommand);
+
+            sendAsync.Should()
+                .ThrowAsync<ConfigurationException>()
+                .WithMessage($"Handler of type {nameof(MyFeatureSwitchedConfigHandlerAsync)} does not have a Feature Switch configuration!");
+
+            _provider.GetService<MyFeatureSwitchedConfigHandlerAsync>().DidReceive().Should().BeFalse(); 
         }
 
         public void Dispose()

--- a/tests/Paramore.Brighter.Core.Tests/FeatureSwitch/When_A_Handler_Is_Feature_Switch_Missing_Config_SilentOff.cs
+++ b/tests/Paramore.Brighter.Core.Tests/FeatureSwitch/When_A_Handler_Is_Feature_Switch_Missing_Config_SilentOff.cs
@@ -23,11 +23,11 @@ THE SOFTWARE. */
 #endregion
 
 using System;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
 using Paramore.Brighter.Core.Tests.FeatureSwitch.TestDoubles;
 using Paramore.Brighter.FeatureSwitch;
-using Polly.Registry;
 using Microsoft.Extensions.DependencyInjection;
 using Paramore.Brighter.Extensions.DependencyInjection;
 using Xunit;
@@ -38,47 +38,57 @@ namespace Paramore.Brighter.Core.Tests.FeatureSwitch
     [Collection("CommandProcessor")] 
     public class FeatureSwitchByConfigMissingConfigStrategySilentOffTests : IDisposable
     {
-        private readonly MyCommand _myCommand = new MyCommand();
-        private readonly SubscriberRegistry _registry;
-        private readonly ServiceProviderHandlerFactory _handlerFactory;
-        private readonly IAmAFeatureSwitchRegistry _featureSwitchRegistry;
+        private readonly MyCommand _myCommand = new();
+        private readonly MyCommandAsync _myAsyncCommand = new();
 
-        private CommandProcessor _commandProcessor;
-        private IServiceProvider _provider;
+        private readonly CommandProcessor _commandProcessor;
+        private readonly IServiceProvider _provider;
 
         public FeatureSwitchByConfigMissingConfigStrategySilentOffTests()
         {
-            _registry = new SubscriberRegistry();
-            _registry.Register<MyCommand, MyFeatureSwitchedConfigHandler>();
+            SubscriberRegistry registry = new();
+            registry.Register<MyCommand, MyFeatureSwitchedConfigHandler>();
+            registry.RegisterAsync<MyCommandAsync, MyFeatureSwitchedConfigHandlerAsync>();
 
             var container = new ServiceCollection();
             container.AddSingleton<MyFeatureSwitchedConfigHandler>();
+            container.AddSingleton<MyFeatureSwitchedConfigHandlerAsync>();
             container.AddTransient<FeatureSwitchHandler<MyCommand>>();
+            container.AddTransient<FeatureSwitchHandlerAsync<MyCommandAsync>>();
             container.AddSingleton<IBrighterOptions>(new BrighterOptions() {HandlerLifetime = ServiceLifetime.Transient});
 
             _provider = container.BuildServiceProvider();
-            _handlerFactory = new ServiceProviderHandlerFactory(_provider);
+            ServiceProviderHandlerFactory handlerFactory = new(_provider);
 
-            _featureSwitchRegistry = new FakeConfigRegistry();
+            IAmAFeatureSwitchRegistry featureSwitchRegistry = new FakeConfigRegistry
+            {
+                MissingConfigStrategy = MissingConfigStrategy.SilentOff
+            };
+            
+            _commandProcessor = CommandProcessorBuilder
+                .With()
+                .ConfigureFeatureSwitches(featureSwitchRegistry)
+                .Handlers(new HandlerConfiguration(registry, handlerFactory))
+                .DefaultPolicy()
+                .NoExternalBus()
+                .RequestContextFactory(new InMemoryRequestContextFactory())
+                .Build();
         }        
 
         [Fact]
         public void When_Sending_A_Command_To_The_Processor_When_A_Feature_Switch_Has_No_Config_And_Strategy_Is_SilentOff()
         {
-            _featureSwitchRegistry.MissingConfigStrategy = MissingConfigStrategy.SilentOff;
-
-          _commandProcessor = CommandProcessorBuilder
-                .With()
-                .ConfigureFeatureSwitches(_featureSwitchRegistry)
-                .Handlers(new HandlerConfiguration(_registry, _handlerFactory))
-                .DefaultPolicy()
-                .NoExternalBus()
-                .RequestContextFactory(new InMemoryRequestContextFactory())
-                .Build();
-            
             _commandProcessor.Send(_myCommand);
 
-            _provider.GetService<MyFeatureSwitchedConfigHandler>().DidReceive(_myCommand).Should().BeFalse();
+            _provider.GetService<MyFeatureSwitchedConfigHandler>().DidReceive().Should().BeFalse();
+        }    
+
+        [Fact]
+        public async Task When_Sending_A_Async_Command_To_The_Processor_When_A_Feature_Switch_Has_No_Config_And_Strategy_Is_SilentOff()
+        {
+            await _commandProcessor.SendAsync(_myAsyncCommand);
+
+            _provider.GetService<MyFeatureSwitchedConfigHandlerAsync>().DidReceive().Should().BeFalse();
         }
 
         public void Dispose()

--- a/tests/Paramore.Brighter.Core.Tests/FeatureSwitch/When_A_Handler_Is_Feature_Switch_Off.cs
+++ b/tests/Paramore.Brighter.Core.Tests/FeatureSwitch/When_A_Handler_Is_Feature_Switch_Off.cs
@@ -23,10 +23,10 @@ THE SOFTWARE. */
 #endregion
 
 using System;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
 using Paramore.Brighter.Core.Tests.FeatureSwitch.TestDoubles;
-using Polly.Registry;
 using Microsoft.Extensions.DependencyInjection;
 using Paramore.Brighter.Extensions.DependencyInjection;
 using Xunit;
@@ -37,39 +37,49 @@ namespace Paramore.Brighter.Core.Tests.FeatureSwitch
     [Collection("CommandProcessor")]
     public class CommandProcessorWithFeatureSwitchOffInPipelineTests : IDisposable
     {
-        private readonly MyCommand _myCommand = new MyCommand();
-        private readonly SubscriberRegistry _registry;
-        private readonly ServiceProviderHandlerFactory _handlerFactory;
+        private readonly MyCommand _myCommand = new();
+        private readonly MyCommandAsync _myAsyncCommand = new();
 
-        private CommandProcessor _commandProcessor;
+        private readonly CommandProcessor _commandProcessor;
 
         public CommandProcessorWithFeatureSwitchOffInPipelineTests()
-        {            
-            _registry = new SubscriberRegistry();
-            _registry.Register<MyCommand, MyFeatureSwitchedOffHandler>();
+        {
+            SubscriberRegistry registry = new();
+            registry.Register<MyCommand, MyFeatureSwitchedOffHandler>();
+            registry.RegisterAsync<MyCommandAsync, MyFeatureSwitchedOffHandlerAsync>();
 
             var container = new ServiceCollection();
             container.AddSingleton<MyFeatureSwitchedOffHandler>();
+            container.AddSingleton<MyFeatureSwitchedOffHandlerAsync>();
             container.AddTransient<FeatureSwitchHandler<MyCommand>>();
-            container.AddSingleton<IBrighterOptions>(new BrighterOptions() {HandlerLifetime = ServiceLifetime.Transient});
+            container.AddTransient<FeatureSwitchHandlerAsync<MyCommandAsync>>();
+            container.AddSingleton<IBrighterOptions>(new BrighterOptions {HandlerLifetime = ServiceLifetime.Transient});
 
-            _handlerFactory = new ServiceProviderHandlerFactory(container.BuildServiceProvider());
+            ServiceProviderHandlerFactory handlerFactory = new(container.BuildServiceProvider());
+            
+            _commandProcessor = CommandProcessorBuilder
+                .With()
+                .Handlers(new HandlerConfiguration(registry, handlerFactory))
+                .DefaultPolicy()
+                .NoExternalBus()
+                .RequestContextFactory(new InMemoryRequestContextFactory())
+                .Build();
         }
 
         [Fact]
         public void When_Sending_A_Command_To_The_Processor_When_A_Feature_Switch_Is_Off()
         {
-            _commandProcessor = CommandProcessorBuilder
-                .With()
-                .Handlers(new HandlerConfiguration(_registry, _handlerFactory))
-                .DefaultPolicy()
-                .NoExternalBus()
-                .RequestContextFactory(new InMemoryRequestContextFactory())
-                .Build();
-            
             _commandProcessor.Send(_myCommand);
 
-            MyFeatureSwitchedOffHandler.DidReceive(_myCommand).Should().BeFalse();
+            MyFeatureSwitchedOffHandler.DidReceive().Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task When_Sending_A_Async_Command_To_The_Processor_When_A_Feature_Switch_Is_Off()
+        {
+            await _commandProcessor.SendAsync(_myAsyncCommand);
+
+            MyFeatureSwitchedOffHandlerAsync.DidReceive().Should().BeFalse();
         }
 
         public void Dispose()

--- a/tests/Paramore.Brighter.Core.Tests/FeatureSwitch/When_A_Handler_Is_Feature_Switch_On.cs
+++ b/tests/Paramore.Brighter.Core.Tests/FeatureSwitch/When_A_Handler_Is_Feature_Switch_On.cs
@@ -23,10 +23,10 @@ THE SOFTWARE. */
 #endregion
 
 using System;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
 using Paramore.Brighter.Core.Tests.FeatureSwitch.TestDoubles;
-using Polly.Registry;
 using Microsoft.Extensions.DependencyInjection;
 using Paramore.Brighter.Extensions.DependencyInjection;
 using Xunit;
@@ -37,39 +37,49 @@ namespace Paramore.Brighter.Core.Tests.FeatureSwitch
     [Collection("CommandProcessor")]
     public class CommandProcessorWithFeatureSwitchOnInPipelineTests : IDisposable
     {
-        private readonly MyCommand _myCommand = new MyCommand();
-        private readonly SubscriberRegistry _registry;
-        private readonly ServiceProviderHandlerFactory _handlerFactory;
+        private readonly MyCommand _myCommand = new();
+        private readonly MyCommandAsync _myAsyncCommand = new();
 
-        private CommandProcessor _commandProcessor;
+        private readonly CommandProcessor _commandProcessor;
 
         public CommandProcessorWithFeatureSwitchOnInPipelineTests()
         {
-            _registry = new SubscriberRegistry();
-            _registry.Register<MyCommand, MyFeatureSwitchedOnHandler>();
+            SubscriberRegistry registry = new();
+            registry.Register<MyCommand, MyFeatureSwitchedOnHandler>();
+            registry.RegisterAsync<MyCommandAsync, MyFeatureSwitchedOnHandlerAsync>();
 
             var container = new ServiceCollection();
             container.AddSingleton<MyFeatureSwitchedOnHandler>();
+            container.AddSingleton<MyFeatureSwitchedOnHandlerAsync>();
             container.AddTransient<FeatureSwitchHandler<MyCommand>>();
-            container.AddSingleton<IBrighterOptions>(new BrighterOptions() {HandlerLifetime = ServiceLifetime.Transient});
+            container.AddTransient<FeatureSwitchHandlerAsync<MyCommandAsync>>();
+            container.AddSingleton<IBrighterOptions>(new BrighterOptions {HandlerLifetime = ServiceLifetime.Transient});
 
-            _handlerFactory = new ServiceProviderHandlerFactory(container.BuildServiceProvider());
+            ServiceProviderHandlerFactory handlerFactory = new(container.BuildServiceProvider());
+            
+            _commandProcessor = CommandProcessorBuilder
+                .With()
+                .Handlers(new HandlerConfiguration(registry, handlerFactory))
+                .DefaultPolicy()
+                .NoExternalBus()
+                .RequestContextFactory(new InMemoryRequestContextFactory())
+                .Build();
         }
 
         [Fact]
         public void When_Sending_A_Command_To_The_Processor_When_A_Feature_Switch_Is_On()
         {
-            _commandProcessor = CommandProcessorBuilder
-                .With()
-                .Handlers(new HandlerConfiguration(_registry, _handlerFactory))
-                .DefaultPolicy()
-                .NoExternalBus()
-                .RequestContextFactory(new InMemoryRequestContextFactory())
-                .Build();
-
             _commandProcessor.Send(_myCommand);
 
             MyFeatureSwitchedOnHandler.DidReceive(_myCommand).Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task When_Sending_A_Async_Command_To_The_Processor_When_A_Feature_Switch_Is_On()
+        {
+            await _commandProcessor.SendAsync(_myAsyncCommand);
+
+            MyFeatureSwitchedOnHandlerAsync.DidReceive().Should().BeTrue();
         }
 
         public void Dispose()


### PR DESCRIPTION
When I wrote the original `FeatureSwitch[Attribute|Handler]` I didn't add an async version for using with handlers that extend `RequestHandlerAsync`, this PR adds that functionality. 