### PR TITLE
Support multiple policy async

### DIFF
--- a/src/Paramore.Brighter/Policies/Attributes/UsePolicyAsyncAttribute.cs
+++ b/src/Paramore.Brighter/Policies/Attributes/UsePolicyAsyncAttribute.cs
@@ -23,7 +23,10 @@ THE SOFTWARE. */
 #endregion
 
 using System;
+using System.Collections.Generic;
+using Paramore.Brighter.Extensions;
 using Paramore.Brighter.Policies.Handlers;
+using Polly.Registry;
 
 namespace Paramore.Brighter.Policies.Attributes
 {
@@ -38,7 +41,7 @@ namespace Paramore.Brighter.Policies.Attributes
     [AttributeUsage(AttributeTargets.Method)]
     public class UsePolicyAsyncAttribute : RequestHandlerAttribute
     {
-        private readonly string _policy;
+        private readonly List<string> _policies = new List<string>();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="UsePolicyAsyncAttribute" /> class.
@@ -47,7 +50,17 @@ namespace Paramore.Brighter.Policies.Attributes
         /// <param name="step">The step.</param>
         public UsePolicyAsyncAttribute(string policy, int step) : base(step, HandlerTiming.Before)
         {
-            _policy = policy;
+            _policies.Add(policy);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UsePolicyAsyncAttribute" /> class.
+        /// </summary>
+        /// <param name="policies">A set of policy keys, used as a lookup into an <see cref="IAmAPolicyRegistry" />.</param>
+        /// <param name="step">The step</param>
+        public UsePolicyAsyncAttribute(string[] policies, int step) : base(step, HandlerTiming.Before)
+        {
+            policies.Each(p => _policies.Add(p));
         }
 
         /// <summary>
@@ -56,7 +69,7 @@ namespace Paramore.Brighter.Policies.Attributes
         /// <returns>System.Object[].</returns>
         public override object[] InitializerParams()
         {
-            return new object[] { _policy};
+            return new object[] { _policies};
         }
 
         /// <summary>

--- a/src/Paramore.Brighter/Policies/Handlers/ExceptionPolicyHandlerAsync.cs
+++ b/src/Paramore.Brighter/Policies/Handlers/ExceptionPolicyHandlerAsync.cs
@@ -22,10 +22,13 @@ THE SOFTWARE. */
 
 #endregion
 
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Paramore.Brighter.Extensions;
 using Paramore.Brighter.Policies.Attributes;
 using Polly;
+using Polly.Registry;
 
 namespace Paramore.Brighter.Policies.Handlers
 {
@@ -42,8 +45,8 @@ namespace Paramore.Brighter.Policies.Handlers
     /// <typeparam name="TRequest">The type of the t request.</typeparam>
     public class ExceptionPolicyHandlerAsync<TRequest> : RequestHandlerAsync<TRequest> where TRequest : class, IRequest
     {
-        private AsyncPolicy _policy;
-
+         private bool _initialized = false;
+        private List<AsyncPolicy> _policies = new List<AsyncPolicy>();
         /// <summary>
         /// Initializes from attribute parameters. This will get the <see cref="IAmAPolicyRegistry" /> from the <see cref="IRequestContext" /> and query it for the
         /// policy identified in <see cref="UsePolicyAttribute" />
@@ -54,7 +57,9 @@ namespace Paramore.Brighter.Policies.Handlers
         {
             //we expect the first and only parameter to be a string
             var policyName = (string)initializerList[0];
-            _policy = Context.Policies.Get<AsyncPolicy>(policyName);
+            var policies = (List<string>)initializerList[0];
+            policies.Each(p => _policies.Add(Context.Policies.Get<AsyncPolicy>(p)));
+            _initialized = true;
         }
 
         /// <summary>
@@ -65,7 +70,23 @@ namespace Paramore.Brighter.Policies.Handlers
         /// <returns>AA Task<TRequest> that wraps the asynchronous call to the policy, which itself wraps the handler chain</TRequest></returns>
         public override async Task<TRequest> HandleAsync(TRequest command, CancellationToken cancellationToken = default)
         {
-            return await _policy.ExecuteAsync(async () => await base.HandleAsync(command, cancellationToken)).ConfigureAwait(ContinueOnCapturedContext);
+            if (_policies.Count == 1)
+            {
+                return await _policies[0].ExecuteAsync(async () => await base.HandleAsync(command, cancellationToken))
+                    .ConfigureAwait(ContinueOnCapturedContext);
+            }
+            else
+            {
+                var policyWrap = _policies[0].WrapAsync(_policies[1]);
+                if (_policies.Count <= 2) return await policyWrap.ExecuteAsync(async () => await base.HandleAsync(command, cancellationToken));
+                
+                //we have more than two policies, so we need to wrap them
+                for (int i = 2; i < _policies.Count; i++)
+                {
+                    policyWrap = policyWrap.WrapAsync(_policies[i]);
+                }
+                return await policyWrap.ExecuteAsync(async () => await base.HandleAsync(command,cancellationToken));
+            }
         }
     }
 }

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/TestDoubles/MyCommand.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/TestDoubles/MyCommand.cs
@@ -26,7 +26,7 @@ using System;
 
 namespace Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles
 {
-    internal class MyCommand : Command
+    public class MyCommand : Command
     {
         public MyCommand()
             :base(Guid.NewGuid()) 

--- a/tests/Paramore.Brighter.Core.Tests/ExceptionPolicy/TestDoubles/MyMultiplePoliciesFailsWithDivideByZeroHandlerAsync.cs
+++ b/tests/Paramore.Brighter.Core.Tests/ExceptionPolicy/TestDoubles/MyMultiplePoliciesFailsWithDivideByZeroHandlerAsync.cs
@@ -1,0 +1,29 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
+using Paramore.Brighter.Policies.Attributes;
+
+namespace Paramore.Brighter.Core.Tests.ExceptionPolicy;
+
+public class MyMultiplePoliciesFailsWithDivideByZeroHandlerAsync : RequestHandlerAsync<MyCommand>
+{
+    public static bool ReceivedCommand { get; set; }
+
+    public MyMultiplePoliciesFailsWithDivideByZeroHandlerAsync()
+    {
+        ReceivedCommand = false;
+    }
+
+    [UsePolicyAsync(new [] {"MyDivideByZeroBreakerPolicyAsync", "MyDivideByZeroRetryPolicyAsync", }, 1)]
+    public override Task<MyCommand> HandleAsync(MyCommand command, CancellationToken cancellationToken = default)
+    {
+        ReceivedCommand = true;
+        return base.HandleAsync(command, cancellationToken);
+    }
+
+    public static bool ShouldReceive(MyCommand myCommand)
+    {
+        return ReceivedCommand;
+    }
+    
+}

--- a/tests/Paramore.Brighter.Core.Tests/ExceptionPolicy/When_Sending_A_Command_That_Retries_Then_Repeatedly_Fails_Breaks_The_Circuit_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/ExceptionPolicy/When_Sending_A_Command_That_Retries_Then_Repeatedly_Fails_Breaks_The_Circuit_Async.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using FluentAssertions;
+using FluentAssertions.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
+using Paramore.Brighter.Core.Tests.ExceptionPolicy.TestDoubles;
+using Paramore.Brighter.Core.Tests.TestHelpers;
+using Paramore.Brighter.Extensions.DependencyInjection;
+using Paramore.Brighter.Policies.Handlers;
+using Polly;
+using Polly.CircuitBreaker;
+using Polly.Registry;
+using Xunit;
+
+namespace Paramore.Brighter.Core.Tests.ExceptionPolicy
+{
+    [Collection("CommandProcessor")]
+     public class CommandProcessorWithBothRetryAndCircuitBreakerAsync : IDisposable
+    {
+        private readonly CommandProcessor _commandProcessor;
+        private Exception _thirdException;
+        private Exception _firstException;
+        private Exception _secondException;
+        private int _retryCount;
+        private Context _context;
+
+        public CommandProcessorWithBothRetryAndCircuitBreakerAsync()
+        {
+            var registry = new SubscriberRegistry();
+            registry.RegisterAsync<MyCommand, MyMultiplePoliciesFailsWithDivideByZeroHandlerAsync>();
+
+            var container = new ServiceCollection();
+            container.AddSingleton<MyMultiplePoliciesFailsWithDivideByZeroHandlerAsync>();
+            container.AddSingleton<ExceptionPolicyHandler<MyCommand>>();
+            container.AddSingleton<IBrighterOptions>(new BrighterOptions()
+            {
+                HandlerLifetime = ServiceLifetime.Transient
+            });
+
+
+            var handlerFactory = new ServiceProviderHandlerFactory(container.BuildServiceProvider());
+
+            var policyRegistry = new PolicyRegistry();
+
+            var retryPolicy = Policy
+                .Handle<DivideByZeroException>()
+                .WaitAndRetryAsync(new[] { 10.Milliseconds(), 20.Milliseconds(), 30.Milliseconds() },
+                    (exception, timeSpan) =>
+                    {
+                        _retryCount++;
+                    });
+
+            var breakerPolicy = Policy.Handle<DivideByZeroException>()
+                .CircuitBreakerAsync(
+                    exceptionsAllowedBeforeBreaking: 2,
+                    durationOfBreak: TimeSpan.FromSeconds(30),
+                    onBreak: (exception, timespan, context) =>
+                    {
+                    },
+                    onReset: context =>  _context = context
+                );
+
+            policyRegistry.Add("MyDivideByZeroRetryPolicyAsync", retryPolicy);
+            policyRegistry.Add("MyDivideByZeroBreakerPolicyAsync", breakerPolicy);
+
+
+            MyMultiplePoliciesFailsWithDivideByZeroHandlerAsync.ReceivedCommand = false;
+
+            _commandProcessor = new CommandProcessor(registry, handlerFactory, new InMemoryRequestContextFactory(),
+                policyRegistry);
+        }
+
+        [Fact]
+        public void When_Sending_A_Command_That_Retries_Then_Repeatedly_Fails_Breaks_The_Circuit()
+        {
+            //First two should be caught, and increment the count
+            _firstException = Catch.Exception(async () => await _commandProcessor.SendAsync(new MyCommand()));
+            //should have retried three times
+            _retryCount.Should().Be(3);
+            _retryCount = 0;
+            _secondException = Catch.Exception(async() => await _commandProcessor.SendAsync(new MyCommand()));
+            //should have retried three times
+            _retryCount.Should().Be(3);
+            _retryCount = 0;
+
+            //this one should tell us that the circuit is broken
+            _thirdException = Catch.Exception(async() => await _commandProcessor.SendAsync(new MyCommand()));
+            //should have retried three times
+            _retryCount.Should().Be(0);
+
+            //_should bubble up the first_exception
+            _firstException.Should().BeOfType<DivideByZeroException>();
+            //_should bubble up the second exception
+            _secondException.Should().BeOfType<DivideByZeroException>();
+            //_should bubble up the circuit breaker exception
+            _thirdException.Should().BeOfType<BrokenCircuitException>();
+        }
+
+        public void Dispose()
+        {
+            CommandProcessor.ClearExtServiceBus();
+        }
+    }
+}


### PR DESCRIPTION
We moved support for multiple polices to the attribute, so as to avoid issues when we tried to create multiple instances of the handler with Scoped or Singleton lifetimes.

We forgot async as part of that.