### PR TITLE
Ensure we support net7.0 explicitly

### DIFF
--- a/src/Paramore.Brighter.Dapper/Paramore.Brighter.Dapper.csproj
+++ b/src/Paramore.Brighter.Dapper/Paramore.Brighter.Dapper.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;net6.0;net7.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Paramore.Brighter.DynamoDb/Paramore.Brighter.DynamoDb.csproj
+++ b/src/Paramore.Brighter.DynamoDb/Paramore.Brighter.DynamoDb.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;net6.0;net7.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Paramore.Brighter.Extensions.DependencyInjection/Paramore.Brighter.Extensions.DependencyInjection.csproj
+++ b/src/Paramore.Brighter.Extensions.DependencyInjection/Paramore.Brighter.Extensions.DependencyInjection.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net7.0</TargetFrameworks>
     <Authors>Daniel Stockhammer, Toby Henderson</Authors>
     <Description>Brighter Microsoft.Extensions.DependencyInjection support</Description>
   </PropertyGroup>

--- a/src/Paramore.Brighter.Extensions.Hosting/Paramore.Brighter.Extensions.Hosting.csproj
+++ b/src/Paramore.Brighter.Extensions.Hosting/Paramore.Brighter.Extensions.Hosting.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;net6.0;net7.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Paramore.Brighter.Inbox.DynamoDB/Paramore.Brighter.Inbox.DynamoDB.csproj
+++ b/src/Paramore.Brighter.Inbox.DynamoDB/Paramore.Brighter.Inbox.DynamoDB.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.103.22" />

--- a/src/Paramore.Brighter.Inbox.MsSql/Paramore.Brighter.Inbox.MsSql.csproj
+++ b/src/Paramore.Brighter.Inbox.MsSql/Paramore.Brighter.Inbox.MsSql.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>This is an implementation of the outbox used for decoupled invocation of commands by Paramore.Brighter, using MS Sql Server</Description>
     <Authors>Francesco Pighi</Authors>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net7.0</TargetFrameworks>
     <PackageTags>RabbitMQ;AMQP;Command;Event;Service Activator;Decoupled;Invocation;Messaging;Remote;Command Dispatcher;Command Processor;Request;Service;Task Queue;Work Queue;Retry;Circuit Breaker;Availability</PackageTags>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Paramore.Brighter.Inbox.MySql/Paramore.Brighter.Inbox.MySql.csproj
+++ b/src/Paramore.Brighter.Inbox.MySql/Paramore.Brighter.Inbox.MySql.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>This is an implementation of the outbox used for decoupled invocation of commands by Paramore.Brighter, using MySql</Description>
     <Authors>Derek Comartin</Authors>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net7.0</TargetFrameworks>
     <PackageTags>MySql;Command;Event;Service Activator;Decoupled;Invocation;Messaging;Remote;Command Dispatcher;Command Processor;Request;Service;Task Queue;Work Queue;Retry;Circuit Breaker;Availability</PackageTags>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Paramore.Brighter.Inbox.Postgres/Paramore.Brighter.Inbox.Postgres.csproj
+++ b/src/Paramore.Brighter.Inbox.Postgres/Paramore.Brighter.Inbox.Postgres.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>This is an implementation of the inbox used for decoupled invocation of commands by Paramore.Brighter, using PostgreSql</Description>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net7.0</TargetFrameworks>
     <PackageTags>MySql;Command;Event;Service Activator;Decoupled;Invocation;Messaging;Remote;Command Dispatcher;Command Processor;Request;Service;Task Queue;Work Queue;Retry;Circuit Breaker;Availability</PackageTags>
   </PropertyGroup>
 

--- a/src/Paramore.Brighter.Inbox.Sqlite/Paramore.Brighter.Inbox.Sqlite.csproj
+++ b/src/Paramore.Brighter.Inbox.Sqlite/Paramore.Brighter.Inbox.Sqlite.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>This is an implementation of the inbox used for decoupled invocation of commands by Paramore.Brighter, using Sqlite</Description>
     <Authors>Ian Cooper</Authors>
