### PR TITLE
Add random sharding for the DynamoDb outbox

### DIFF
--- a/src/Paramore.Brighter.Outbox.DynamoDB/DynamoDbConfiguration.cs
+++ b/src/Paramore.Brighter.Outbox.DynamoDB/DynamoDbConfiguration.cs
@@ -32,13 +32,23 @@ namespace Paramore.Brighter.Outbox.DynamoDB
         /// Timeout in milliseconds
         /// </summary>
         public int Timeout { get; }
+        /// <summary>
+        /// Number of shards to use for the outstanding index
+        /// </summary>
+        public int NumberOfShards { get; }
+        /// <summary>
+        /// Optional time to live for the messages in the outbox
+        /// By default, messages will not expire
+        /// </summary>
+        public TimeSpan? TimeToLive { get; set; }
     
         [Obsolete("Use the DynamoDbConfiguration without AWSCredentials and without RegionEndpoint")]
         public DynamoDbConfiguration(
             AWSCredentials credentials, 
             RegionEndpoint region,
             string tableName = null,
-            int timeout = 500)
+            int timeout = 500,
+            int numberOfShards = 3)
         {
             Credentials = credentials;
             Region = region;
@@ -46,14 +56,16 @@ namespace Paramore.Brighter.Outbox.DynamoDB
             OutstandingIndexName = "Outstanding";
             DeliveredIndexName = "Delivered";
             Timeout = timeout;
+            NumberOfShards = numberOfShards;
         }
 
-        public DynamoDbConfiguration(string tableName = null, int timeout = 500)
+        public DynamoDbConfiguration(string tableName = null, int timeout = 500, int numberOfShards = 3)
         {
             TableName = tableName ?? "brighter_outbox";
             OutstandingIndexName = "Outstanding";
             DeliveredIndexName = "Delivered";
             Timeout = timeout;
+            NumberOfShards = numberOfShards;
         }
     }
 }

--- a/src/Paramore.Brighter.Outbox.DynamoDB/DynamoDbConfiguration.cs
+++ b/src/Paramore.Brighter.Outbox.DynamoDB/DynamoDbConfiguration.cs
@@ -33,7 +33,7 @@ namespace Paramore.Brighter.Outbox.DynamoDB
         /// </summary>
         public int Timeout { get; }
         /// <summary>
-        /// Number of shards to use for the outstanding index
+        /// Number of shards to use for the outstanding index. Maximum of 20
         /// </summary>
         public int NumberOfShards { get; }
         /// <summary>

--- a/src/Paramore.Brighter.Outbox.DynamoDB/DynamoDbOutbox.cs
+++ b/src/Paramore.Brighter.Outbox.DynamoDB/DynamoDbOutbox.cs
@@ -26,6 +26,7 @@ THE SOFTWARE. */
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 using Amazon.DynamoDBv2;
@@ -55,7 +56,11 @@ namespace Paramore.Brighter.Outbox.DynamoDB
         {
             _configuration = configuration;
             _context = new DynamoDBContext(client);
-            _dynamoOverwriteTableConfig = new DynamoDBOperationConfig { OverrideTableName = _configuration.TableName };
+            _dynamoOverwriteTableConfig = new DynamoDBOperationConfig
+            {
+                OverrideTableName = _configuration.TableName,
+                ConsistentRead = true
+            };
         }
 
         /// <summary>
