### PR TITLE
Add 1 MS deplay to CleanUpDb to allow time for test{guid}.db to fully…

### DIFF
--- a/tests/Paramore.Brighter.Sqlite.Tests/SqliteTestHelper.cs
+++ b/tests/Paramore.Brighter.Sqlite.Tests/SqliteTestHelper.cs
@@ -1,5 +1,6 @@
-using System;
+﻿using System;
 using System.IO;
+using System.Threading.Tasks;
 using Microsoft.Data.Sqlite;
 using Paramore.Brighter.Inbox.Sqlite;
 using Paramore.Brighter.Outbox.Sqlite;
@@ -49,10 +50,11 @@ namespace Paramore.Brighter.Sqlite.Tests
             return Path.Combine(_connectionStringPathDir, $"test{guidInPath}.db");
         }
 
-        public void CleanUpDb()
+        public async void CleanUpDb()
         {
             try
             {
+                await Task.Delay(1);
                 File.Delete(_connectionStringPath);
                 Directory.Delete(_connectionStringPathDir, true);
             }


### PR DESCRIPTION
Pull request for bug #2940 

Added code to CleanUpDb to wait for one millisecond to allow test{guid}.db to fully close.  In the process made CleanUpDb async.  I decided not to rename CleanUpDbAsync which I would normally have done.