-    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net6.0;net7.0</TargetFrameworks>
     <PackageTags>RabbitMQ;AMQP;Command;Event;Service Activator;Decoupled;Invocation;Messaging;Remote;Command Dispatcher;Command Processor;Request;Service;Task Queue;Work Queue;Retry;Circuit Breaker;Availability</PackageTags>
   </PropertyGroup>
 

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS/Paramore.Brighter.MessagingGateway.AWSSQS.csproj
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS/Paramore.Brighter.MessagingGateway.AWSSQS.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>Provides an implementation of the messaging gateway for decoupled invocation in the Paramore.Brighter pipeline, using awssqs</Description>
     <Authors>Deniz Kocak</Authors>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net7.0</TargetFrameworks>
     <PackageTags>awssqs;AMQP;Command;Event;Service Activator;Decoupled;Invocation;Messaging;Remote;Command Dispatcher;Command Processor;Request;Service;Task Queue;Work Queue;Retry;Circuit Breaker;Availability</PackageTags>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/Paramore.Brighter.MessagingGateway.AzureServiceBus.csproj
+++ b/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/Paramore.Brighter.MessagingGateway.AzureServiceBus.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>Provides an implementation of the messaging gateway for decoupled invocation in the Paramore.Brighter pipeline, using azureservicebus</Description>
     <Authors>Yiannis Triantafyllopoulos</Authors>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net7.0</TargetFrameworks>
     <PackageTags>awssqs;AMQP;Command;Event;Service Activator;Decoupled;Invocation;Messaging;Remote;Command Dispatcher;Command Processor;Request;Service;Task Queue;Work Queue;Retry;Circuit Breaker;Availability</PackageTags>
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>

--- a/src/Paramore.Brighter.MessagingGateway.Kafka/Paramore.Brighter.MessagingGateway.Kafka.csproj
+++ b/src/Paramore.Brighter.MessagingGateway.Kafka/Paramore.Brighter.MessagingGateway.Kafka.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>Provides an implementation of the messaging gateway for decoupled invocation in the Paramore.Brighter pipeline, using Kafka.</Description>
     <Authors>Wayne Hunsley</Authors>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net7.0</TargetFrameworks>
     <PackageTags>Kafka;Command;Event;Service Activator;Decoupled;Invocation;Messaging;Remote;Command Dispatcher;Command Processor;Request;Service;Task Queue;Work Queue;Retry;Circuit Breaker;Availability</PackageTags>
     <SignAssembly>false</SignAssembly>
   </PropertyGroup>

--- a/src/Paramore.Brighter.MessagingGateway.MsSql/Paramore.Brighter.MessagingGateway.MsSql.csproj
+++ b/src/Paramore.Brighter.MessagingGateway.MsSql/Paramore.Brighter.MessagingGateway.MsSql.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>Provides an implementation of the messaging gateway for decoupled invocation in the Paramore.Brighter pipeline, using MS Sql Server</Description>
     <Authors>Fred Hoogduin</Authors>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net7.0</TargetFrameworks>
     <PackageTags>RabbitMQ;AMQP;Command;Event;Service Activator;Decoupled;Invocation;Messaging;Remote;Command Dispatcher;Command Processor;Request;Service;Task Queue;Work Queue;Retry;Circuit Breaker;Availability</PackageTags>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Paramore.Brighter.MessagingGateway.RESTMS/Paramore.Brighter.MessagingGateway.RESTMS.csproj