@@ -90,7 +95,9 @@ namespace Paramore.Brighter.Outbox.DynamoDB
         /// <param name="cancellationToken">Allows the sender to cancel the request pipeline. Optional</param>        
         public async Task AddAsync(Message message, int outBoxTimeout = -1, CancellationToken cancellationToken = default, IAmABoxTransactionConnectionProvider transactionConnectionProvider = null)
         {
-            var messageToStore = new MessageItem(message);
+            var shard = GetShardNumber();
+            var expiresAt = GetExpirationTime();
+            var messageToStore = new MessageItem(message, shard, expiresAt);
 
             if (transactionConnectionProvider != null)
             {
@@ -311,19 +318,8 @@ namespace Paramore.Brighter.Outbox.DynamoDB
             var dispatchedTime = now.Subtract(TimeSpan.FromMilliseconds(millisecondsDispatchedSince));
             var topic = (string)args["Topic"];
 
-            // We get all the messages for topic, added within a time range
-            // There should be few enough of those that we can efficiently filter for those
-            // that don't have a delivery date.
-            var queryConfig = new QueryOperationConfig
-            {
-                IndexName = _configuration.OutstandingIndexName,
-                KeyExpression = new KeyTopicCreatedTimeExpression().Generate(topic, dispatchedTime),
-                FilterExpression = new NoDispatchTimeExpression().Generate(),
-                ConsistentRead = false
-            };
-           
             //block async to make this sync
-            var messages = PageAllMessagesAsync(queryConfig).Result.ToList();
+            var messages = QueryAllOutstandingShardsAsync(topic, dispatchedTime).Result.ToList();
             return messages.Select(msg => msg.ConvertToMessage());
         }
 
@@ -357,19 +353,8 @@ namespace Paramore.Brighter.Outbox.DynamoDB
             var minimumAge = DateTime.UtcNow.Subtract(TimeSpan.FromMilliseconds(millisecondsDispatchedSince));
             var topic = (string)args["Topic"];
 
-            // We get all the messages for topic, added within a time range
-            // There should be few enough of those that we can efficiently filter for those
-            // that don't have a delivery date.
-            var queryConfig = new QueryOperationConfig
-            {
-                IndexName = _configuration.OutstandingIndexName,
-                KeyExpression = new KeyTopicCreatedTimeExpression().Generate(topic, minimumAge),
-                FilterExpression = new NoDispatchTimeExpression().Generate(),
-                ConsistentRead = false
-            };
-           
             //block async to make this sync
-            var messages = (await PageAllMessagesAsync(queryConfig, cancellationToken)).ToList();
+            var messages = (await QueryAllOutstandingShardsAsync(topic, minimumAge, cancellationToken)).ToList();
             return messages.Select(msg => msg.ConvertToMessage());
         }
 
@@ -413,6 +398,49 @@ namespace Paramore.Brighter.Outbox.DynamoDB
 
             return messages;
         }
+        
+        private async Task<IEnumerable<MessageItem>> QueryAllOutstandingShardsAsync(string topic, DateTime minimumAge, CancellationToken cancellationToken = default)
+        {
+            using var semaphore = new SemaphoreSlim(20);
+            var tasks = new List<Task<IEnumerable<MessageItem>>>();
+
+            for (int shard = 0; shard < _configuration.NumberOfShards; shard++)
+            {
+                await semaphore.WaitAsync(cancellationToken);
+                
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    break;
+                }
+                
+                // We get all the messages for topic, added within a time range
+                // There should be few enough of those that we can efficiently filter for those
+                // that don't have a delivery date.
+                var queryConfig = new QueryOperationConfig
+                {
+                    IndexName = _configuration.OutstandingIndexName,
+                    KeyExpression = new KeyTopicCreatedTimeExpression().Generate(topic, minimumAge, shard),
+                    FilterExpression = new NoDispatchTimeExpression().Generate(),
+                    ConsistentRead = false
+                };
+
+                var task = PageAllMessagesAsync(queryConfig, cancellationToken)
+                    .ContinueWith(t =>
+                    {
+                        semaphore.Release();
+                        return t.Result;
+                    }, cancellationToken);
+
+                tasks.Add(task);
+            }
+
+            await Task.WhenAll(tasks);
+
+            return tasks
+                .SelectMany(x => x.Result)
+                .OrderBy(x => x.CreatedAt);
+        }
+        
         private async Task WriteMessageToOutbox(CancellationToken cancellationToken, MessageItem messageToStore)
         {
             await _context.SaveAsync(
@@ -420,6 +448,26 @@ namespace Paramore.Brighter.Outbox.DynamoDB
                     _dynamoOverwriteTableConfig,
                     cancellationToken)
                 .ConfigureAwait(ContinueOnCapturedContext);
+        }
+
+        private int GetShardNumber()
+        {
+            if (_configuration.NumberOfShards <= 0)
+            {
+                return 0;
+            }
+
+            return RandomNumberGenerator.GetInt32(_configuration.NumberOfShards);
+        }
+
+        private long? GetExpirationTime()
+        {
+            if (_configuration.TimeToLive.HasValue)
+            {
+                return DateTimeOffset.UtcNow.Add(_configuration.TimeToLive.Value).ToUnixTimeSeconds();
+            }
+
+            return null;
         }
      }
 }

