### PR TITLE
Fix for Dockerfile smell DL3008

### DIFF
--- a/Docker/RabbitMQ/Dockerfile
+++ b/Docker/RabbitMQ/Dockerfile
@@ -2,7 +2,7 @@ FROM rabbitmq:3-management
 
 RUN apt-get update
 
-RUN apt-get install -y curl && apt-get install -y zip
+RUN apt-get install -y curl=7.68.* && apt-get install -y zip=3.0-*
 
 RUN curl -O https://dl.bintray.com/rabbitmq/community-plugins/3.8.x/rabbitmq_delayed_message_exchange/rabbitmq_delayed_message_exchange-20191008-3.8.x.zip\
 && unzip rabbitmq_delayed_message_exchange-20191008-3.8.x.zip -d $RABBITMQ_HOME/plugins \


### PR DESCRIPTION
Hi!
The Dockerfile placed at "Docker/RabbitMQ/Dockerfile" contains the best practice violation [DL3008](https://github.com/hadolint/hadolint/wiki/DL3008) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL3008 occurs when the version pinning for the installed packages with apt is not specified. This could lead to unexpected behavior when building the Dockerfile.
In this pull request, we propose a fix for that smell generated by our fixing tool. We have verified that the patch is correct before opening the pull request.
To fix this smell, specifically, we use a heuristic approach that selects the most probable version tag for a given apt package corresponding to the latest version at the current date. The package versions are retrieved using the Canonical Launchpad APIs.

This change is only aimed at fixing that specific smell. If the fix is not valid or useful, please briefly indicate the reason and suggestions for possible improvements.

Thanks in advance