+++ b/src/Paramore.Brighter.MessagingGateway.RESTMS/Paramore.Brighter.MessagingGateway.RESTMS.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>Provides an implementation of the messaging gateway for decoupled invocation in the Paramore.Brighter pipeline, using restms</Description>
     <Authors>Ian Cooper</Authors>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net7.0</TargetFrameworks>
     <PackageTags>awssqs;AMQP;Command;Event;Service Activator;Decoupled;Invocation;Messaging;Remote;Command Dispatcher;Command Processor;Request;Service;Task Queue;Work Queue;Retry;Circuit Breaker;Availability</PackageTags>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Paramore.Brighter.MessagingGateway.RMQ/Paramore.Brighter.MessagingGateway.RMQ.csproj
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ/Paramore.Brighter.MessagingGateway.RMQ.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>Provides an implementation of the messaging gateway for decoupled invocation in the Paramore.Brighter pipeline, using RabbitMQ</Description>
     <Authors>Ian Cooper</Authors>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net7.0</TargetFrameworks>
     <PackageTags>RabbitMQ;AMQP;Command;Event;Service Activator;Decoupled;Invocation;Messaging;Remote;Command Dispatcher;Command Processor;Request;Service;Task Queue;Work Queue;Retry;Circuit Breaker;Availability</PackageTags>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Paramore.Brighter.MessagingGateway.Redis/Paramore.Brighter.MessagingGateway.Redis.csproj
+++ b/src/Paramore.Brighter.MessagingGateway.Redis/Paramore.Brighter.MessagingGateway.Redis.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>Provides an implementation of the messaging gateway for decoupled invocation in the Paramore.Brighter pipeline, using Redis&lt;</Description>
     <Authors>Ian Cooper</Authors>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net7.0</TargetFrameworks>
     <PackageTags>Redis;Command;Event;Service Activator;Decoupled;Invocation;Messaging;Remote;Command Dispatcher;Command Processor;Request;Service;Task Queue;Work Queue;Retry;Circuit Breaker;Availability</PackageTags>
     <SignAssembly>false</SignAssembly>
   </PropertyGroup>

--- a/src/Paramore.Brighter.MsSql.Azure/Paramore.Brighter.MsSql.Azure.csproj
+++ b/src/Paramore.Brighter.MsSql.Azure/Paramore.Brighter.MsSql.Azure.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
       <Description>This is the MsSql Connection providers for Access Token authentication using Azure.Idenity</Description>
       <Authors>Paul Reardon</Authors>
-      <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+      <TargetFrameworks>netstandard2.0;net6.0;net7.0</TargetFrameworks>
       <PackageTags>RabbitMQ;AMQP;Command;Event;Service Activator;Decoupled;Invocation;Messaging;Remote;Command Dispatcher;Command Processor;Request;Service;Task Queue;Work Queue;Retry;Circuit Breaker;Availability</PackageTags>
     </PropertyGroup>
 

--- a/src/Paramore.Brighter.MsSql.Dapper/Paramore.Brighter.MsSql.Dapper.csproj
+++ b/src/Paramore.Brighter.MsSql.Dapper/Paramore.Brighter.MsSql.Dapper.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-      <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+      <TargetFrameworks>netstandard2.0;net6.0;net7.0</TargetFrameworks>
     </PropertyGroup>
 
   <ItemGroup>

--- a/src/Paramore.Brighter.MsSql.EntityFrameworkCore/Paramore.Brighter.MsSql.EntityFrameworkCore.csproj
+++ b/src/Paramore.Brighter.MsSql.EntityFrameworkCore/Paramore.Brighter.MsSql.EntityFrameworkCore.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>This is the MsSql Connection provider to obtain the connection from Entity Framework Core.</Description>
     <Authors>Paul Reardon</Authors>
-    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net6.0;net7.0</TargetFrameworks>
     <PackageTags>RabbitMQ;AMQP;Command;Event;Service Activator;Decoupled;Invocation;Messaging;Remote;Command Dispatcher;Command Processor;Request;Service;Task Queue;Work Queue;Retry;Circuit Breaker;Availability</PackageTags>
   </PropertyGroup>
 

--- a/src/Paramore.Brighter.MsSql/Paramore.Brighter.MsSql.csproj
+++ b/src/Paramore.Brighter.MsSql/Paramore.Brighter.MsSql.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
       <Description>This is the common components required to connect to MsSql for Inbox, Outbox, and Messaging Gateway.</Description>
       <Authors>Paul Reardon</Authors>
