### PR TITLE
Only One Instance of UsePolicy and Fallback Decorators; Support Multiple Policies

### DIFF
--- a/samples/WebAPI_Dynamo/GreetingsEntities/GreetingsEntities.csproj
+++ b/samples/WebAPI_Dynamo/GreetingsEntities/GreetingsEntities.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.102.13" />
+      <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.102.14" />
     </ItemGroup>
 
 </Project>

--- a/samples/WebAPI_Dynamo/SalutationEntities/SalutationEntities.csproj
+++ b/samples/WebAPI_Dynamo/SalutationEntities/SalutationEntities.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.102.13" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.102.14" />
   </ItemGroup>
 
 </Project>

--- a/src/Paramore.Brighter.DynamoDb/Paramore.Brighter.DynamoDb.csproj
+++ b/src/Paramore.Brighter.DynamoDb/Paramore.Brighter.DynamoDb.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.102.13" />
+      <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.102.14" />
       <PackageReference Update="MinVer" Version="4.3.0">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Paramore.Brighter.Inbox.DynamoDB/Paramore.Brighter.Inbox.DynamoDB.csproj
+++ b/src/Paramore.Brighter.Inbox.DynamoDB/Paramore.Brighter.Inbox.DynamoDB.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.102.13" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.102.14" />
     <PackageReference Update="MinVer" Version="4.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS/Paramore.Brighter.MessagingGateway.AWSSQS.csproj
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS/Paramore.Brighter.MessagingGateway.AWSSQS.csproj
@@ -9,11 +9,11 @@
     <ProjectReference Include="..\Paramore.Brighter\Paramore.Brighter.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.101.34" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.101.35" />
     <PackageReference Include="Polly" Version="7.2.3" />
     <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.101.35" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.7.100.99" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.101.36" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.7.100.100" />
     <PackageReference Update="MinVer" Version="4.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Paramore.Brighter.MessagingGateway.Redis/RedisMessageConsumer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.Redis/RedisMessageConsumer.cs
