### PR TITLE
fix: Allows setting of TransactionConnectionProvider on RPC mode

### DIFF
--- a/src/Paramore.Brighter.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Paramore.Brighter.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -356,7 +356,8 @@ namespace Paramore.Brighter.Extensions.DependencyInjection
 
             if (externalBusType == ExternalBusType.None)
                 return messagingBuilder.NoExternalBus();
-            else if (externalBusType == ExternalBusType.FireAndForget)
+            
+            if (externalBusType == ExternalBusType.FireAndForget)
                 return messagingBuilder.ExternalBus(
                     new ExternalBusConfiguration(
                         producerRegistry, 
@@ -366,8 +367,8 @@ namespace Paramore.Brighter.Extensions.DependencyInjection
                         transformerFactory: transformerFactory),
                     outbox,
                     overridingConnectionProvider);
-            else if (externalBusType == ExternalBusType.RPC)
-            {
+
+            if (externalBusType == ExternalBusType.RPC)
                 return messagingBuilder.ExternalRPC(
                     new ExternalBusConfiguration(
                         producerRegistry,
@@ -375,8 +376,8 @@ namespace Paramore.Brighter.Extensions.DependencyInjection
                         responseChannelFactory: options.ChannelFactory,
                         useInbox: inboxConfiguration),
                     outbox,
-                    useRequestResponse.ReplyQueueSubscriptions);
-            }
+                    useRequestResponse.ReplyQueueSubscriptions,
+                    overridingConnectionProvider);
 
             throw new ArgumentOutOfRangeException("The external bus type requested was not understood");
         }

--- a/src/Paramore.Brighter/CommandProcessorBuilder.cs
+++ b/src/Paramore.Brighter/CommandProcessorBuilder.cs
@@ -192,8 +192,9 @@ namespace Paramore.Brighter
         /// <param name="configuration"></param>
         /// <param name="outbox">The outbox</param>
         /// <param name="subscriptions">Subscriptions for creating reply queues</param>
+        /// <param name="boxTransactionConnectionProvider"></param>
         /// <returns></returns>
-        public INeedARequestContext ExternalRPC(ExternalBusConfiguration configuration, IAmAnOutbox<Message> outbox, IEnumerable<Subscription> subscriptions)
+        public INeedARequestContext ExternalRPC(ExternalBusConfiguration configuration, IAmAnOutbox<Message> outbox, IEnumerable<Subscription> subscriptions, IAmABoxTransactionConnectionProvider boxTransactionConnectionProvider = null)
         {
             _useRequestReplyQueues = true;
             _replySubscriptions = subscriptions;
@@ -203,6 +204,7 @@ namespace Paramore.Brighter
             _responseChannelFactory = configuration.ResponseChannelFactory;
             _outbox = outbox;
             _transformerFactory = configuration.TransformerFactory;
+            _overridingBoxTransactionConnectionProvider = boxTransactionConnectionProvider;
              
             return this;
         }
@@ -263,7 +265,8 @@ namespace Paramore.Brighter
                     outBox: _outbox,
                     producerRegistry: _producers,
                     replySubscriptions: _replySubscriptions,
-                    responseChannelFactory: _responseChannelFactory, boxTransactionConnectionProvider: _overridingBoxTransactionConnectionProvider);
+                    responseChannelFactory: _responseChannelFactory, 
+                    boxTransactionConnectionProvider: _overridingBoxTransactionConnectionProvider);
             }
             else
             {
@@ -338,7 +341,8 @@ namespace Paramore.Brighter
         /// <param name="externalBusConfiguration"></param>
         /// <param name="outboxSync">The outbox</param>
         /// <param name="subscriptions">Subscriptions for creating Reply queues</param>
-        INeedARequestContext ExternalRPC(ExternalBusConfiguration externalBusConfiguration, IAmAnOutbox<Message> outboxSync, IEnumerable<Subscription> subscriptions);
+        /// <param name="boxTransactionConnectionProvider">The connection provider to use when adding messages to the bus</param>
+        INeedARequestContext ExternalRPC(ExternalBusConfiguration externalBusConfiguration, IAmAnOutbox<Message> outboxSync, IEnumerable<Subscription> subscriptions, IAmABoxTransactionConnectionProvider boxTransactionConnectionProvider = null);
     }
 
     /// <summary>


### PR DESCRIPTION
This fixes an issue where you are unable to set the implementation of the `IAmABoxTransactionConnectionProvider` when using `useRequestResponseQueues = true`.

It looks like this was just an oversight as the `boxTransactionConnectionProvider` is set to the value of `_overridingBoxTransactionConnectionProvider` later on.