-      <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+      <TargetFrameworks>netstandard2.0;net6.0;net7.0</TargetFrameworks>
       <PackageTags>RabbitMQ;AMQP;Command;Event;Service Activator;Decoupled;Invocation;Messaging;Remote;Command Dispatcher;Command Processor;Request;Service;Task Queue;Work Queue;Retry;Circuit Breaker;Availability</PackageTags>
     </PropertyGroup>
 

--- a/src/Paramore.Brighter.MySql.Dapper/Paramore.Brighter.MySql.Dapper.csproj
+++ b/src/Paramore.Brighter.MySql.Dapper/Paramore.Brighter.MySql.Dapper.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-      <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+      <TargetFrameworks>netstandard2.0;net6.0;net7.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Paramore.Brighter.MySql.EntityFrameworkCore/Paramore.Brighter.MySql.EntityFrameworkCore.csproj
+++ b/src/Paramore.Brighter.MySql.EntityFrameworkCore/Paramore.Brighter.MySql.EntityFrameworkCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.1;net6.0;net7.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Paramore.Brighter.MySql/Paramore.Brighter.MySql.csproj
+++ b/src/Paramore.Brighter.MySql/Paramore.Brighter.MySql.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;net6.0;net7.0</TargetFrameworks>
     </PropertyGroup>
 
   <ItemGroup>

--- a/src/Paramore.Brighter.Outbox.DynamoDB/Paramore.Brighter.Outbox.DynamoDB.csproj
+++ b/src/Paramore.Brighter.Outbox.DynamoDB/Paramore.Brighter.Outbox.DynamoDB.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.103.22" />

--- a/src/Paramore.Brighter.Outbox.EventStore/Paramore.Brighter.Outbox.EventStore.csproj
+++ b/src/Paramore.Brighter.Outbox.EventStore/Paramore.Brighter.Outbox.EventStore.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>This is an implementation of the outbox used for decoupled invocation of commands by Paramore.Brighter, using Event Store</Description>
     <Authors>George Ayris</Authors>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net7.0</TargetFrameworks>
     <PackageTags>RabbitMQ;AMQP;Command;Event;Service Activator;Decoupled;Invocation;Messaging;Remote;Command Dispatcher;Command Processor;Request;Service;Task Queue;Work Queue;Retry;Circuit Breaker;Availability</PackageTags>
     <SignAssembly>false</SignAssembly>
   </PropertyGroup>

--- a/src/Paramore.Brighter.Outbox.MsSql/Paramore.Brighter.Outbox.MsSql.csproj
+++ b/src/Paramore.Brighter.Outbox.MsSql/Paramore.Brighter.Outbox.MsSql.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>This is an implementation of the outbox used for decoupled invocation of commands by Paramore.Brighter, using MS Sql Server</Description>
     <Authors>Francesco Pighi</Authors>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net7.0</TargetFrameworks>
     <PackageTags>RabbitMQ;AMQP;Command;Event;Service Activator;Decoupled;Invocation;Messaging;Remote;Command Dispatcher;Command Processor;Request;Service;Task Queue;Work Queue;Retry;Circuit Breaker;Availability</PackageTags>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Paramore.Brighter.Outbox.MySql/Paramore.Brighter.Outbox.MySql.csproj
+++ b/src/Paramore.Brighter.Outbox.MySql/Paramore.Brighter.Outbox.MySql.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>This is an implementation of the outbox used for decoupled invocation of commands by Paramore.Brighter, using MySql</Description>
     <Authors>Derek Comartin</Authors>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net7.0</TargetFrameworks>
     <PackageTags>RabbitMQ;AMQP;Command;Event;Service Activator;Decoupled;Invocation;Messaging;Remote;Command Dispatcher;Command Processor;Request;Service;Task Queue;Work Queue;Retry;Circuit Breaker;Availability</PackageTags>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Paramore.Brighter.Outbox.PostgreSql/Paramore.Brighter.Outbox.PostgreSql.csproj
