### PR TITLE
Missing Dependencies for Built In Types break with validation

### DIFF
--- a/samples/HelloWorld/Properties/launchSettings.json
+++ b/samples/HelloWorld/Properties/launchSettings.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "Development": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/samples/HelloWorldAsync/Properties/launchSettings.json
+++ b/samples/HelloWorldAsync/Properties/launchSettings.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "Development": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/Paramore.Brighter/Transforms/Storage/NullLuggageStore.cs
+++ b/src/Paramore.Brighter/Transforms/Storage/NullLuggageStore.cs
@@ -1,0 +1,29 @@
+﻿using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Paramore.Brighter.Transforms.Storage
+{
+    public class NullLuggageStore : IAmAStorageProviderAsync
+    {
+        public Task DeleteAsync(string claimCheck, CancellationToken cancellationToken)
+        {
+            throw new System.NotImplementedException("This is a null store, you must register a real store after Brighter");
+        }
+
+        public Task<Stream> RetrieveAsync(string claimCheck, CancellationToken cancellationToken)
+        {
+            throw new System.NotImplementedException("This is a null store, you must register a real store after Brighter");
+        }
+
+        public Task<bool> HasClaimAsync(string claimCheck, CancellationToken cancellationToken)
+        {
+            throw new System.NotImplementedException("This is a null store, you must register a real store after Brighter");
+        }
+
+        public Task<string> StoreAsync(Stream stream, CancellationToken cancellationToken)
+        {
+            throw new System.NotImplementedException("This is a null store, you must register a real store after Brighter");
+        }
+    }
+}

--- a/src/Paramore.Brighter/Transforms/Transformers/ClaimCheckTransformer.cs
+++ b/src/Paramore.Brighter/Transforms/Transformers/ClaimCheckTransformer.cs
@@ -50,6 +50,18 @@ namespace Paramore.Brighter.Transforms.Transformers
             _store = store;
         }
 
+        /// <summary>
+        /// NOTE: Default constructor is not intended for usage, but is required for the service activator to not throw an exception
+        /// due to missing dependencies when auto-registration registers this transformer but you do not use the claim check
+        /// functionality
+        /// If you forget to register your storage provider, you will get a not implemented exception when you try to use the
+        /// claim check functionality
+        /// </summary>
+        public ClaimCheckTransformer()
+        {
+            _store = new NullLuggageStore();
+        }
+
         public void Dispose()
         {
         }

--- a/tests/Paramore.Brighter.Extensions.Tests/AssemblyResolutionMissingDependenciesTests.cs
+++ b/tests/Paramore.Brighter.Extensions.Tests/AssemblyResolutionMissingDependenciesTests.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Paramore.Brighter.ServiceActivator.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Paramore.Brighter.Extensions.Tests;
+
+public class AssemblyResolutionMissingDependenciesTests
+{
+    [Fact]
+    public void When_we_auto_register_handlers_from_assemblies_with_missing_dependencies()
+    {
+        //arrange
+        var factory =
+            new DefaultServiceProviderFactory(new ServiceProviderOptions
+            {
+                ValidateOnBuild = true, ValidateScopes = true
+            });
+
+        var services = new ServiceCollection();
+
+        services.AddServiceActivator().AutoFromAssemblies();
+        
+        //act
+        var provider = factory.CreateServiceProvider(services);
+        
+        //assert
+        //we will not get here, if we have a missing dependency
+        Assert.True(true);
+        
+    }
+}


### PR DESCRIPTION
This PR addresses #2514 where when the ServiceCollection is validated when it is built (the DefaultServiceProviderFactory call to CreateServiceProvider when your options have been set to validate) and we have missing dependencies for built-in types that we have registered.

This is valuable behaviour but not for built in types that you are not using.
