### PR TITLE
Compress and Decompress Transform

### DIFF
--- a/src/Paramore.Brighter/MessageBody.cs
+++ b/src/Paramore.Brighter/MessageBody.cs
@@ -63,7 +63,7 @@ namespace Paramore.Brighter
         /// </summary>
         /// <param name="body">The body of the message, usually XML or JSON.</param>
         /// <param name="bodyType">The type of the message, usualy XML or JSON. Defaults to JSON</param>
-        public MessageBody(string body, string bodyType = "JSON")
+        public MessageBody(string body, string bodyType = "application/json")
         {
             Bytes = Encoding.UTF8.GetBytes(body);
             BodyType = bodyType;
@@ -78,7 +78,7 @@ namespace Paramore.Brighter
         public MessageBody(byte[] bytes, string bodyType)
         {
             Bytes = bytes;
-            BodyType = bodyType ?? "JSON";
+            BodyType = bodyType ?? "application/json";
         }
 
         /// <summary>

--- a/src/Paramore.Brighter/Transforms/Attributes/Compress.cs
+++ b/src/Paramore.Brighter/Transforms/Attributes/Compress.cs
@@ -1,0 +1,76 @@
+﻿#region Licence
+/* The MIT License (MIT)
+Copyright © 2022 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+using System;
+using System.IO.Compression;
+using Paramore.Brighter.Transforms.Transformers;
+
+namespace Paramore.Brighter.Transforms.Attributes
+{
+    /// <summary>
+    /// Compresses the payload of a message to reduce its size
+    /// </summary>
+    public class Compress : WrapWithAttribute
+    {
+        private readonly CompressionMethod _compressionMethod;
+        private readonly CompressionLevel _compressionLevel;
+        private readonly int _thresholdInKb;
+
+        /// <summary>
+        /// Configures compression for a message
+        /// </summary>
+        /// <param name="step">The order in which to perform compression</param>
+        /// <param name="compressionMethod">The compression method> One of <see cref="CompressionMethod"/>: GZip, Zlib, or Brotli. Defaults to Gzip </param>
+        /// <param name="compressionLevel">The level of compression <see cref="CompressionLevel"/></param>
+        /// <param name="thresholdInKb">How large the payload should be before we try to compress it.</param>
+        public Compress(
+            int step, 
+            CompressionMethod compressionMethod = CompressionMethod.GZip, 
+            CompressionLevel compressionLevel = CompressionLevel.Optimal, 
+            int thresholdInKb = 0) : base(step)
+        {
+            _compressionMethod = compressionMethod;
+            _compressionLevel = compressionLevel;
+            _thresholdInKb = thresholdInKb;
+        }
+        
+        /// <summary>
+        /// Passes the parameters used to configure this attribute to the runtime type that implements it
+        /// </summary>
+        /// <returns>Configuration values</returns>
+        public override object[] InitializerParams()
+        {
+            return new object[] { _compressionMethod, _compressionLevel, _thresholdInKb };
+        }
+
+        /// <summary>
+        /// The runtime type that implements this middleware step
+        /// </summary>
+        /// <returns>The type for the compression middleware</returns>
+        public override Type GetHandlerType()
+        {
+            return typeof(CompressPayloadTransformer);
+        }
+    }
+}

--- a/src/Paramore.Brighter/Transforms/Attributes/Decompress.cs
+++ b/src/Paramore.Brighter/Transforms/Attributes/Decompress.cs
@@ -1,0 +1,75 @@
+﻿#region Licence
+/* The MIT License (MIT)
+Copyright © 2022 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+using System;
+using Paramore.Brighter.Transforms.Transformers;
+
+namespace Paramore.Brighter.Transforms.Attributes
+{
+    /// <summary>
+    /// Decompresses a compressed payload.
+    /// Assumes that the payload is compressed with a supported <see cref="CompressionMethod"/> and that the type
+    /// for that compression method is indicated by the <see cref="MessageBody"/> BodyType, passed in via the message headers,
+    /// as this is used to figure out if the content is compressed or not. (The content may have fallen below a
+    /// compression threshold and be the original content type
+    /// </summary>
+    public class Decompress: UnwrapWithAttribute
+    {
+        private readonly CompressionMethod _compressionMethod;
+        private readonly string _contentType;
+
+        /// <summary>
+        /// Configures decompression of a payload
+        /// </summary>
+        /// <param name="step">The order to run this step in</param>
+        /// <param name="compressionMethod">The <see cref="CompressionMethod"/> used to compress the payload. Supported decompression is Gzip, Zlib and Brotli. Defaults to GZip</param>
+        /// <param name="contentType">The type to set on the message ***after** decompression. Defaults to "application/json". Should be the uncompressed type of the message. </param>
+        public Decompress(
+            int step,
+            CompressionMethod compressionMethod = CompressionMethod.GZip,
+            string contentType = "application/json") : base(step)
+        {
+            _compressionMethod = compressionMethod;
+            _contentType = contentType;
+        }
+        
+        /// <summary>
+        /// Passes the parameters used to configure this attribute to the runtime type that implements it
+        /// </summary>
+        /// <returns>Configuration values</returns>
+        public override object[] InitializerParams()
+        {
+            return new object[] { _compressionMethod, _contentType };
+        }
+
+        /// <summary>
+        /// The runtime type that implements this middleware step
+        /// </summary>
+        /// <returns>The type for the compression middleware</returns>
+        public override Type GetHandlerType()
+        {
+            return typeof(CompressPayloadTransformer);
+        }
+    }
+}

--- a/src/Paramore.Brighter/Transforms/Transformers/CompressPayloadTransformer.cs
+++ b/src/Paramore.Brighter/Transforms/Transformers/CompressPayloadTransformer.cs
@@ -96,13 +96,16 @@ namespace Paramore.Brighter.Transforms.Transformers
             {
                 case CompressionMethod.GZip:
                     return new GZipStream(compressed, CompressionMode.Decompress);
-                case CompressionMethod.Zlib:
-                    return new DeflateStream(compressed, CompressionMode.Decompress);
+
 #if NETSTANDARD2_0
+                case CompressionMethod.Zlib:
+                    throw new ArgumentException("Zlib is not supported in nestandard20");
                 case CompressionMethod.Brotli:
                     throw new ArgumentException("Brotli is not supported in nestandard20");
 #else
-                  case CompressionMethod.Brotli:
+                case CompressionMethod.Zlib:
+                    return new ZLibStream(compressed, CompressionMode.Decompress); 
+                case CompressionMethod.Brotli:
                     return new BrotliStream(compressed, CompressionMode.Decompress);              
 #endif
                 default:

--- a/src/Paramore.Brighter/Transforms/Transformers/CompressPayloadTransformer.cs
+++ b/src/Paramore.Brighter/Transforms/Transformers/CompressPayloadTransformer.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.IO;
+using System.IO.Compression;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Paramore.Brighter.Transforms.Transformers
+{
+    public class CompressPayloadTransformer : IAmAMessageTransformAsync
+    {
+        private CompressionMethod _compressionMethod = CompressionMethod.GZip;
+        private CompressionLevel _compressionLevel = CompressionLevel.Optimal;
+        private int _thresholdInKb;
+        private string _contentType = "application/json";
+
+        public void Dispose() { }
+
+        public void InitializeWrapFromAttributeParams(params object[] initializerList)
+        {
+            _compressionMethod = (CompressionMethod)initializerList[0];
+            _compressionLevel = (CompressionLevel)initializerList[1];
+            _thresholdInKb = (int)initializerList[2];
+
+        }
+
+        public void InitializeUnwrapFromAttributeParams(params object[] initializerList)
+        {
+            _compressionMethod = (CompressionMethod)initializerList[0];
+            _contentType = (string)initializerList[1];
+        }
+
+        public async Task<Message> WrapAsync(Message message, CancellationToken cancellationToken = default)
+        {
+            var bytes = message.Body.Bytes;
+            using var input = new MemoryStream(bytes);
+            using var output = new MemoryStream();
+            
+            (Stream compressionStream, string mimeType) = CreateCompressionStream(output);
+            await input.CopyToAsync(compressionStream);
+            await compressionStream.FlushAsync(cancellationToken);
+
+            message.Body = new MessageBody(output.ToArray(), mimeType);
+
+            return message;
+        }
+
+
+        public async Task<Message> UnwrapAsync(Message message, CancellationToken cancellationToken = default)
+        {
+            var bytes = message.Body.Bytes;
+            using var input = new MemoryStream(bytes);
+            using var output = new MemoryStream();
+            
+            Stream deCompressionStream = CreateDecompressionStream(input);
+            await deCompressionStream.CopyToAsync(output);
+            await input.FlushAsync(cancellationToken);
+
+            message.Body = new MessageBody(output.ToArray(), _contentType);
+
+            return message;
+        }
+       
+        private (Stream , string) CreateCompressionStream(MemoryStream uncompressed)
+        {
+            switch (_compressionMethod)
+            {
+                case CompressionMethod.GZip:
+                    return (new GZipStream(uncompressed, _compressionLevel), "application/gzip");
+                case CompressionMethod.Deflate:
+                    return (new DeflateStream(uncompressed, _compressionLevel), "application/x-deflate");
+#if NETSTANDARD2_0
+                case CompressionMethod.Brotli:
+                    throw new ArgumentException("Brotli is not supported in nestandard20");
+#else
+                  case CompressionMethod.Brotli:
+                    return (new BrotliStream(uncompressed, _compressionLevel), "pplication/x-brotli");              
+#endif
+                default:
+                    return (uncompressed, "application/json");
+            }
+        }
+        
+        private Stream CreateDecompressionStream(MemoryStream compressed)
+        {
+            switch (_compressionMethod)
+            {
+                case CompressionMethod.GZip:
+                    return new GZipStream(compressed, CompressionMode.Decompress);
+                case CompressionMethod.Deflate:
+                    return new DeflateStream(compressed, CompressionMode.Decompress);
+#if NETSTANDARD2_0
+                case CompressionMethod.Brotli:
+                    throw new ArgumentException("Brotli is not supported in nestandard20");
+#else
+                  case CompressionMethod.Brotli:
+                    return new BrotliStream(compressed, CompressionMode.Decompress);              
+#endif
+                default:
+                    return compressed;
+            }
+        }
+
+    }
+}

--- a/src/Paramore.Brighter/Transforms/Transformers/CompressPayloadTransformer.cs
+++ b/src/Paramore.Brighter/Transforms/Transformers/CompressPayloadTransformer.cs
@@ -10,7 +10,7 @@ namespace Paramore.Brighter.Transforms.Transformers
     {
         private CompressionMethod _compressionMethod = CompressionMethod.GZip;
         private CompressionLevel _compressionLevel = CompressionLevel.Optimal;
-        private int _thresholdInKb;
+        private int _thresholdInBytes;
         private string _contentType = "application/json";
 
         public void Dispose() { }
@@ -19,7 +19,7 @@ namespace Paramore.Brighter.Transforms.Transformers
         {
             _compressionMethod = (CompressionMethod)initializerList[0];
             _compressionLevel = (CompressionLevel)initializerList[1];
-            _thresholdInKb = (int)initializerList[2];
+            _thresholdInBytes = (int)initializerList[2] * 1024;
 
         }
 
@@ -32,6 +32,10 @@ namespace Paramore.Brighter.Transforms.Transformers
         public async Task<Message> WrapAsync(Message message, CancellationToken cancellationToken = default)
         {
             var bytes = message.Body.Bytes;
+
+            //don't transform it too small
+            if (bytes.Length < _thresholdInBytes) return message;
+            
             using var input = new MemoryStream(bytes);
             using var output = new MemoryStream();
             

--- a/src/Paramore.Brighter/Transforms/Transformers/CompressionMethod.cs
+++ b/src/Paramore.Brighter/Transforms/Transformers/CompressionMethod.cs
@@ -1,0 +1,9 @@
+﻿namespace Paramore.Brighter.Transforms.Transformers
+{
+    public enum CompressionMethod
+    {
+        GZip,
+        Brotli,
+        Deflate
+    }
+}

--- a/src/Paramore.Brighter/Transforms/Transformers/CompressionMethod.cs
+++ b/src/Paramore.Brighter/Transforms/Transformers/CompressionMethod.cs
@@ -4,6 +4,6 @@
     {
         GZip,
         Brotli,
-        Deflate
+        Zlib
     }
 }

--- a/tests/Paramore.Brighter.Core.Tests/Claims/Test Doubles/MyLargeCommand.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Claims/Test Doubles/MyLargeCommand.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Paramore.Brighter.Core.Tests.TestHelpers;
 
 namespace Paramore.Brighter.Core.Tests.Claims.Test_Doubles;
 

--- a/tests/Paramore.Brighter.Core.Tests/Claims/When_a_message_is_under_the_threshold.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Claims/When_a_message_is_under_the_threshold.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Paramore.Brighter.Core.Tests.TestHelpers;
 using Paramore.Brighter.Transforms.Storage;
 using Paramore.Brighter.Transforms.Transformers;
 using Xunit;

--- a/tests/Paramore.Brighter.Core.Tests/Claims/When_a_message_unwraps_a_large_payload.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Claims/When_a_message_unwraps_a_large_payload.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Paramore.Brighter.Core.Tests.TestHelpers;
 using Paramore.Brighter.Transforms.Storage;
 using Paramore.Brighter.Transforms.Transformers;
 using Xunit;

--- a/tests/Paramore.Brighter.Core.Tests/Claims/When_a_message_wraps_a_large_payload.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Claims/When_a_message_wraps_a_large_payload.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Paramore.Brighter.Core.Tests.TestHelpers;
 using Paramore.Brighter.Transforms.Storage;
 using Paramore.Brighter.Transforms.Transformers;
 using Xunit;

--- a/tests/Paramore.Brighter.Core.Tests/Claims/When_luggage_should_be_kept_in_the_store.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Claims/When_luggage_should_be_kept_in_the_store.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Paramore.Brighter.Core.Tests.TestHelpers;
 using Paramore.Brighter.Transforms.Storage;
 using Paramore.Brighter.Transforms.Transformers;
 using Xunit;

--- a/tests/Paramore.Brighter.Core.Tests/Claims/When_unwrapping_a_large_message.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Claims/When_unwrapping_a_large_message.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Paramore.Brighter.Core.Tests.Claims.Test_Doubles;
+using Paramore.Brighter.Core.Tests.TestHelpers;
 using Paramore.Brighter.Transforms.Storage;
 using Paramore.Brighter.Transforms.Transformers;
 using Xunit;

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_An_Exception_Is_Thrown_Terminate_The_Pipeline.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_An_Exception_Is_Thrown_Terminate_The_Pipeline.cs
@@ -27,6 +27,7 @@ using FluentAssertions;
 using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
 using Polly.Registry;
 using Microsoft.Extensions.DependencyInjection;
+using Paramore.Brighter.Core.Tests.TestHelpers;
 using Paramore.Brighter.Extensions.DependencyInjection;
 using Xunit;
 

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Building_A_Pipeline_Failures_Should_Be_ConfigurationErrors.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Building_A_Pipeline_Failures_Should_Be_ConfigurationErrors.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using FluentAssertions;
 using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
+using Paramore.Brighter.Core.Tests.TestHelpers;
 using Xunit;
 
 namespace Paramore.Brighter.Core.Tests.CommandProcessors

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Building_A_Sync_Pipeline_That_Has_Async_Handlers.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Building_A_Sync_Pipeline_That_Has_Async_Handlers.cs
@@ -27,6 +27,7 @@ using System.Linq;
 using FluentAssertions;
 using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
 using Microsoft.Extensions.DependencyInjection;
+using Paramore.Brighter.Core.Tests.TestHelpers;
 using Paramore.Brighter.Extensions.DependencyInjection;
 using Xunit;
 

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Building_An_Async_Pipeline_Failures_Should_Be_ConfigurationErrors.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Building_An_Async_Pipeline_Failures_Should_Be_ConfigurationErrors.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using FluentAssertions;
 using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
+using Paramore.Brighter.Core.Tests.TestHelpers;
 using Xunit;
 
 namespace Paramore.Brighter.Core.Tests.CommandProcessors

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Building_An_Async_Pipeline_That_Has_Sync_Handlers.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Building_An_Async_Pipeline_That_Has_Sync_Handlers.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using FluentAssertions;
 using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
 using Microsoft.Extensions.DependencyInjection;
+using Paramore.Brighter.Core.Tests.TestHelpers;
 using Paramore.Brighter.Extensions.DependencyInjection;
 using Xunit;
 

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Calling_A_Server_Via_The_Command_Processor_With_No_In_Mapper.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Calling_A_Server_Via_The_Command_Processor_With_No_In_Mapper.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using FluentAssertions;
 using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
+using Paramore.Brighter.Core.Tests.TestHelpers;
 using Paramore.Brighter.ServiceActivator.TestHelpers;
 using Polly;
 using Polly.Registry;

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Calling_A_Server_Via_The_Command_Processor_With_No_Out_Mapper.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Calling_A_Server_Via_The_Command_Processor_With_No_Out_Mapper.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using FluentAssertions;
 using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
+using Paramore.Brighter.Core.Tests.TestHelpers;
 using Paramore.Brighter.ServiceActivator.TestHelpers;
 using Polly;
 using Polly.Registry;

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Calling_A_Server_Via_The_Command_Processor_With_No_Timeout.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Calling_A_Server_Via_The_Command_Processor_With_No_Timeout.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using FluentAssertions;
 using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
+using Paramore.Brighter.Core.Tests.TestHelpers;
 using Paramore.Brighter.ServiceActivator.TestHelpers;
 using Polly;
 using Polly.Registry;

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Posting_A_Message_And_There_Is_No_Message_Mapper_Registry.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Posting_A_Message_And_There_Is_No_Message_Mapper_Registry.cs
@@ -27,6 +27,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using FluentAssertions;
 using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
+using Paramore.Brighter.Core.Tests.TestHelpers;
 using Polly;
 using Polly.Registry;
 using Xunit;

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Posting_A_Message_And_There_Is_No_Message_Mapper_Registry_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Posting_A_Message_And_There_Is_No_Message_Mapper_Registry_Async.cs
@@ -28,6 +28,7 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
+using Paramore.Brighter.Core.Tests.TestHelpers;
 using Polly;
 using Polly.Registry;
 using Xunit;

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Posting_A_Message_And_There_Is_No_Message_Producer.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Posting_A_Message_And_There_Is_No_Message_Producer.cs
@@ -26,6 +26,7 @@ using System;
 using System.Text.Json;
 using FluentAssertions;
 using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
+using Paramore.Brighter.Core.Tests.TestHelpers;
 using Polly;
 using Polly.CircuitBreaker;
 using Polly.Registry;

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Posting_A_Message_And_There_Is_No_Message_Store.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Posting_A_Message_And_There_Is_No_Message_Store.cs
@@ -26,6 +26,7 @@ using System;
 using System.Collections.Generic;
 using FluentAssertions;
 using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
+using Paramore.Brighter.Core.Tests.TestHelpers;
 using Polly;
 using Polly.Registry;
 using Xunit;

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Posting_A_Message_And_There_Is_No_Message_Store_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Posting_A_Message_And_There_Is_No_Message_Store_Async.cs
@@ -27,6 +27,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
+using Paramore.Brighter.Core.Tests.TestHelpers;
 using Polly;
 using Polly.Registry;
 using Xunit;

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Publishing_To_Multiple_Subscribers_Should_Aggregate_Exceptions_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Publishing_To_Multiple_Subscribers_Should_Aggregate_Exceptions_Async.cs
@@ -29,6 +29,7 @@ using FluentAssertions;
 using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
 using Polly.Registry;
 using Microsoft.Extensions.DependencyInjection;
+using Paramore.Brighter.Core.Tests.TestHelpers;
 using Paramore.Brighter.Extensions.DependencyInjection;
 using Xunit;
 

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_There_Are_Multiple_Possible_Command_Handlers_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_There_Are_Multiple_Possible_Command_Handlers_Async.cs
@@ -29,6 +29,7 @@ using FluentAssertions;
 using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
 using Polly.Registry;
 using Microsoft.Extensions.DependencyInjection;
+using Paramore.Brighter.Core.Tests.TestHelpers;
 using Paramore.Brighter.Extensions.DependencyInjection;
 using Xunit;
 

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_There_Are_Multiple_Subscribers_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_There_Are_Multiple_Subscribers_Async.cs
@@ -29,6 +29,7 @@ using FluentAssertions;
 using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
 using Polly.Registry;
 using Microsoft.Extensions.DependencyInjection;
+using Paramore.Brighter.Core.Tests.TestHelpers;
 using Paramore.Brighter.Extensions.DependencyInjection;
 using Xunit;
 

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_There_Are_No_Command_Handlers_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_There_Are_No_Command_Handlers_Async.cs
@@ -28,6 +28,7 @@ using FluentAssertions;
 using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
 using Polly.Registry;
 using Microsoft.Extensions.DependencyInjection;
+using Paramore.Brighter.Core.Tests.TestHelpers;
 using Paramore.Brighter.Extensions.DependencyInjection;
 using Xunit;
 

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_There_Are_No_Subscribers_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_There_Are_No_Subscribers_Async.cs
@@ -27,6 +27,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
+using Paramore.Brighter.Core.Tests.TestHelpers;
 using Polly.Registry;
 using Xunit;
 

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_There_Is_No_Sync_Or_Async_Handler_Factories.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_There_Is_No_Sync_Or_Async_Handler_Factories.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
+using Paramore.Brighter.Core.Tests.TestHelpers;
 using Paramore.Brighter.Extensions.DependencyInjection;
 using Polly.Registry;
 using Xunit;

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_publishing_to_multiple_subscribers_should_aggregate_exceptions.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_publishing_to_multiple_subscribers_should_aggregate_exceptions.cs
@@ -28,6 +28,7 @@ using FluentAssertions;
 using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
 using Polly.Registry;
 using Microsoft.Extensions.DependencyInjection;
+using Paramore.Brighter.Core.Tests.TestHelpers;
 using Paramore.Brighter.Extensions.DependencyInjection;
 using Xunit;
 

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_there_are_multiple_possible_command_handlers.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_there_are_multiple_possible_command_handlers.cs
@@ -28,6 +28,7 @@ using FluentAssertions;
 using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
 using Polly.Registry;
 using Microsoft.Extensions.DependencyInjection;
+using Paramore.Brighter.Core.Tests.TestHelpers;
 using Paramore.Brighter.Extensions.DependencyInjection;
 using Xunit;
 

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_there_are_multiple_subscribers.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_there_are_multiple_subscribers.cs
@@ -28,6 +28,7 @@ using FluentAssertions;
 using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
 using Polly.Registry;
 using Microsoft.Extensions.DependencyInjection;
+using Paramore.Brighter.Core.Tests.TestHelpers;
 using Paramore.Brighter.Extensions.DependencyInjection;
 using Xunit;
 

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_there_are_no_command_handlers.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_there_are_no_command_handlers.cs
@@ -27,6 +27,7 @@ using FluentAssertions;
 using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
 using Polly.Registry;
 using Microsoft.Extensions.DependencyInjection;
+using Paramore.Brighter.Core.Tests.TestHelpers;
 using Paramore.Brighter.Extensions.DependencyInjection;
 using Xunit;
 

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_there_are_no_subscribers.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_there_are_no_subscribers.cs
@@ -26,6 +26,7 @@ using System;
 using System.Collections.Generic;
 using FluentAssertions;
 using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
+using Paramore.Brighter.Core.Tests.TestHelpers;
 using Polly.Registry;
 using Xunit;
 

--- a/tests/Paramore.Brighter.Core.Tests/Compression/When_a_message_compresses_a_large_payload.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Compression/When_a_message_compresses_a_large_payload.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.IO.Compression;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Paramore.Brighter.Core.Tests.TestHelpers;
+using Paramore.Brighter.Transforms.Transformers;
+using Xunit;
+
+namespace Paramore.Brighter.Core.Tests.Compression;
+
+public class CompressLargePayloadTests
+{
+    private readonly CompressPayloadTransformer _transformer;
+    private readonly string _body;
+    private readonly Message _message;
+    private const ushort GZIP_LEAD_BYTES = 0x8b1f;
+
+    public CompressLargePayloadTests()
+    {
+        _transformer = new CompressPayloadTransformer();
+        _transformer.InitializeWrapFromAttributeParams(CompressionMethod.GZip, CompressionLevel.Optimal, 5);
+        
+        _body = DataGenerator.CreateString(6000);
+        _message = new Message(
+            new MessageHeader(Guid.NewGuid(), "test_topic", MessageType.MT_EVENT, DateTime.UtcNow),
+            new MessageBody(_body));        
+    }
+
+    [Fact]
+    public async Task When_a_message_compresses_a_large_payload()
+    {
+        var compressedMessage = await _transformer.WrapAsync(_message);
+
+        //look for gzip in the bytes
+        compressedMessage.Body.Bytes.Should().NotBeNull();
+        compressedMessage.Body.Bytes.Length.Should().BeGreaterThanOrEqualTo(2);
+        compressedMessage.Body.BodyType.Should().Be("application/gzip");
+        BitConverter.ToUInt16(compressedMessage.Body.Bytes, 0).Should().Be(GZIP_LEAD_BYTES);
+
+    }
+}

--- a/tests/Paramore.Brighter.Core.Tests/Compression/When_a_message_is_not_compressed.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Compression/When_a_message_is_not_compressed.cs
@@ -1,19 +1,80 @@
-﻿using Xunit;
+﻿using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Paramore.Brighter.Transforms.Transformers;
+using Xunit;
 
 namespace Paramore.Brighter.Core.Tests.Compression;
 
 public class UncompressedPayloadTests
 {
- 
-
-    public UncompressedPayloadTests()
+    
+    [Fact]
+    public async Task When_a_message_is_not_gzip_compressed()
     {
         
+        //arrange
+        var transformer = new CompressPayloadTransformer();
+        transformer.InitializeUnwrapFromAttributeParams(CompressionMethod.GZip, "application/json");
+        
+        var smallContent = "small message";
+        string mimeType = "application/json";
+
+        var body = new MessageBody(smallContent, mimeType);
+        
+        var message = new Message(
+            new MessageHeader(Guid.NewGuid(), "test_topic", MessageType.MT_EVENT, DateTime.UtcNow),body);
+        
+        //act
+        var msg = await transformer.UnwrapAsync(message);
+        
+        //assert
+        msg.Body.Value.Should().Be(smallContent);
     }
     
     [Fact]
-    public void When_a_message_is_not_compressed()
+    public async Task When_a_message_is_not_zlib_compressed()
     {
-        //we should confirm that a payload is compressed before decompressing, as it might have fallen below the threshold
+        
+        //arrange
+        var transformer = new CompressPayloadTransformer();
+        transformer.InitializeUnwrapFromAttributeParams(CompressionMethod.Zlib, "application/json");
+        
+        var smallContent = "small message";
+        string mimeType = "application/json";
+
+        var body = new MessageBody(smallContent, mimeType);
+        
+        var message = new Message(
+            new MessageHeader(Guid.NewGuid(), "test_topic", MessageType.MT_EVENT, DateTime.UtcNow),body);
+        
+        //act
+        var msg = await transformer.UnwrapAsync(message);
+        
+        //assert
+        msg.Body.Value.Should().Be(smallContent);
+    }
+    
+    [Fact]
+    public async Task When_a_message_is_not_brotli_compressed()
+    {
+        
+        //arrange
+        var transformer = new CompressPayloadTransformer();
+        transformer.InitializeUnwrapFromAttributeParams(CompressionMethod.Brotli, "application/json");
+        
+        var smallContent = "small message";
+        string mimeType = "application/json";
+
+        var body = new MessageBody(smallContent, mimeType);
+        
+        var message = new Message(
+            new MessageHeader(Guid.NewGuid(), "test_topic", MessageType.MT_EVENT, DateTime.UtcNow),body);
+        
+        //act
+        var msg = await transformer.UnwrapAsync(message);
+        
+        //assert
+        msg.Body.Value.Should().Be(smallContent);
     }
 }

--- a/tests/Paramore.Brighter.Core.Tests/Compression/When_a_message_is_not_compressed.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Compression/When_a_message_is_not_compressed.cs
@@ -1,0 +1,19 @@
+﻿using Xunit;
+
+namespace Paramore.Brighter.Core.Tests.Compression;
+
+public class UncompressedPayloadTests
+{
+ 
+
+    public UncompressedPayloadTests()
+    {
+        
+    }
+    
+    [Fact]
+    public void When_a_message_is_not_compressed()
+    {
+        //we should confirm that a payload is compressed before decompressing, as it might have fallen below the threshold
+    }
+}

--- a/tests/Paramore.Brighter.Core.Tests/Compression/When_a_message_is_under_the_threshold.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Compression/When_a_message_is_under_the_threshold.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.IO.Compression;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Paramore.Brighter.Core.Tests.TestHelpers;
+using Paramore.Brighter.Transforms.Transformers;
+using Xunit;
+
+namespace Paramore.Brighter.Core.Tests.Compression;
+
+public class SmallPayloadNotCompressedTests
+{
+    private readonly CompressPayloadTransformer _transformer;
+    private readonly string _body;
+    private readonly Message _message;
+    private const ushort GZIP_LEAD_BYTES = 0x8b1f;
+    
+    
+    public SmallPayloadNotCompressedTests()
+    {
+        _transformer = new CompressPayloadTransformer();
+        _transformer.InitializeWrapFromAttributeParams(CompressionMethod.GZip, CompressionLevel.Optimal, 5);
+
+        _body = "small message";
+        _message = new Message(
+            new MessageHeader(Guid.NewGuid(), "test_topic", MessageType.MT_EVENT, DateTime.UtcNow),
+            new MessageBody(_body));      
+    }
+    
+    
+    [Fact]
+    public async Task When_a_message_is_under_the_threshold()
+    {
+        var uncompressedMessage = await _transformer.WrapAsync(_message);
+
+        //look for gzip in the bytes
+        uncompressedMessage.Body.BodyType.Should().Be("application/json");
+        uncompressedMessage.Body.Value.Should().Be(_message.Body.Value);
+    }
+}

--- a/tests/Paramore.Brighter.Core.Tests/Compression/When_decompressing_a_large_payload_in_a_message.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Compression/When_decompressing_a_large_payload_in_a_message.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.IO;
+using System.IO.Compression;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Paramore.Brighter.Core.Tests.TestHelpers;
+using Paramore.Brighter.Transforms.Transformers;
+using Xunit;
+
+namespace Paramore.Brighter.Core.Tests.Compression;
+
+public class UncompressLargePayloadTests
+{
+    [Fact]
+    public async Task When_decompressing_a_large_payload_in_a_message()
+    {
+        //arrange
+        var transformer = new CompressPayloadTransformer();
+        transformer.InitializeUnwrapFromAttributeParams(CompressionMethod.GZip, "application/json");
+        
+        var largeContent = DataGenerator.CreateString(6000);
+        
+        using var input = new MemoryStream(Encoding.ASCII.GetBytes(largeContent));
+        using var output = new MemoryStream();
+
+        Stream compressionStream = new GZipStream(output, CompressionLevel.Optimal);
+            
+        string mimeType = "application/gzip";
+        await input.CopyToAsync(compressionStream);
+        await compressionStream.FlushAsync();
+
+        var body = new MessageBody(output.ToArray(), mimeType);
+        
+        var message = new Message(
+            new MessageHeader(Guid.NewGuid(), "test_topic", MessageType.MT_EVENT, DateTime.UtcNow),body);
+        
+        //act
+        var msg = await transformer.UnwrapAsync(message);
+        
+        //assert
+        msg.Body.Value.Should().Be(largeContent);
+
+    }
+}

--- a/tests/Paramore.Brighter.Core.Tests/ControlBus/When_we_build_a_control_bus_we_can_send_configuration_messages_to_it.cs
+++ b/tests/Paramore.Brighter.Core.Tests/ControlBus/When_we_build_a_control_bus_we_can_send_configuration_messages_to_it.cs
@@ -25,6 +25,7 @@ THE SOFTWARE. */
 using System;
 using FakeItEasy;
 using FluentAssertions;
+using Paramore.Brighter.Core.Tests.TestHelpers;
 using Xunit;
 using Paramore.Brighter.ServiceActivator;
 using Paramore.Brighter.ServiceActivator.ControlBus;

--- a/tests/Paramore.Brighter.Core.Tests/ExceptionPolicy/When_A_Fallback_Is_Broken_Ciruit_Only.cs
+++ b/tests/Paramore.Brighter.Core.Tests/ExceptionPolicy/When_A_Fallback_Is_Broken_Ciruit_Only.cs
@@ -30,6 +30,7 @@ using Xunit;
 using Paramore.Brighter.Policies.Handlers;
 using Polly.Registry;
 using Microsoft.Extensions.DependencyInjection;
+using Paramore.Brighter.Core.Tests.TestHelpers;
 using Paramore.Brighter.Extensions.DependencyInjection;
 
 namespace Paramore.Brighter.Core.Tests.ExceptionPolicy

--- a/tests/Paramore.Brighter.Core.Tests/ExceptionPolicy/When_Sending_A_Command_And_The_Policy_Is_Not_In_The_Registry.cs
+++ b/tests/Paramore.Brighter.Core.Tests/ExceptionPolicy/When_Sending_A_Command_And_The_Policy_Is_Not_In_The_Registry.cs
@@ -31,6 +31,7 @@ using Xunit;
 using Paramore.Brighter.Policies.Handlers;
 using Polly.Registry;
 using Microsoft.Extensions.DependencyInjection;
+using Paramore.Brighter.Core.Tests.TestHelpers;
 using Paramore.Brighter.Extensions.DependencyInjection;
 
 namespace Paramore.Brighter.Core.Tests.ExceptionPolicy

--- a/tests/Paramore.Brighter.Core.Tests/ExceptionPolicy/When_Sending_A_Command_And_The_Policy_Is_Not_In_The_Registry_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/ExceptionPolicy/When_Sending_A_Command_And_The_Policy_Is_Not_In_The_Registry_Async.cs
@@ -32,6 +32,7 @@ using Xunit;
 using Paramore.Brighter.Policies.Handlers;
 using Polly.Registry;
 using Microsoft.Extensions.DependencyInjection;
+using Paramore.Brighter.Core.Tests.TestHelpers;
 using Paramore.Brighter.Extensions.DependencyInjection;
 
 namespace Paramore.Brighter.Core.Tests.ExceptionPolicy

--- a/tests/Paramore.Brighter.Core.Tests/ExceptionPolicy/When_Sending_A_Command_That_Repeatedely_Fails_Break_The_Circuit.cs
+++ b/tests/Paramore.Brighter.Core.Tests/ExceptionPolicy/When_Sending_A_Command_That_Repeatedely_Fails_Break_The_Circuit.cs
@@ -32,6 +32,7 @@ using Polly;
 using Polly.CircuitBreaker;
 using Polly.Registry;
 using Microsoft.Extensions.DependencyInjection;
+using Paramore.Brighter.Core.Tests.TestHelpers;
 using Paramore.Brighter.Extensions.DependencyInjection;
 
 namespace Paramore.Brighter.Core.Tests.ExceptionPolicy

--- a/tests/Paramore.Brighter.Core.Tests/ExceptionPolicy/When_Sending_A_Command_That_Repeatedely_Fails_Break_The_Circuit_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/ExceptionPolicy/When_Sending_A_Command_That_Repeatedely_Fails_Break_The_Circuit_Async.cs
@@ -33,6 +33,7 @@ using Polly;
 using Polly.CircuitBreaker;
 using Polly.Registry;
 using Microsoft.Extensions.DependencyInjection;
+using Paramore.Brighter.Core.Tests.TestHelpers;
 using Paramore.Brighter.Extensions.DependencyInjection;
 
 namespace Paramore.Brighter.Core.Tests.ExceptionPolicy

--- a/tests/Paramore.Brighter.Core.Tests/ExceptionPolicy/When_Sending_A_Command_That_Should_Retry_Failure.cs
+++ b/tests/Paramore.Brighter.Core.Tests/ExceptionPolicy/When_Sending_A_Command_That_Should_Retry_Failure.cs
@@ -32,6 +32,7 @@ using Paramore.Brighter.Policies.Handlers;
 using Polly;
 using Polly.Registry;
 using Microsoft.Extensions.DependencyInjection;
+using Paramore.Brighter.Core.Tests.TestHelpers;
 using Paramore.Brighter.Extensions.DependencyInjection;
 
 namespace Paramore.Brighter.Core.Tests.ExceptionPolicy

--- a/tests/Paramore.Brighter.Core.Tests/ExceptionPolicy/When_Sending_A_Command_That_Should_Retry_Failure_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/ExceptionPolicy/When_Sending_A_Command_That_Should_Retry_Failure_Async.cs
@@ -9,6 +9,7 @@ using Paramore.Brighter.Policies.Handlers;
 using Polly;
 using Polly.Registry;
 using Microsoft.Extensions.DependencyInjection;
+using Paramore.Brighter.Core.Tests.TestHelpers;
 using Paramore.Brighter.Extensions.DependencyInjection;
 
 namespace Paramore.Brighter.Core.Tests.ExceptionPolicy

--- a/tests/Paramore.Brighter.Core.Tests/FeatureSwitch/When_A_Handler_Is_Feature_Switch_Missing_Config_Exception.cs
+++ b/tests/Paramore.Brighter.Core.Tests/FeatureSwitch/When_A_Handler_Is_Feature_Switch_Missing_Config_Exception.cs
@@ -28,6 +28,7 @@ using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
 using Paramore.Brighter.Core.Tests.FeatureSwitch.TestDoubles;
 using Paramore.Brighter.FeatureSwitch;
 using Microsoft.Extensions.DependencyInjection;
+using Paramore.Brighter.Core.Tests.TestHelpers;
 using Paramore.Brighter.Extensions.DependencyInjection;
 using Xunit;
 using Paramore.Brighter.FeatureSwitch.Handlers;

--- a/tests/Paramore.Brighter.Core.Tests/MessageSerialisation/When_Creating_A_Pipeline_Builder_Without_A_Registry.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageSerialisation/When_Creating_A_Pipeline_Builder_Without_A_Registry.cs
@@ -1,5 +1,6 @@
 ﻿using FluentAssertions;
 using Paramore.Brighter.Core.Tests.MessageSerialisation.Test_Doubles;
+using Paramore.Brighter.Core.Tests.TestHelpers;
 using Xunit;
 
 namespace Paramore.Brighter.Core.Tests.MessageSerialisation;

--- a/tests/Paramore.Brighter.Core.Tests/MessageSerialisation/When_Unwrapping_A_Message_Mapper_But_Not_In_Transform_Factory.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageSerialisation/When_Unwrapping_A_Message_Mapper_But_Not_In_Transform_Factory.cs
@@ -2,6 +2,7 @@
 using System.Text.Json;
 using FluentAssertions;
 using Paramore.Brighter.Core.Tests.MessageSerialisation.Test_Doubles;
+using Paramore.Brighter.Core.Tests.TestHelpers;
 using Xunit;
 
 namespace Paramore.Brighter.Core.Tests.MessageSerialisation;

--- a/tests/Paramore.Brighter.Core.Tests/MessageSerialisation/When_Unwrapping_But_No_Registered_Mapper.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageSerialisation/When_Unwrapping_But_No_Registered_Mapper.cs
@@ -2,6 +2,7 @@
 using System.Text.Json;
 using FluentAssertions;
 using Paramore.Brighter.Core.Tests.MessageSerialisation.Test_Doubles;
+using Paramore.Brighter.Core.Tests.TestHelpers;
 using Xunit;
 
 namespace Paramore.Brighter.Core.Tests.MessageSerialisation;

--- a/tests/Paramore.Brighter.Core.Tests/MessageSerialisation/When_Wrapping_A_Message_Mapper_But_Not_In_Transform_Factory.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageSerialisation/When_Wrapping_A_Message_Mapper_But_Not_In_Transform_Factory.cs
@@ -1,5 +1,6 @@
 ﻿using FluentAssertions;
 using Paramore.Brighter.Core.Tests.MessageSerialisation.Test_Doubles;
+using Paramore.Brighter.Core.Tests.TestHelpers;
 using Xunit;
 
 namespace Paramore.Brighter.Core.Tests.MessageSerialisation;

--- a/tests/Paramore.Brighter.Core.Tests/MessageSerialisation/When_Wrapping_But_No_Registered_Mapper.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageSerialisation/When_Wrapping_But_No_Registered_Mapper.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using FluentAssertions;
 using Paramore.Brighter.Core.Tests.MessageSerialisation.Test_Doubles;
+using Paramore.Brighter.Core.Tests.TestHelpers;
 using Xunit;
 
 namespace Paramore.Brighter.Core.Tests.MessageSerialisation;

--- a/tests/Paramore.Brighter.Core.Tests/Monitoring/When_Monitoring_We_Should_Record_But_Rethrow_Exceptions_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Monitoring/When_Monitoring_We_Should_Record_But_Rethrow_Exceptions_Async.cs
@@ -36,6 +36,7 @@ using Polly.Registry;
 using Microsoft.Extensions.DependencyInjection;
 using Paramore.Brighter.Extensions.DependencyInjection;
 using System.Text.Json;
+using Paramore.Brighter.Core.Tests.TestHelpers;
 
 namespace Paramore.Brighter.Core.Tests.Monitoring
 {

--- a/tests/Paramore.Brighter.Core.Tests/Monitoring/When_monitoring_we_should_record_but_rethrow_exceptions.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Monitoring/When_monitoring_we_should_record_but_rethrow_exceptions.cs
@@ -32,6 +32,7 @@ using Paramore.Brighter.Monitoring.Events;
 using Paramore.Brighter.Monitoring.Handlers;
 using Polly.Registry;
 using Microsoft.Extensions.DependencyInjection;
+using Paramore.Brighter.Core.Tests.TestHelpers;
 using Paramore.Brighter.Extensions.DependencyInjection;
 using Xunit;
 

--- a/tests/Paramore.Brighter.Core.Tests/OnceOnly/When_Handling_A_Command_With_A_Inbox_Enabled_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/OnceOnly/When_Handling_A_Command_With_A_Inbox_Enabled_Async.cs
@@ -5,6 +5,7 @@ using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
 using Paramore.Brighter.Core.Tests.OnceOnly.TestDoubles;
 using Polly.Registry;
 using Microsoft.Extensions.DependencyInjection;
+using Paramore.Brighter.Core.Tests.TestHelpers;
 using Paramore.Brighter.Extensions.DependencyInjection;
 using Xunit;
 using Paramore.Brighter.Inbox.Handlers;

--- a/tests/Paramore.Brighter.Core.Tests/TestHelpers/Catch.cs
+++ b/tests/Paramore.Brighter.Core.Tests/TestHelpers/Catch.cs
@@ -27,7 +27,7 @@ using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
 
-namespace Paramore.Brighter.Core.Tests
+namespace Paramore.Brighter.Core.Tests.TestHelpers
 {
     [DebuggerStepThrough]
     public static class Catch

--- a/tests/Paramore.Brighter.Core.Tests/TestHelpers/DataGenerator.cs
+++ b/tests/Paramore.Brighter.Core.Tests/TestHelpers/DataGenerator.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Linq;
 
-namespace Paramore.Brighter.Core.Tests.Claims;
+namespace Paramore.Brighter.Core.Tests.TestHelpers;
 
 public static class DataGenerator
 {

--- a/tests/Paramore.Brighter.Core.Tests/Timeout/When_sending_a_command_to_the_processor_failing_a_timeout_policy_check.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Timeout/When_sending_a_command_to_the_processor_failing_a_timeout_policy_check.cs
@@ -30,6 +30,7 @@ using Paramore.Brighter.Core.Tests.Timeout.Test_Doubles;
 using Xunit;
 using Polly.Registry;
 using Microsoft.Extensions.DependencyInjection;
+using Paramore.Brighter.Core.Tests.TestHelpers;
 using Paramore.Brighter.Extensions.DependencyInjection;
 using Paramore.Brighter.Policies.Handlers;
 


### PR DESCRIPTION
This transform allows you to compress the message body, and to decompress it.

Typically this is a good first step before external storage, and it is worth noting that both this and Claim Check can be used together by ordering the steps so that we first attempt to Compress and only if it is still over our threshold store in the luggage store.