+++ b/src/Paramore.Brighter.Outbox.PostgreSql/Paramore.Brighter.Outbox.PostgreSql.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>This is an implementation of the outbox used for decoupled invocation of commands by Paramore.Brighter, using PostgreSql</Description>
     <Authors>Tarun Pothulapati</Authors>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net7.0</TargetFrameworks>
     <PackageTags>RabbitMQ;AMQP;Command;Event;Service Activator;Decoupled;Invocation;Messaging;Remote;Command Dispatcher;Command Processor;Request;Service;Task Queue;Work Queue;Retry;Circuit Breaker;Availability</PackageTags>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Paramore.Brighter.Outbox.Sqlite/Paramore.Brighter.Outbox.Sqlite.csproj
+++ b/src/Paramore.Brighter.Outbox.Sqlite/Paramore.Brighter.Outbox.Sqlite.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>This is an implementation of the outbox used for decoupled invocation of commands by Paramore.Brighter, using Sqlite</Description>
     <Authors>Francesco Pighi</Authors>
-    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net6.0;net7.0</TargetFrameworks>
     <PackageTags>RabbitMQ;AMQP;Command;Event;Service Activator;Decoupled;Invocation;Messaging;Remote;Command Dispatcher;Command Processor;Request;Service;Task Queue;Work Queue;Retry;Circuit Breaker;Availability</PackageTags>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Paramore.Brighter.PostgreSql.EntityFrameworkCore/Paramore.Brighter.PostgreSql.EntityFrameworkCore.csproj
+++ b/src/Paramore.Brighter.PostgreSql.EntityFrameworkCore/Paramore.Brighter.PostgreSql.EntityFrameworkCore.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Authors>Sam Rumley</Authors>
     <Description>Common components required to get a PostgreSql connection from Entity Framework Core.</Description>
-    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net6.0;net7.0</TargetFrameworks>
     <PackageTags>RabbitMQ;AMQP;Command;Event;Service Activator;Decoupled;Invocation;Messaging;Remote;Command Dispatcher;Command Processor;Request;Service;Task Queue;Work Queue;Retry;Circuit Breaker;Availability</PackageTags>
   </PropertyGroup>
 

--- a/src/Paramore.Brighter.PostgreSql/Paramore.Brighter.PostgreSql.csproj
+++ b/src/Paramore.Brighter.PostgreSql/Paramore.Brighter.PostgreSql.csproj
@@ -4,7 +4,7 @@
     <Authors>Sam Rumley</Authors>
     <Description>Common components required to connect to PostgreSql for inbox and outbox.</Description>
     <PackageTags>RabbitMQ;AMQP;Command;Event;Service Activator;Decoupled;Invocation;Messaging;Remote;Command Dispatcher;Command Processor;Request;Service;Task Queue;Work Queue;Retry;Circuit Breaker;Availability</PackageTags>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Paramore.Brighter.ServiceActivator.Extensions.DependencyInjection/Paramore.Brighter.ServiceActivator.Extensions.DependencyInjection.csproj
+++ b/src/Paramore.Brighter.ServiceActivator.Extensions.DependencyInjection/Paramore.Brighter.ServiceActivator.Extensions.DependencyInjection.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net7.0</TargetFrameworks>
     <Description>Service Activator Microsoft.Extensions.DependencyInjection support</Description>
     <Authors>Toby Henderson</Authors>
   </PropertyGroup>

--- a/src/Paramore.Brighter.ServiceActivator.Extensions.Diagnostics/Paramore.Brighter.ServiceActivator.Extensions.Diagnostics.csproj
+++ b/src/Paramore.Brighter.ServiceActivator.Extensions.Diagnostics/Paramore.Brighter.ServiceActivator.Extensions.Diagnostics.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net7.0</TargetFrameworks>
     <Description>This Microsoft Extensions Diagnostics Health Checks for Service Activator</Description>
     <Authors>Paul Reardon</Authors>
     <LangVersion>latest</LangVersion>

