### PR TITLE
Feature 2942 Support NetStandard 2.0 for SQLite projects

### DIFF
--- a/src/Paramore.Brighter.Inbox.Sqlite/Paramore.Brighter.Inbox.Sqlite.csproj
+++ b/src/Paramore.Brighter.Inbox.Sqlite/Paramore.Brighter.Inbox.Sqlite.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>This is an implementation of the inbox used for decoupled invocation of commands by Paramore.Brighter, using Sqlite</Description>
     <Authors>Ian Cooper</Authors>
-    <TargetFrameworks>netstandard2.0;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net7.0;net8.0</TargetFrameworks>
     <PackageTags>RabbitMQ;AMQP;Command;Event;Service Activator;Decoupled;Invocation;Messaging;Remote;Command Dispatcher;Command Processor;Request;Service;Task Queue;Work Queue;Retry;Circuit Breaker;Availability</PackageTags>
   </PropertyGroup>
 

--- a/src/Paramore.Brighter.Inbox.Sqlite/Paramore.Brighter.Inbox.Sqlite.csproj
+++ b/src/Paramore.Brighter.Inbox.Sqlite/Paramore.Brighter.Inbox.Sqlite.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>This is an implementation of the inbox used for decoupled invocation of commands by Paramore.Brighter, using Sqlite</Description>
     <Authors>Ian Cooper</Authors>
-    <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net7.0;net8.0</TargetFrameworks>
     <PackageTags>RabbitMQ;AMQP;Command;Event;Service Activator;Decoupled;Invocation;Messaging;Remote;Command Dispatcher;Command Processor;Request;Service;Task Queue;Work Queue;Retry;Circuit Breaker;Availability</PackageTags>
   </PropertyGroup>
 

--- a/src/Paramore.Brighter.Outbox.Sqlite/Paramore.Brighter.Outbox.Sqlite.csproj
+++ b/src/Paramore.Brighter.Outbox.Sqlite/Paramore.Brighter.Outbox.Sqlite.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>This is an implementation of the outbox used for decoupled invocation of commands by Paramore.Brighter, using Sqlite</Description>
     <Authors>Francesco Pighi</Authors>
-    <TargetFrameworks>netstandard2.0;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net7.0;net8.0</TargetFrameworks>
     <PackageTags>RabbitMQ;AMQP;Command;Event;Service Activator;Decoupled;Invocation;Messaging;Remote;Command Dispatcher;Command Processor;Request;Service;Task Queue;Work Queue;Retry;Circuit Breaker;Availability</PackageTags>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Paramore.Brighter.Outbox.Sqlite/Paramore.Brighter.Outbox.Sqlite.csproj
+++ b/src/Paramore.Brighter.Outbox.Sqlite/Paramore.Brighter.Outbox.Sqlite.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>This is an implementation of the outbox used for decoupled invocation of commands by Paramore.Brighter, using Sqlite</Description>
     <Authors>Francesco Pighi</Authors>
-    <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net7.0;net8.0</TargetFrameworks>
     <PackageTags>RabbitMQ;AMQP;Command;Event;Service Activator;Decoupled;Invocation;Messaging;Remote;Command Dispatcher;Command Processor;Request;Service;Task Queue;Work Queue;Retry;Circuit Breaker;Availability</PackageTags>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Paramore.Brighter.Outbox.Sqlite/SqliteOutbox.cs
+++ b/src/Paramore.Brighter.Outbox.Sqlite/SqliteOutbox.cs
@@ -194,7 +194,11 @@ namespace Paramore.Brighter.Outbox.Sqlite
                 }
                 finally
                 {
+#if NETSTANDARD2_0
+                    connection.Close();
+#else
                     await connection.CloseAsync();
+#endif
                 }
             }
         }
@@ -411,7 +415,11 @@ namespace Paramore.Brighter.Outbox.Sqlite
             var i = dr.GetOrdinal("Body");
             var body = dr.GetStream(i);
             var buffer = new byte[body.Length];
+#if NETSTANDARD2_0
+            body.Read(buffer, 0, buffer.Length);
+#else
             body.Read(buffer);
+#endif
             return buffer;
         }
 

--- a/src/Paramore.Brighter.Sqlite.Dapper/Paramore.Brighter.Sqlite.Dapper.csproj
+++ b/src/Paramore.Brighter.Sqlite.Dapper/Paramore.Brighter.Sqlite.Dapper.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-      <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0</TargetFrameworks>
+      <TargetFrameworks>netstandard2.0;net6.0;net7.0;net8.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Paramore.Brighter.Sqlite.Dapper/Paramore.Brighter.Sqlite.Dapper.csproj
+++ b/src/Paramore.Brighter.Sqlite.Dapper/Paramore.Brighter.Sqlite.Dapper.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-      <TargetFrameworks>netstandard2.0;net6.0;net7.0;net8.0</TargetFrameworks>
+      <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net7.0;net8.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Paramore.Brighter.Sqlite/Paramore.Brighter.Sqlite.csproj
+++ b/src/Paramore.Brighter.Sqlite/Paramore.Brighter.Sqlite.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Authors>Ian Cooper</Authors>
         <PackageTags>RabbitMQ;AMQP;Command;Event;Service Activator;Decoupled;Invocation;Messaging;Remote;Command Dispatcher;Command Processor;Request;Service;Task Queue;Work Queue;Retry;Circuit Breaker;Availability</PackageTags>
-      <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0</TargetFrameworks>
+      <TargetFrameworks>netstandard2.0;net6.0;net7.0;net8.0</TargetFrameworks>
     </PropertyGroup>
   
      <ItemGroup>

--- a/src/Paramore.Brighter.Sqlite/Paramore.Brighter.Sqlite.csproj
+++ b/src/Paramore.Brighter.Sqlite/Paramore.Brighter.Sqlite.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Authors>Ian Cooper</Authors>
         <PackageTags>RabbitMQ;AMQP;Command;Event;Service Activator;Decoupled;Invocation;Messaging;Remote;Command Dispatcher;Command Processor;Request;Service;Task Queue;Work Queue;Retry;Circuit Breaker;Availability</PackageTags>
-      <TargetFrameworks>netstandard2.0;net6.0;net7.0;net8.0</TargetFrameworks>
+      <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net7.0;net8.0</TargetFrameworks>
     </PropertyGroup>
   
      <ItemGroup>


### PR DESCRIPTION
Add NetStandard2.0 support for Sqlite projects.  Make asynchronous calls on NetStandard2.1, synchronous and without cancellation support on NetStandard 2.0.

I plan to use SQLite support on a Net462 project without only supports NetStandard2.0.