### PR TITLE
Kafka Headers

### DIFF
--- a/src/Paramore.Brighter.DynamoDb/GUIDConverter.cs
+++ b/src/Paramore.Brighter.DynamoDb/GUIDConverter.cs
@@ -9,10 +9,6 @@ namespace Paramore.Brighter.DynamoDb
         public DynamoDBEntry ToEntry(object value)
         {
             var uuid = (Guid)value;
-            if (uuid == null)
-                throw new InvalidOperationException(
-                    $"Supplied type was of type {value.GetType().Name} not Accounts.Application.CardDetails");
-
             var json = uuid.ToString();
 
             DynamoDBEntry entry = new Primitive

--- a/src/Paramore.Brighter.MessagingGateway.Kafka/BrighterDefinedHeaders.cs
+++ b/src/Paramore.Brighter.MessagingGateway.Kafka/BrighterDefinedHeaders.cs
@@ -22,21 +22,26 @@ THE SOFTWARE. */
 
 #endregion
 
-using Confluent.Kafka;
+namespace Paramore.Brighter.MessagingGateway.Kafka;
 
-namespace Paramore.Brighter.MessagingGateway.Kafka
+public static class BrighterDefinedHeaders
 {
-    /// <summary>
-    /// There is a default implementation to build Kafka message before sending to a Kafka topic.
-    /// This interface allow a custom implementation of building the message header.
-    /// </summary>
-    public interface IKafkaMessageHeaderBuilder
+    public static readonly string[] HeadersToReset;
+
+    static BrighterDefinedHeaders()
     {
-        /// <summary>
-        /// Method to build the message header.
-        /// </summary>
-        /// <param name="message">The Brighter Message</param>
-        /// <returns>The Headers object</returns>
-        Headers Build(Message message);
+        HeadersToReset = new[] {
+            HeaderNames.MESSAGE_ID,
+            HeaderNames.MESSAGE_TYPE,
+            HeaderNames.TOPIC,
+            HeaderNames.CORRELATION_ID,
+            HeaderNames.TIMESTAMP,
+            HeaderNames.PARTITIONKEY,
+            HeaderNames.CONTENT_TYPE,
+            HeaderNames.REPLY_TO,
+            HeaderNames.DELAYED_MILLISECONDS,
+            HeaderNames.HANDLED_COUNT
+        };  
     }
+
 }

--- a/src/Paramore.Brighter.MessagingGateway.Kafka/HeaderNames.cs
+++ b/src/Paramore.Brighter.MessagingGateway.Kafka/HeaderNames.cs
@@ -28,6 +28,11 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
     public class HeaderNames
     {
         /// <summary>
+        /// A dictionary of user defined values
+        /// </summary>
+        public static string BAG { get; } = "Bag";
+        
+        /// <summary>
         /// What is the content type of the message§
         /// </summary>
         public static string CONTENT_TYPE { get; set; } = "ContentType";
@@ -36,6 +41,17 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
         /// The correlation id
         /// </summary>
         public const string CORRELATION_ID = "CorrelationId";
+
+        /// <summary>
+        /// If the message was deferred, how long for?
+        /// </summary>
+        public static string DELAYED_MILLISECONDS { get; } =  "x-delay";
+
+        /// <summary>
+        /// How many times has the message been retried with a delay
+        /// </summary>
+        public static string HANDLED_COUNT { get; } = "HandledCount" ;
+
 
         /// <summary>
         /// The message type

--- a/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaDefaultMessageHeaderBuilder.cs
+++ b/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaDefaultMessageHeaderBuilder.cs
@@ -5,7 +5,7 @@ using Paramore.Brighter.Extensions;
 
 namespace Paramore.Brighter.MessagingGateway.Kafka
 {
-    internal class KafkaDefaultMessageHeaderBuilder : IKafkaMessageHeaderBuilder
+    public class KafkaDefaultMessageHeaderBuilder : IKafkaMessageHeaderBuilder
     {
         private static readonly string[] s_headersToReset;
 

--- a/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaDefaultMessageHeaderBuilder.cs
+++ b/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaDefaultMessageHeaderBuilder.cs
@@ -1,24 +1,41 @@
-﻿using System;
+﻿#region Licence
+/* The MIT License (MIT)
+Copyright © 2024 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+using System;
+using System.Globalization;
 using System.Linq;
 using Confluent.Kafka;
 using Paramore.Brighter.Extensions;
 
 namespace Paramore.Brighter.MessagingGateway.Kafka
 {
+    /// <summary>
+    /// This class serializes Brighter headers to Kafka. Kafka uses a byte[] for its header values. We convert all
+    /// header values into a string, and then get a UTF8 encoded set of bytes for that string.
+    /// </summary>
     public class KafkaDefaultMessageHeaderBuilder : IKafkaMessageHeaderBuilder
     {
-        private static readonly string[] s_headersToReset;
-
-        static KafkaDefaultMessageHeaderBuilder()
-        {
-            s_headersToReset = new[] {
-                HeaderNames.MESSAGE_TYPE,
-                HeaderNames.TOPIC,
-                HeaderNames.CORRELATION_ID,
-                HeaderNames.TIMESTAMP
-            };
-        }
-
         public static KafkaDefaultMessageHeaderBuilder Instance => new KafkaDefaultMessageHeaderBuilder();
 
         public Headers Build(Message message)
@@ -31,9 +48,9 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
             };
 
             if (message.Header.TimeStamp != default)
-                headers.Add(HeaderNames.TIMESTAMP, BitConverter.GetBytes(new DateTimeOffset(message.Header.TimeStamp).ToUnixTimeMilliseconds()));
+                headers.Add(HeaderNames.TIMESTAMP, new DateTimeOffset(message.Header.TimeStamp).ToString().ToByteArray());
             else
-                headers.Add(HeaderNames.TIMESTAMP, BitConverter.GetBytes(DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()));
+                headers.Add(HeaderNames.TIMESTAMP, DateTimeOffset.UtcNow.ToString().ToByteArray());
             
             if (message.Header.CorrelationId != Guid.Empty)
                 headers.Add(HeaderNames.CORRELATION_ID, message.Header.CorrelationId.ToString().ToByteArray());
@@ -47,29 +64,42 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
             if (!string.IsNullOrEmpty(message.Header.ReplyTo))
                 headers.Add(HeaderNames.REPLY_TO, message.Header.ReplyTo.ToByteArray());
             
+            headers.Add(HeaderNames.DELAYED_MILLISECONDS, message.Header.DelayedMilliseconds.ToString().ToByteArray());
+            
+            headers.Add(HeaderNames.HANDLED_COUNT, message.Header.HandledCount.ToString().ToByteArray());
+            
             message.Header.Bag.Each((header) =>
             {
-                if (!s_headersToReset.Any(htr => htr.Equals(header.Key)))
+                if (!BrighterDefinedHeaders.HeadersToReset.Any(htr => htr.Equals(header.Key)))
                 {
                     switch (header.Value)
                     {
                         case string stringValue:
                             headers.Add(header.Key, stringValue.ToByteArray());
                             break;
-                        case int intValue:
-                            headers.Add(header.Key, BitConverter.GetBytes(intValue));
+                        case DateTime dateTimeValue:
+                            headers.Add(header.Key, dateTimeValue.ToString(CultureInfo.InvariantCulture).ToByteArray());
                             break;
-                        case Guid guidValue:
+                       case Guid guidValue:
                             headers.Add(header.Key, guidValue.ToString().ToByteArray());
+                            break;
+                       case bool boolValue:
+                            headers.Add(header.Key, boolValue.ToString().ToByteArray());
+                            break;
+                        case int intValue:
+                            headers.Add(header.Key, intValue.ToString().ToByteArray());
+                            break; 
+                        case double doubleValue:
+                            headers.Add(header.Key, doubleValue.ToString(CultureInfo.InvariantCulture).ToByteArray());
+                            break;
+                        case float floatValue:
+                            headers.Add(header.Key, floatValue.ToString(CultureInfo.InvariantCulture).ToByteArray());
+                            break;
+                        case long longValue:
+                            headers.Add(header.Key, longValue.ToString().ToByteArray());
                             break;
                         case byte[] byteArray:
                             headers.Add(header.Key, byteArray);
-                            break;
-                        case double doubleValue:
-                            headers.Add(header.Key, BitConverter.GetBytes(doubleValue));
-                            break;
-                        case DateTime dateTimeValue:
-                            headers.Add(header.Key, dateTimeValue.ToString().ToByteArray());
                             break;
                         default:
                             headers.Add(header.Key, header.Value.ToString().ToByteArray());
@@ -77,7 +107,7 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
                     }
                 }
             });
-
+            
             return headers;
         }
     }

--- a/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaDefaultMessageHeaderBuilder.cs
+++ b/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaDefaultMessageHeaderBuilder.cs
@@ -60,10 +60,16 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
                             headers.Add(header.Key, BitConverter.GetBytes(intValue));
                             break;
                         case Guid guidValue:
-                            headers.Add(header.Key, guidValue.ToByteArray());
+                            headers.Add(header.Key, guidValue.ToString().ToByteArray());
                             break;
                         case byte[] byteArray:
                             headers.Add(header.Key, byteArray);
+                            break;
+                        case double doubleValue:
+                            headers.Add(header.Key, BitConverter.GetBytes(doubleValue));
+                            break;
+                        case DateTime dateTimeValue:
+                            headers.Add(header.Key, dateTimeValue.ToString().ToByteArray());
                             break;
                         default:
                             headers.Add(header.Key, header.Value.ToString().ToByteArray());

--- a/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaHeadersTools.cs
+++ b/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaHeadersTools.cs
@@ -1,4 +1,28 @@
-﻿using System;
+﻿#region Licence
+/* The MIT License (MIT)
+Copyright © 2024 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+using System;
 using System.Linq;
 using Confluent.Kafka;
 

--- a/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaHeadersTools.cs
+++ b/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaHeadersTools.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using Confluent.Kafka;
 
 namespace Paramore.Brighter.MessagingGateway.Kafka

--- a/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaMessageConsumer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaMessageConsumer.cs
@@ -20,6 +20,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE. */
 #endregion
+
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaMessagePublisher.cs
+++ b/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaMessagePublisher.cs
@@ -1,4 +1,28 @@
-﻿using System;
+﻿#region Licence
+/* The MIT License (MIT)
+Copyright © 2024 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+using System;
 using System.Threading.Tasks;
 using Confluent.Kafka;
 

--- a/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaMessagingGateway.cs
+++ b/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaMessagingGateway.cs
@@ -1,4 +1,28 @@
-﻿using System;
+﻿#region Licence
+/* The MIT License (MIT)
+Copyright © 2024 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/tests/Paramore.Brighter.Core.Tests/MessageSerialisation/When_Deserializing_A_Message_Header_Bag.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageSerialisation/When_Deserializing_A_Message_Header_Bag.cs
@@ -50,7 +50,10 @@ namespace Paramore.Brighter.Core.Tests.MessageSerialisation
              //Assert
              foreach (var key in expectedBag.Keys)
              {
-                 if (key != "myArrayKey") deserializedHeader.Bag[key].Should().Be(expectedBag[key]);
+                 if (key != "myArrayKey")
+                 {
+                     deserializedHeader.Bag[key].Should().Be(expectedBag[key]);
+                 }
                  if (key == "myArrayKey")
                  {
                      var expectedVals = (int[])expectedBag[key];

--- a/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/When_converting_brighterheader_to_kafkaheader.cs
+++ b/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/When_converting_brighterheader_to_kafkaheader.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Paramore.Brighter.MessagingGateway.Kafka;
+using Xunit;
+
+namespace Paramore.Brighter.Kafka.Tests.MessagingGateway;
+
+public class KafkaDefaultMessageHeaderBuilderTests 
+{
+    public KafkaDefaultMessageHeaderBuilderTests()
+    {
+        var message = new Message(
+            new MessageHeader(
+                messageId: Guid.NewGuid(),
+                topic: "test",
+                messageType: MessageType.MT_COMMAND,
+                timeStamp: DateTime.UtcNow,
+                correlationId: Guid.NewGuid()
+            ),
+            new MessageBody("test content")
+        );
+    }
+
+    [Fact]
+    public void When_converting_brighterheader_to_kafkaheader()
+    {
+        var builder = new KafkaDefaultMessageHeaderBuilder();
+
+    }
+}

--- a/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/When_converting_brighterheader_to_kafkaheader.cs
+++ b/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/When_converting_brighterheader_to_kafkaheader.cs
@@ -1,4 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Confluent.Kafka;
+using FluentAssertions;
 using Paramore.Brighter.MessagingGateway.Kafka;
 using Xunit;
 
@@ -6,7 +10,8 @@ namespace Paramore.Brighter.Kafka.Tests.MessagingGateway;
 
 public class KafkaDefaultMessageHeaderBuilderTests 
 {
-    public KafkaDefaultMessageHeaderBuilderTests()
+    [Fact]
+    public void When_converting_brighterheader_to_kafkaheader()
     {
         var message = new Message(
             new MessageHeader(
@@ -14,16 +19,44 @@ public class KafkaDefaultMessageHeaderBuilderTests
                 topic: "test",
                 messageType: MessageType.MT_COMMAND,
                 timeStamp: DateTime.UtcNow,
-                correlationId: Guid.NewGuid()
+                correlationId: Guid.NewGuid(),
+                replyTo: "test",
+                contentType: "application/octet",
+                partitionKey: "mykey"
             ),
             new MessageBody("test content")
         );
-    }
 
-    [Fact]
-    public void When_converting_brighterheader_to_kafkaheader()
-    {
+        Dictionary<string,object> bag = message.Header.Bag;
+        bag.Add("myguid", Guid.NewGuid());
+        bag.Add("mystring", "string value");
+        bag.Add("myint", 7);
+        bag.Add("mydouble", 3.56);
+        bag.Add("mybytearray", Encoding.UTF8.GetBytes("mybytes"));
+        bag.Add("mydatetime", DateTime.UtcNow);
+        bag.Add("mydateonly", DateOnly.FromDateTime(DateTime.UtcNow));
+        
         var builder = new KafkaDefaultMessageHeaderBuilder();
+        Headers headers = builder.Build(message);
+        
+        //known properties
+        headers.GetLastBytes(HeaderNames.MESSAGE_TYPE).Should().Equal(message.Header.MessageType.ToString().ToByteArray());
+        headers.GetLastBytes(HeaderNames.MESSAGE_ID).Should().Equal(message.Header.Id.ToString().ToByteArray());
+        headers.GetLastBytes(HeaderNames.TOPIC).Should().Equal(message.Header.Topic.ToByteArray());
+        headers.GetLastBytes(HeaderNames.TIMESTAMP).Should()
+            .Equal(BitConverter.GetBytes(new DateTimeOffset(message.Header.TimeStamp).ToUnixTimeMilliseconds()));
+        headers.GetLastBytes(HeaderNames.CORRELATION_ID).Should()
+            .Equal(message.Header.CorrelationId.ToString().ToByteArray());
+        headers.GetLastBytes(HeaderNames.PARTITIONKEY).Should().Equal(message.Header.PartitionKey.ToByteArray());
+        headers.GetLastBytes(HeaderNames.CONTENT_TYPE).Should().Equal(message.Header.ContentType.ToByteArray());
+        headers.GetLastBytes(HeaderNames.REPLY_TO).Should().Equal(message.Header.ReplyTo.ToByteArray());
 
+        //bag properties    
+        headers.GetLastBytes("myguid").Should().Equal(bag["myguid"].ToString().ToByteArray());
+        headers.GetLastBytes("mystring").Should().Equal(bag["mystring"].ToString().ToByteArray());
+        headers.GetLastBytes("myint").Should().Equal(BitConverter.GetBytes((int)bag["myint"]));
+        headers.GetLastBytes("mydouble").Should().Equal(BitConverter.GetBytes((double)bag["mydouble"]));
+        headers.GetLastBytes("mybytearray").Should().Equal((byte[])bag["mybytearray"]);
+        headers.GetLastBytes("mydatetime").Should().Equal(((DateTime)bag["mydatetime"]).ToString().ToByteArray());
     }
 }

--- a/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/When_converting_brighterheader_to_kafkaheader.cs
+++ b/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/When_converting_brighterheader_to_kafkaheader.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text;
+using System.Text.Json;
 using Confluent.Kafka;
 using FluentAssertions;
 using Paramore.Brighter.MessagingGateway.Kafka;
@@ -13,6 +15,7 @@ public class KafkaDefaultMessageHeaderBuilderTests
     [Fact]
     public void When_converting_brighterheader_to_kafkaheader()
     {
+        //arrange
         var message = new Message(
             new MessageHeader(
                 messageId: Guid.NewGuid(),
@@ -27,36 +30,43 @@ public class KafkaDefaultMessageHeaderBuilderTests
             new MessageBody("test content")
         );
 
+        message.Header.DelayedMilliseconds = 500;
+        message.Header.HandledCount = 2;
+
         Dictionary<string,object> bag = message.Header.Bag;
         bag.Add("myguid", Guid.NewGuid());
         bag.Add("mystring", "string value");
         bag.Add("myint", 7);
         bag.Add("mydouble", 3.56);
-        bag.Add("mybytearray", Encoding.UTF8.GetBytes("mybytes"));
         bag.Add("mydatetime", DateTime.UtcNow);
-        bag.Add("mydateonly", DateOnly.FromDateTime(DateTime.UtcNow));
         
+        //act
         var builder = new KafkaDefaultMessageHeaderBuilder();
         Headers headers = builder.Build(message);
+        
+        //assert
         
         //known properties
         headers.GetLastBytes(HeaderNames.MESSAGE_TYPE).Should().Equal(message.Header.MessageType.ToString().ToByteArray());
         headers.GetLastBytes(HeaderNames.MESSAGE_ID).Should().Equal(message.Header.Id.ToString().ToByteArray());
         headers.GetLastBytes(HeaderNames.TOPIC).Should().Equal(message.Header.Topic.ToByteArray());
         headers.GetLastBytes(HeaderNames.TIMESTAMP).Should()
-            .Equal(BitConverter.GetBytes(new DateTimeOffset(message.Header.TimeStamp).ToUnixTimeMilliseconds()));
+            .Equal(new DateTimeOffset(message.Header.TimeStamp).ToUnixTimeMilliseconds().ToString().ToByteArray());
         headers.GetLastBytes(HeaderNames.CORRELATION_ID).Should()
             .Equal(message.Header.CorrelationId.ToString().ToByteArray());
         headers.GetLastBytes(HeaderNames.PARTITIONKEY).Should().Equal(message.Header.PartitionKey.ToByteArray());
         headers.GetLastBytes(HeaderNames.CONTENT_TYPE).Should().Equal(message.Header.ContentType.ToByteArray());
         headers.GetLastBytes(HeaderNames.REPLY_TO).Should().Equal(message.Header.ReplyTo.ToByteArray());
+        headers.GetLastBytes(HeaderNames.DELAYED_MILLISECONDS).Should()
+            .Equal(message.Header.DelayedMilliseconds.ToString().ToByteArray());
+        headers.GetLastBytes(HeaderNames.HANDLED_COUNT).Should()
+            .Equal(message.Header.HandledCount.ToString().ToByteArray());    
 
         //bag properties    
         headers.GetLastBytes("myguid").Should().Equal(bag["myguid"].ToString().ToByteArray());
         headers.GetLastBytes("mystring").Should().Equal(bag["mystring"].ToString().ToByteArray());
-        headers.GetLastBytes("myint").Should().Equal(BitConverter.GetBytes((int)bag["myint"]));
-        headers.GetLastBytes("mydouble").Should().Equal(BitConverter.GetBytes((double)bag["mydouble"]));
-        headers.GetLastBytes("mybytearray").Should().Equal((byte[])bag["mybytearray"]);
-        headers.GetLastBytes("mydatetime").Should().Equal(((DateTime)bag["mydatetime"]).ToString().ToByteArray());
+        headers.GetLastBytes("myint").Should().Equal(bag["myint"].ToString().ToByteArray());
+        headers.GetLastBytes("mydouble").Should().Equal(bag["mydouble"].ToString().ToByteArray());
+        headers.GetLastBytes("mydatetime").Should().Equal(((DateTime)bag["mydatetime"]).ToString(CultureInfo.InvariantCulture).ToByteArray());
     }
 }

--- a/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/When_converting_kafkaheader_to_brighterheader.cs
+++ b/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/When_converting_kafkaheader_to_brighterheader.cs
@@ -63,7 +63,7 @@ public class KafkaHeaderToBrighterTests
         readMessage.Header.Topic.Should().Be(message.Header.Topic);
         readMessage.Header.DelayedMilliseconds.Should().Be(message.Header.DelayedMilliseconds);
         readMessage.Header.HandledCount.Should().Be(message.Header.HandledCount);
-        //readMessage.Header.TimeStamp.ToString("u").Should().Be(message.Header.TimeStamp.ToString("u"));            
+        readMessage.Header.TimeStamp.ToString("u").Should().Be(message.Header.TimeStamp.ToString("u"));            
         
         //NOTE: Because we can only coerce the byte[] to a string for a unknown bag key, coercing to a specific
         //type has to be done by the user of the bag.

--- a/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/When_converting_kafkaheader_to_brighterheader.cs
+++ b/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/When_converting_kafkaheader_to_brighterheader.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Confluent.Kafka;
+using FluentAssertions;
+using Paramore.Brighter.MessagingGateway.Kafka;
+using Xunit;
+
+namespace Paramore.Brighter.Kafka.Tests.MessagingGateway;
+
+public class KafkaHeaderToBrighterTests  
+{
+    [Fact]
+    public void When_converting_kafkaheader_to_brighterheader()
+    {
+        //arrange
+        
+        var message = new Message(
+            new MessageHeader(
+                messageId: Guid.NewGuid(),
+                topic: "test",
+                messageType: MessageType.MT_COMMAND,
+                timeStamp: DateTime.UtcNow,
+                correlationId: Guid.NewGuid(),
+                replyTo: "test",
+                contentType: "application/octet",
+                partitionKey: "mykey"
+            ),
+            new MessageBody("test content")
+        );
+        
+        message.Header.DelayedMilliseconds = 500;
+        message.Header.HandledCount = 2;
+
+        Dictionary<string,object> bag = message.Header.Bag;
+        bag.Add("myguid", Guid.NewGuid());
+        bag.Add("mystring", "string value");
+        bag.Add("myint", 7);
+        bag.Add("mydouble", 3.56);
+        bag.Add("mydatetime", DateTime.UtcNow);
+        
+        var builder = new KafkaDefaultMessageHeaderBuilder();
+        Headers headers = builder.Build(message);
+
+        var result = new ConsumeResult<string, byte[]>();
+        result.Topic = "test";
+        result.Message = new Message<string, byte[]>
+        {
+            Headers = headers, 
+            Key = message.Id.ToString(), 
+            Value = "test content"u8.ToArray()
+        };
+
+        //act
+        var readMessage = new KafkaMessageCreator().CreateMessage(result);
+
+        //assert
+        readMessage.Id.Should().Be(message.Id);
+        readMessage.Header.MessageType.Should().Be(message.Header.MessageType);
+        readMessage.Header.Id.Should().Be(message.Header.Id);
+        readMessage.Header.CorrelationId.Should().Be(message.Header.CorrelationId);
+        readMessage.Header.ContentType.Should().Be(message.Header.ContentType);
+        readMessage.Header.Topic.Should().Be(message.Header.Topic);
+        readMessage.Header.DelayedMilliseconds.Should().Be(message.Header.DelayedMilliseconds);
+        readMessage.Header.HandledCount.Should().Be(message.Header.HandledCount);
+        //readMessage.Header.TimeStamp.ToString("u").Should().Be(message.Header.TimeStamp.ToString("u"));            
+        
+        //NOTE: Because we can only coerce the byte[] to a string for a unknown bag key, coercing to a specific
+        //type has to be done by the user of the bag.
+        readMessage.Header.Bag["myguid"].Should().Be(bag["myguid"].ToString());
+        readMessage.Header.Bag["mystring"].Should().Be(bag["mystring"].ToString());
+        readMessage.Header.Bag["myint"].Should().Be(bag["myint"].ToString());
+        readMessage.Header.Bag["mydouble"].Should().Be(bag["mydouble"].ToString());
+        readMessage.Header.Bag["mydatetime"].Should().Be(((DateTime)bag["mydatetime"]).ToString(CultureInfo.InvariantCulture));
+    }
+}

--- a/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/When_posting_a_message.cs
+++ b/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/When_posting_a_message.cs
@@ -119,8 +119,8 @@ namespace Paramore.Brighter.Kafka.Tests.MessagingGateway
             receivedMessage.Header.PartitionKey.Should().Be(_partitionKey);
             receivedMessage.Body.Bytes.Should().Equal(message.Body.Bytes);
             receivedMessage.Body.Value.Should().Be(message.Body.Value);
-            receivedMessage.Header.TimeStamp.ToString("yyyy-MM-ddTHH:mm:ss.fffZ")
-                .Should().Be(message.Header.TimeStamp.ToString("yyyy-MM-ddTHH:mm:ss.fffZ"));
+            receivedMessage.Header.TimeStamp.ToString("yyyy-MM-ddTHH:mm:ssZ")
+                .Should().Be(message.Header.TimeStamp.ToString("yyyy-MM-ddTHH:mm:ssZ"));
             receivedCommand.Id.Should().Be(command.Id);
             receivedCommand.Value.Should().Be(command.Value);
         }

--- a/tests/Paramore.Brighter.Kafka.Tests/README.md
+++ b/tests/Paramore.Brighter.Kafka.Tests/README.md
@@ -1,0 +1,22 @@
+# Kafka Test Dependencies
+
+## Running the docker-based tests
+
+Tests which talk to a Docker hosted Kafka instance assume the following:
+
+* No security
+* A Kafka instance running on `localhost:9092`
+* A Zookeeper instance running on `localhost:2181`
+* A schema registry running on `localhost:8081`
+
+
+## Running the confluent-based tests
+
+Tests which talk to a Confluent hosted Kafka instance have an attribute trait of "Confluent". They assume the following:
+
+* You have set environment variables for the following:
+  * CONFLUENT_BOOSTRAP_SERVER - the Kafka instance to connect to
+  * CONFLUENT_SASL_USERNAME - the username to use for SASL
+  * CONFLUENT_SASL_PASSWORD - the password to use for SASL
+
+  


### PR DESCRIPTION
Our implementation of a header builder for Kafka lacked tests and had bugs around GUIDs. Adding tests revealed naive thinking about translating headers to and from Kafka.

* A Kafka header a string key and a byte[] value
* If it is a Brighter header, we can convert a type to a byte[] and back.
* If it a user defined header (the bag) we can at best convert the type to a string and byte[] and then back to a string
     *  We would need to know the serialized type to convert back into the same type
     * Adding type information has implications for security if implemented (see retirement of BinaryFormatter)
     * We can in this case expect the consumer to convert back from a string to a type they know

We used unix timestamps for our own Header timestamp. There is no need to do this, and it simplifies not tol