### PR TITLE
Convert a DateTime to a string representation with millisecond accuracy

### DIFF
--- a/src/Paramore.Brighter.Outbox.Sqlite/SqliteOutbox.cs
+++ b/src/Paramore.Brighter.Outbox.Sqlite/SqliteOutbox.cs
@@ -27,6 +27,7 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
+using System.Globalization;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -258,7 +259,7 @@ namespace Paramore.Brighter.Outbox.Sqlite
                 {
                     ParameterName = $"@{prefix}Timestamp",
                     SqliteType = SqliteType.Text,
-                    Value = message.Header.TimeStamp.ToString("s")
+                    Value = message.Header.TimeStamp.ToString("yyyy-MM-dd HH:mm:ss.fff", CultureInfo.InvariantCulture)
                 },
                 new SqliteParameter
                 {


### PR DESCRIPTION
#2944 .  In Sqlite implementation, the timestamp has only second precision.  as it was using "s".  Convert it to a dateime format with millisecond accuracy.

Note, I chose not to convert it here to UniversalTime().  Dispatch converts to universal time so maybe we should be consistent here.

DispatchedAt?.ToUniversalTime()