--- a/src/Paramore.Brighter.ServiceActivator.Extensions.Hosting/Paramore.Brighter.ServiceActivator.Extensions.Hosting.csproj
+++ b/src/Paramore.Brighter.ServiceActivator.Extensions.Hosting/Paramore.Brighter.ServiceActivator.Extensions.Hosting.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net7.0</TargetFrameworks>
     <Description>Service Activator Microsoft.Extensions.Hosting (IHostBuilder) support for background tasks</Description>
     <Authors>Toby Henderson</Authors>
   </PropertyGroup>

--- a/src/Paramore.Brighter.ServiceActivator/Paramore.Brighter.ServiceActivator.csproj
+++ b/src/Paramore.Brighter.ServiceActivator/Paramore.Brighter.ServiceActivator.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>The Command Dispatcher pattern is an addition to the Command design pattern that decouples the dispatcher for a service from its execution. A Command Dispatcher component maps commands to handlers. A Command Processor pattern provides a  framework for handling orthogonal concerns such as logging, timeouts, or circuit breakers</Description>
     <Authors>Ian Cooper</Authors>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net7.0</TargetFrameworks>
     <PackageTags>Command;Event;Service Activator;Decoupled;Invocation;Messaging;Remote;Command Dispatcher;Command Processor;Request;Service;Task Queue;Work Queue;Retry;Circuit Breaker;Availability</PackageTags>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Paramore.Brighter.Sqlite.Dapper/Paramore.Brighter.Sqlite.Dapper.csproj
+++ b/src/Paramore.Brighter.Sqlite.Dapper/Paramore.Brighter.Sqlite.Dapper.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-      <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
+      <TargetFrameworks>netstandard2.1;net6.0;net7.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Paramore.Brighter.Sqlite.EntityFrameworkCore/Paramore.Brighter.Sqlite.EntityFrameworkCore.csproj
+++ b/src/Paramore.Brighter.Sqlite.EntityFrameworkCore/Paramore.Brighter.Sqlite.EntityFrameworkCore.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <Authors>Ian Cooper</Authors>
-        <TargetFrameworks>net6.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>netstandard2.1;net6.0;net7.0</TargetFrameworks>
         <PackageTags>RabbitMQ;AMQP;Command;Event;Service Activator;Decoupled;Invocation;Messaging;Remote;Command Dispatcher;Command Processor;Request;Service;Task Queue;Work Queue;Retry;Circuit Breaker;Availability</PackageTags>
     </PropertyGroup>      
   

--- a/src/Paramore.Brighter.Sqlite/Paramore.Brighter.Sqlite.csproj
+++ b/src/Paramore.Brighter.Sqlite/Paramore.Brighter.Sqlite.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Authors>Ian Cooper</Authors>
         <PackageTags>RabbitMQ;AMQP;Command;Event;Service Activator;Decoupled;Invocation;Messaging;Remote;Command Dispatcher;Command Processor;Request;Service;Task Queue;Work Queue;Retry;Circuit Breaker;Availability</PackageTags>
-      <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
+      <TargetFrameworks>netstandard2.1;net6.0;net7.0</TargetFrameworks>
     </PropertyGroup>
   
      <ItemGroup>

--- a/src/Paramore.Brighter/Paramore.Brighter.csproj
+++ b/src/Paramore.Brighter/Paramore.Brighter.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>The Command Dispatcher pattern is an addition to the Command design pattern that decouples the dispatcher for a service from its execution. A Command Dispatcher component maps commands to handlers. A Command Processor pattern provides a  framework for handling orthogonal concerns such as logging, timeouts, or circuit breakers</Description>
     <Authors>Ian Cooper</Authors>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net7.0</TargetFrameworks>
     <PackageTags>Command;Event;Command Dispatcher;Command Processor;Request;Service;Task Queue;Work Queue;Retry;Circuit Breaker;Availability</PackageTags>
     <LangVersion>8</LangVersion>
   </PropertyGroup>


### PR DESCRIPTION
This issue popped up for EF Core, where having net60 assemblies in the stack caused issues. Although we could just fix it for the assemblies that directly depend on EF Core, the risk is that other dependencies may require all their dependencies to be the same version, so this explicitly adds net70 to the targets

We will need to add net80 soon.