--- a/src/Paramore.Brighter.Outbox.DynamoDB/KeyTopicCreatedTimeExpression.cs
+++ b/src/Paramore.Brighter.Outbox.DynamoDB/KeyTopicCreatedTimeExpression.cs
@@ -10,7 +10,7 @@ namespace Paramore.Brighter.Outbox.DynamoDB
 
         public KeyTopicCreatedTimeExpression()
         {
-            _expression = new Expression { ExpressionStatement = "Topic = :v_Topic and CreatedTime < :v_CreatedTime" };
+            _expression = new Expression { ExpressionStatement = "TopicShard = :v_TopicShard and CreatedTime < :v_CreatedTime" };
         }
 
         public override string ToString()
@@ -18,10 +18,10 @@ namespace Paramore.Brighter.Outbox.DynamoDB
             return _expression.ExpressionStatement;
         }
 
-        public Expression Generate(string topicName, DateTime createdTime)
+        public Expression Generate(string topicName, DateTime createdTime, int shard)
         {
             var values = new Dictionary<string, DynamoDBEntry>();
-            values.Add(":v_Topic", topicName);
+            values.Add(":v_TopicShard", $"{topicName}_{shard}");
             values.Add(":v_CreatedTime", createdTime.Ticks);
 
             _expression.ExpressionAttributeValues = values;

--- a/src/Paramore.Brighter.Outbox.DynamoDB/MessageItem.cs
+++ b/src/Paramore.Brighter.Outbox.DynamoDB/MessageItem.cs
@@ -92,9 +92,19 @@ namespace Paramore.Brighter.Outbox.DynamoDB
         /// The Topic the message was published to
         /// </summary>
         /// 
-        [DynamoDBGlobalSecondaryIndexHashKey("Delivered", "Outstanding")]
+        [DynamoDBGlobalSecondaryIndexHashKey("Delivered")]
         [DynamoDBProperty]
         public string Topic { get; set; }
+        
+        /// <summary>
+        /// The Topic suffixed with the shard number
+        /// </summary>
+        [DynamoDBGlobalSecondaryIndexHashKey("Outstanding")]
+        [DynamoDBProperty]
+        public string TopicShard { get; set; }
+        
+        [DynamoDBProperty]
+        public long? ExpiresAt { get; set; }
 
 
         public MessageItem()
@@ -102,7 +112,7 @@ namespace Paramore.Brighter.Outbox.DynamoDB
             /*Deserialization*/
         }
 
-        public MessageItem(Message message)
+        public MessageItem(Message message, int shard = 0, long? expiresAt = null)
         {
             var date = message.Header.TimeStamp == DateTime.MinValue ? DateTime.UtcNow : message.Header.TimeStamp;
 
@@ -119,6 +129,8 @@ namespace Paramore.Brighter.Outbox.DynamoDB
             PartitionKey = message.Header.PartitionKey;
             ReplyTo = message.Header.ReplyTo;
             Topic = message.Header.Topic;
+            TopicShard = $"{Topic}_{shard}";
+            ExpiresAt = expiresAt;
         }
 
         public Message ConvertToMessage()


### PR DESCRIPTION
Addresses #2810

- Add configuration for number of shards (default 3, max 20)
- Add optional configuration for TTL (default null - so forever)
- Applies random sharding when writing items into the dynamo outbox for the 'Outstanding' index PK
- Query all shards when getting all outstanding messages