### PR TITLE
Configure RabbitMq continuation timeout

### DIFF
--- a/src/Paramore.Brighter.MessagingGateway.RMQ/RmqMessageGateway.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ/RmqMessageGateway.cs
@@ -76,7 +76,8 @@ namespace Paramore.Brighter.MessagingGateway.RMQ
             _connectionFactory = new ConnectionFactory
             {
                 Uri = Connection.AmpqUri.Uri,
-                RequestedHeartbeat = TimeSpan.FromSeconds(connection.Heartbeat)
+                RequestedHeartbeat = TimeSpan.FromSeconds(connection.Heartbeat),
+                ContinuationTimeout = TimeSpan.FromSeconds(connection.ContinuationTimeout)
             };
 
             DelaySupported = Connection.Exchange.SupportDelay;

--- a/src/Paramore.Brighter.MessagingGateway.RMQ/RmqMessagingGatewayConnection.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ/RmqMessagingGatewayConnection.cs
@@ -67,6 +67,11 @@ namespace Paramore.Brighter.MessagingGateway.RMQ
         /// </summary>
         public bool PersistMessages { get; set; }
 
+        /// <summary>
+        ///     Gets or sets RabbitMq protocol timeouts, in seconds. Defaults to 20s.
+        ///     <see cref="ConnectionFactory.ContinuationTimeout" /> for more information.
+        /// </summary>
+        public ushort ContinuationTimeout { get; set; } = 20;
     }
 
     /// <summary>


### PR DESCRIPTION
Small pull request to permit the configuration of RabbitMq continuation timeout.

The default value configured by RabbitMq can be too low for some use cases, resulting in TimeoutException.

```json
{
  "@t": "2023-10-13T10:42:21.2540140Z",
  "@mt": "exception capturée par polly, attente de {Secondes} avant réessai ({NbEssai}/{NbEssaiTotal})",
  "@l": "Warning",
  "@x": "System.TimeoutException: The operation has timed out.\n   at RabbitMQ.Client.Impl.SimpleBlockingRpcContinuation.GetReply(TimeSpan timeout)\n   at RabbitMQ.Client.Impl.ModelBase.ModelRpc(MethodBase method, ContentHeaderBase header, Byte[] body)\n   at RabbitMQ.Client.Framing.Impl.Model._Private_ConfirmSelect(Boolean nowait)\n   at RabbitMQ.Client.Impl.ModelBase.ConfirmSelect()\n   at RabbitMQ.Client.Impl.AutorecoveringModel.ConfirmSelect()\n   at Paramore.Brighter.MessagingGateway.RMQ.RmqMessageProducer.SendWithDelay(Message message, Int32 delayMilliseconds) in /_/src/Paramore.Brighter.MessagingGateway.RMQ/RmqMessageProducer.cs:line 133\n   at Paramore.Brighter.MessagingGateway.RMQ.RmqMessageProducer.Send(Message message) in /_/src/Paramore.Brighter.MessagingGateway.RMQ/RmqMessageProducer.cs:line 110\n   at Paramore.Brighter.ExternalBusServices.<>c__DisplayClass49_1.<Dispatch>b__0() in /_/src/Paramore.Brighter/ExternalBusServices.cs:line 382\n   at Polly.Policy.<>c__DisplayClass138_0.<Implementation>b__0(Context ctx, CancellationToken token)\n   at Polly.Retry.RetryEngine.Implementation[TResult](Func`3 action, Context context, CancellationToken cancellationToken, ExceptionPredicates shouldRetryExceptionPredicates, ResultPredicates`1 shouldRetryResultPredicates, Action`4 onRetry, Int32 permittedRetryCount, IEnumerable`1 sleepDurationsEnumerable, Func`4 sleepDurationProvider)",
  "Secondes": 2,
  "NbEssai": 1,
  "NbEssaiTotal": 5,
  "appid": "relations-messagerie"
}
```