@@ -107,7 +107,7 @@ namespace Paramore.Brighter.MessagingGateway.Redis
         /// <returns>The message read from the list</returns>
         public Message[] Receive(int timeoutInMilliseconds)
         {
-            s_logger.LogDebug("RedisMessageConsumer: Preparing to retrieve next message from queue {ChannelName} with routing key {Topic} via exchange {ExchangeName} on subscription {3}", _queueName, Topic);
+            s_logger.LogDebug("RedisMessageConsumer: Preparing to retrieve next message from queue {ChannelName} with routing key {Topic}", _queueName, Topic);
 
             if (_inflight.Any())
             {
@@ -215,7 +215,7 @@ namespace Paramore.Brighter.MessagingGateway.Redis
                 msg = client.GetValue(key);
                 s_logger.LogInformation(
                     "Redis: Received message from queue {ChannelName} with routing key {Topic}, message: {Request}",
-                    _queueName, Topic, JsonSerializer.Serialize(msg, JsonSerialisationOptions.Options), Environment.NewLine);
+                    _queueName, Topic, JsonSerializer.Serialize(msg, JsonSerialisationOptions.Options));
             }
             else
             {

--- a/src/Paramore.Brighter.MsSql.Dapper/Paramore.Brighter.MsSql.Dapper.csproj
+++ b/src/Paramore.Brighter.MsSql.Dapper/Paramore.Brighter.MsSql.Dapper.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.1" />
     <PackageReference Update="MinVer" Version="4.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Paramore.Brighter.MsSql/Paramore.Brighter.MsSql.csproj
+++ b/src/Paramore.Brighter.MsSql/Paramore.Brighter.MsSql.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.0" />
+      <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.1" />
       <PackageReference Update="MinVer" Version="4.3.0">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Paramore.Brighter.Outbox.DynamoDB/Paramore.Brighter.Outbox.DynamoDB.csproj
+++ b/src/Paramore.Brighter.Outbox.DynamoDB/Paramore.Brighter.Outbox.DynamoDB.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.102.13" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.102.14" />
     <PackageReference Update="MinVer" Version="4.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Paramore.Brighter.Tranformers.AWS/Paramore.Brighter.Tranformers.AWS.csproj
+++ b/src/Paramore.Brighter.Tranformers.AWS/Paramore.Brighter.Tranformers.AWS.csproj
@@ -18,8 +18,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.103.36" />
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.101.34" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.103.37" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.101.35" />
     <PackageReference Include="Polly" Version="7.2.3" />
     <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
   </ItemGroup>

--- a/src/Paramore.Brighter/Policies/Attributes/FallbackPolicyAsyncAttribute.cs
+++ b/src/Paramore.Brighter/Policies/Attributes/FallbackPolicyAsyncAttribute.cs
@@ -30,7 +30,7 @@ namespace Paramore.Brighter.Policies.Attributes
     /// <summary>
     /// Class FallbackPolicyAttribute.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    [AttributeUsage(AttributeTargets.Method)]
     public class FallbackPolicyAsyncAttribute : RequestHandlerAttribute
     {
         private readonly bool _backstop;

--- a/src/Paramore.Brighter/Policies/Attributes/FallbackPolicyAttribute.cs
+++ b/src/Paramore.Brighter/Policies/Attributes/FallbackPolicyAttribute.cs
@@ -30,7 +30,7 @@ namespace Paramore.Brighter.Policies.Attributes
     /// <summary>
     /// Class FallbackPolicyAttribute.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    [AttributeUsage(AttributeTargets.Method)]
     public class FallbackPolicyAttribute : RequestHandlerAttribute
     {
         readonly bool _backstop;

--- a/src/Paramore.Brighter/Policies/Attributes/UsePolicyAsyncAttribute.cs
+++ b/src/Paramore.Brighter/Policies/Attributes/UsePolicyAsyncAttribute.cs
@@ -35,7 +35,7 @@ namespace Paramore.Brighter.Policies.Attributes
     /// assumed that you have registered required policies with a Policy Registry such as <see cref="PolicyRegistry" /> and configured that as a
     /// dependency of the <see cref="CommandProcessor" /> using the <see cref="CommandProcessorBuilder" />
     /// </summary>
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    [AttributeUsage(AttributeTargets.Method)]
     public class UsePolicyAsyncAttribute : RequestHandlerAttribute
     {
         private readonly string _policy;

--- a/src/Paramore.Brighter/Policies/Attributes/UsePolicyAtttribute.cs
+++ b/src/Paramore.Brighter/Policies/Attributes/UsePolicyAtttribute.cs
@@ -23,7 +23,10 @@ THE SOFTWARE. */
 #endregion
 
 using System;
+using System.Collections.Generic;
+using Paramore.Brighter.Extensions;
 using Paramore.Brighter.Policies.Handlers;
+using Polly.Registry;
 
 namespace Paramore.Brighter.Policies.Attributes
 {
@@ -35,10 +38,10 @@ namespace Paramore.Brighter.Policies.Attributes
     /// assumed that you have registered required policies with a Policy Registry such as <see cref="PolicyRegistry"/> and configured that as a 
     /// dependency of the <see cref="CommandProcessor"/> using the <see cref="CommandProcessorBuilder"/>
     /// </summary>
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    [AttributeUsage(AttributeTargets.Method)]
     public class UsePolicyAttribute : RequestHandlerAttribute
     {
-        private readonly string _policy;
+        private readonly List<string> _policies = new List<string>();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="UsePolicyAttribute"/> class.
@@ -47,7 +50,17 @@ namespace Paramore.Brighter.Policies.Attributes
         /// <param name="step">The step.</param>
         public UsePolicyAttribute(string policy, int step) : base(step, HandlerTiming.Before)
         {
-            _policy = policy;
+            _policies.Add(policy);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UsePolicyAttribute"/> class.
+        /// </summary>
+        /// <param name="policies">A list of policies, The policies wrap each other and our evaluated left to right</param>
+        /// <param name="step">The step.</param>
+        public UsePolicyAttribute(string[] policies, int step) : base(step, HandlerTiming.Before)
+        {
+            policies.Each(p => _policies.Add(p));
         }
 
         /// <summary>
@@ -56,7 +69,7 @@ namespace Paramore.Brighter.Policies.Attributes
         /// <returns>System.Object[].</returns>
         public override object[] InitializerParams()
         {
-            return new object[] { _policy };
+            return new object[] { _policies };
         }
 
         /// <summary>

--- a/tests/Paramore.Brighter.Core.Tests/ExceptionPolicy/TestDoubles/MyDoesNotFailMultiplePoliciesHandler.cs
+++ b/tests/Paramore.Brighter.Core.Tests/ExceptionPolicy/TestDoubles/MyDoesNotFailMultiplePoliciesHandler.cs
@@ -1,0 +1,51 @@
+#region Licence
+/* The MIT License (MIT)
+Copyright © 2014 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
+using Paramore.Brighter.Policies.Attributes;
+
+namespace Paramore.Brighter.Core.Tests.ExceptionPolicy.TestDoubles
+{
+    internal class MyDoesNotFailMultiplePoliciesHandler : RequestHandler<MyCommand>
+    {
+        public static bool ReceivedCommand { get; set; }
+
+        static MyDoesNotFailMultiplePoliciesHandler()
+        {
+            ReceivedCommand = false;
+        }
+
+        [UsePolicy(new[] {"MyDivideByZeroRetryPolicy", "MyDivideByZeroBreakerPolicy"}, 1)]
+        public override MyCommand Handle(MyCommand command)
+        {
+            ReceivedCommand = true;
+            return base.Handle(command);
+        }
+
+        public static bool Shouldreceive(MyCommand myCommand)
+        {
+            return ReceivedCommand;
+        }
+    }
+}

--- a/tests/Paramore.Brighter.Core.Tests/ExceptionPolicy/When_Sending_A_Command_That_Passes_Multiple_Policy_Checks.cs
+++ b/tests/Paramore.Brighter.Core.Tests/ExceptionPolicy/When_Sending_A_Command_That_Passes_Multiple_Policy_Checks.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using FluentAssertions;
+using FluentAssertions.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
+using Paramore.Brighter.Core.Tests.ExceptionPolicy.TestDoubles;
+using Paramore.Brighter.Extensions.DependencyInjection;
+using Paramore.Brighter.Policies.Handlers;
+using Polly;
+using Polly.Registry;
+using Xunit;
+
+namespace Paramore.Brighter.Core.Tests;
+
+public class CommandProcessorWithMultipleExceptionPoliciesNothingThrowTests : IDisposable
+{
+    private readonly CommandProcessor _commandProcessor;
+    private readonly MyCommand _myCommand = new MyCommand();
+    private int _retryCount;
+
+    public CommandProcessorWithMultipleExceptionPoliciesNothingThrowTests()
+    {
+        var registry = new SubscriberRegistry();
+        registry.Register<MyCommand, MyDoesNotFailMultiplePoliciesHandler>();
+
+        var container = new ServiceCollection();
+        container.AddTransient<MyDoesNotFailMultiplePoliciesHandler>();
+        container.AddTransient<ExceptionPolicyHandler<MyCommand>>();
+        container.AddSingleton<IBrighterOptions>(new BrighterOptions() {HandlerLifetime = ServiceLifetime.Transient});
+
+
+        var handlerFactory = new ServiceProviderHandlerFactory(container.BuildServiceProvider());
+            
+        var policyRegistry = new PolicyRegistry();
+
+        var retryPolicy = Policy
+            .Handle<DivideByZeroException>()
+            .WaitAndRetry(new[]
+            {
+                1.Seconds(),
+                2.Seconds(),
+                3.Seconds()
+            }, (exception, timeSpan) =>
+            {
+                _retryCount++;
+            });
+
+        var breakerPolicy = Policy.Handle<DivideByZeroException>()
+            .CircuitBreaker(1, TimeSpan.FromMilliseconds(500));
+
+        policyRegistry.Add("MyDivideByZeroRetryPolicy", retryPolicy);
+        policyRegistry.Add("MyDivideByZeroBreakerPolicy", breakerPolicy);
+
+        MyDoesNotFailMultiplePoliciesHandler.ReceivedCommand = false;
+
+        _commandProcessor = new CommandProcessor(registry, handlerFactory, new InMemoryRequestContextFactory(), policyRegistry);        
+
+    }
+    
+    [Fact]
+    public void When_Sending_A_Command_That_Passes_Multiple_Policy_Checks()
+    {
+        _commandProcessor.Send(_myCommand);
+
+        //_should_send_the_command_to_the_command_handler
+        MyDoesNotFailMultiplePoliciesHandler.Shouldreceive(_myCommand).Should().BeTrue();
+        //_should_not_retry
+        _retryCount.Should().Be(0); 
+    }
+
+    public void Dispose()
+    {
+        CommandProcessor.ClearExtServiceBus();
+    }
+}


### PR DESCRIPTION
We made the attributes UsePolicy and FallbackPolicy (along with their async versions) support multiple instances, to allow you to wrap one policy in another. As noted in #2562 this causes an issue if the handler is not transient as we will be returned the same instance by most factories (including our own default one). When that happens, the code to set up the linked list used in tracing will create a loop that causes a stack overflow.

Polly now supports PolicyWrap to enable the combination of policies, wrapping one inside another.

So to resolve the bug we have both removed the AllowMultiple on these attributes and supported passing multiple policies into UsePolicy (which are evaluated left-to-right as per Polly convention).

This removes the bug and simplifies usage of multiple policies