### PR TITLE
String Identifier for Messages and Requests

### DIFF
--- a/docs/adr/0008-support-cloud-events.md
+++ b/docs/adr/0008-support-cloud-events.md
@@ -1,0 +1,58 @@
+# 8. Support Cloud Events 
+
+Date: 2019-08-01
+
+## Status
+
+Accepted
+
+## Context
+
+Without a standard for metadata, each messaging framework has its own set of metadata fields. This makes it difficult to write code that can work with multiple messaging frameworks. [CloudEvents](https://github.com/cloudevents/spec?tab=readme-ov-file) is a specification for describing event data in a common way. The specification is designed to make it easier to write code that can work with any messaging framework that supports CloudEvents.
+
+We see increasing adoption of CloudEvents as the header standard. We know that the .NET 9 Eventing Framework will use CloudEvents and has listed it as a requirement for the framework. We also know that the Azure Event Grid service supports CloudEvents. Finally, CloudEvents is a CNCF project.
+
+CloudEvents has two options for how metadata is added to a message: structured and binary. The structured mode is a JSON object that is added to the message body. The binary mode is a set of headers that are added to the message. 
+
+## Decision
+
+Given that we want to be interoperable, and often operate in mixed-stack environments, we should support CloudEvents. It is up to the transport to choose between binary and structured, initially though we will support binary adding structured if we see demand or a transport does not have headers.
+
+Because some Cloud Events values are user-defined we will need to allow user-defined values to be passed to the message mapper. Because these user defined values can be determined at design time we will use the Publication to provide the values. This means that the Message Mapper must take the Publication as a parameter. We have two options here: the first is to use DI and register the message mapper with the DI container. The second is to pass the publication directly. As we do not want to have a dependency on a DI framework we will pass the publication directly.
+
+This will result in the following breaking changes:
+
+* Message Id will change from a GUID to a string
+* Correlation Id will change from a GUID to a string
+* Our Bag should support our usage of OTel via [CloudEvents attributes](https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/extensions/distributed-tracing.md) over an explicit property; we should revise how we handle OTel
+
+We will need to add the following CloudEvents properties which have no equivalent in MessageHeader:
+
+* Source: a URI giving the source for the event
+* Type: a string giving the type of the event
+* DataSchema: a URI giving the schema for the data
+* Subject: a string giving the subject of the event
+* Time: a string giving the time of the event
+* SpecVersion: a string giving the version of the CloudEvents spec
+
+Our transports will need to be able to interpret metadata where it comes from cloud events, and where it comes from native headers (see the [AMQP specification for CloudEvents](https://github.com/cloudevents/spec/blob/main/cloudevents/bindings/amqp-protocol-binding.md) as an example). In all cases we should try to read native headers first, then CloudEvents headers and overwrite the native headers with the CloudEvents headers if they exist. Our existing option types for reading headers should support this approach. When writing, we should write both native and CloudEvents headers.
+
+In addition we have a number of Brighter metadata fields that are not part of CloudEvents. We will need to decide how to handle these. We could add them as extensions to CloudEvents, or we could add them as custom header values. We will need to decide on a case by case basis, depending on the transport's native headers.
+
+To identify CloudEvents properties we will introduce a CloudEvents attribute to markup header properties:
+
+[CloudEventAttribute type: CloudEventsAttribute.Required]
+
+Where CloudEventsAttribute.Required is an enum with the following values:
+
+* Required: The property is required by CloudEvents
+* Optional: The property is optional by CloudEvents
+* Extension: The property is an extension to CloudEvents
+* NotUsed: The property is not used by CloudEvents
+
+Where header values are Required, we should not allow them to be empty or null and should throw an exception from the constructor. This will impact our existing MT_EMPTY message, which will instead need to use null object values.
+
+
+## Consequences
+                  
+Passing the Publication to the Message Mapper has advantages. Our ability to provide a generic message mapper has previously been constrained by the Message Mapper not having access to key fields on the Publication, such as the topic/routing key that the message is to be sent over. Whilst the objective of this change is not to provide a generic message mapper, it will allow us to provide a more generic message mapper in the future.

--- a/samples/ASBTaskQueue/GreetingsSender.Web/Controllers/HomeController.cs
+++ b/samples/ASBTaskQueue/GreetingsSender.Web/Controllers/HomeController.cs
@@ -100,7 +100,7 @@ namespace GreetingsSender.Web.Controllers
             
             await _commandProcessor.DepositPostAsync(greetingAsync2);
 
-            var msgs = new List<Guid>();
+            var msgs = new List<string>();
             // msgs.Add(greeting.Id);
             // msgs.Add(greetingAsync.Id);
             msgs.Add(greeting2.Id);

--- a/samples/KafkaSchemaRegistry/GreetingsSender/TimedMessageGenerator.cs
+++ b/samples/KafkaSchemaRegistry/GreetingsSender/TimedMessageGenerator.cs
@@ -45,7 +45,7 @@ namespace GreetingsSender
         {
             _iteration++;
 
-            var greetingEvent = new GreetingEvent{ Id = Guid.NewGuid(), Greeting = $"Hello # {_iteration}"};
+            var greetingEvent = new GreetingEvent{ Id = Guid.NewGuid().ToString(), Greeting = $"Hello # {_iteration}"};
             
             await _processor.PostAsync(greetingEvent);
 

--- a/samples/KafkaTaskQueue/GreetingsSender/TimedMessageGenerator.cs
+++ b/samples/KafkaTaskQueue/GreetingsSender/TimedMessageGenerator.cs
@@ -36,7 +36,7 @@ namespace GreetingsSender
         {
             _iteration++;
 
-            var greetingEvent = new GreetingEvent{ Id = Guid.NewGuid(), Greeting = $"Hello # {_iteration}"};
+            var greetingEvent = new GreetingEvent{ Id = Guid.NewGuid().ToString(), Greeting = $"Hello # {_iteration}"};
             
             processor.Post(greetingEvent);
 

--- a/samples/OpenTelemetry/Sweeper/Program.cs
+++ b/samples/OpenTelemetry/Sweeper/Program.cs
@@ -51,7 +51,7 @@ if (outBox == null)
 
 outBox.Add(
     new Message(
-        new MessageHeader(Guid.NewGuid(), "Test.Topic", MessageType.MT_COMMAND, DateTime.UtcNow),
+        new MessageHeader(Guid.NewGuid().ToString(), "Test.Topic", MessageType.MT_COMMAND, DateTime.UtcNow),
         new MessageBody("Hello"))
     );
 

--- a/samples/RMQRequestReply/Greetings/Ports/Mappers/GreetingReplyMessageMapper.cs
+++ b/samples/RMQRequestReply/Greetings/Ports/Mappers/GreetingReplyMessageMapper.cs
@@ -25,7 +25,7 @@ namespace Greetings.Ports.Mappers
             var replyAddress = new ReplyAddress(topic: message.Header.ReplyTo, correlationId: message.Header.CorrelationId);
             var reply = new GreetingReply(replyAddress);
             var body = JsonSerializer.Deserialize<GreetingsReplyBody>(message.Body.Value);
-            reply.Id = Guid.Parse(body.Id);
+            reply.Id = body.Id;
             reply.Salutation = body.Salutation;
 
             return reply;

--- a/samples/WebAPI_Dapper/GreetingsPorts/Handlers/AddGreetingHandlerAsync.cs
+++ b/samples/WebAPI_Dapper/GreetingsPorts/Handlers/AddGreetingHandlerAsync.cs
@@ -23,7 +23,7 @@ namespace GreetingsPorts.Handlers
         [UsePolicyAsync(step:1, policy: Policies.Retry.EXPONENTIAL_RETRYPOLICYASYNC)]
         public override async Task<AddGreeting> HandleAsync(AddGreeting addGreeting, CancellationToken cancellationToken = default)
         {
-            var posts = new List<Guid>();
+            var posts = new List<string>();
             
             //We use the unit of work to grab connection and transaction, because Outbox needs
             //to share them 'behind the scenes'

--- a/samples/WebAPI_Dapper/GreetingsWeb/Properties/launchSettings.json
+++ b/samples/WebAPI_Dapper/GreetingsWeb/Properties/launchSettings.json
@@ -18,7 +18,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "BRIGHTER_GREETINGS_DATABASE": "Sqlite",
-        "BRIGHTER_TRANSPORT": "RabbitMQ"
+        "BRIGHTER_TRANSPORT": "Kafka"
       }
     },
     "ProductionMySql": {

--- a/samples/WebAPI_Dapper/SalutationPorts/Handlers/GreetingMadeHandlerAsync.cs
+++ b/samples/WebAPI_Dapper/SalutationPorts/Handlers/GreetingMadeHandlerAsync.cs
@@ -25,7 +25,7 @@ namespace SalutationPorts.Handlers
         [UsePolicyAsync(step:2, policy: Policies.Retry.EXPONENTIAL_RETRYPOLICYASYNC)]
         public override async Task<GreetingMade> HandleAsync(GreetingMade @event, CancellationToken cancellationToken = default)
         {
-            var posts = new List<Guid>();
+            var posts = new List<string>();
             
             var tx = await transactionConnectionProvider.GetTransactionAsync(cancellationToken);
             var conn = tx.Connection; 

--- a/samples/WebAPI_Dynamo/GreetingsPorts/Handlers/AddGreetingHandlerAsync.cs
+++ b/samples/WebAPI_Dynamo/GreetingsPorts/Handlers/AddGreetingHandlerAsync.cs
@@ -24,7 +24,7 @@ namespace GreetingsPorts.Handlers
         [UsePolicyAsync(step:1, policy: Policies.Retry.EXPONENTIAL_RETRYPOLICYASYNC)]
         public override async Task<AddGreeting> HandleAsync(AddGreeting addGreeting, CancellationToken cancellationToken = default)
         {
-            var posts = new List<Guid>();
+            var posts = new List<string>();
             
             //We use the unit of work to grab connection and transaction, because Outbox needs
             //to share them 'behind the scenes'

--- a/samples/WebAPI_Dynamo/SalutationPorts/Handlers/GreetingMadeHandler.cs
+++ b/samples/WebAPI_Dynamo/SalutationPorts/Handlers/GreetingMadeHandler.cs
@@ -26,7 +26,7 @@ namespace SalutationPorts.Handlers
         [UsePolicyAsync(step:2, policy: Policies.Retry.EXPONENTIAL_RETRYPOLICY_ASYNC)]
         public override async Task<GreetingMade> HandleAsync(GreetingMade @event, CancellationToken cancellationToken = default)
         {
-            var posts = new List<Guid>();
+            var posts = new List<string>();
             var context = new DynamoDBContext(transactionProvider.DynamoDb);
             var tx = await transactionProvider.GetTransactionAsync(cancellationToken);
             try

--- a/samples/WebAPI_EFCore/GreetingsPorts/Handlers/AddGreetingHandlerAsync.cs
+++ b/samples/WebAPI_EFCore/GreetingsPorts/Handlers/AddGreetingHandlerAsync.cs
@@ -23,7 +23,7 @@ namespace GreetingsPorts.Handlers
         [UsePolicyAsync(step:1, policy: Policies.Retry.EXPONENTIAL_RETRYPOLICYASYNC)]
         public override async Task<AddGreeting> HandleAsync(AddGreeting addGreeting, CancellationToken cancellationToken = default)
         {
-            var posts = new List<Guid>();
+            var posts = new List<string>();
             
             await provider.GetTransactionAsync(cancellationToken);
             try

--- a/samples/WebAPI_EFCore/SalutationPorts/Handlers/GreetingMadeHandler.cs
+++ b/samples/WebAPI_EFCore/SalutationPorts/Handlers/GreetingMadeHandler.cs
@@ -23,7 +23,7 @@ namespace SalutationPorts.Handlers
         [UsePolicyAsync(step:2, policy: Policies.Retry.EXPONENTIAL_RETRYPOLICY_ASYNC)]
         public override async Task<GreetingMade> HandleAsync(GreetingMade @event, CancellationToken cancellationToken = default)
         {
-            var posts = new List<Guid>();
+            var posts = new List<string>();
             
             var tx = await provider.GetTransactionAsync(cancellationToken);
             try

--- a/src/Paramore.Brighter.Archive.Azure/AzureBlobArchiveProvider.cs
+++ b/src/Paramore.Brighter.Archive.Azure/AzureBlobArchiveProvider.cs
@@ -61,12 +61,12 @@ public class AzureBlobArchiveProvider : IAmAnArchiveProvider
     /// <summary>
     /// Archive messages in Parallel
     /// </summary>
-    /// <param name="message">Message to send</param>
+    /// <param name="messages">Messages to send</param>
     /// <param name="cancellationToken">The Cancellation Token</param>
     /// <returns>IDs of successfully archived messages</returns>
-    public async Task<Guid[]> ArchiveMessagesAsync(Message[] messages, CancellationToken cancellationToken)
+    public async Task<string[]> ArchiveMessagesAsync(Message[] messages, CancellationToken cancellationToken)
     {
-        var uploads = new Queue<Task<Guid?>>();
+        var uploads = new Queue<Task<string>>();
 
         foreach (var message in messages)
         {
@@ -75,12 +75,12 @@ public class AzureBlobArchiveProvider : IAmAnArchiveProvider
 
         var results = await Task.WhenAll(uploads);
 #pragma warning disable CS8629 // Nullable value type may be null.
-        return results.Where(r => r.HasValue).Select(r => r.Value).ToArray();
+        return results.Where(r => !string.IsNullOrEmpty(r)).Select(r => r).ToArray();
 #pragma warning restore CS8629 // Nullable value type may be null.
 
     }
 
-    private async Task<Guid?> UploadSafe(Message message, CancellationToken cancellationToken)
+    private async Task<string> UploadSafe(Message message, CancellationToken cancellationToken)
     {
         try
         {

--- a/src/Paramore.Brighter.Inbox.DynamoDB/CommandItem.cs
+++ b/src/Paramore.Brighter.Inbox.DynamoDB/CommandItem.cs
@@ -30,7 +30,7 @@ namespace Paramore.Brighter.Inbox.DynamoDB
             var type = typeof(T).Name;
             
             Time = $"{TimeStamp.Ticks}";
-            CommandId = command.Id.ToString();
+            CommandId = command.Id;
             CommandType = typeof(T).Name;
             CommandBody = JsonSerializer.Serialize(command, JsonSerialisationOptions.Options);
             ContextKey = contextKey;

--- a/src/Paramore.Brighter.Inbox.DynamoDB/DynamoDbInbox.cs
+++ b/src/Paramore.Brighter.Inbox.DynamoDB/DynamoDbInbox.cs
@@ -78,7 +78,7 @@ namespace Paramore.Brighter.Inbox.DynamoDB
         /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
         /// <param name="timeoutInMilliseconds">Timeout in milliseconds; -1 for default timeout</param>
         /// <returns><see cref="T"/></returns>
-        public T Get<T>(Guid id, string contextKey, int timeoutInMilliseconds = -1) where T : class, IRequest
+        public T Get<T>(string id, string contextKey, int timeoutInMilliseconds = -1) where T : class, IRequest
         {
             return GetCommandAsync<T>(id, contextKey)
                 .ConfigureAwait(false)
@@ -110,12 +110,13 @@ namespace Paramore.Brighter.Inbox.DynamoDB
         /// <param name="timeoutInMilliseconds">Timeout in milliseconds; -1 for default timeout</param>
         /// <param name="cancellationToken">Allow the sender to cancel the request, optional</param>
         /// <returns><see cref="Task{T}"/></returns>
-        public async Task<T> GetAsync<T>(Guid id, string contextKey, int timeoutInMilliseconds = -1, CancellationToken cancellationToken = default) where T : class, IRequest
+        public async Task<T> GetAsync<T>(string id, string contextKey, int timeoutInMilliseconds = -1,
+            CancellationToken cancellationToken = default) where T : class, IRequest
         {                
             return await GetCommandAsync<T>(id, contextKey, cancellationToken).ConfigureAwait(false);
         }
 
-       /// <summary>
+        /// <summary>
         /// Checks if the command exists based on the id
         /// </summary>
         /// <param name="id">The identifier</param>
@@ -124,7 +125,8 @@ namespace Paramore.Brighter.Inbox.DynamoDB
         /// <param name="cancellationToken">Allow the sender to cancel the request, optional</param>
         /// <typeparam name="T">Type of command being checked</typeparam>
         /// <returns><see langword="true"/> if Command exists, otherwise <see langword="false"/></returns>
-        public async Task<bool> ExistsAsync<T>(Guid id, string contextKey, int timeoutInMilliseconds = -1, CancellationToken cancellationToken = default) where T : class, IRequest
+        public async Task<bool> ExistsAsync<T>(string id, string contextKey, int timeoutInMilliseconds = -1,
+            CancellationToken cancellationToken = default) where T : class, IRequest
        {
            try
            {
@@ -139,19 +141,19 @@ namespace Paramore.Brighter.Inbox.DynamoDB
 
 
        /// <summary>
-        ///     Checks if the command exists based on the id
-        /// </summary>
-        /// <param name="id">The identifier</param>
-        /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
-        /// <param name="timeoutInMilliseconds">Timeout is ignored as DynamoDB handles timeout and retries</param>        
-        /// <typeparam name="T">Type of command being checked</typeparam>
-        /// <returns><see langword="true"/> if Command exists, otherwise <see langword="false"/></returns>
-        public bool Exists<T>(Guid id, string contextKey, int timeoutInMilliseconds = -1) where T : class, IRequest
+       ///     Checks if the command exists based on the id
+       /// </summary>
+       /// <param name="id">The identifier</param>
+       /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
+       /// <param name="timeoutInMilliseconds">Timeout is ignored as DynamoDB handles timeout and retries</param>
+       /// <typeparam name="T">Type of command being checked</typeparam>
+       /// <returns><see langword="true"/> if Command exists, otherwise <see langword="false"/></returns>
+       public bool Exists<T>(string id, string contextKey, int timeoutInMilliseconds = -1) where T : class, IRequest
         {
             return ExistsAsync<T>(id, contextKey).Result;
         }
 
-        private async Task<T> GetCommandAsync<T>(Guid id, string contextKey, CancellationToken cancellationToken = default) where T : class, IRequest
+        private async Task<T> GetCommandAsync<T>(string id, string contextKey, CancellationToken cancellationToken = default) where T : class, IRequest
         {
             var queryConfig = new QueryOperationConfig
             {

--- a/src/Paramore.Brighter.Inbox.DynamoDB/DynamoDbInbox.cs
+++ b/src/Paramore.Brighter.Inbox.DynamoDB/DynamoDbInbox.cs
@@ -110,8 +110,7 @@ namespace Paramore.Brighter.Inbox.DynamoDB
         /// <param name="timeoutInMilliseconds">Timeout in milliseconds; -1 for default timeout</param>
         /// <param name="cancellationToken">Allow the sender to cancel the request, optional</param>
         /// <returns><see cref="Task{T}"/></returns>
-        public async Task<T> GetAsync<T>(string id, string contextKey, int timeoutInMilliseconds = -1,
-            CancellationToken cancellationToken = default) where T : class, IRequest
+        public async Task<T> GetAsync<T>(string id, string contextKey, int timeoutInMilliseconds = -1, CancellationToken cancellationToken = default) where T : class, IRequest
         {                
             return await GetCommandAsync<T>(id, contextKey, cancellationToken).ConfigureAwait(false);
         }
@@ -125,8 +124,7 @@ namespace Paramore.Brighter.Inbox.DynamoDB
         /// <param name="cancellationToken">Allow the sender to cancel the request, optional</param>
         /// <typeparam name="T">Type of command being checked</typeparam>
         /// <returns><see langword="true"/> if Command exists, otherwise <see langword="false"/></returns>
-        public async Task<bool> ExistsAsync<T>(string id, string contextKey, int timeoutInMilliseconds = -1,
-            CancellationToken cancellationToken = default) where T : class, IRequest
+        public async Task<bool> ExistsAsync<T>(string id, string contextKey, int timeoutInMilliseconds = -1, CancellationToken cancellationToken = default) where T : class, IRequest
        {
            try
            {
@@ -178,8 +176,8 @@ namespace Paramore.Brighter.Inbox.DynamoDB
             
             var messages = new List<CommandItem<T>>();
             do
-            {
-              messages.AddRange(await asyncSearch.GetNextSetAsync().ConfigureAwait(false));
+            { 
+                messages.AddRange(await asyncSearch.GetNextSetAsync().ConfigureAwait(false));
             } while (!asyncSearch.IsDone);
 
             return messages;

--- a/src/Paramore.Brighter.Inbox.DynamoDB/KeyIdContextExpression.cs
+++ b/src/Paramore.Brighter.Inbox.DynamoDB/KeyIdContextExpression.cs
@@ -14,7 +14,7 @@ namespace Paramore.Brighter.Inbox.DynamoDB
             _expression.ExpressionStatement = "CommandId = :v_CommandId and ContextKey = :v_ContextKey";
         }
 
-        public Expression Generate(Guid id, string contextKey)
+        public Expression Generate(string id, string contextKey)
         {
             var values = new Dictionary<string, DynamoDBEntry>();
             values.Add(":v_CommandId", id);

--- a/src/Paramore.Brighter.Inbox.MsSql/MsSqlInbox.cs
+++ b/src/Paramore.Brighter.Inbox.MsSql/MsSqlInbox.cs
@@ -112,7 +112,7 @@ namespace Paramore.Brighter.Inbox.MsSql
         /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
         /// <param name="timeoutInMilliseconds">Timeout in milliseconds; -1 for default timeout</param>
         /// <returns>T.</returns>
-        public T Get<T>(Guid id, string contextKey, int timeoutInMilliseconds = -1) where T : class, IRequest
+        public T Get<T>(string id, string contextKey, int timeoutInMilliseconds = -1) where T : class, IRequest
         {
             var sql = $"select * from {_configuration.InBoxTableName} where CommandId = @commandId AND ContextKey = @contextKey";
             var parameters = new[]
@@ -132,7 +132,7 @@ namespace Paramore.Brighter.Inbox.MsSql
         /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
         /// <param name="timeoutInMilliseconds"></param>
         /// <returns>True if it exists, False otherwise</returns>
-        public bool Exists<T>(Guid id, string contextKey, int timeoutInMilliseconds = -1) where T : class, IRequest
+        public bool Exists<T>(string id, string contextKey, int timeoutInMilliseconds = -1) where T : class, IRequest
         {
             var sql = $"SELECT TOP 1 CommandId FROM {_configuration.InBoxTableName} WHERE CommandId = @commandId AND ContextKey = @contextKey";
             var parameters = new[]
@@ -188,8 +188,10 @@ namespace Paramore.Brighter.Inbox.MsSql
         /// <param name="id">The identifier.</param>
         /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
         /// <param name="timeoutInMilliseconds"></param>
+        /// <param name="cancellationToken"></param>
         /// <returns>True if it exists, False otherwise</returns>
-        public async Task<bool> ExistsAsync<T>(Guid id, string contextKey, int timeoutInMilliseconds = -1, CancellationToken cancellationToken = default) where T : class, IRequest
+        public async Task<bool> ExistsAsync<T>(string id, string contextKey, int timeoutInMilliseconds = -1,
+            CancellationToken cancellationToken = default) where T : class, IRequest
         {
             var sql = $"SELECT TOP 1 CommandId FROM {_configuration.InBoxTableName} WHERE CommandId = @commandId AND ContextKey = @contextKey";
             var parameters = new[]
@@ -230,7 +232,8 @@ namespace Paramore.Brighter.Inbox.MsSql
         /// <param name="timeoutInMilliseconds">Timeout in milliseconds; -1 for default timeout</param>
         /// <param name="cancellationToken">Allow the sender to cancel the request</param>
         /// <returns><see cref="Task{T}" />.</returns>
-        public async Task<T> GetAsync<T>(Guid id, string contextKey, int timeoutInMilliseconds = -1, CancellationToken cancellationToken = default)
+        public async Task<T> GetAsync<T>(string id, string contextKey, int timeoutInMilliseconds = -1,
+            CancellationToken cancellationToken = default)
             where T : class, IRequest
         {
             var sql = $"select * from {_configuration.InBoxTableName} where CommandId = @commandId AND ContextKey = @contextKey";
@@ -320,7 +323,7 @@ namespace Paramore.Brighter.Inbox.MsSql
             return parameters;
         }
 
-        private TResult ReadCommand<TResult>(IDataReader dr, Guid commandId) where TResult : class, IRequest
+        private TResult ReadCommand<TResult>(IDataReader dr, string commandId) where TResult : class, IRequest
         {
             if (dr.Read())
             {

--- a/src/Paramore.Brighter.Inbox.MsSql/SqlInboxBuilder.cs
+++ b/src/Paramore.Brighter.Inbox.MsSql/SqlInboxBuilder.cs
@@ -33,7 +33,7 @@ namespace Paramore.Brighter.Inbox.MsSql
                     CREATE TABLE {0}
                         (
                             [Id] [BIGINT] IDENTITY(1, 1) NOT NULL ,
-                            [CommandId] [UNIQUEIDENTIFIER] NOT NULL ,
+                            [CommandId] [NVARCHAR](256) NOT NULL ,
                             [CommandType] [NVARCHAR](256) NULL ,
                             [CommandBody] [NVARCHAR](MAX) NULL ,
                             [Timestamp] [DATETIME] NULL ,

--- a/src/Paramore.Brighter.Inbox.MySql/MySqlInbox.cs
+++ b/src/Paramore.Brighter.Inbox.MySql/MySqlInbox.cs
@@ -99,7 +99,7 @@ namespace Paramore.Brighter.Inbox.MySql
         /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
         /// <param name="timeoutInMilliseconds">Timeout in milliseconds; -1 for default timeout</param>
         /// <returns>T.</returns>
-        public T Get<T>(Guid id, string contextKey, int timeoutInMilliseconds = -1) where T : class, IRequest
+        public T Get<T>(string id, string contextKey, int timeoutInMilliseconds = -1) where T : class, IRequest
         {
             var sql = $"select * from {_configuration.InBoxTableName} where CommandId = @commandId and ContextKey = @contextKey";
             var parameters = new[]
@@ -120,7 +120,7 @@ namespace Paramore.Brighter.Inbox.MySql
         /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
         /// <param name="timeoutInMilliseconds"></param>
         /// <returns>True if it exists, False otherwise</returns>
-        public bool Exists<T>(Guid id, string contextKey, int timeoutInMilliseconds = -1) where T : class, IRequest
+        public bool Exists<T>(string id, string contextKey, int timeoutInMilliseconds = -1) where T : class, IRequest
         {
             var sql = $"SELECT CommandId FROM {_configuration.InBoxTableName} WHERE CommandId = @commandId and ContextKey = @contextKey LIMIT 1";
             var parameters = new[]
@@ -140,8 +140,10 @@ namespace Paramore.Brighter.Inbox.MySql
         /// <param name="id">The identifier.</param>
         /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
         /// <param name="timeoutInMilliseconds"></param>
+        /// <param name="cancellationToken"></param>
         /// <returns>True if it exists, False otherwise</returns>
-        public async Task<bool> ExistsAsync<T>(Guid id, string contextKey, int timeoutInMilliseconds = -1, CancellationToken cancellationToken = default) where T : class, IRequest
+        public async Task<bool> ExistsAsync<T>(string id, string contextKey, int timeoutInMilliseconds = -1,
+            CancellationToken cancellationToken = default) where T : class, IRequest
         {
             var sql = $"SELECT CommandId FROM {_configuration.InBoxTableName} WHERE CommandId = @commandId and ContextKey = @contextKey LIMIT 1";
             var parameters = new[]
@@ -219,7 +221,8 @@ namespace Paramore.Brighter.Inbox.MySql
         /// <param name="timeoutInMilliseconds">Timeout in milliseconds; -1 for default timeout</param>
         /// <param name="cancellationToken">Allow the sender to cancel the request</param>
         /// <returns><see cref="Task{T}" />.</returns>
-        public async Task<T> GetAsync<T>(Guid id, string contextKey, int timeoutInMilliseconds = -1, CancellationToken cancellationToken = default)
+        public async Task<T> GetAsync<T>(string id, string contextKey, int timeoutInMilliseconds = -1,
+            CancellationToken cancellationToken = default)
             where T : class, IRequest
         {
             var sql = $"select * from {_configuration.InBoxTableName} where CommandId = @commandId and ContextKey = @contextKey";
@@ -316,7 +319,7 @@ namespace Paramore.Brighter.Inbox.MySql
             return parameters;
         }
 
-        private TResult ReadCommand<TResult>(IDataReader dr, Guid id) where TResult : class, IRequest
+        private TResult ReadCommand<TResult>(IDataReader dr, string id) where TResult : class, IRequest
         {
             if (dr.Read())
             {

--- a/src/Paramore.Brighter.Inbox.MySql/MySqlInboxBuilder.cs
+++ b/src/Paramore.Brighter.Inbox.MySql/MySqlInboxBuilder.cs
@@ -33,7 +33,7 @@ namespace Paramore.Brighter.Inbox.MySql
     {
         private const string OutboxDDL = @"CREATE TABLE {0} 
             ( 
-                `CommandId` CHAR(36) NOT NULL , 
+                `CommandId` VARCHAR(255) NOT NULL , 
                 `CommandType` VARCHAR(256) NOT NULL , 
                 `CommandBody` TEXT NOT NULL , 
                 `Timestamp` TIMESTAMP(4) NOT NULL , 

--- a/src/Paramore.Brighter.Inbox.Postgres/PostgreSqlInbox.cs
+++ b/src/Paramore.Brighter.Inbox.Postgres/PostgreSqlInbox.cs
@@ -287,7 +287,7 @@ namespace Paramore.Brighter.Inbox.Postgres
             }
         }
 
-        private TResult ReadCommand<TResult>(IDataReader dr, Guid commandId) where TResult : class, IRequest
+        private TResult ReadCommand<TResult>(IDataReader dr, string commandId) where TResult : class, IRequest
         {
             if (dr.Read())
             {

--- a/src/Paramore.Brighter.Inbox.Postgres/PostgreSqlInbox.cs
+++ b/src/Paramore.Brighter.Inbox.Postgres/PostgreSqlInbox.cs
@@ -88,7 +88,7 @@ namespace Paramore.Brighter.Inbox.Postgres
             }
         }
 
-        public T Get<T>(Guid id, string contextKey, int timeoutInMilliseconds = -1) where T : class, IRequest
+        public T Get<T>(string id, string contextKey, int timeoutInMilliseconds = -1) where T : class, IRequest
         {
             var sql = $"SELECT * FROM {_configuration.InBoxTableName} WHERE CommandId = @CommandId AND ContextKey = @ContextKey";
             var parameters = new[]
@@ -100,7 +100,7 @@ namespace Paramore.Brighter.Inbox.Postgres
             return ExecuteCommand(command => ReadCommand<T>(command.ExecuteReader(), id), sql, timeoutInMilliseconds, parameters);
         }
 
-        public bool Exists<T>(Guid id, string contextKey, int timeoutInMilliseconds = -1) where T : class, IRequest
+        public bool Exists<T>(string id, string contextKey, int timeoutInMilliseconds = -1) where T : class, IRequest
         {
             var sql = $"SELECT DISTINCT CommandId FROM {_configuration.InBoxTableName} WHERE CommandId = @CommandId AND ContextKey = @ContextKey FETCH FIRST 1 ROWS ONLY";
             var parameters = new[]
@@ -143,7 +143,8 @@ namespace Paramore.Brighter.Inbox.Postgres
             }
         }
 
-        public async Task<T> GetAsync<T>(Guid id, string contextKey, int timeoutInMilliseconds = -1, CancellationToken cancellationToken = default) where T : class, IRequest
+        public async Task<T> GetAsync<T>(string id, string contextKey, int timeoutInMilliseconds = -1,
+            CancellationToken cancellationToken = default) where T : class, IRequest
         {
             var sql = $"SELECT * FROM {_configuration.InBoxTableName} WHERE CommandId = @CommandId AND ContextKey = @ContextKey";
 
@@ -162,7 +163,8 @@ namespace Paramore.Brighter.Inbox.Postgres
                 .ConfigureAwait(ContinueOnCapturedContext);
         }
 
-        public async Task<bool> ExistsAsync<T>(Guid id, string contextKey, int timeoutInMilliseconds = -1, CancellationToken cancellationToken = default) where T : class, IRequest
+        public async Task<bool> ExistsAsync<T>(string id, string contextKey, int timeoutInMilliseconds = -1,
+            CancellationToken cancellationToken = default) where T : class, IRequest
         {
             var sql = $"SELECT DISTINCT CommandId FROM {_configuration.InBoxTableName} WHERE CommandId = @CommandId AND ContextKey = @ContextKey FETCH FIRST 1 ROWS ONLY";
             var parameters = new[]

--- a/src/Paramore.Brighter.Inbox.Postgres/PostgreSqlInboxBuilder.cs
+++ b/src/Paramore.Brighter.Inbox.Postgres/PostgreSqlInboxBuilder.cs
@@ -33,7 +33,7 @@ namespace Paramore.Brighter.Inbox.Postgres
         private const string OutboxDDL = @"
                     CREATE TABLE {0}
                         (
-                            CommandId uuid NOT NULL ,
+                            CommandId VARCHAR(256) NOT NULL ,
                             CommandType VARCHAR(256) NULL ,
                             CommandBody TEXT NULL ,
                             Timestamp timestamptz  NULL ,

--- a/src/Paramore.Brighter.Inbox.Sqlite/SqliteInbox.cs
+++ b/src/Paramore.Brighter.Inbox.Sqlite/SqliteInbox.cs
@@ -90,7 +90,7 @@ namespace Paramore.Brighter.Inbox.Sqlite
                    sqlException.SqliteErrorCode == SqliteUniqueKeyError;
         }
 
-        public T Get<T>(Guid id, string contextKey, int timeoutInMilliseconds = -1) where T : class, IRequest
+        public T Get<T>(string id, string contextKey, int timeoutInMilliseconds = -1) where T : class, IRequest
         {
             var sql = $"select * from {this.OutboxTableName} where CommandId = @CommandId and ContextKey = @ContextKey";
             var parameters = new[]
@@ -110,7 +110,7 @@ namespace Paramore.Brighter.Inbox.Sqlite
         /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
         /// <param name="timeoutInMilliseconds"></param>
         /// <returns>True if it exists, False otherwise</returns>
-        public bool Exists<T>(Guid id, string contextKey, int timeoutInMilliseconds = -1) where T : class, IRequest
+        public bool Exists<T>(string id, string contextKey, int timeoutInMilliseconds = -1) where T : class, IRequest
         {
             var sql = $"SELECT CommandId FROM {OutboxTableName} WHERE CommandId = @CommandId and ContextKey = @ContextKey LIMIT 1";
             var parameters = new[]
@@ -128,9 +128,12 @@ namespace Paramore.Brighter.Inbox.Sqlite
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="id">The identifier.</param>
+        /// <param name="contextKey"></param>
         /// <param name="timeoutInMilliseconds"></param>
+        /// <param name="cancellationToken"></param>
         /// <returns>True if it exists, False otherwise</returns>
-        public async Task<bool> ExistsAsync<T>(Guid id, string contextKey, int timeoutInMilliseconds = -1, CancellationToken cancellationToken = default) where T : class, IRequest
+        public async Task<bool> ExistsAsync<T>(string id, string contextKey, int timeoutInMilliseconds = -1,
+            CancellationToken cancellationToken = default) where T : class, IRequest
         {
             var sql = $"SELECT CommandId FROM {OutboxTableName} WHERE CommandId = @CommandId and ContextKey = @ContextKey LIMIT 1";
             var parameters = new[]
@@ -178,7 +181,8 @@ namespace Paramore.Brighter.Inbox.Sqlite
             }
         }
 
-        public async Task<T> GetAsync<T>(Guid id, string contextKey, int timeoutInMilliseconds = -1, CancellationToken cancellationToken = default) where T : class, IRequest
+        public async Task<T> GetAsync<T>(string id, string contextKey, int timeoutInMilliseconds = -1,
+            CancellationToken cancellationToken = default) where T : class, IRequest
         {
             var sql = $"select * from {OutboxTableName} where CommandId = @CommandId and ContextKey = @ContextKey";
             var parameters = new[]
@@ -283,7 +287,7 @@ namespace Paramore.Brighter.Inbox.Sqlite
             return parameters;
         }
 
-        private TResult ReadCommand<TResult>(IDataReader dr, Guid id) where TResult : class, IRequest
+        private TResult ReadCommand<TResult>(IDataReader dr, string id) where TResult : class, IRequest
         {
             using (dr)
             {

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS/ISqsMessageCreator.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS/ISqsMessageCreator.cs
@@ -41,10 +41,10 @@ namespace Paramore.Brighter.MessagingGateway.AWSSQS
             return new HeaderResult<string>(string.Empty, true);
         }
 
-        protected Message FailureMessage(HeaderResult<string> topic, HeaderResult<Guid> messageId)
+        protected Message FailureMessage(HeaderResult<string> topic, HeaderResult<string> messageId)
         {
             var header = new MessageHeader(
-                messageId.Success ? messageId.Result : Guid.Empty,
+                messageId.Success ? messageId.Result : string.Empty,
                 topic.Success ? topic.Result : string.Empty,
                 MessageType.MT_UNACCEPTABLE);
             var message = new Message(header, new MessageBody(string.Empty));

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS/SqsInlineMessageCreator.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS/SqsInlineMessageCreator.cs
@@ -38,7 +38,7 @@ namespace Paramore.Brighter.MessagingGateway.AWSSQS
         public Message CreateMessage(Amazon.SQS.Model.Message sqsMessage)
         {
             var topic = HeaderResult<string>.Empty();
-            var messageId = HeaderResult<Guid>.Empty();
+            var messageId = HeaderResult<string>.Empty();
             var contentType = HeaderResult<string>.Empty();
             var correlationId = HeaderResult<Guid>.Empty();
             var handledCount = HeaderResult<int>.Empty();
@@ -213,17 +213,14 @@ namespace Paramore.Brighter.MessagingGateway.AWSSQS
             return new HeaderResult<Guid>(Guid.Empty, true);
         }
 
-        private HeaderResult<Guid> ReadMessageId()
+        private HeaderResult<string> ReadMessageId()
         {
             if (_messageAttributes.TryGetValue(HeaderNames.Id, out var messageId))
             {
-                if (Guid.TryParse(messageId.GetValueInString(), out var value))
-                {
-                    return new HeaderResult<Guid>(value, true);
-                }
+                return new HeaderResult<string>(messageId.GetValueInString(), true);
             }
 
-            return new HeaderResult<Guid>(Guid.Empty, true);
+            return new HeaderResult<string>(string.Empty, true);
         }
 
         private HeaderResult<string> ReadTopic()

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS/SqsInlineMessageCreator.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS/SqsInlineMessageCreator.cs
@@ -40,7 +40,7 @@ namespace Paramore.Brighter.MessagingGateway.AWSSQS
             var topic = HeaderResult<string>.Empty();
             var messageId = HeaderResult<string>.Empty();
             var contentType = HeaderResult<string>.Empty();
-            var correlationId = HeaderResult<Guid>.Empty();
+            var correlationId = HeaderResult<string>.Empty();
             var handledCount = HeaderResult<int>.Empty();
             var messageType = HeaderResult<MessageType>.Empty();
             var timeStamp = HeaderResult<DateTime>.Empty();
@@ -200,17 +200,14 @@ namespace Paramore.Brighter.MessagingGateway.AWSSQS
             return new HeaderResult<int>(0, true);
         }
 
-        private HeaderResult<Guid> ReadCorrelationId()
+        private HeaderResult<string> ReadCorrelationId()
         {
             if (_messageAttributes.TryGetValue(HeaderNames.CorrelationId, out var correlationId))
             {
-                if (Guid.TryParse(correlationId.GetValueInString(), out var value))
-                {
-                    return new HeaderResult<Guid>(value, true);
-                }
+                return new HeaderResult<string>(correlationId.GetValueInString(), true);
             }
 
-            return new HeaderResult<Guid>(Guid.Empty, true);
+            return new HeaderResult<string>(string.Empty, true);
         }
 
         private HeaderResult<string> ReadMessageId()

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS/SqsMessageCreator.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS/SqsMessageCreator.cs
@@ -52,7 +52,7 @@ namespace Paramore.Brighter.MessagingGateway.AWSSQS
         public Message CreateMessage(Amazon.SQS.Model.Message sqsMessage)
         {
             var topic = HeaderResult<string>.Empty();
-            var messageId = HeaderResult<Guid>.Empty();
+            var messageId = HeaderResult<string>.Empty();
             var contentType = HeaderResult<string>.Empty();
             var correlationId = HeaderResult<Guid>.Empty();
             var handledCount = HeaderResult<int>.Empty();
@@ -201,16 +201,13 @@ namespace Paramore.Brighter.MessagingGateway.AWSSQS
             return new HeaderResult<string>(String.Empty, true);
         }
 
-        private HeaderResult<Guid> ReadMessageId(Amazon.SQS.Model.Message sqsMessage)
+        private HeaderResult<string> ReadMessageId(Amazon.SQS.Model.Message sqsMessage)
         {
             if (sqsMessage.MessageAttributes.TryGetValue(HeaderNames.Id, out MessageAttributeValue value))
             {
-                if (Guid.TryParse(value.StringValue, out Guid messageId))
-                {
-                    return new HeaderResult<Guid>(messageId, true);
-                }
+                return new HeaderResult<string>(value.StringValue, true);
             }
-            return new HeaderResult<Guid>(Guid.Empty, true);
+            return new HeaderResult<string>(string.Empty, true);
         }
 
         private HeaderResult<string> ReadTopic(Amazon.SQS.Model.Message sqsMessage)

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS/SqsMessageCreator.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS/SqsMessageCreator.cs
@@ -54,7 +54,7 @@ namespace Paramore.Brighter.MessagingGateway.AWSSQS
             var topic = HeaderResult<string>.Empty();
             var messageId = HeaderResult<string>.Empty();
             var contentType = HeaderResult<string>.Empty();
-            var correlationId = HeaderResult<Guid>.Empty();
+            var correlationId = HeaderResult<string>.Empty();
             var handledCount = HeaderResult<int>.Empty();
             var messageType = HeaderResult<MessageType>.Empty();
             var timeStamp = HeaderResult<DateTime>.Empty();
@@ -180,16 +180,13 @@ namespace Paramore.Brighter.MessagingGateway.AWSSQS
             return new HeaderResult<int>(0, true);
         }
 
-        private HeaderResult<Guid> ReadCorrelationid(Amazon.SQS.Model.Message sqsMessage)
+        private HeaderResult<string> ReadCorrelationid(Amazon.SQS.Model.Message sqsMessage)
         {
-            if (sqsMessage.MessageAttributes.TryGetValue(HeaderNames.CorrelationId, out MessageAttributeValue value))
+            if (sqsMessage.MessageAttributes.TryGetValue(HeaderNames.CorrelationId, out MessageAttributeValue correlationId))
             {
-                if (Guid.TryParse(value.StringValue, out Guid correlationId))
-                {
-                    return new HeaderResult<Guid>(correlationId, true);
-                }
+                return new HeaderResult<string>(correlationId.StringValue, true);
             }
-            return new HeaderResult<Guid>(Guid.Empty, true);
+            return new HeaderResult<string>(string.Empty, true);
          }
 
         private HeaderResult<string> ReadContentType(Amazon.SQS.Model.Message sqsMessage)

--- a/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusConsumer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusConsumer.cs
@@ -96,7 +96,9 @@ namespace Paramore.Brighter.MessagingGateway.AzureServiceBus
                 if (_serviceBusReceiver is {IsClosedOrClosing: true} && !_subscriptionConfiguration.RequireSession)
                 {
                     s_logger.LogDebug("Message Receiver is closing...");
-                    var message = new Message(new MessageHeader(Guid.NewGuid(), _topicName, MessageType.MT_QUIT), new MessageBody(string.Empty));
+                    var message = new Message(
+                        new MessageHeader(string.Empty, _topicName, MessageType.MT_QUIT), 
+                        new MessageBody(string.Empty));
                     messagesToReturn.Add(message);
                     return messagesToReturn.ToArray();
                 }
@@ -283,8 +285,8 @@ namespace Paramore.Brighter.MessagingGateway.AzureServiceBus
             
             var handledCount = GetHandledCount(azureServiceBusMessage);
             var headers = new MessageHeader(azureServiceBusMessage.Id, _topicName, messageType, DateTime.UtcNow,
-                handledCount, 0, azureServiceBusMessage.CorrelationId, contentType: azureServiceBusMessage.ContentType,
-                replyTo: replyAddress);
+                handledCount, 0, azureServiceBusMessage.CorrelationId,
+                replyTo: replyAddress, contentType: azureServiceBusMessage.ContentType);
 
             if (_receiveMode.Equals(ServiceBusReceiveMode.PeekLock))
                 headers.Bag.Add(ASBConstants.LockTokenHeaderBagKey, azureServiceBusMessage.LockToken);
@@ -379,7 +381,7 @@ namespace Paramore.Brighter.MessagingGateway.AzureServiceBus
             }
         }
 
-        private void HandleASBException(ServiceBusException ex, Guid messageId)
+        private void HandleASBException(ServiceBusException ex, string messageId)
         {
             if (ex.Reason == ServiceBusFailureReason.MessageLockLost)
                 s_logger.LogError(ex, "Error completing peak lock on message with id {Id}", messageId);

--- a/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusMessageProducer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusMessageProducer.cs
@@ -111,11 +111,12 @@ namespace Paramore.Brighter.MessagingGateway.AzureServiceBus
         /// Sends a Batch of Messages
         /// </summary>
         /// <param name="messages">The messages to send.</param>
-        /// <param name="batchSize">The size of batches to send messages in.</param>
         /// <param name="cancellationToken">The Cancellation Token.</param>
+        /// <param name="batchSize">The size of batches to send messages in.</param>
         /// <returns>List of Messages successfully sent.</returns>
         /// <exception cref="NotImplementedException"></exception>
-        public async IAsyncEnumerable<Guid[]> SendAsync(IEnumerable<Message> messages, [EnumeratorCancellation] CancellationToken cancellationToken)
+        public async IAsyncEnumerable<string[]> SendAsync(IEnumerable<Message> messages,
+            [EnumeratorCancellation] CancellationToken cancellationToken)
         {
             var topics = messages.Select(m => m.Header.Topic).Distinct();
             if (topics.Count() != 1)

--- a/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusWrappers/BrokeredMessageWrapper.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusWrappers/BrokeredMessageWrapper.cs
@@ -19,7 +19,7 @@ namespace Paramore.Brighter.MessagingGateway.AzureServiceBus.AzureServiceBusWrap
 
         public string LockToken => _brokeredMessage.LockToken;
 
-        public Guid Id => Guid.Parse(_brokeredMessage.MessageId);
+        public string Id => _brokeredMessage.MessageId;
 
         public Guid CorrelationId
         {

--- a/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusWrappers/BrokeredMessageWrapper.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusWrappers/BrokeredMessageWrapper.cs
@@ -21,13 +21,13 @@ namespace Paramore.Brighter.MessagingGateway.AzureServiceBus.AzureServiceBusWrap
 
         public string Id => _brokeredMessage.MessageId;
 
-        public Guid CorrelationId
+        public string CorrelationId
         {
             get
             {
                 return string.IsNullOrEmpty(_brokeredMessage.CorrelationId)
-                    ? Guid.Empty
-                    : Guid.Parse(_brokeredMessage.CorrelationId);
+                    ? string.Empty
+                    : _brokeredMessage.CorrelationId;
             }
         }
 

--- a/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusWrappers/IBrokeredMessageWrapper.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusWrappers/IBrokeredMessageWrapper.cs
@@ -26,7 +26,7 @@ namespace Paramore.Brighter.MessagingGateway.AzureServiceBus.AzureServiceBusWrap
         /// <summary>
         /// The message Id.
         /// </summary>
-        Guid Id { get; }
+        string Id { get; }
 
         /// <summary>
         /// The Correlation Id.

--- a/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusWrappers/IBrokeredMessageWrapper.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusWrappers/IBrokeredMessageWrapper.cs
@@ -31,7 +31,7 @@ namespace Paramore.Brighter.MessagingGateway.AzureServiceBus.AzureServiceBusWrap
         /// <summary>
         /// The Correlation Id.
         /// </summary>
-        Guid CorrelationId { get; }
+        string CorrelationId { get; }
 
         /// <summary>
         /// The Mime Type.

--- a/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaDefaultMessageHeaderBuilder.cs
+++ b/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaDefaultMessageHeaderBuilder.cs
@@ -44,7 +44,7 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
             {
                 new Header(HeaderNames.MESSAGE_TYPE, message.Header.MessageType.ToString().ToByteArray()),
                 new Header(HeaderNames.TOPIC, message.Header.Topic.ToByteArray()),
-                new Header(HeaderNames.MESSAGE_ID, message.Header.Id.ToString().ToByteArray()),
+                new Header(HeaderNames.MESSAGE_ID, message.Header.Id.ToByteArray()),
             };
 
             if (message.Header.TimeStamp != default)
@@ -52,8 +52,8 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
             else
                 headers.Add(HeaderNames.TIMESTAMP, DateTimeOffset.UtcNow.ToString().ToByteArray());
             
-            if (message.Header.CorrelationId != Guid.Empty)
-                headers.Add(HeaderNames.CORRELATION_ID, message.Header.CorrelationId.ToString().ToByteArray());
+            if (message.Header.CorrelationId != string.Empty)
+                headers.Add(HeaderNames.CORRELATION_ID, message.Header.CorrelationId.ToByteArray());
 
             if (!string.IsNullOrEmpty(message.Header.PartitionKey))
                 headers.Add(HeaderNames.PARTITIONKEY, message.Header.PartitionKey.ToByteArray());

--- a/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaMessageProducer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaMessageProducer.cs
@@ -33,7 +33,7 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
 {
     internal class KafkaMessageProducer : KafkaMessagingGateway, IAmAMessageProducerSync, IAmAMessageProducerAsync, ISupportPublishConfirmation
     {
-        public event Action<bool, Guid> OnMessagePublished;
+        public event Action<bool, string> OnMessagePublished;
         /// <summary>
         /// How many outstanding messages may the outbox have before we terminate the programme with an OutboxLimitReached exception?
         /// -1 => No limit, although the Outbox may discard older entries which is implementation dependent
@@ -309,15 +309,15 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
                 if (headers.TryGetLastBytesIgnoreCase(HeaderNames.MESSAGE_ID, out byte[] messageIdBytes))
                 {
                     var val = messageIdBytes.FromByteArray();
-                    if (!string.IsNullOrEmpty(val) && (Guid.TryParse(val, out Guid messageId)))
+                    if (!string.IsNullOrEmpty(val))
                     {
-                        Task.Run(() => OnMessagePublished?.Invoke(true, messageId));
+                        Task.Run(() => OnMessagePublished?.Invoke(true, val));
                         return;
                     }
                 }
             }
             
-            Task.Run((() =>OnMessagePublished?.Invoke(false, Guid.Empty)));
+            Task.Run((() =>OnMessagePublished?.Invoke(false, string.Empty)));
         }
     }
 }

--- a/src/Paramore.Brighter.MessagingGateway.RMQ/RmqMessageCreator.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ/RmqMessageCreator.cs
@@ -260,7 +260,7 @@ namespace Paramore.Brighter.MessagingGateway.RMQ
                 return new HeaderResult<string>(newMessageId, true);
             }
 
-            return new HeaderResult<string>(newMessageId, true);
+            return new HeaderResult<string>(messageId, true);
         }
 
         private HeaderResult<bool> ReadRedeliveredFlag(bool redelivered)

--- a/src/Paramore.Brighter.MessagingGateway.RMQ/RmqMessageCreator.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ/RmqMessageCreator.cs
@@ -86,7 +86,7 @@ namespace Paramore.Brighter.MessagingGateway.RMQ
                 if (headers.TryGetValue(HeaderNames.CORRELATION_ID, out object correlationHeader))
                 {
                     var correlationId = Encoding.UTF8.GetString((byte[])correlationHeader);
-                    message.Header.CorrelationId = Guid.Parse(correlationId);
+                    message.Header.CorrelationId = correlationId;
                 }
 
                 message.DeliveryTag = deliveryTag.Result;

--- a/src/Paramore.Brighter.MessagingGateway.RMQ/RmqMessagePublisher.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ/RmqMessagePublisher.cs
@@ -96,8 +96,8 @@ internal class RmqMessagePublisher
                 { HeaderNames.HANDLED_COUNT, message.Header.HandledCount }
             };
 
-            if (message.Header.CorrelationId != Guid.Empty)
-                headers.Add(HeaderNames.CORRELATION_ID, message.Header.CorrelationId.ToString());
+            if (message.Header.CorrelationId != string.Empty)
+                headers.Add(HeaderNames.CORRELATION_ID, message.Header.CorrelationId);
 
             message.Header.Bag.Each(header =>
             {
@@ -145,8 +145,8 @@ internal class RmqMessagePublisher
                 {HeaderNames.HANDLED_COUNT, message.Header.HandledCount},
              };
 
-            if (message.Header.CorrelationId != Guid.Empty)
-                headers.Add(HeaderNames.CORRELATION_ID, message.Header.CorrelationId.ToString());
+            if (message.Header.CorrelationId != string.Empty)
+                headers.Add(HeaderNames.CORRELATION_ID, message.Header.CorrelationId);
 
             message.Header.Bag.Each((header) =>
             {

--- a/src/Paramore.Brighter.MessagingGateway.RMQ/RmqMessagePublisher.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ/RmqMessagePublisher.cs
@@ -133,7 +133,7 @@ internal class RmqMessagePublisher
         /// <param name="delayMilliseconds">Delay in ms.</param>
         public void RequeueMessage(Message message, string queueName, int delayMilliseconds)
         {
-            var messageId = Guid.NewGuid() ;
+            var messageId = Guid.NewGuid().ToString() ;
             const string deliveryTag = "1";
 
             s_logger.LogInformation("RmqMessagePublisher: Regenerating message {Id} with DeliveryTag of {1} to {2} with DeliveryTag of {DeliveryTag}", message.Id, deliveryTag, messageId, 1);
@@ -177,7 +177,7 @@ internal class RmqMessagePublisher
                 message.Body.Bytes);
         }
 
-        private IBasicProperties CreateBasicProperties(Guid id, DateTime timeStamp, string type, string contentType,
+        private IBasicProperties CreateBasicProperties(string id, DateTime timeStamp, string type, string contentType,
             string replyTo, bool persistMessage, IDictionary<string, object> headers = null)
         {
             var basicProperties = _channel.CreateBasicProperties();
@@ -185,7 +185,7 @@ internal class RmqMessagePublisher
             basicProperties.DeliveryMode = (byte) (persistMessage ? 2 : 1); // delivery mode set to 2 if message is persistent or 1 if non-persistent
             basicProperties.ContentType = contentType;
             basicProperties.Type = type;
-            basicProperties.MessageId = id.ToString();
+            basicProperties.MessageId = id;
             basicProperties.Timestamp = new AmqpTimestamp(UnixTimestamp.GetUnixTimestampSeconds(timeStamp));
             if (!string.IsNullOrEmpty(replyTo))
                 basicProperties.ReplyTo = replyTo;

--- a/src/Paramore.Brighter.MessagingGateway.Redis/RedisMessageConsumer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.Redis/RedisMessageConsumer.cs
@@ -43,7 +43,7 @@ namespace Paramore.Brighter.MessagingGateway.Redis
         
         private readonly string _queueName;
         
-        private readonly Dictionary<Guid, string> _inflight = new Dictionary<Guid, string>();
+        private readonly Dictionary<string, string> _inflight = new Dictionary<string, string>();
  
         /// <summary>
         /// Creates a consumer that reads from a List in Redis via a BLPOP (so will block).

--- a/src/Paramore.Brighter.MessagingGateway.Redis/RedisMessageCreator.cs
+++ b/src/Paramore.Brighter.MessagingGateway.Redis/RedisMessageCreator.cs
@@ -199,14 +199,14 @@ namespace Paramore.Brighter.MessagingGateway.Redis
 
         private HeaderResult<string> ReadCorrelationId(Dictionary<string, string> headers)
         {
-            var messageId = string.Empty;
+            var newCorrelationId = string.Empty;
             
-            if (headers.TryGetValue(HeaderNames.CORRELATION_ID, out string header))
+            if (headers.TryGetValue(HeaderNames.CORRELATION_ID, out string correlatonId))
             {
-                return new HeaderResult<string>(messageId, true);
+                return new HeaderResult<string>(correlatonId, true);
             }
             
-            return new HeaderResult<string>(messageId, false);
+            return new HeaderResult<string>(newCorrelationId, false);
         }
 
          private HeaderResult<int> ReadDelayedMilliseconds(Dictionary<string, string> headers)

--- a/src/Paramore.Brighter.MessagingGateway.Redis/RedisMessageCreator.cs
+++ b/src/Paramore.Brighter.MessagingGateway.Redis/RedisMessageCreator.cs
@@ -197,19 +197,16 @@ namespace Paramore.Brighter.MessagingGateway.Redis
             return new HeaderResult<string>(String.Empty, false);
         }
 
-        private HeaderResult<Guid> ReadCorrelationId(Dictionary<string, string> headers)
+        private HeaderResult<string> ReadCorrelationId(Dictionary<string, string> headers)
         {
-            var messageId = Guid.Empty;
+            var messageId = string.Empty;
             
             if (headers.TryGetValue(HeaderNames.CORRELATION_ID, out string header))
             {
-                if (Guid.TryParse(header, out messageId))
-                {
-                    return new HeaderResult<Guid>(messageId, true);
-                }
+                return new HeaderResult<string>(messageId, true);
             }
             
-            return new HeaderResult<Guid>(messageId, false);
+            return new HeaderResult<string>(messageId, false);
         }
 
          private HeaderResult<int> ReadDelayedMilliseconds(Dictionary<string, string> headers)

--- a/src/Paramore.Brighter.MessagingGateway.Redis/RedisMessageCreator.cs
+++ b/src/Paramore.Brighter.MessagingGateway.Redis/RedisMessageCreator.cs
@@ -180,10 +180,10 @@ namespace Paramore.Brighter.MessagingGateway.Redis
         /// <param name="topic"></param>
         /// <param name="messageId"></param>
         /// <returns></returns>
-        private MessageHeader FailureMessageHeader(HeaderResult<string> topic, HeaderResult<Guid> messageId)
+        private MessageHeader FailureMessageHeader(HeaderResult<string> topic, HeaderResult<string> messageId)
         {
             return new MessageHeader(
-                messageId.Success ? messageId.Result : Guid.Empty,
+                messageId.Success ? messageId.Result : string.Empty,
                 topic.Success ? topic.Result : string.Empty,
                 MessageType.MT_UNACCEPTABLE);
         }
@@ -270,19 +270,14 @@ namespace Paramore.Brighter.MessagingGateway.Redis
             return new HeaderResult<MessageType>(MessageType.MT_EVENT, true);
         }
 
-        private HeaderResult<Guid> ReadMessageId(IDictionary<string, string> headers)
+        private HeaderResult<string> ReadMessageId(IDictionary<string, string> headers)
         {
-            var messageId = Guid.Empty;
-            
             if (headers.TryGetValue(HeaderNames.MESSAGE_ID, out string header))
             {
-                if (Guid.TryParse(header, out messageId))
-                {
-                    return new HeaderResult<Guid>(messageId, true);
-                }
+                    return new HeaderResult<string>(header, true);
             }
             
-            return new HeaderResult<Guid>(messageId, false);
+            return new HeaderResult<string>(string.Empty, false);
         }
         
         private HeaderResult<string> ReadReplyTo(Dictionary<string, string> headers)

--- a/src/Paramore.Brighter.Outbox.DynamoDB/DynamoDbOutbox.cs
+++ b/src/Paramore.Brighter.Outbox.DynamoDB/DynamoDbOutbox.cs
@@ -168,7 +168,7 @@ namespace Paramore.Brighter.Outbox.DynamoDB
         /// </summary>
         /// <param name="messageIds">The messages to delete</param>
         /// <param name="args">Additional parameters required to search if needed</param>
-        public void Delete(Guid[] messageIds, Dictionary<string, object> args = null)
+        public void Delete(string[] messageIds, Dictionary<string, object> args = null)
         {
             DeleteAsync(messageIds).GetAwaiter().GetResult();
         }
@@ -179,7 +179,8 @@ namespace Paramore.Brighter.Outbox.DynamoDB
         /// <param name="messageIds">The messages to delete</param>
         /// <param name="args">Additional parameters required to search if needed</param>
         /// <param name="cancellationToken">Should the operation be cancelled</param>
-        public async Task DeleteAsync(Guid[] messageIds, Dictionary<string, object> args = null, CancellationToken cancellationToken = default)
+        public async Task DeleteAsync(string[] messageIds, Dictionary<string, object> args = null,
+            CancellationToken cancellationToken = default)
         {
             foreach (var messageId in messageIds)
             {
@@ -294,7 +295,7 @@ namespace Paramore.Brighter.Outbox.DynamoDB
         /// <param name="outBoxTimeout">Timeout in milliseconds; -1 for default timeout</param>
         /// <param name="args"></param>
         /// <returns><see cref="T:Paramore.Brighter.Message" /></returns>
-        public Message Get(Guid messageId, int outBoxTimeout = -1, Dictionary<string, object> args = null)
+        public Message Get(string messageId, int outBoxTimeout = -1, Dictionary<string, object> args = null)
         {
             return GetMessage(messageId)
                 .ConfigureAwait(ContinueOnCapturedContext)
@@ -311,7 +312,8 @@ namespace Paramore.Brighter.Outbox.DynamoDB
         /// <param name="args">For outboxes that require additional parameters such as topic, provide an optional arg</param>
         /// <param name="cancellationToken"></param>
         /// <returns><see cref="T:Paramore.Brighter.Message" /></returns>
-        public async Task<Message> GetAsync(Guid messageId,
+        public async Task<Message> GetAsync(
+            string messageId,
             int outBoxTimeout = -1,
             Dictionary<string, object> args = null,
             CancellationToken cancellationToken = default)
@@ -328,7 +330,7 @@ namespace Paramore.Brighter.Outbox.DynamoDB
         /// <param name="args"></param>
         /// <param name="cancellationToken">Allows the sender to cancel the request pipeline. Optional</param>
         public async Task MarkDispatchedAsync(
-            Guid id, 
+            string id, 
             DateTime? dispatchedAt = null, 
             Dictionary<string, object> args = null, 
             CancellationToken cancellationToken = default
@@ -344,12 +346,10 @@ namespace Paramore.Brighter.Outbox.DynamoDB
                 cancellationToken).ConfigureAwait(ContinueOnCapturedContext);
        }
 
-        public async Task MarkDispatchedAsync(
-            IEnumerable<Guid> ids, 
-            DateTime? dispatchedAt = null, 
+        public async Task MarkDispatchedAsync(IEnumerable<string> ids,
+            DateTime? dispatchedAt = null,
             Dictionary<string, object> args = null,
-            CancellationToken cancellationToken = default
-            )
+            CancellationToken cancellationToken = default)
         {
             foreach(var messageId in ids)
             {
@@ -363,7 +363,7 @@ namespace Paramore.Brighter.Outbox.DynamoDB
         /// <param name="id">The id of the message to update</param>
         /// <param name="dispatchedAt">When was the message dispatched, defaults to UTC now</param>
         /// <param name="args"></param>
-        public void MarkDispatched(Guid id, DateTime? dispatchedAt = null, Dictionary<string, object> args = null)
+        public void MarkDispatched(string id, DateTime? dispatchedAt = null, Dictionary<string, object> args = null)
         {
             var message = _context.LoadAsync<MessageItem>(id.ToString(), _dynamoOverwriteTableConfig).Result;
             MarkMessageDispatched(dispatchedAt ?? DateTime.UtcNow, message);
@@ -459,7 +459,7 @@ namespace Paramore.Brighter.Outbox.DynamoDB
            return tcs.Task;
        }
        
-        private async Task<Message> GetMessage(Guid id, CancellationToken cancellationToken = default)
+        private async Task<Message> GetMessage(string id, CancellationToken cancellationToken = default)
         {
             MessageItem messageItem = await _context.LoadAsync<MessageItem>(id.ToString(), _dynamoOverwriteTableConfig, cancellationToken);
             return messageItem?.ConvertToMessage() ?? new Message();

--- a/src/Paramore.Brighter.Outbox.DynamoDB/MessageItem.cs
+++ b/src/Paramore.Brighter.Outbox.DynamoDB/MessageItem.cs
@@ -138,10 +138,10 @@ namespace Paramore.Brighter.Outbox.DynamoDB
         {
             //following type may be missing on older data
             var characterEncoding = CharacterEncoding != null ? (CharacterEncoding) Enum.Parse(typeof(CharacterEncoding), CharacterEncoding) : Brighter.CharacterEncoding.UTF8;
-            var correlationId = Guid.Parse(CorrelationId);
+            var correlationId = CorrelationId;
             var bag = JsonSerializer.Deserialize<Dictionary<string, object>>(HeaderBag,
                 JsonSerialisationOptions.Options);
-            var messageId = Guid.Parse(MessageId);
+            var messageId = MessageId;
             var messageType = (MessageType)Enum.Parse(typeof(MessageType), MessageType);
             var timestamp = new DateTime(CreatedTime, DateTimeKind.Utc);
 

--- a/src/Paramore.Brighter.Outbox.DynamoDB/MessageItem.cs
+++ b/src/Paramore.Brighter.Outbox.DynamoDB/MessageItem.cs
@@ -152,8 +152,7 @@ namespace Paramore.Brighter.Outbox.DynamoDB
                 timeStamp: timestamp,
                 correlationId: correlationId,
                 replyTo: ReplyTo,
-                partitionKey: PartitionKey,
-                contentType: ContentType);
+                contentType: ContentType, partitionKey: PartitionKey);
 
             foreach (var key in bag.Keys)
             {

--- a/src/Paramore.Brighter.Outbox.MsSql/MsSqlOutbox.cs
+++ b/src/Paramore.Brighter.Outbox.MsSql/MsSqlOutbox.cs
@@ -247,7 +247,7 @@ namespace Paramore.Brighter.Outbox.MsSql
                 new SqlParameter
                 {
                     ParameterName = $"{prefix}MessageId", 
-                    DbType = DbType.Guid,
+                    DbType = DbType.String,
                     Value = (object)message.Id ?? DBNull.Value
                 },
                 new SqlParameter
@@ -271,7 +271,7 @@ namespace Paramore.Brighter.Outbox.MsSql
                 new SqlParameter
                 {
                     ParameterName = $"{prefix}CorrelationId",
-                    DbType = DbType.Guid,
+                    DbType = DbType.String,
                     Value = (object)message.Header.CorrelationId ?? DBNull.Value
                 },
                 new SqlParameter

--- a/src/Paramore.Brighter.Outbox.MsSql/MsSqlOutbox.cs
+++ b/src/Paramore.Brighter.Outbox.MsSql/MsSqlOutbox.cs
@@ -319,7 +319,7 @@ namespace Paramore.Brighter.Outbox.MsSql
         private static MessageType GetMessageType(DbDataReader dr) =>
             (MessageType)Enum.Parse(typeof(MessageType), dr.GetString(dr.GetOrdinal("MessageType")));
 
-        private static Guid GetMessageId(DbDataReader dr) => dr.GetGuid(dr.GetOrdinal("MessageId"));
+        private static string GetMessageId(DbDataReader dr) => dr.GetString(dr.GetOrdinal("MessageId"));
 
         private string GetContentType(DbDataReader dr)
         {
@@ -348,12 +348,12 @@ namespace Paramore.Brighter.Outbox.MsSql
             return dictionaryBag;
         }
 
-        private Guid? GetCorrelationId(DbDataReader dr)
+        private string GetCorrelationId(DbDataReader dr)
         {
             var ordinal = dr.GetOrdinal("CorrelationId");
             if (dr.IsDBNull(ordinal)) return null; 
             
-            var correlationId = dr.GetGuid(ordinal);
+            var correlationId = dr.GetString(ordinal);
             return correlationId;
         }
 

--- a/src/Paramore.Brighter.Outbox.MsSql/SqlOutboxBuilder.cs
+++ b/src/Paramore.Brighter.Outbox.MsSql/SqlOutboxBuilder.cs
@@ -35,11 +35,11 @@ namespace Paramore.Brighter.Outbox.MsSql
         CREATE TABLE {0}
             (
               [Id] [BIGINT] NOT NULL IDENTITY ,
-              [MessageId] UNIQUEIDENTIFIER NOT NULL,
+              [MessageId] NVARCHAR(255) NOT NULL,
               [Topic] NVARCHAR(255) NULL,
               [MessageType] NVARCHAR(32) NULL,
               [Timestamp] DATETIME NULL,
-              [CorrelationId] UNIQUEIDENTIFIER NULL,
+              [CorrelationId] NVARCHAR(255) NULL,
               [ReplyTo] NVARCHAR(255) NULL,
               [ContentType] NVARCHAR(128) NULL,  
               [PartitionKey] NVARCHAR(255) NULL, 
@@ -54,11 +54,11 @@ namespace Paramore.Brighter.Outbox.MsSql
         CREATE TABLE {0}
             (
               [Id] [BIGINT] NOT NULL IDENTITY,
-              [MessageId] UNIQUEIDENTIFIER NOT NULL,
+              [MessageId] NVARCHAR(255) NOT NULL,
               [Topic] NVARCHAR(255) NULL,
               [MessageType] NVARCHAR(32) NULL,
               [Timestamp] DATETIME NULL,
-              [CorrelationId] UNIQUEIDENTIFIER NULL,
+              [CorrelationId] NVARCHAR(255) NULL,
               [ReplyTo] NVARCHAR(255) NULL,
               [ContentType] NVARCHAR(128) NULL,  
               [PartitionKey] NVARCHAR(255) NULL,

--- a/src/Paramore.Brighter.Outbox.MySql/MySqlOutbox.cs
+++ b/src/Paramore.Brighter.Outbox.MySql/MySqlOutbox.cs
@@ -445,12 +445,12 @@ namespace Paramore.Brighter.Outbox.MySql
             return contentType;
         }
 
-        private Guid? GetCorrelationId(IDataReader dr)
+        private string GetCorrelationId(IDataReader dr)
         {
             var ordinal = dr.GetOrdinal("CorrelationId");
             if (dr.IsDBNull(ordinal)) return null;
 
-            var correlationId = dr.GetGuid(ordinal);
+            var correlationId = dr.GetString(ordinal);
             return correlationId;
         }
 

--- a/src/Paramore.Brighter.Outbox.MySql/MySqlOutbox.cs
+++ b/src/Paramore.Brighter.Outbox.MySql/MySqlOutbox.cs
@@ -226,7 +226,7 @@ namespace Paramore.Brighter.Outbox.MySql
             {
                 new MySqlParameter
                 {
-                    ParameterName = $"@{prefix}MessageId", DbType = DbType.String, Value = message.Id.ToString()
+                    ParameterName = $"@{prefix}MessageId", DbType = DbType.String, Value = message.Id
                 },
                 new MySqlParameter
                 {
@@ -248,7 +248,7 @@ namespace Paramore.Brighter.Outbox.MySql
                 {
                     ParameterName = $"@{prefix}CorrelationId",
                     DbType = DbType.String,
-                    Value = message.Header.CorrelationId.ToString()
+                    Value = message.Header.CorrelationId
                 },
                 new MySqlParameter
                 {

--- a/src/Paramore.Brighter.Outbox.MySql/MySqlOutbox.cs
+++ b/src/Paramore.Brighter.Outbox.MySql/MySqlOutbox.cs
@@ -279,8 +279,11 @@ namespace Paramore.Brighter.Outbox.MySql
             };
         }
 
-        protected override IDbDataParameter[] CreatePagedOutstandingParameters(double milliSecondsSinceAdded,
-            int pageSize, int pageNumber)
+        protected override IDbDataParameter[] CreatePagedOutstandingParameters(
+            double milliSecondsSinceAdded,
+            int pageSize, 
+            int pageNumber
+            )
         {
             var offset = (pageNumber - 1) * pageSize;
             var parameters = new IDbDataParameter[3];
@@ -461,7 +464,7 @@ namespace Paramore.Brighter.Outbox.MySql
 
         private static string GetMessageId(IDataReader dr)
         {
-            return dr.GetString(0);
+            return dr.GetString(dr.GetOrdinal("MessageId"));
         }
 
         private string GetPartitionKey(IDataReader dr)

--- a/src/Paramore.Brighter.Outbox.MySql/MySqlOutbox.cs
+++ b/src/Paramore.Brighter.Outbox.MySql/MySqlOutbox.cs
@@ -459,9 +459,9 @@ namespace Paramore.Brighter.Outbox.MySql
             return (MessageType)Enum.Parse(typeof(MessageType), dr.GetString(dr.GetOrdinal("MessageType")));
         }
 
-        private static Guid GetMessageId(IDataReader dr)
+        private static string GetMessageId(IDataReader dr)
         {
-            return dr.GetGuid(0);
+            return dr.GetString(0);
         }
 
         private string GetPartitionKey(IDataReader dr)

--- a/src/Paramore.Brighter.Outbox.MySql/MySqlOutboxBuilder.cs
+++ b/src/Paramore.Brighter.Outbox.MySql/MySqlOutboxBuilder.cs
@@ -34,11 +34,11 @@ namespace Paramore.Brighter.Outbox.MySql
     public class MySqlOutboxBuilder
     {
         const string TextOutboxDdl = @"CREATE TABLE {0} ( 
-	`MessageId` CHAR(36) NOT NULL , 
+	`MessageId`VARCHAR(255) NOT NULL , 
 	`Topic` VARCHAR(255) NOT NULL , 
 	`MessageType` VARCHAR(32) NOT NULL , 
 	`Timestamp` TIMESTAMP(3) NOT NULL , 
-    `CorrelationId` CHAR(36) NULL ,
+    `CorrelationId`VARCHAR(255) NULL ,
     `ReplyTo` VARCHAR(255) NULL ,
     `ContentType` VARCHAR(128) NULL , 
     `PartitionKey` VARCHAR(128) NULL , 
@@ -52,11 +52,11 @@ namespace Paramore.Brighter.Outbox.MySql
 ) ENGINE = InnoDB;";
         
         const string BinaryOutboxDdl = @"CREATE TABLE {0} ( 
-	`MessageId` CHAR(36) NOT NULL , 
+	`MessageId` VARCHAR(255) NOT NULL , 
 	`Topic` VARCHAR(255) NOT NULL , 
 	`MessageType` VARCHAR(32) NOT NULL , 
 	`Timestamp` TIMESTAMP(3) NOT NULL , 
-    `CorrelationId` CHAR(36) NULL ,
+    `CorrelationId` VARCHAR(255) NULL ,
     `ReplyTo` VARCHAR(255) NULL ,
     `ContentType` VARCHAR(128) NULL ,  
     `PartitionKey` VARCHAR(128) NULL ,

--- a/src/Paramore.Brighter.Outbox.PostgreSql/PostgreSqlOutbox.cs
+++ b/src/Paramore.Brighter.Outbox.PostgreSql/PostgreSqlOutbox.cs
@@ -427,13 +427,13 @@ namespace Paramore.Brighter.Outbox.PostgreSql
             return dictionaryBag;
         }
 
-        private Guid? GetCorrelationId(DbDataReader dr)
+        private string GetCorrelationId(DbDataReader dr)
         {
             var ordinal = dr.GetOrdinal("CorrelationId");
             if (dr.IsDBNull(ordinal))
                 return null;
 
-            var correlationId = dr.GetGuid(ordinal);
+            var correlationId = dr.GetString(ordinal);
             return correlationId;
         }
 
@@ -447,9 +447,9 @@ namespace Paramore.Brighter.Outbox.PostgreSql
             return (MessageType)Enum.Parse(typeof(MessageType), dr.GetString(dr.GetOrdinal("MessageType")));
         }
 
-        private static Guid GetMessageId(DbDataReader dr)
+        private static string GetMessageId(DbDataReader dr)
         {
-            return dr.GetGuid(dr.GetOrdinal("MessageId"));
+            return dr.GetString(dr.GetOrdinal("MessageId"));
         }
 
         private string GetPartitionKey(DbDataReader dr)

--- a/src/Paramore.Brighter.Outbox.PostgreSql/PostgreSqlOutbox.cs
+++ b/src/Paramore.Brighter.Outbox.PostgreSql/PostgreSqlOutbox.cs
@@ -244,7 +244,7 @@ namespace Paramore.Brighter.Outbox.PostgreSql
             {
                 new NpgsqlParameter
                 {
-                    ParameterName = $"{prefix}MessageId", NpgsqlDbType = NpgsqlDbType.Uuid, Value = message.Id
+                    ParameterName = $"{prefix}MessageId", NpgsqlDbType = NpgsqlDbType.Text, Value = message.Id
                 },
                 new NpgsqlParameter
                 {
@@ -267,7 +267,7 @@ namespace Paramore.Brighter.Outbox.PostgreSql
                 new NpgsqlParameter
                 {
                     ParameterName = $"{prefix}CorrelationId",
-                    NpgsqlDbType = NpgsqlDbType.Uuid,
+                    NpgsqlDbType = NpgsqlDbType.Text,
                     Value = message.Header.CorrelationId
                 },
                 new NpgsqlParameter

--- a/src/Paramore.Brighter.Outbox.PostgreSql/PostgreSqlOutboxBulder.cs
+++ b/src/Paramore.Brighter.Outbox.PostgreSql/PostgreSqlOutboxBulder.cs
@@ -33,11 +33,11 @@ namespace Paramore.Brighter.Outbox.PostgreSql
        CREATE TABLE {0}
             (
                 Id bigserial PRIMARY KEY,
-                MessageId uuid UNIQUE NOT NULL,
+                MessageId character varying(255) UNIQUE NOT NULL,
                 Topic character varying(255) NULL,
                 MessageType character varying(32) NULL,
                 Timestamp timestamptz NULL,
-                CorrelationId uuid NULL,
+                CorrelationId character varying(255) NULL,
                 ReplyTo character varying(255) NULL,
                 ContentType character varying(128) NULL,
                 PartitionKey character varying(128) NULL,  
@@ -51,11 +51,11 @@ namespace Paramore.Brighter.Outbox.PostgreSql
        CREATE TABLE {0}
             (
                 Id bigserial PRIMARY KEY,
-                MessageId uuid UNIQUE NOT NULL,
+                MessageId character varying(255) UNIQUE NOT NULL,
                 Topic character varying(255) NULL,
                 MessageType character varying(32) NULL,
                 Timestamp timestamptz NULL,
-                CorrelationId uuid NULL,
+                CorrelationId character varying(255) NULL,
                 ReplyTo character varying(255) NULL,
                 ContentType character varying(128) NULL,
                 PartitionKey character varying(128) NULL,  

--- a/src/Paramore.Brighter.Outbox.Sqlite/SqliteOutbox.cs
+++ b/src/Paramore.Brighter.Outbox.Sqlite/SqliteOutbox.cs
@@ -452,14 +452,13 @@ namespace Paramore.Brighter.Outbox.Sqlite
             var contentType = dr.GetString(ordinal);
             return contentType;
         }
-
-
-        private Guid? GetCorrelationId(IDataReader dr)
+        
+        private string GetCorrelationId(IDataReader dr)
         {
             var ordinal = dr.GetOrdinal("CorrelationId");
             if (dr.IsDBNull(ordinal)) return null;
 
-            var correlationId = dr.GetGuid(ordinal);
+            var correlationId = dr.GetString(ordinal);
             return correlationId;
         }
 
@@ -468,9 +467,9 @@ namespace Paramore.Brighter.Outbox.Sqlite
             return (MessageType)Enum.Parse(typeof(MessageType), dr.GetString(dr.GetOrdinal("MessageType")));
         }
 
-        private static Guid GetMessageId(IDataReader dr)
+        private static string GetMessageId(IDataReader dr)
         {
-            return Guid.Parse(dr.GetString(dr.GetOrdinal("MessageId")));
+            return dr.GetString(dr.GetOrdinal("MessageId"));
         }
 
         private string GetPartitionKey(IDataReader dr)

--- a/src/Paramore.Brighter.ServiceActivator.Control/Events/NodeStatusEvent.cs
+++ b/src/Paramore.Brighter.ServiceActivator.Control/Events/NodeStatusEvent.cs
@@ -7,7 +7,7 @@ public record NodeStatusEvent : IEvent
     /// <summary>
     /// The event Id
     /// </summary>
-    public Guid Id { get; set; }
+    public string Id { get; set; }
 
     /// <summary>
     /// The Diagnostics Span

--- a/src/Paramore.Brighter.ServiceActivator.Control/Extensions/DispatcherExtensions.cs
+++ b/src/Paramore.Brighter.ServiceActivator.Control/Extensions/DispatcherExtensions.cs
@@ -29,7 +29,7 @@ public static class DispatcherExtensions
     {
         return new NodeStatusEvent()
         {
-            Id = Guid.NewGuid(),
+            Id = Guid.NewGuid().ToString(),
             AvailableTopics = nodeStatus.AvailableTopics,
             ExecutingAssemblyVersion = nodeStatus.ExecutingAssemblyVersion,
             NodeName = nodeStatus.NodeName,

--- a/src/Paramore.Brighter.ServiceActivator/ControlBus/ControlBusReceiverBuilder.cs
+++ b/src/Paramore.Brighter.ServiceActivator/ControlBus/ControlBusReceiverBuilder.cs
@@ -204,17 +204,17 @@ namespace Paramore.Brighter.ServiceActivator.ControlBus
                //discard message 
             }
             
-            public void Delete(Guid[] messageIds, Dictionary<string, object> args = null)
+            public void Delete(string[] messageIds, Dictionary<string, object> args = null)
             {
                 //ignore
             }
 
-            public Message Get(Guid messageId, int outBoxTimeout = -1, Dictionary<string, object> args = null)
+            public Message Get(string messageId, int outBoxTimeout = -1, Dictionary<string, object> args = null)
             {
                  return null;
             }
 
-            public void MarkDispatched(Guid id, DateTime? dispatchedAt = null, Dictionary<string, object> args = null)
+            public void MarkDispatched(string id, DateTime? dispatchedAt = null, Dictionary<string, object> args = null)
             {
                 //ignore
             }

--- a/src/Paramore.Brighter.ServiceActivator/Ports/Mappers/HeartbeatRequestCommandMessageMapper.cs
+++ b/src/Paramore.Brighter.ServiceActivator/Ports/Mappers/HeartbeatRequestCommandMessageMapper.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Text.Json;
+﻿using System.Text.Json;
 using Paramore.Brighter.ServiceActivator.Ports.Commands;
 
 namespace Paramore.Brighter.ServiceActivator.Ports.Mappers
@@ -15,7 +14,7 @@ namespace Paramore.Brighter.ServiceActivator.Ports.Mappers
                 correlationId: request.ReplyAddress.CorrelationId, 
                 replyTo: request.ReplyAddress.Topic);
 
-            var json = JsonSerializer.Serialize(new HeartBeatRequestBody(request.Id.ToString()), JsonSerialisationOptions.Options);
+            var json = JsonSerializer.Serialize(new HeartBeatRequestBody(request.Id), JsonSerialisationOptions.Options);
             var body = new MessageBody(json);
             var message = new Message(header, body);
             return message;

--- a/src/Paramore.Brighter.ServiceActivator/Ports/Mappers/HeartbeatRequestCommandMessageMapper.cs
+++ b/src/Paramore.Brighter.ServiceActivator/Ports/Mappers/HeartbeatRequestCommandMessageMapper.cs
@@ -27,7 +27,7 @@ namespace Paramore.Brighter.ServiceActivator.Ports.Mappers
             var replyAddress = new ReplyAddress(topic: message.Header.ReplyTo, correlationId: message.Header.CorrelationId);
             var request = new HeartbeatRequest(replyAddress);
             var messageBody = JsonSerializer.Deserialize<HeartBeatRequestBody>(message.Body.Value, JsonSerialisationOptions.Options);
-            request.Id = Guid.Parse(messageBody.Id);
+            request.Id = messageBody.Id;
             return request;
         }
     }

--- a/src/Paramore.Brighter/Command.cs
+++ b/src/Paramore.Brighter/Command.cs
@@ -38,15 +38,24 @@ namespace Paramore.Brighter
         /// </summary>
         /// <value>The identifier.</value>
         [NJsonSchema.Annotations.NotNull]
-        public Guid Id { get; set; }
+        public string Id { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Command"/> class.
         /// </summary>
         /// <param name="id">The identifier.</param>
-        public Command(Guid id)
+        public Command(string id)
         {
             Id = id;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Command"/> class. 
+        /// </summary>
+        /// <param name="id">The identifier</param>
+        public Command(Guid id)
+        {
+           Id = id.ToString(); 
         }
         
         /// <summary>

--- a/src/Paramore.Brighter/CommandProcessor.cs
+++ b/src/Paramore.Brighter/CommandProcessor.cs
@@ -388,7 +388,9 @@ namespace Paramore.Brighter
         /// <param name="continueOnCapturedContext">Should we use the calling thread's synchronization context when continuing or a default thread synchronization context. Defaults to false</param>
         /// <param name="cancellationToken">Allows the sender to cancel the request pipeline. Optional</param>
         /// <returns>awaitable <see cref="Task"/>.</returns>
-        public async Task PublishAsync<T>(T @event, bool continueOnCapturedContext = false,
+        public async Task PublishAsync<T>(
+            T @event,
+            bool continueOnCapturedContext = false,
             CancellationToken cancellationToken = default)
             where T : class, IRequest
         {
@@ -521,7 +523,8 @@ namespace Paramore.Brighter
         /// <typeparam name="TRequest">The type of the request</typeparam>
         /// <typeparam name="TTransaction">The type of Db transaction used by the Outbox</typeparam>
         /// <returns>The Id of the Message that has been deposited.</returns>
-        public string DepositPost<TRequest, TTransaction>(TRequest request,
+        public string DepositPost<TRequest, TTransaction>(
+            TRequest request,
             IAmABoxTransactionProvider<TTransaction> transactionProvider,
             Dictionary<string, object> args = null) 
             where TRequest : class, IRequest
@@ -572,7 +575,8 @@ namespace Paramore.Brighter
         /// <typeparam name="TRequest">The type of the request</typeparam>
         /// <typeparam name="TTransaction">The type of transaction used by the Outbox</typeparam>
         /// <returns>The Id of the Message that has been deposited.</returns>
-        public string[] DepositPost<TRequest, TTransaction>(IEnumerable<TRequest> requests,
+        public string[] DepositPost<TRequest, TTransaction>(
+            IEnumerable<TRequest> requests,
             IAmABoxTransactionProvider<TTransaction> transactionProvider,
             Dictionary<string, object> args = null) where TRequest : class, IRequest
         {
@@ -611,7 +615,8 @@ namespace Paramore.Brighter
         /// <param name="cancellationToken">The Cancellation Token.</param>
         /// <typeparam name="TRequest">The type of the request</typeparam>
         /// <returns></returns>
-        public async Task<string> DepositPostAsync<TRequest>(TRequest request,
+        public async Task<string> DepositPostAsync<TRequest>(
+            TRequest request,
             Dictionary<string, object> args = null,
             bool continueOnCapturedContext = false,
             CancellationToken cancellationToken = default) where TRequest : class, IRequest
@@ -639,7 +644,8 @@ namespace Paramore.Brighter
         /// <typeparam name="TRequest">The type of the request</typeparam>
         /// <typeparam name="TTransaction">The type of the transaction used by the Outbox</typeparam>
         /// <returns></returns>
-        public async Task<string> DepositPostAsync<TRequest, TTransaction>(TRequest request,
+        public async Task<string> DepositPostAsync<TRequest, TTransaction>(
+            TRequest request,
             IAmABoxTransactionProvider<TTransaction> transactionProvider,
             Dictionary<string, object> args = null,
             bool continueOnCapturedContext = false,
@@ -675,8 +681,9 @@ namespace Paramore.Brighter
         /// <param name="cancellationToken">The Cancellation Token.</param>
         /// <typeparam name="TRequest">The type of the request</typeparam>
         /// <returns></returns>
-        public async Task<string[]> DepositPostAsync<TRequest>(IEnumerable<TRequest> requests,
-            Dictionary<string, object> args,
+        public async Task<string[]> DepositPostAsync<TRequest>(
+            IEnumerable<TRequest> requests,
+            Dictionary<string, object> args = null,
             bool continueOnCapturedContext = false,
             CancellationToken cancellationToken = default) where TRequest : class, IRequest
         {
@@ -703,7 +710,8 @@ namespace Paramore.Brighter
         /// <typeparam name="TRequest">The type of the request</typeparam>
         /// <typeparam name="TTransaction">The type of transaction used with the Outbox</typeparam>
         /// <returns></returns>
-        public async Task<string[]> DepositPostAsync<TRequest, TTransaction>(IEnumerable<TRequest> requests,
+        public async Task<string[]> DepositPostAsync<TRequest, TTransaction>(
+            IEnumerable<TRequest> requests,
             IAmABoxTransactionProvider<TTransaction> transactionProvider,
             Dictionary<string, object> args = null,
             bool continueOnCapturedContext = false,
@@ -824,7 +832,7 @@ namespace Paramore.Brighter
             {
                 s_logger.LogInformation("Create reply queue for topic {ChannelName}", channelName);
                 request.ReplyAddress.Topic = routingKey;
-                request.ReplyAddress.CorrelationId = channelName;
+                request.ReplyAddress.CorrelationId = channelName.ToString();
 
                 //we do this to create the channel on the broker, or we won't have anything to send to; we 
                 //retry in case the subscription is poor. An alternative would be to extract the code from

--- a/src/Paramore.Brighter/Event.cs
+++ b/src/Paramore.Brighter/Event.cs
@@ -40,15 +40,24 @@ namespace Paramore.Brighter
         /// </summary>
         /// <value>The identifier.</value>
         [NJsonSchema.Annotations.NotNull]
-        public Guid Id { get; set; }
+        public string Id { get; set; }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Event"/> class.
+        /// </summary>
+        /// <param name="id">The identifier.</param>
+        public Event(string id)
+        {
+            Id = id;
+        }
+        
         /// <summary>
         /// Initializes a new instance of the <see cref="Event"/> class.
         /// </summary>
         /// <param name="id">The identifier.</param>
         public Event(Guid id)
         {
-            Id = id;
+            Id = id.ToString();
         }
         
         /// <summary>

--- a/src/Paramore.Brighter/IAmABulkMessageProducerAsync.cs
+++ b/src/Paramore.Brighter/IAmABulkMessageProducerAsync.cs
@@ -47,6 +47,6 @@ namespace Paramore.Brighter
         /// </summary>
         /// <param name="messages">The messages.</param>
         /// <param name="cancellationToken">The Cancellation Token.</param>
-        IAsyncEnumerable<Guid[]> SendAsync(IEnumerable<Message> messages, CancellationToken cancellationToken);
+        IAsyncEnumerable<string[]> SendAsync(IEnumerable<Message> messages, CancellationToken cancellationToken);
     }
 }

--- a/src/Paramore.Brighter/IAmACommandProcessor.cs
+++ b/src/Paramore.Brighter/IAmACommandProcessor.cs
@@ -106,20 +106,20 @@ namespace Paramore.Brighter
         /// Intended for use with the Outbox pattern: http://gistlabs.com/2014/05/the-outbox/ normally you include the
         /// call to DepositPostBox within the scope of the transaction to write corresponding entity state to your
         /// database, that you want to signal via the request to downstream consumers
-        /// Pass deposited Guid to <see cref="CommandProcessor.ClearOutbox"/> 
+        /// Pass deposited message to <see cref="CommandProcessor.ClearOutbox"/> 
         /// </summary>
         /// <param name="request">The request to save to the outbox</param>
         /// <param name="args">For transports or outboxes that require additional parameters such as topic, provide an optional arg</param>
         /// <typeparam name="TRequest">The type of the request</typeparam>
         /// <returns></returns>
-        Guid DepositPost<TRequest>(TRequest request, Dictionary<string, object> args = null) where TRequest : class, IRequest;
+        string DepositPost<TRequest>(TRequest request, Dictionary<string, object> args = null) where TRequest : class, IRequest;
 
         /// <summary>
         /// Adds a message into the outbox, and returns the id of the saved message.
         /// Intended for use with the Outbox pattern: http://gistlabs.com/2014/05/the-outbox/ normally you include the
         /// call to DepositPostBox within the scope of the transaction to write corresponding entity state to your
         /// database, that you want to signal via the request to downstream consumers
-        /// Pass deposited Guid to <see cref="CommandProcessor.ClearOutbox"/> 
+        /// Pass deposited message to <see cref="CommandProcessor.ClearOutbox"/> 
         /// </summary>
         /// <param name="request">The request to save to the outbox</param>
         /// <param name="transactionProvider">If using an Outbox, the transaction provider for the Outbox</param>
@@ -127,32 +127,31 @@ namespace Paramore.Brighter
         /// <typeparam name="TRequest">The type of the request</typeparam>
         /// <typeparam name="TTransaction">The type of transaction used by the outbox</typeparam>
         /// <returns></returns>
-        Guid DepositPost<TRequest, TTransaction>(
+        string DepositPost<TRequest, TTransaction>(
             TRequest request,
-            IAmABoxTransactionProvider<TTransaction> transactionProvider, 
+            IAmABoxTransactionProvider<TTransaction> transactionProvider,
             Dictionary<string, object> args = null
-            ) 
-            where TRequest : class, IRequest;
+            ) where TRequest : class, IRequest;
 
         /// <summary>
         /// Adds a messages into the outbox, and returns the id of the saved message.
         /// Intended for use with the Outbox pattern: http://gistlabs.com/2014/05/the-outbox/ normally you include the
         /// call to DepositPostBox within the scope of the transaction to write corresponding entity state to your
         /// database, that you want to signal via the request to downstream consumers
-        /// Pass deposited Guid to <see cref="ClearOutbox"/> 
+        /// Pass deposited message to <see cref="ClearOutbox"/> 
         /// </summary>
         /// <param name="requests">The requests to save to the outbox</param>
         /// <param name="args">For transports or outboxes that require additional parameters such as topic, provide an optional arg</param>
         /// <typeparam name="TRequest">The type of the request</typeparam>
         /// <returns>The Id of the Message that has been deposited.</returns>
-        Guid[] DepositPost<TRequest>(IEnumerable<TRequest> requests, Dictionary<string, object> args = null) where TRequest : class, IRequest;
+        string[] DepositPost<TRequest>(IEnumerable<TRequest> requests, Dictionary<string, object> args = null) where TRequest : class, IRequest;
 
         /// <summary>
         /// Adds a messages into the outbox, and returns the id of the saved message.
         /// Intended for use with the Outbox pattern: http://gistlabs.com/2014/05/the-outbox/ normally you include the
         /// call to DepositPostBox within the scope of the transaction to write corresponding entity state to your
         /// database, that you want to signal via the request to downstream consumers
-        /// Pass deposited Guid to <see cref="ClearOutbox(System.Guid[])"/> 
+        /// Pass deposited message to <see cref="ClearOutbox(System.string[])"/> 
         /// </summary>
         /// <param name="requests">The requests to save to the outbox</param>
         /// <param name="transactionProvider">If using an Outbox, the transaction provider for the Outbox</param>
@@ -160,30 +159,31 @@ namespace Paramore.Brighter
         /// <typeparam name="TRequest">The type of the request</typeparam>
         /// <typeparam name="TTransaction">The type of transaction used by the outbox</typeparam>
         /// <returns>The Id of the Message that has been deposited.</returns>
-        Guid[] DepositPost<TRequest, TTransaction>(
+        string[] DepositPost<TRequest, TTransaction>(
             IEnumerable<TRequest> requests,
             IAmABoxTransactionProvider<TTransaction> transactionProvider,
-            Dictionary<string, object> args = null) where TRequest : class, IRequest;
+            Dictionary<string, object> args = null
+            ) where TRequest : class, IRequest;
 
         /// <summary>
         /// Adds a message into the outbox, and returns the id of the saved message.
         /// Intended for use with the Outbox pattern: http://gistlabs.com/2014/05/the-outbox/ normally you include the
         /// call to DepositPostBox within the scope of the transaction to write corresponding entity state to your
         /// database, that you want to signal via the request to downstream consumers
-        /// Pass deposited Guid to <see cref="CommandProcessor.ClearOutboxAsync"/> 
+        /// Pass deposited message to <see cref="CommandProcessor.ClearOutboxAsync"/> 
         /// </summary>
         /// <param name="request">The request to save to the outbox</param>
-        /// <param name="continueOnCapturedContext">Should we use the calling thread's synchronization context when continuing or a default thread synchronization context. Defaults to false</param>
         /// <param name="args">For outboxes that require additional parameters such as topic, provide an optional arg</param>
+        /// <param name="continueOnCapturedContext">Should we use the calling thread's synchronization context when continuing or a default thread synchronization context. Defaults to false</param>
         /// <param name="cancellationToken">The Cancellation Token.</param>
         /// <typeparam name="TRequest">The type of the request</typeparam>
         /// <returns></returns>
-        Task<Guid> DepositPostAsync<TRequest>(
-            TRequest request, 
+        Task<string> DepositPostAsync<TRequest>(
+            TRequest request,
             Dictionary<string, object> args = null,
-            bool continueOnCapturedContext = false, 
+            bool continueOnCapturedContext = false,
             CancellationToken cancellationToken = default
-        ) where TRequest : class, IRequest;
+            ) where TRequest : class, IRequest;
 
 
         /// <summary>
@@ -191,7 +191,7 @@ namespace Paramore.Brighter
         /// Intended for use with the Outbox pattern: http://gistlabs.com/2014/05/the-outbox/ normally you include the
         /// call to DepositPostBox within the scope of the transaction to write corresponding entity state to your
         /// database, that you want to signal via the request to downstream consumers
-        /// Pass deposited Guid to <see cref="CommandProcessor.ClearOutboxAsync"/> 
+        /// Pass deposited message to <see cref="CommandProcessor.ClearOutboxAsync"/> 
         /// </summary>
         /// <param name="request">The request to save to the outbox</param>
         /// <param name="transactionProvider">If using an Outbox, the transaction provider for the Outbox</param>
@@ -201,20 +201,20 @@ namespace Paramore.Brighter
         /// <typeparam name="T">The type of the request</typeparam>
         /// <typeparam name="TTransaction">The type of transaction used by the outbox</typeparam>
         /// <returns></returns>
-        Task<Guid> DepositPostAsync<T, TTransaction>(
-            T request, 
+        Task<string> DepositPostAsync<T, TTransaction>(
+            T request,
             IAmABoxTransactionProvider<TTransaction> transactionProvider,
             Dictionary<string, object> args = null,
-            bool continueOnCapturedContext = false, 
+            bool continueOnCapturedContext = false,
             CancellationToken cancellationToken = default
             ) where T : class, IRequest;
-        
+
         /// <summary>
         /// Adds a message into the outbox, and returns the id of the saved message.
         /// Intended for use with the Outbox pattern: http://gistlabs.com/2014/05/the-outbox/ normally you include the
         /// call to DepositPostBox within the scope of the transaction to write corresponding entity state to your
         /// database, that you want to signal via the request to downstream consumers
-        /// Pass deposited Guid to <see cref="ClearOutboxAsync"/> 
+        /// Pass deposited message to <see cref="ClearOutboxAsync"/> 
         /// </summary>
         /// <param name="requests">The requests to save to the outbox</param>
         /// <param name="args">For transports or outboxes that require additional parameters such as topic, provide an optional arg</param>
@@ -223,19 +223,19 @@ namespace Paramore.Brighter
         /// <typeparam name="TRequest">The type of the request</typeparam>
         /// <typeparam name="TTransaction">The type of transaction used by the outbox</typeparam>
         /// <returns></returns>
-        Task<Guid[]> DepositPostAsync<TRequest>(
-            IEnumerable<TRequest> requests, 
+        Task<string[]> DepositPostAsync<TRequest>(
+            IEnumerable<TRequest> requests,
             Dictionary<string, object> args,
             bool continueOnCapturedContext = false,
             CancellationToken cancellationToken = default
-        ) where TRequest : class, IRequest;
+            ) where TRequest : class, IRequest;
 
         /// <summary>
         /// Adds a message into the outbox, and returns the id of the saved message.
         /// Intended for use with the Outbox pattern: http://gistlabs.com/2014/05/the-outbox/ normally you include the
         /// call to DepositPostBox within the scope of the transaction to write corresponding entity state to your
         /// database, that you want to signal via the request to downstream consumers
-        /// Pass deposited Guid to <see cref="ClearOutboxAsync"/> 
+        /// Pass deposited message to <see cref="ClearOutboxAsync"/> 
         /// </summary>
         /// <param name="requests">The requests to save to the outbox</param>
         /// <param name="transactionProvider">If using an Outbox, the transaction provider for the Outbox</param>
@@ -245,8 +245,8 @@ namespace Paramore.Brighter
         /// <typeparam name="T">The type of the request</typeparam>
         /// <typeparam name="TTransaction">The type of transaction used by the outbox</typeparam>
         /// <returns></returns>
-        Task<Guid[]> DepositPostAsync<T, TTransaction>(
-            IEnumerable<T> requests, 
+        Task<string[]> DepositPostAsync<T, TTransaction>(
+            IEnumerable<T> requests,
             IAmABoxTransactionProvider<TTransaction> transactionProvider = null,
             Dictionary<string, object> args = null,
             bool continueOnCapturedContext = false,
@@ -258,8 +258,8 @@ namespace Paramore.Brighter
         /// Intended for use with the Outbox pattern: http://gistlabs.com/2014/05/the-outbox/ <see cref="DepositPostBox"/>
         /// </summary>
         /// <param name="ids">The ids to flush</param>
-        /// <param name="args">For transports or outboxes that require additional parameters such as topic, provide an optional arg</param>       
-        void ClearOutbox(Guid[] ids, Dictionary<string, object> args = null);
+        /// <param name="args">For transports or outboxes that require additional parameters such as topic, provide an optional arg</param>
+        void ClearOutbox(string[] ids, Dictionary<string, object> args = null);
 
         /// <summary>
         /// Flushes any outstanding message box message to the broker.
@@ -278,9 +278,8 @@ namespace Paramore.Brighter
         /// <param name="args">For transports or outboxes that require additional parameters such as topic, provide an optional arg</param>
         /// <param name="continueOnCapturedContext"></param>
         /// <param name="cancellationToken"></param>
-        Task ClearOutboxAsync(
-            IEnumerable<Guid> posts, 
-            Dictionary<string, object> args = null, 
+        Task ClearOutboxAsync(IEnumerable<string> posts,
+            Dictionary<string, object> args = null,
             bool continueOnCapturedContext = false,
             CancellationToken cancellationToken = default);
 

--- a/src/Paramore.Brighter/IAmAnArchiveProvider.cs
+++ b/src/Paramore.Brighter/IAmAnArchiveProvider.cs
@@ -45,13 +45,13 @@ namespace Paramore.Brighter
         /// <param name="message">Message to send</param>
         /// <param name="cancellationToken">The Cancellation Token</param>
         Task ArchiveMessageAsync(Message message, CancellationToken cancellationToken);
-        
+
         /// <summary>
         /// Archive messages in Parallel
         /// </summary>
         /// <param name="messages">Messages to send</param>
         /// <param name="cancellationToken">The Cancellation Token</param>
         /// <returns>IDs of successfully archived messages</returns>
-        Task<Guid[]> ArchiveMessagesAsync(Message[] messages, CancellationToken cancellationToken);
+        Task<string[]> ArchiveMessagesAsync(Message[] messages, CancellationToken cancellationToken);
     }
 }

--- a/src/Paramore.Brighter/IAmAnExternalBusService.cs
+++ b/src/Paramore.Brighter/IAmAnExternalBusService.cs
@@ -23,7 +23,7 @@ namespace Paramore.Brighter
         /// <param name="args">For outboxes that require additional parameters such as topic, provide an optional arg</param>
         /// <exception cref="InvalidOperationException">Thrown if there is no async outbox defined</exception>
         /// <exception cref="NullReferenceException">Thrown if a message cannot be found</exception>
-        void ClearOutbox(Guid[] posts, Dictionary<string, object> args = null);
+        void ClearOutbox(string[] posts, Dictionary<string, object> args = null);
 
         /// <summary>
         /// This is the clear outbox for explicit clearing of messages.
@@ -34,8 +34,7 @@ namespace Paramore.Brighter
         /// <param name="cancellationToken">Allow cancellation of the operation</param>
         /// <exception cref="InvalidOperationException">Thrown if there is no async outbox defined</exception>
         /// <exception cref="NullReferenceException">Thrown if a message cannot be found</exception>
-        Task ClearOutboxAsync(
-            IEnumerable<Guid> posts,
+        Task ClearOutboxAsync(IEnumerable<string> posts,
             bool continueOnCapturedContext = false,
             Dictionary<string, object> args = null,
             CancellationToken cancellationToken = default);

--- a/src/Paramore.Brighter/IAmAnInboxAsync.cs
+++ b/src/Paramore.Brighter/IAmAnInboxAsync.cs
@@ -49,20 +49,24 @@ namespace Paramore.Brighter
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="id">The identifier.</param>
+        /// <param name="contextKey"></param>
         /// <param name="timeoutInMilliseconds"></param>
         /// <param name="cancellationToken">Allow the sender to cancel the operation, if the parameter is supplied</param>
         /// <returns><see cref="Task{T}"/>.</returns>
-        Task<T> GetAsync<T>(Guid id, string contextKey, int timeoutInMilliseconds = -1, CancellationToken cancellationToken = default) where T : class, IRequest;
+        Task<T> GetAsync<T>(string id, string contextKey, int timeoutInMilliseconds = -1,
+            CancellationToken cancellationToken = default) where T : class, IRequest;
 
         /// <summary>
         /// Checks whether a command with the specified identifier exists in the store
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="id">The identifier.</param>
+        /// <param name="contextKey"></param>
         /// <param name="timeoutInMilliseconds"></param>
         /// <param name="cancellationToken">Allow the sender to cancel the operation, if the parameter is supplied</param>
         /// <returns>True if it exists, False otherwise</returns>
-        Task<bool> ExistsAsync<T>(Guid id, string contextKey, int timeoutInMilliseconds = -1, CancellationToken cancellationToken = default) where T : class, IRequest;
+        Task<bool> ExistsAsync<T>(string id, string contextKey, int timeoutInMilliseconds = -1,
+            CancellationToken cancellationToken = default) where T : class, IRequest;
 
         /// <summary>
         /// If false we the default thread synchronization context to run any continuation, if true we re-use the original synchronization context.

--- a/src/Paramore.Brighter/IAmAnInboxSync.cs
+++ b/src/Paramore.Brighter/IAmAnInboxSync.cs
@@ -49,7 +49,7 @@ namespace Paramore.Brighter
         /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
         /// <param name="timeoutInMilliseconds"></param>
         /// <returns>T.</returns>
-        T Get<T>(Guid id, string contextKey, int timeoutInMilliseconds = -1) where T : class, IRequest;
+        T Get<T>(string id, string contextKey, int timeoutInMilliseconds = -1) where T : class, IRequest;
 
         /// <summary>
         /// Checks whether a command with the specified identifier exists in the store
@@ -59,6 +59,6 @@ namespace Paramore.Brighter
         /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
         /// <param name="timeoutInMilliseconds"></param>
         /// <returns>True if it exists, False otherwise</returns>
-        bool Exists<T>(Guid id, string contextKey, int timeoutInMilliseconds = -1) where T : class, IRequest;
+        bool Exists<T>(string id, string contextKey, int timeoutInMilliseconds = -1) where T : class, IRequest;
     }
 }

--- a/src/Paramore.Brighter/IAmAnOutboxAsync.cs
+++ b/src/Paramore.Brighter/IAmAnOutboxAsync.cs
@@ -75,14 +75,18 @@ namespace Paramore.Brighter
             int outBoxTimeout = -1,
             IAmABoxTransactionProvider<TTransaction> transactionProvider = null,
             CancellationToken cancellationToken = default);
-        
+
         /// <summary>
         /// Delete the specified messages
         /// </summary>
         /// <param name="messageIds">The id of the message to delete</param>
         /// <param name="args">Additional parameters required for search, if any</param>
         /// <param name="cancellationToken">The Cancellation Token</param>
-        Task DeleteAsync(Guid[] messageIds, Dictionary<string, object> args = null, CancellationToken cancellationToken = default);
+        Task DeleteAsync(
+            string[] messageIds, 
+            Dictionary<string, object> args = null,
+            CancellationToken cancellationToken = default
+            );
         
         /// <summary>
         /// Retrieves messages that have been sent within the window
@@ -111,7 +115,7 @@ namespace Paramore.Brighter
         /// <param name="cancellationToken">Allows the sender to cancel the request pipeline. Optional</param>
         /// <returns><see cref="Task{Message}"/>.</returns>
         Task<Message> GetAsync(
-            Guid messageId, 
+            string messageId, 
             int outBoxTimeout = -1,
             Dictionary<string, object> args = null,
             CancellationToken cancellationToken = default);
@@ -124,7 +128,7 @@ namespace Paramore.Brighter
         /// <param name="args">A dictionary of provider specific arguments</param>
         /// <param name="cancellationToken">Allows the sender to cancel the request pipeline. Optional</param>
         Task MarkDispatchedAsync(
-            Guid id, 
+            string id, 
             DateTime? dispatchedAt = null, 
             Dictionary<string, object> args = null, 
             CancellationToken cancellationToken = default);
@@ -137,9 +141,9 @@ namespace Paramore.Brighter
         /// <param name="args">A dictionary of provider specfic arguments</param>
         /// <param name="cancellationToken">Allows the sender to cancel the request pipeline. Optional</param>
         Task MarkDispatchedAsync(
-            IEnumerable<Guid> ids, 
-            DateTime? dispatchedAt = null, 
-            Dictionary<string, object> args = null, 
+            IEnumerable<string> ids,
+            DateTime? dispatchedAt = null,
+            Dictionary<string, object> args = null,
             CancellationToken cancellationToken = default);
  
         /// <summary>

--- a/src/Paramore.Brighter/IAmAnOutboxSync.cs
+++ b/src/Paramore.Brighter/IAmAnOutboxSync.cs
@@ -58,7 +58,7 @@ namespace Paramore.Brighter
         /// </summary>
         /// <param name="messageIds">The id of the message to delete</param>
         /// <param name="args">Additional parameters required for search, if any</param>
-        void Delete(Guid[] messageIds, Dictionary<string, object> args = null);
+        void Delete(string[] messageIds, Dictionary<string, object> args = null);
         
         /// <summary>
         /// Retrieves messages that have been sent within the window
@@ -75,7 +75,7 @@ namespace Paramore.Brighter
             int pageNumber = 1, 
             int outboxTimeout = -1,
             Dictionary<string, object> args = null);
-        
+
         /// <summary>
         /// Gets the specified message identifier.
         /// </summary>
@@ -83,7 +83,7 @@ namespace Paramore.Brighter
         /// <param name="outBoxTimeout">The time allowed for the read in milliseconds; on  a -2 default</param>
         /// <param name="args">For outboxes that require additional parameters such as topic, provide an optional arg</param>
         /// <returns>Task&lt;Message&gt;.</returns>
-        Message Get(Guid messageId, int outBoxTimeout = -1, Dictionary<string, object> args = null);
+        Message Get(string messageId, int outBoxTimeout = -1, Dictionary<string, object> args = null);
 
         /// <summary>
         /// Update a message to show it is dispatched
@@ -91,7 +91,7 @@ namespace Paramore.Brighter
         /// <param name="id">The id of the message to update</param>
         /// <param name="dispatchedAt">When was the message dispatched, defaults to UTC now</param>
         /// <param name="args">Dictionary to allow platform specific parameters to be passed to the interface</param>
-        void MarkDispatched(Guid id, DateTime? dispatchedAt = null, Dictionary<string, object> args = null);
+        void MarkDispatched(string id, DateTime? dispatchedAt = null, Dictionary<string, object> args = null);
 
         /// <summary>
         /// Messages still outstanding in the Outbox because their timestamp

--- a/src/Paramore.Brighter/IRequest.cs
+++ b/src/Paramore.Brighter/IRequest.cs
@@ -38,7 +38,7 @@ namespace Paramore.Brighter
         /// Gets or sets the identifier.
         /// </summary>
         /// <value>The identifier.</value>
-        Guid Id { get; set; }
+        string Id { get; set; }
 
         /// <summary>
         /// Gets or sets the span that this operation live within

--- a/src/Paramore.Brighter/ISupportPublishConfirmation.cs
+++ b/src/Paramore.Brighter/ISupportPublishConfirmation.cs
@@ -15,6 +15,6 @@ namespace Paramore.Brighter
         /// bool => was the message published
         /// Guid => what was the id of the published message
         /// </summary>
-        event Action<bool, Guid> OnMessagePublished;
+        event Action<bool, string> OnMessagePublished;
    }
 }

--- a/src/Paramore.Brighter/InMemoryInbox.cs
+++ b/src/Paramore.Brighter/InMemoryInbox.cs
@@ -91,7 +91,7 @@ namespace Paramore.Brighter
         /// <param name="id">The Guid for the request</param>
         /// <param name="contextKey">The handler this is for</param>
         /// <returns></returns>
-        public static string CreateKey(Guid id, string contextKey)
+        public static string CreateKey(string id, string contextKey)
         {
             return $"{id}:{contextKey}";
         }
@@ -177,7 +177,7 @@ namespace Paramore.Brighter
         /// <param name="timeoutInMilliseconds">The timeout in milliseconds.</param>
         /// <returns>ICommand.</returns>
         /// <exception cref="System.TypeLoadException"></exception>
-        public T Get<T>(Guid id, string contextKey, int timeoutInMilliseconds = -1) where T : class, IRequest
+        public T Get<T>(string id, string contextKey, int timeoutInMilliseconds = -1) where T : class, IRequest
         {
             ClearExpiredMessages();
             
@@ -189,7 +189,7 @@ namespace Paramore.Brighter
             throw new RequestNotFoundException<T>(id);
         }
 
-        public bool Exists<T>(Guid id, string contextKey, int timeoutInMilliseconds = -1) where T : class, IRequest
+        public bool Exists<T>(string id, string contextKey, int timeoutInMilliseconds = -1) where T : class, IRequest
         {
             ClearExpiredMessages();
 
@@ -203,8 +203,10 @@ namespace Paramore.Brighter
         /// <param name="id">The identifier.</param>
         /// <param name="contextKey"></param>
         /// <param name="timeoutInMilliseconds"></param>
+        /// <param name="cancellationToken"></param>
         /// <returns>True if it exists, False otherwise</returns>
-        public Task<bool> ExistsAsync<T>(Guid id, string contextKey, int timeoutInMilliseconds = -1, CancellationToken cancellationToken = default) where T : class, IRequest
+        public Task<bool> ExistsAsync<T>(string id, string contextKey, int timeoutInMilliseconds = -1,
+            CancellationToken cancellationToken = default) where T : class, IRequest
         {
             var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
@@ -231,7 +233,8 @@ namespace Paramore.Brighter
         /// <returns><see cref="Task{T}" />.</returns>
         /// <returns><see cref="Task" />Allows the sender to cancel the call, optional</returns>
         /// <exception cref="System.NotImplementedException"></exception>
-        public Task<T> GetAsync<T>(Guid id, string contextKey, int timeoutInMilliseconds = -1, CancellationToken cancellationToken = default) where T : class, IRequest
+        public Task<T> GetAsync<T>(string id, string contextKey, int timeoutInMilliseconds = -1,
+            CancellationToken cancellationToken = default) where T : class, IRequest
         {
             var tcs = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
 

--- a/src/Paramore.Brighter/Inbox/Exceptions/RequestNotFoundException.cs
+++ b/src/Paramore.Brighter/Inbox/Exceptions/RequestNotFoundException.cs
@@ -4,12 +4,12 @@ namespace Paramore.Brighter.Inbox.Exceptions
 {
     public class RequestNotFoundException<T> : Exception where T : IRequest
     {
-        public RequestNotFoundException(Guid id)
+        public RequestNotFoundException(string id)
             :this(id, null)
         {
         }
 
-        public RequestNotFoundException(Guid id, Exception innerException)
+        public RequestNotFoundException(string id, Exception innerException)
             : base($"Command '{id}' of type {typeof(T).FullName} does not exist", innerException)
         {
         }

--- a/src/Paramore.Brighter/Message.cs
+++ b/src/Paramore.Brighter/Message.cs
@@ -59,7 +59,7 @@ namespace Paramore.Brighter
         /// Gets the identifier of the message.
         /// </summary>
         /// <value>The identifier.</value>
-        public Guid Id
+        public string Id
         {
             get { return Header.Id; }
         }
@@ -109,7 +109,7 @@ namespace Paramore.Brighter
         /// </summary>
         public Message()
         {
-            Header = new MessageHeader(messageId: Guid.Empty, topic: string.Empty, messageType: MessageType.MT_NONE);
+            Header = new MessageHeader(messageId: string.Empty, topic: string.Empty, messageType: MessageType.MT_NONE);
             Body = new MessageBody(string.Empty);
         }
 

--- a/src/Paramore.Brighter/MessageFactory.cs
+++ b/src/Paramore.Brighter/MessageFactory.cs
@@ -37,7 +37,7 @@ namespace Paramore.Brighter
         /// <returns>Message.</returns>
         public static Message CreateQuitMessage()
         {
-            return new Message(new MessageHeader(Guid.Empty, string.Empty, MessageType.MT_QUIT), new MessageBody(string.Empty));
+            return new Message(new MessageHeader(string.Empty, string.Empty, MessageType.MT_QUIT), new MessageBody(string.Empty));
         }
     }
 }

--- a/src/Paramore.Brighter/MessageHeader.cs
+++ b/src/Paramore.Brighter/MessageHeader.cs
@@ -105,7 +105,7 @@ namespace Paramore.Brighter
         /// name from UpperCase to camelCase
         /// </summary>
         /// <value>The bag.</value>
-        public Dictionary<string, object> Bag { get; set; } = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+        public Dictionary<string, object> Bag { get; set; } = new(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
         /// Gets the number of times this message has been seen 

--- a/src/Paramore.Brighter/MessageHeader.cs
+++ b/src/Paramore.Brighter/MessageHeader.cs
@@ -122,7 +122,7 @@ namespace Paramore.Brighter
         /// allows the originator to match responses to requests
         /// </summary>
         /// <value>The correlation identifier.</value>
-        public Guid CorrelationId { get; set; }
+        public string CorrelationId { get; set; }
 
         /// <summary>
         /// Gets or sets the ContentType used to describe how the message payload
@@ -164,11 +164,10 @@ namespace Paramore.Brighter
         /// <param name="replyTo">Used for a request-reply message to indicate the private channel to reply to</param>
         /// <param name="contentType">The type of the payload of the message</param>
         /// <param name="partitionKey">How should we group messages that must be processed together i.e. consistent hashing</param>
-        public MessageHeader(
-            string messageId,
+        public MessageHeader(string messageId,
             string topic,
             MessageType messageType,
-            Guid? correlationId = null,
+            string correlationId = null,
             string replyTo = "",
             string contentType = "",
             string partitionKey = "")
@@ -179,7 +178,7 @@ namespace Paramore.Brighter
             TimeStamp = DateTime.UtcNow;
             HandledCount = 0;
             DelayedMilliseconds = 0;
-            CorrelationId = correlationId ?? Guid.Empty;
+            CorrelationId = correlationId ?? string.Empty;
             ReplyTo = replyTo;
             ContentType = contentType;
             PartitionKey = partitionKey;
@@ -201,11 +200,11 @@ namespace Paramore.Brighter
             string topic,
             MessageType messageType,
             DateTime timeStamp,
-            Guid? correlationId = null,
+            string correlationId = null,
             string replyTo = null,
             string contentType = "text/plain",
             string partitionKey = "")
-            : this((string)messageId, topic, messageType, correlationId, replyTo, contentType, partitionKey)
+            : this((string)messageId, topic, messageType, (string)correlationId, replyTo, contentType, partitionKey)
         {
             TimeStamp = timeStamp;
         }
@@ -229,7 +228,7 @@ namespace Paramore.Brighter
             DateTime timeStamp,
             int handledCount,
             int delayedMilliseconds,
-            Guid? correlationId = null,
+            string correlationId = null,
             string replyTo = null,
             string contentType = "text/plain",
             string partitionKey = "")

--- a/src/Paramore.Brighter/MessageHeader.cs
+++ b/src/Paramore.Brighter/MessageHeader.cs
@@ -85,7 +85,7 @@ namespace Paramore.Brighter
         /// Gets the identifier.
         /// </summary>
         /// <value>The identifier.</value>
-        public Guid Id { get; set; }
+        public string Id { get; set; }
 
         /// <summary>
         /// Gets the topic.
@@ -165,7 +165,7 @@ namespace Paramore.Brighter
         /// <param name="contentType">The type of the payload of the message</param>
         /// <param name="partitionKey">How should we group messages that must be processed together i.e. consistent hashing</param>
         public MessageHeader(
-            Guid messageId,
+            string messageId,
             string topic,
             MessageType messageType,
             Guid? correlationId = null,
@@ -197,8 +197,7 @@ namespace Paramore.Brighter
         /// <param name="replyTo">Used for a request-reply message to indicate the private channel to reply to</param>
         /// <param name="contentType">The type of the payload of the message, defaults to tex/plain</param>
         /// <param name="partitionKey">How should we group messages that must be processed together i.e. consistent hashing</param>
-        public MessageHeader(
-            Guid messageId,
+        public MessageHeader(string messageId,
             string topic,
             MessageType messageType,
             DateTime timeStamp,
@@ -206,7 +205,7 @@ namespace Paramore.Brighter
             string replyTo = null,
             string contentType = "text/plain",
             string partitionKey = "")
-            : this(messageId, topic, messageType, correlationId, replyTo, contentType, partitionKey)
+            : this((string)messageId, topic, messageType, correlationId, replyTo, contentType, partitionKey)
         {
             TimeStamp = timeStamp;
         }
@@ -224,8 +223,7 @@ namespace Paramore.Brighter
         /// <param name="replyTo">Used for a request-reply message to indicate the private channel to reply to</param>
         /// <param name="contentType">The type of the payload of the message, defaults to tex/plain</param>
         /// <param name="partitionKey">How should we group messages that must be processed together i.e. consistent hashing</param>
-        public MessageHeader(
-            Guid messageId,
+        public MessageHeader(string messageId,
             string topic,
             MessageType messageType,
             DateTime timeStamp,
@@ -235,7 +233,7 @@ namespace Paramore.Brighter
             string replyTo = null,
             string contentType = "text/plain",
             string partitionKey = "")
-            : this(messageId, topic, messageType, timeStamp, correlationId, replyTo, contentType, partitionKey)
+            : this((string)messageId, topic, messageType, timeStamp, correlationId, replyTo, contentType, partitionKey)
         {
             HandledCount = handledCount;
             DelayedMilliseconds = delayedMilliseconds;

--- a/src/Paramore.Brighter/MessageRecovery.cs
+++ b/src/Paramore.Brighter/MessageRecovery.cs
@@ -64,7 +64,7 @@ namespace Paramore.Brighter
             where T : Message
         {
             IEnumerable<Message> foundMessages = messageIds 
-                .Select(messageId => outBox.Get(Guid.Parse(messageId)))
+                .Select(messageId => outBox.Get(messageId))
                 .Where(fm => fm != null)
                 .ToList();
 

--- a/src/Paramore.Brighter/NullOutboxArchiveProvider.cs
+++ b/src/Paramore.Brighter/NullOutboxArchiveProvider.cs
@@ -63,15 +63,14 @@ namespace Paramore.Brighter
 
             return Task.CompletedTask;
         }
-        
+
         /// <summary>
         /// Archive messages in Parallel
         /// </summary>
         /// <param name="messages">Messages to send</param>
         /// <param name="cancellationToken">The Cancellation Token</param>
         /// <returns>IDs of successfully archived messages</returns>
-
-        public Task<Guid[]> ArchiveMessagesAsync(Message[] messages, CancellationToken cancellationToken)
+        public Task<string[]> ArchiveMessagesAsync(Message[] messages, CancellationToken cancellationToken)
         {
             _logger.LogDebug("Messages with Ids {MessageIds} will not be stored",
                 string.Join(",", messages.Select(m => m.Id.ToString()).ToArray()));

--- a/src/Paramore.Brighter/OutboxArchiver.cs
+++ b/src/Paramore.Brighter/OutboxArchiver.cs
@@ -112,20 +112,6 @@ namespace Paramore.Brighter
 
                 if (!messages.Any()) return;
 
-                Guid[] successfullyArchivedMessages;
-                if (parallelArchiving)
-                {
-                    successfullyArchivedMessages = await _archiveProvider.ArchiveMessagesAsync(messages.ToArray(), cancellationToken);
-                }
-                else
-                {
-                    foreach (var message in messages)
-                    {
-                        await _archiveProvider.ArchiveMessageAsync(message, cancellationToken);
-                    }
-                    successfullyArchivedMessages = messages.Select(m => m.Id).ToArray();
-                }
-
                 await _outboxAsync.DeleteAsync(
                     messages.Select(e => e.Id).ToArray(), cancellationToken: cancellationToken);
             }

--- a/src/Paramore.Brighter/ReplyAddress.cs
+++ b/src/Paramore.Brighter/ReplyAddress.cs
@@ -38,13 +38,13 @@ namespace Paramore.Brighter
         /// The default constructor is mainly intended to use for 
         /// </summary>
         public ReplyAddress() { }
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="ReplyAddress"/> class.
         /// </summary>
         /// <param name="topic">The topic.</param>
         /// <param name="correlationId">The correlation identifier.</param>
-        public ReplyAddress(string topic, Guid correlationId)
+        public ReplyAddress(string topic, string correlationId)
         {
             Topic = topic;
             CorrelationId = correlationId;
@@ -60,6 +60,6 @@ namespace Paramore.Brighter
         /// Gets the correlation identifier.
         /// </summary>
         /// <value>The correlation identifier.</value>
-        public Guid CorrelationId { get; set; }
+        public string CorrelationId { get; set; }
     }
 }

--- a/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/When_a_message_consumer_reads_multiple_messages.cs
+++ b/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/When_a_message_consumer_reads_multiple_messages.cs
@@ -58,22 +58,22 @@ namespace Paramore.Brighter.AWS.Tests.MessagingGateway
         public async Task When_a_message_consumer_reads_multiple_messages()
         {
             var messageOne = new Message(
-                new MessageHeader(Guid.NewGuid(), _topicName, MessageType.MT_COMMAND, Guid.NewGuid(), string.Empty, _contentType),
+                new MessageHeader(Guid.NewGuid().ToString(), _topicName, MessageType.MT_COMMAND, Guid.NewGuid().ToString(), string.Empty, _contentType),
                 new MessageBody("test content one")
                 );
             
             var messageTwo= new Message(
-                new MessageHeader(Guid.NewGuid(), _topicName, MessageType.MT_COMMAND, Guid.NewGuid(), string.Empty, _contentType),
+                new MessageHeader(Guid.NewGuid().ToString(), _topicName, MessageType.MT_COMMAND, Guid.NewGuid().ToString(), string.Empty, _contentType),
                 new MessageBody("test content two")
                 );
            
             var messageThree= new Message(
-                new MessageHeader(Guid.NewGuid(), _topicName, MessageType.MT_COMMAND, Guid.NewGuid(), string.Empty, _contentType),
+                new MessageHeader(Guid.NewGuid().ToString(), _topicName, MessageType.MT_COMMAND, Guid.NewGuid().ToString(), string.Empty, _contentType),
                 new MessageBody("test content three")
                 );
              
             var messageFour= new Message(
-                new MessageHeader(Guid.NewGuid(), _topicName, MessageType.MT_COMMAND, Guid.NewGuid(), string.Empty, _contentType),
+                new MessageHeader(Guid.NewGuid().ToString(), _topicName, MessageType.MT_COMMAND, Guid.NewGuid().ToString(), string.Empty, _contentType),
                 new MessageBody("test content four")
                 );
              

--- a/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/When_infastructure_exists_can_assume.cs
+++ b/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/When_infastructure_exists_can_assume.cs
@@ -23,7 +23,7 @@ namespace Paramore.Brighter.AWS.Tests.MessagingGateway
         public AWSAssumeInfrastructureTests()
         {
             _myCommand = new MyCommand{Value = "Test"};
-            Guid correlationId = Guid.NewGuid();
+            string correlationId = Guid.NewGuid().ToString();
             string replyTo = "http:\\queueUrl";
             string contentType = "text\\plain";
             var channelName = $"Producer-Send-Tests-{Guid.NewGuid().ToString()}".Truncate(45);

--- a/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/When_infastructure_exists_can_verify.cs
+++ b/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/When_infastructure_exists_can_verify.cs
@@ -24,7 +24,7 @@ namespace Paramore.Brighter.AWS.Tests.MessagingGateway
         public AWSValidateInfrastructureTests()
         {
             _myCommand = new MyCommand{Value = "Test"};
-            Guid correlationId = Guid.NewGuid();
+            string correlationId = Guid.NewGuid().ToString();
             string replyTo = "http:\\queueUrl";
             string contentType = "text\\plain";
             var channelName = $"Producer-Send-Tests-{Guid.NewGuid().ToString()}".Truncate(45);

--- a/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/When_infastructure_exists_can_verify_by_arn.cs
+++ b/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/When_infastructure_exists_can_verify_by_arn.cs
@@ -25,7 +25,7 @@ namespace Paramore.Brighter.AWS.Tests.MessagingGateway
         public AWSValidateInfrastructureByArnTests()
         {
             _myCommand = new MyCommand{Value = "Test"};
-            Guid correlationId = Guid.NewGuid();
+            string correlationId = Guid.NewGuid().ToString();
             string replyTo = "http:\\queueUrl";
             string contentType = "text\\plain";
             var channelName = $"Producer-Send-Tests-{Guid.NewGuid().ToString()}".Truncate(45);

--- a/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/When_infastructure_exists_can_verify_by_convention.cs
+++ b/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/When_infastructure_exists_can_verify_by_convention.cs
@@ -24,7 +24,7 @@ namespace Paramore.Brighter.AWS.Tests.MessagingGateway
         public AWSValidateInfrastructureByConventionTests()
         {
             _myCommand = new MyCommand{Value = "Test"};
-            Guid correlationId = Guid.NewGuid();
+            string correlationId = Guid.NewGuid().ToString();
             string replyTo = "http:\\queueUrl";
             string contentType = "text\\plain";
             var channelName = $"Producer-Send-Tests-{Guid.NewGuid().ToString()}".Truncate(45);

--- a/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/When_posting_a_message_via_the_messaging_gateway.cs
+++ b/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/When_posting_a_message_via_the_messaging_gateway.cs
@@ -19,7 +19,7 @@ namespace Paramore.Brighter.AWS.Tests.MessagingGateway
         private readonly SqsMessageProducer _messageProducer;
         private readonly ChannelFactory _channelFactory;
         private readonly MyCommand _myCommand;
-        private readonly Guid _correlationId;
+        private readonly string _correlationId;
         private readonly string _replyTo;
         private readonly string _contentType;
         private readonly string _topicName;
@@ -27,7 +27,7 @@ namespace Paramore.Brighter.AWS.Tests.MessagingGateway
         public SqsMessageProducerSendTests()
         {
             _myCommand = new MyCommand{Value = "Test"};
-            _correlationId = Guid.NewGuid();
+            _correlationId = Guid.NewGuid().ToString();
             _replyTo = "http:\\queueUrl";
             _contentType = "text\\plain";
             var channelName = $"Producer-Send-Tests-{Guid.NewGuid().ToString()}".Truncate(45);

--- a/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/When_raw_message_delivery_disabled.cs
+++ b/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/When_raw_message_delivery_disabled.cs
@@ -52,10 +52,11 @@ namespace Paramore.Brighter.AWS.Tests.MessagingGateway
         public void When_raw_message_delivery_disabled()
         {
             //arrange
-            var messageHeader = new MessageHeader(Guid.NewGuid(), 
+            var messageHeader = new MessageHeader(
+                Guid.NewGuid().ToString(), 
                 _topicName, 
                 MessageType.MT_COMMAND, 
-                correlationId: Guid.NewGuid(), 
+                correlationId: Guid.NewGuid().ToString(), 
                 replyTo: string.Empty, 
                 contentType: "text\\plain");
 

--- a/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/When_rejecting_a_message_through_gateway_with_requeue.cs
+++ b/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/When_rejecting_a_message_through_gateway_with_requeue.cs
@@ -24,7 +24,7 @@ namespace Paramore.Brighter.AWS.Tests.MessagingGateway
         public SqsMessageConsumerRequeueTests()
         {
             _myCommand = new MyCommand{Value = "Test"};
-            Guid correlationId = Guid.NewGuid();
+            string correlationId = Guid.NewGuid().ToString();
             string replyTo = "http:\\queueUrl";
             string contentType = "text\\plain";
             var channelName = $"Consumer-Requeue-Tests-{Guid.NewGuid().ToString()}".Truncate(45);

--- a/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/When_requeueing_a_message.cs
+++ b/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/When_requeueing_a_message.cs
@@ -24,7 +24,7 @@ namespace Paramore.Brighter.AWS.Tests.MessagingGateway
         public SqsMessageProducerRequeueTests()
         {
             MyCommand myCommand = new MyCommand{Value = "Test"};
-            Guid correlationId = Guid.NewGuid();
+            string correlationId = Guid.NewGuid().ToString();
             string replyTo = "http:\\queueUrl";
             string contentType = "text\\plain";
             var channelName = $"Producer-Requeue-Tests-{Guid.NewGuid().ToString()}".Truncate(45);

--- a/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/When_requeueing_redrives_to_the_dlq.cs
+++ b/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/When_requeueing_redrives_to_the_dlq.cs
@@ -29,7 +29,7 @@ namespace Paramore.Brighter.AWS.Tests.MessagingGateway
         public SqsMessageProducerDlqTests ()
         {
             MyCommand myCommand = new MyCommand{Value = "Test"};
-            Guid correlationId = Guid.NewGuid();
+            string correlationId = Guid.NewGuid().ToString();
             string replyTo = "http:\\queueUrl";
             string contentType = "text\\plain";
             var channelName = $"Producer-DLQ-Tests-{Guid.NewGuid().ToString()}".Truncate(45);

--- a/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/When_throwing_defer_action_respect_redrive.cs
+++ b/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/When_throwing_defer_action_respect_redrive.cs
@@ -33,7 +33,7 @@ namespace Paramore.Brighter.AWS.Tests.MessagingGateway
 
         public SnsReDrivePolicySDlqTests()
         {
-            Guid correlationId = Guid.NewGuid();
+            string correlationId = Guid.NewGuid().ToString();
             string replyTo = "http:\\queueUrl";
             string contentType = "text\\plain";
             var channelName = $"Redrive-Tests-{Guid.NewGuid().ToString()}".Truncate(45);
@@ -138,7 +138,7 @@ namespace Paramore.Brighter.AWS.Tests.MessagingGateway
             await Task.Delay(5000);
 
             //send a quit message to the pump to terminate it 
-            var quitMessage = new Message(new MessageHeader(Guid.Empty, "", MessageType.MT_QUIT), new MessageBody(""));
+            var quitMessage = new Message(new MessageHeader(string.Empty, "", MessageType.MT_QUIT), new MessageBody(""));
             _channel.Enqueue(quitMessage);
 
             //wait for the pump to stop once it gets a quit message

--- a/tests/Paramore.Brighter.Azure.Tests/AzureBlobArchiveProviderTests.cs
+++ b/tests/Paramore.Brighter.Azure.Tests/AzureBlobArchiveProviderTests.cs
@@ -81,7 +81,7 @@ public class AzureBlobArchiveProviderTests
         var tags = (await blobClient.GetTagsAsync()).Value.Tags;
 
         Assert.That(tags["topic"], Is.EqualTo(eventMessage.Header.Topic));
-        Assert.That(Guid.Parse(tags["correlationId"]), Is.EqualTo(eventMessage.Header.CorrelationId));
+        Assert.That(tags["correlationId"], Is.EqualTo(eventMessage.Header.CorrelationId));
         Assert.That(tags["message_type"], Is.EqualTo(eventMessage.Header.MessageType.ToString()));
         Assert.That(DateTime.Parse(tags["timestamp"]), Is.EqualTo(eventMessage.Header.TimeStamp));
         Assert.That(tags["content_type"], Is.EqualTo(eventMessage.Header.ContentType));
@@ -175,7 +175,7 @@ public class AzureBlobArchiveProviderTests
         var tags = (await blobClient.GetTagsAsync()).Value.Tags;
 
         Assert.That(tags["topic"], Is.EqualTo(eventMessage.Header.Topic));
-        Assert.That(Guid.Parse(tags["correlationId"]), Is.EqualTo(eventMessage.Header.CorrelationId));
+        Assert.That(tags["correlationId"], Is.EqualTo(eventMessage.Header.CorrelationId));
         Assert.That(tags["message_type"], Is.EqualTo(eventMessage.Header.MessageType.ToString()));
         Assert.That(DateTime.Parse(tags["timestamp"]), Is.EqualTo(eventMessage.Header.TimeStamp));
         Assert.That(tags["content_type"], Is.EqualTo(eventMessage.Header.ContentType));

--- a/tests/Paramore.Brighter.AzureServiceBus.Tests/AzureServiceBusConsumerTests.cs
+++ b/tests/Paramore.Brighter.AzureServiceBus.Tests/AzureServiceBusConsumerTests.cs
@@ -235,7 +235,7 @@ namespace Paramore.Brighter.AzureServiceBus.Tests
         public void When_requeue_is_called_and_the_delay_is_zero_the_send_method_is_called()
         {
             var messageLockTokenOne = Guid.NewGuid();
-            var messageHeader = new MessageHeader(Guid.NewGuid(), "topic", MessageType.MT_EVENT);
+            var messageHeader = new MessageHeader(Guid.NewGuid().ToString(), "topic", MessageType.MT_EVENT);
             var message = new Message(messageHeader, new MessageBody("body"));
             message.Header.Bag.Add("LockToken", messageLockTokenOne);
 
@@ -248,7 +248,7 @@ namespace Paramore.Brighter.AzureServiceBus.Tests
         public void When_requeue_is_called_and_the_delay_is_more_than_zero_the_sendWithDelay_method_is_called()
         {
             var messageLockTokenOne = Guid.NewGuid();
-            var messageHeader = new MessageHeader(Guid.NewGuid(), "topic", MessageType.MT_EVENT);
+            var messageHeader = new MessageHeader(Guid.NewGuid().ToString(), "topic", MessageType.MT_EVENT);
             var message = new Message(messageHeader, new MessageBody("body"));
             message.Header.Bag.Add("LockToken", messageLockTokenOne);
 

--- a/tests/Paramore.Brighter.AzureServiceBus.Tests/AzureServiceBusMessageProducerTests.cs
+++ b/tests/Paramore.Brighter.AzureServiceBus.Tests/AzureServiceBusMessageProducerTests.cs
@@ -36,7 +36,10 @@ namespace Paramore.Brighter.AzureServiceBus.Tests
             A.CallTo(() => _topicClientProvider.Get("topic")).Returns(_topicClient);
             A.CallTo(() => _topicClient.SendAsync(A<ServiceBusMessage>.Ignored, CancellationToken.None)).ReturnsLazily((ServiceBusMessage g, CancellationToken ct) => Task.FromResult(sentMessage = g));
 
-            _producer.Send(new Message(new MessageHeader(Guid.NewGuid(), "topic", MessageType.MT_EVENT), new MessageBody(messageBody, "JSON")));
+            _producer.Send(new Message(
+                new MessageHeader(Guid.NewGuid().ToString(), "topic", MessageType.MT_EVENT), 
+                new MessageBody(messageBody, "JSON"))
+            );
 
             Assert.Equal(messageBody, sentMessage.Body.ToArray());
             Assert.Equal("MT_EVENT", sentMessage.ApplicationProperties["MessageType"]);
@@ -53,7 +56,10 @@ namespace Paramore.Brighter.AzureServiceBus.Tests
             A.CallTo(() => _topicClientProvider.Get("topic")).Returns(_topicClient);
             A.CallTo(() => _topicClient.SendAsync(A<ServiceBusMessage>.Ignored, CancellationToken.None)).ReturnsLazily((ServiceBusMessage g, CancellationToken ct) => Task.FromResult(sentMessage = g));
 
-            _producer.Send(new Message(new MessageHeader(Guid.NewGuid(), "topic", MessageType.MT_COMMAND), new MessageBody(messageBody, "JSON")));
+            _producer.Send(new Message(
+                new MessageHeader(Guid.NewGuid().ToString(), "topic", MessageType.MT_COMMAND), 
+                new MessageBody(messageBody, "JSON"))
+            );
 
             Assert.Equal(messageBody, sentMessage.Body.ToArray());
             Assert.Equal("MT_COMMAND", sentMessage.ApplicationProperties["MessageType"]);
@@ -70,7 +76,9 @@ namespace Paramore.Brighter.AzureServiceBus.Tests
             A.CallTo(() => _topicClientProvider.Get("topic")).Returns(_topicClient);
             A.CallTo(() => _topicClient.SendAsync(A<ServiceBusMessage>.Ignored, CancellationToken.None)).ReturnsLazily((ServiceBusMessage g, CancellationToken ct) => Task.FromResult(sentMessage = g));
 
-            _producer.Send(new Message(new MessageHeader(Guid.NewGuid(), "topic", MessageType.MT_NONE), new MessageBody(messageBody, "JSON")));
+            _producer.Send(new Message(
+                new MessageHeader(Guid.NewGuid().ToString(), "topic", MessageType.MT_NONE), 
+                new MessageBody(messageBody, "JSON")));
 
             A.CallTo(() => _nameSpaceManagerWrapper.CreateTopic("topic", null)).MustHaveHappenedOnceExactly();
             Assert.Equal(messageBody, sentMessage.Body.ToArray());
@@ -86,7 +94,9 @@ namespace Paramore.Brighter.AzureServiceBus.Tests
 
             try
             {
-                _producer.Send(new Message(new MessageHeader(Guid.NewGuid(), "topic", MessageType.MT_NONE), new MessageBody("Message", "JSON")));
+                _producer.Send(new Message(
+                    new MessageHeader(Guid.NewGuid().ToString(), "topic", MessageType.MT_NONE), 
+                    new MessageBody("Message", "JSON")));
             }
             catch (Exception)
             {
@@ -111,7 +121,8 @@ namespace Paramore.Brighter.AzureServiceBus.Tests
                 Task.FromResult(sentMessage = g));
 
             _producer.SendWithDelay(
-                new Message(new MessageHeader(Guid.NewGuid(), "topic", MessageType.MT_EVENT),
+                new Message(
+                    new MessageHeader(Guid.NewGuid().ToString(), "topic", MessageType.MT_EVENT),
                     new MessageBody(messageBody, "JSON")), 1);
 
             Assert.Equal(messageBody, sentMessage.Body.ToArray());
@@ -131,7 +142,9 @@ namespace Paramore.Brighter.AzureServiceBus.Tests
                 A.CallTo(() => _topicClient.ScheduleMessageAsync(A<ServiceBusMessage>.Ignored, A<DateTimeOffset>.Ignored,
                     CancellationToken.None)).ReturnsLazily((ServiceBusMessage g, DateTimeOffset t, CancellationToken ct) => Task.FromResult(sentMessage = g));
 
-            _producer.SendWithDelay(new Message(new MessageHeader(Guid.NewGuid(), "topic", MessageType.MT_COMMAND), new MessageBody(messageBody, "JSON")), 1);
+            _producer.SendWithDelay(new Message(
+                new MessageHeader(Guid.NewGuid().ToString(), "topic", MessageType.MT_COMMAND), 
+                new MessageBody(messageBody, "JSON")), 1);
 
             Assert.Equal(messageBody, sentMessage.Body.ToArray());
             Assert.Equal("MT_COMMAND", sentMessage.ApplicationProperties["MessageType"]);
@@ -150,7 +163,9 @@ namespace Paramore.Brighter.AzureServiceBus.Tests
                 A.CallTo(() => _topicClient.ScheduleMessageAsync(A<ServiceBusMessage>.Ignored, A<DateTimeOffset>.Ignored,
                     CancellationToken.None)).ReturnsLazily((ServiceBusMessage g, DateTimeOffset t , CancellationToken ct) => Task.FromResult(sentMessage = g));
 
-            _producer.SendWithDelay(new Message(new MessageHeader(Guid.NewGuid(), "topic", MessageType.MT_NONE), new MessageBody(messageBody, "JSON")), 1);
+            _producer.SendWithDelay(new Message(
+                new MessageHeader(Guid.NewGuid().ToString(), "topic", MessageType.MT_NONE), 
+                new MessageBody(messageBody, "JSON")), 1);
 
             A.CallTo(() => _nameSpaceManagerWrapper.CreateTopic("topic", null)).MustHaveHappenedOnceExactly();
             Assert.Equal(messageBody, sentMessage.Body.ToArray());
@@ -167,8 +182,12 @@ namespace Paramore.Brighter.AzureServiceBus.Tests
             A.CallTo(() => _nameSpaceManagerWrapper.TopicExists("topic")).Returns(topicExists);
             A.CallTo(() => _topicClientProvider.Get("topic")).Returns(_topicClient);
 
-            _producer.SendWithDelay(new Message(new MessageHeader(Guid.NewGuid(), "topic", MessageType.MT_NONE), new MessageBody(messageBody, "JSON")), 1);
-            _producer.SendWithDelay(new Message(new MessageHeader(Guid.NewGuid(), "topic", MessageType.MT_NONE), new MessageBody(messageBody, "JSON")), 1);
+            _producer.SendWithDelay(new Message(
+                new MessageHeader(Guid.NewGuid().ToString(), "topic", MessageType.MT_NONE), 
+                new MessageBody(messageBody, "JSON")), 1);
+            _producer.SendWithDelay(new Message(
+                new MessageHeader(Guid.NewGuid().ToString(), "topic", MessageType.MT_NONE), 
+                new MessageBody(messageBody, "JSON")), 1);
 
             if (topicExists == false)
             {
@@ -185,7 +204,11 @@ namespace Paramore.Brighter.AzureServiceBus.Tests
 
             A.CallTo(() => _nameSpaceManagerWrapper.TopicExists("topic")).Throws(new Exception());
 
-            await Assert.ThrowsAsync<Exception>(() => _producer.SendWithDelayAsync(new Message(new MessageHeader(Guid.NewGuid(), "topic", MessageType.MT_NONE), new MessageBody(messageBody, "JSON")), 1));
+            await Assert.ThrowsAsync<Exception>(() => _producer.SendWithDelayAsync(
+                new Message(
+                    new MessageHeader(Guid.NewGuid().ToString(), "topic", MessageType.MT_NONE), 
+                    new MessageBody(messageBody, "JSON")), 1)
+            );
             A.CallTo(() => _nameSpaceManagerWrapper.Reset()).MustHaveHappenedOnceExactly();
         }
 
@@ -199,7 +222,10 @@ namespace Paramore.Brighter.AzureServiceBus.Tests
 
             A.CallTo(() => _topicClientProvider.Get("topic")).Throws(new Exception()).Once().Then.Returns(_topicClient);
 
-           _producer.SendWithDelay(new Message(new MessageHeader(Guid.NewGuid(), "topic", MessageType.MT_NONE), new MessageBody(messageBody, "JSON")));
+           _producer.SendWithDelay(new Message(
+               new MessageHeader(Guid.NewGuid().ToString(), "topic", MessageType.MT_NONE), 
+               new MessageBody(messageBody, "JSON"))
+           );
 
             A.CallTo(() => _topicClient.SendAsync(A<ServiceBusMessage>.Ignored, CancellationToken.None)).MustHaveHappenedOnceExactly();
         }
@@ -211,7 +237,11 @@ namespace Paramore.Brighter.AzureServiceBus.Tests
 
             var producerValidate = new AzureServiceBusMessageProducer(_nameSpaceManagerWrapper, _topicClientProvider, OnMissingChannel.Validate);
 
-            await Assert.ThrowsAsync<ChannelFailureException>(() => producerValidate.SendAsync(new Message(new MessageHeader(Guid.NewGuid(), "topic", MessageType.MT_NONE), new MessageBody(messageBody, "JSON"))));
+            await Assert.ThrowsAsync<ChannelFailureException>(() => producerValidate.SendAsync(
+                new Message(
+                    new MessageHeader(Guid.NewGuid().ToString(), "topic", MessageType.MT_NONE), 
+                    new MessageBody(messageBody, "JSON")))
+            );
         }
     }
 }

--- a/tests/Paramore.Brighter.AzureServiceBus.Tests/MessagingGateway/When_consuming_a_message_via_the_consumer.cs
+++ b/tests/Paramore.Brighter.AzureServiceBus.Tests/MessagingGateway/When_consuming_a_message_via_the_consumer.cs
@@ -18,7 +18,7 @@ namespace Paramore.Brighter.AzureServiceBus.Tests.MessagingGateway
         private readonly Message _message;
         private readonly IAmAChannel _channel;
         private readonly IAmAProducerRegistry _producerRegistry;
-        private readonly Guid _correlationId;
+        private readonly string _correlationId;
         private readonly string _contentType;
         private readonly string _topicName;
         private readonly string _channelName;
@@ -34,7 +34,7 @@ namespace Paramore.Brighter.AzureServiceBus.Tests.MessagingGateway
                 CommandNumber = 26
             };
 
-            _correlationId = Guid.NewGuid();
+            _correlationId = Guid.NewGuid().ToString();
             _channelName = $"Consumer-Tests-{Guid.NewGuid()}".Truncate(50);
             _topicName = $"Consumer-Tests-{Guid.NewGuid()}";
             var routingKey = new RoutingKey(_topicName);

--- a/tests/Paramore.Brighter.AzureServiceBus.Tests/MessagingGateway/When_posting_a_message_via_the_producer.cs
+++ b/tests/Paramore.Brighter.AzureServiceBus.Tests/MessagingGateway/When_posting_a_message_via_the_producer.cs
@@ -17,7 +17,7 @@ namespace Paramore.Brighter.AzureServiceBus.Tests.MessagingGateway
         private readonly IAmAChannel _channel;
         private readonly IAmAProducerRegistry _producerRegistry;
         private readonly ASBTestCommand _command;
-        private readonly Guid _correlationId;
+        private readonly string _correlationId;
         private readonly string _contentType;
         private readonly string _topicName;
         private readonly IAdministrationClientWrapper _administrationClient;
@@ -30,7 +30,7 @@ namespace Paramore.Brighter.AzureServiceBus.Tests.MessagingGateway
                 CommandNumber = 26
             };
 
-            _correlationId = Guid.NewGuid();
+            _correlationId = Guid.NewGuid().ToString();
             var channelName = $"Producer-Send-Tests-{Guid.NewGuid()}".Truncate(50);
             _topicName = $"Producer-Send-Tests-{Guid.NewGuid()}";
             var routingKey = new RoutingKey(_topicName);

--- a/tests/Paramore.Brighter.Core.Tests/Claims/When_a_message_is_under_the_threshold.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Claims/When_a_message_is_under_the_threshold.cs
@@ -25,7 +25,7 @@ public class ClaimCheckSmallPayloadTests
         //but create a string that is just under 5K long - assuming string is 26 + length *2 to allow for 64-bit platform
         string body = DataGenerator.CreateString(2485);
         _message = new Message(
-            new MessageHeader(Guid.NewGuid(), "test_topic", MessageType.MT_EVENT, DateTime.UtcNow),
+            new MessageHeader(Guid.NewGuid().ToString(), "test_topic", MessageType.MT_EVENT, DateTime.UtcNow),
             new MessageBody(body));
     }
 

--- a/tests/Paramore.Brighter.Core.Tests/Claims/When_a_message_is_under_the_threshold_async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Claims/When_a_message_is_under_the_threshold_async.cs
@@ -26,7 +26,7 @@ public class AsyncClaimCheckSmallPayloadTests
         //but create a string that is just under 5K long - assuming string is 26 + length *2 to allow for 64-bit platform
         string body = DataGenerator.CreateString(2485);
         _message = new Message(
-            new MessageHeader(Guid.NewGuid(), "test_topic", MessageType.MT_EVENT, DateTime.UtcNow),
+            new MessageHeader(Guid.NewGuid().ToString(), "test_topic", MessageType.MT_EVENT, DateTime.UtcNow),
             new MessageBody(body));
     }
 

--- a/tests/Paramore.Brighter.Core.Tests/Claims/When_a_message_unwraps_a_large_payload.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Claims/When_a_message_unwraps_a_large_payload.cs
@@ -37,7 +37,7 @@ public class RetrieveClaimLargePayloadTests
         var id = _store.Store(stream);
         
         var message = new Message(
-            new MessageHeader(Guid.NewGuid(), "test_topic", MessageType.MT_EVENT, DateTime.UtcNow),
+            new MessageHeader(Guid.NewGuid().ToString(), "test_topic", MessageType.MT_EVENT, DateTime.UtcNow),
             new MessageBody("Claim Check {id}"));
         message.Header.Bag[ClaimCheckTransformerAsync.CLAIM_CHECK] = id;
         

--- a/tests/Paramore.Brighter.Core.Tests/Claims/When_a_message_unwraps_a_large_payload_async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Claims/When_a_message_unwraps_a_large_payload_async.cs
@@ -37,7 +37,7 @@ public class AsyncRetrieveClaimLargePayloadTests
         var id = await _store.StoreAsync(stream);
         
         var message = new Message(
-            new MessageHeader(Guid.NewGuid(), "test_topic", MessageType.MT_EVENT, DateTime.UtcNow),
+            new MessageHeader(Guid.NewGuid().ToString(), "test_topic", MessageType.MT_EVENT, DateTime.UtcNow),
             new MessageBody("Claim Check {id}"));
         message.Header.Bag[ClaimCheckTransformerAsync.CLAIM_CHECK] = id;
         

--- a/tests/Paramore.Brighter.Core.Tests/Claims/When_a_message_wraps_a_large_payload.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Claims/When_a_message_wraps_a_large_payload.cs
@@ -25,7 +25,7 @@ public class ClaimCheckLargePayloadTests
 
         _body = DataGenerator.CreateString(6000);
         _message = new Message(
-            new MessageHeader(Guid.NewGuid(), "test_topic", MessageType.MT_EVENT, DateTime.UtcNow),
+            new MessageHeader(Guid.NewGuid().ToString(), "test_topic", MessageType.MT_EVENT, DateTime.UtcNow),
             new MessageBody(_body));
     }
     

--- a/tests/Paramore.Brighter.Core.Tests/Claims/When_a_message_wraps_a_large_payload_async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Claims/When_a_message_wraps_a_large_payload_async.cs
@@ -25,7 +25,7 @@ public class AsyncClaimCheckLargePayloadTests
 
         _body = DataGenerator.CreateString(6000);
         _message = new Message(
-            new MessageHeader(Guid.NewGuid(), "test_topic", MessageType.MT_EVENT, DateTime.UtcNow),
+            new MessageHeader(Guid.NewGuid().ToString(), "test_topic", MessageType.MT_EVENT, DateTime.UtcNow),
             new MessageBody(_body));
     }
     

--- a/tests/Paramore.Brighter.Core.Tests/Claims/When_luggage_should_be_kept_in_the_store.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Claims/When_luggage_should_be_kept_in_the_store.cs
@@ -37,7 +37,7 @@ public class RetrieveClaimLeaveLuggage
         var id = _store.Store(stream);
 
         var message = new Message(
-            new MessageHeader(Guid.NewGuid(), "test_topic", MessageType.MT_EVENT, DateTime.UtcNow),
+            new MessageHeader(Guid.NewGuid().ToString(), "test_topic", MessageType.MT_EVENT, DateTime.UtcNow),
             new MessageBody("Claim Check {id}"));
         message.Header.Bag[ClaimCheckTransformerAsync.CLAIM_CHECK] = id;
 

--- a/tests/Paramore.Brighter.Core.Tests/Claims/When_luggage_should_be_kept_in_the_store_async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Claims/When_luggage_should_be_kept_in_the_store_async.cs
@@ -37,7 +37,7 @@ public class AsyncRetrieveClaimLeaveLuggage
         var id = await _store.StoreAsync(stream);
 
         var message = new Message(
-            new MessageHeader(Guid.NewGuid(), "test_topic", MessageType.MT_EVENT, DateTime.UtcNow),
+            new MessageHeader(Guid.NewGuid().ToString(), "test_topic", MessageType.MT_EVENT, DateTime.UtcNow),
             new MessageBody("Claim Check {id}"));
         message.Header.Bag[ClaimCheckTransformerAsync.CLAIM_CHECK] = id;
 

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/TestDoubles/FakeMessageProducer.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/TestDoubles/FakeMessageProducer.cs
@@ -51,7 +51,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles
             return tcs.Task;
         }
 #pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
-        public async IAsyncEnumerable<Guid[]> SendAsync(IEnumerable<Message> messages, [EnumeratorCancellation] CancellationToken cancellationToken)
+        public async IAsyncEnumerable<string[]> SendAsync(IEnumerable<Message> messages, [EnumeratorCancellation] CancellationToken cancellationToken)
 #pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
         {
             var msgs = messages as Message[] ?? messages.ToArray();

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/TestDoubles/FakeMessageProducerWithPublishConfirmation.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/TestDoubles/FakeMessageProducerWithPublishConfirmation.cs
@@ -28,7 +28,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles
 {
     public class FakeMessageProducerWithPublishConfirmation : FakeMessageProducer, ISupportPublishConfirmation
     {
-        public event Action<bool, Guid> OnMessagePublished;
+        public event Action<bool, string> OnMessagePublished;
 
         public new void Send(Message message)
         {

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/TestDoubles/FakeOutbox.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/TestDoubles/FakeOutbox.cs
@@ -107,7 +107,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles
             return _posts.Where(oe => oe.TimeFlushed >= messagesSince).Select(oe => oe.Message).Take(pageSize).ToArray();
         }
 
-        public Message Get(Guid messageId, int outBoxTimeout = -1, Dictionary<string, object> args = null)
+        public Message Get(string messageId, int outBoxTimeout = -1, Dictionary<string, object> args = null)
         {
             foreach (var outboxEntry in _posts)
             {
@@ -129,7 +129,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles
         }
 
         public Task<Message> GetAsync(
-            Guid messageId, 
+            string messageId, 
             int outBoxTimeout = -1, 
             Dictionary<string, object> args = null, 
             CancellationToken cancellationToken = default)
@@ -150,7 +150,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles
         }
 
         public Task<IEnumerable<Message>> GetAsync(
-            IEnumerable<Guid> messageIds, 
+            IEnumerable<string> messageIds, 
             int outBoxTimeout = -1,
             CancellationToken cancellationToken = default)
         {
@@ -162,7 +162,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles
         }
         
         public Task MarkDispatchedAsync(
-            Guid id, 
+            string id, 
             DateTime? dispatchedAt = null, 
             Dictionary<string, object> args = null, 
             CancellationToken cancellationToken = default)
@@ -177,7 +177,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles
         }
 
         public async Task MarkDispatchedAsync(
-            IEnumerable<Guid> ids, DateTime? dispatchedAt = null, 
+            IEnumerable<string> ids, DateTime? dispatchedAt = null, 
             Dictionary<string, object> args = null,
             CancellationToken cancellationToken = default
             )
@@ -209,7 +209,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles
             return Task.FromResult(OutstandingMessages(millSecondsSinceSent, pageSize, pageNumber, args));
         }
 
-        public Task DeleteAsync(Guid[] messageIds,  Dictionary<string, object> args, CancellationToken cancellationToken = default)
+        public Task DeleteAsync(string[] messageIds,  Dictionary<string, object> args, CancellationToken cancellationToken = default)
         {
             Delete(messageIds);
             return Task.CompletedTask;
@@ -233,7 +233,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles
             return _posts.Where(oe => oe.TimeFlushed >= messagesSince).Select(oe => oe.Message).Take(pageSize).ToArray();
         }
 
-        public void MarkDispatched(Guid id, DateTime? dispatchedAt = null, Dictionary<string, object> args = null)
+        public void MarkDispatched(string id, DateTime? dispatchedAt = null, Dictionary<string, object> args = null)
         {
            var entry = _posts.Single(oe => oe.Message.Id == id);
            entry.TimeFlushed = dispatchedAt ?? DateTime.UtcNow;
@@ -254,9 +254,9 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles
                 .ToArray();
         }
 
-       public void Delete(Guid[] messageIds, Dictionary<string, object> args = null)
+       public void Delete(string[] messageIds, Dictionary<string, object> args = null)
        {
-           foreach (Guid messageId in messageIds)
+           foreach (string messageId in messageIds)
            {
                var message = _posts.First(e => e.Message.Id == messageId);
                _posts.Remove(message);

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/TestDoubles/MyCommandHandlerAsync.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/TestDoubles/MyCommandHandlerAsync.cs
@@ -7,9 +7,9 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles
 {
     internal class MyCommandHandlerAsync : RequestHandlerAsync<MyCommand>
     {
-        private readonly IDictionary<string, Guid> _receivedMessages;
+        private readonly IDictionary<string, string> _receivedMessages;
 
-        public MyCommandHandlerAsync(IDictionary<string, Guid> receivedMessages)
+        public MyCommandHandlerAsync(IDictionary<string, string> receivedMessages)
         {
             _receivedMessages = receivedMessages;
         }

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/TestDoubles/MyCommandToFail.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/TestDoubles/MyCommandToFail.cs
@@ -5,7 +5,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles
 {
     internal class MyCommandToFail : ICommand
     { 
-        public Guid Id { get; set; }
+        public string Id { get; set; }
         
         /// <summary>
         /// Gets or sets the span that this operation live within

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/TestDoubles/MyEventHandler.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/TestDoubles/MyEventHandler.cs
@@ -29,9 +29,9 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles
 {
     internal class MyEventHandler : RequestHandler<MyEvent>
     {
-        private readonly IDictionary<string, Guid> _receivedMessages;
+        private readonly IDictionary<string, string> _receivedMessages;
 
-        public MyEventHandler(IDictionary<string, Guid> receivedMessages)
+        public MyEventHandler(IDictionary<string, string> receivedMessages)
         {
             _receivedMessages = receivedMessages;
         }

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/TestDoubles/MyEventHandlerAsync.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/TestDoubles/MyEventHandlerAsync.cs
@@ -31,9 +31,9 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles
 {
     internal class MyEventHandlerAsync : RequestHandlerAsync<MyEvent>
     {
-        private readonly IDictionary<string, Guid> _receivedMessages;
+        private readonly IDictionary<string, string> _receivedMessages;
 
-        public MyEventHandlerAsync(IDictionary<string, Guid> receivedMessages)
+        public MyEventHandlerAsync(IDictionary<string, string> receivedMessages)
         {
             _receivedMessages = receivedMessages;
         }

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/TestDoubles/MyGlobalnboxEventHandler.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/TestDoubles/MyGlobalnboxEventHandler.cs
@@ -29,9 +29,9 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles
 {
     internal class MyGlobalInboxEventHandler : RequestHandler<MyEvent>
     {
-        private readonly IDictionary<string, Guid> _receivedMessages;
+        private readonly IDictionary<string, string> _receivedMessages;
 
-        public MyGlobalInboxEventHandler(IDictionary<string, Guid> receivedMessages)
+        public MyGlobalInboxEventHandler(IDictionary<string, string> receivedMessages)
         {
             _receivedMessages = receivedMessages;
         }

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/TestDoubles/MyOtherEventHandler.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/TestDoubles/MyOtherEventHandler.cs
@@ -29,9 +29,9 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles
 {
     internal class MyOtherEventHandler : RequestHandler<MyEvent>
     {
-        private readonly IDictionary<string, Guid> _receivedMessages;
+        private readonly IDictionary<string, string> _receivedMessages;
 
-        public MyOtherEventHandler(IDictionary<string, Guid> receivedMessages)
+        public MyOtherEventHandler(IDictionary<string, string> receivedMessages)
         {
             _receivedMessages = receivedMessages;
         }

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/TestDoubles/MyOtherEventHandlerAsync.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/TestDoubles/MyOtherEventHandlerAsync.cs
@@ -31,9 +31,9 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles
 {
     internal class MyOtherEventHandlerAsync : RequestHandlerAsync<MyEvent>
     {
-        private readonly IDictionary<string, Guid> _receivedMessages;
+        private readonly IDictionary<string, string> _receivedMessages;
 
-        public MyOtherEventHandlerAsync(IDictionary<string, Guid> receivedMessages)
+        public MyOtherEventHandlerAsync(IDictionary<string, string> receivedMessages)
         {
             _receivedMessages = receivedMessages;
         }

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/TestDoubles/MyRequestMessageMapper.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/TestDoubles/MyRequestMessageMapper.cs
@@ -25,7 +25,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles
             var replyAddress = new ReplyAddress(topic: message.Header.ReplyTo, correlationId: message.Header.CorrelationId);
             var command = new MyRequest(replyAddress);
             var messageBody = JsonSerializer.Deserialize<MyRequestDTO>(message.Body.Value, JsonSerialisationOptions.Options);
-            command.Id = Guid.Parse(messageBody.Id);
+            command.Id = messageBody.Id;
             command.RequestValue = messageBody.RequestValue;
             return command;
         }

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/TestDoubles/MyResponseMessageMapper.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/TestDoubles/MyResponseMessageMapper.cs
@@ -23,7 +23,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles
             var replyAddress = new ReplyAddress(topic: message.Header.ReplyTo, correlationId: message.Header.CorrelationId);
             var command = new MyResponse(replyAddress);
             var messageBody = JsonSerializer.Deserialize<MyResponseObject>(message.Body.Value, JsonSerialisationOptions.Options);
-            command.Id = Guid.Parse(messageBody.Id);
+            command.Id = messageBody.Id;
             command.ReplyValue = messageBody.ReplyValue;
             return command;
         }

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Building_A_Handler_For_An_Async_Command.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Building_A_Handler_For_An_Async_Command.cs
@@ -37,7 +37,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
         private static PipelineBuilder<MyCommand> _chainBuilder;
         private static IHandleRequestsAsync<MyCommand> _chainOfResponsibility;
         private static RequestContext _requestContext;
-        private readonly IDictionary<string, Guid> _receivedMessages = new Dictionary<string, Guid>();
+        private readonly IDictionary<string, string> _receivedMessages = new Dictionary<string, string>();
 
         public PipelineForCommandAsyncTests()
         {

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Building_A_Pipeline_With_Global_Inbox_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Building_A_Pipeline_With_Global_Inbox_Async.cs
@@ -27,7 +27,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
         public PipelineGlobalInboxTestsAsync()
         {
             _inbox = new InMemoryInbox();
-            var handler = new MyCommandHandlerAsync(new Dictionary<string, Guid>());
+            var handler = new MyCommandHandlerAsync(new Dictionary<string, string>());
            
             var registry = new SubscriberRegistry();
             registry.RegisterAsync<MyCommand, MyCommandHandlerAsync>();

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Cancelling_An_Async_Command.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Cancelling_An_Async_Command.cs
@@ -36,7 +36,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
     public class CancellingAsyncPipelineTests : IDisposable
     {
         private readonly CommandProcessor _commandProcessor;
-        private readonly IDictionary<string, Guid> _receivedMessages = new Dictionary<string, Guid>();
+        private readonly IDictionary<string, string> _receivedMessages = new Dictionary<string, string>();
         private readonly MyCommand _myCommand = new MyCommand();
 
         public CancellingAsyncPipelineTests()

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Implicit_Clearing_The_PostBox_On_The_Command_Processor.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Implicit_Clearing_The_PostBox_On_The_Command_Processor.cs
@@ -59,7 +59,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
                 );
             
             _message2 = new Message(
-                new MessageHeader(Guid.NewGuid(), topic, MessageType.MT_COMMAND),
+                new MessageHeader(Guid.NewGuid().ToString(), topic, MessageType.MT_COMMAND),
                 new MessageBody(JsonSerializer.Serialize(myCommand, JsonSerialisationOptions.Options))
             );
 

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Implicit_Clearing_The_PostBox_On_The_Command_Processor_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Implicit_Clearing_The_PostBox_On_The_Command_Processor_Async.cs
@@ -60,7 +60,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
                 );
 
             _message2 = new Message(
-                new MessageHeader(Guid.NewGuid(), topic, MessageType.MT_COMMAND),
+                new MessageHeader(Guid.NewGuid().ToString(), topic, MessageType.MT_COMMAND),
                 new MessageBody(JsonSerializer.Serialize(myCommand, JsonSerialisationOptions.Options))
             );
 

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Inserting_A_Default_Inbox_Into_The_Publish_Pipeline.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Inserting_A_Default_Inbox_Into_The_Publish_Pipeline.cs
@@ -20,7 +20,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
 
         public CommandProcessorBuildDefaultInboxPublishTests()
         {
-            var handler = new MyGlobalInboxEventHandler(new Dictionary<string, Guid>());
+            var handler = new MyGlobalInboxEventHandler(new Dictionary<string, string>());
 
             var subscriberRegistry = new SubscriberRegistry();
             //This handler has no Inbox attribute

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Inserting_A_Default_Inbox_Into_The_Publish_Pipeline_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Inserting_A_Default_Inbox_Into_The_Publish_Pipeline_Async.cs
@@ -21,7 +21,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
 
         public CommandProcessorBuildDefaultInboxPublishAsyncTests()
         {
-            var handler = new MyEventHandlerAsync(new Dictionary<string, Guid>());
+            var handler = new MyEventHandlerAsync(new Dictionary<string, string>());
 
             var subscriberRegistry = new SubscriberRegistry();
             //This handler has no Inbox attribute

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Inserting_A_Default_Inbox_Into_The_Send_Pipeline_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Inserting_A_Default_Inbox_Into_The_Send_Pipeline_Async.cs
@@ -21,7 +21,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
 
         public CommandProcessorBuildDefaultInboxSendAsyncTests()
         {
-             var handler = new MyCommandHandlerAsync(new Dictionary<string, Guid>());
+             var handler = new MyCommandHandlerAsync(new Dictionary<string, string>());
             
              var subscriberRegistry = new SubscriberRegistry();
              //This handler has no Inbox attribute

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Posting_Fails_Limit_Total_Writes_To_OutBox_In_Window.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Posting_Fails_Limit_Total_Writes_To_OutBox_In_Window.cs
@@ -78,7 +78,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
             _fakeMessageProducer.MaxOutStandingMessages = 3;
             _fakeMessageProducer.MaxOutStandingCheckIntervalMilliSeconds = 250;
 
-            var sentList = new List<Guid>(); 
+            var sentList = new List<string>(); 
             bool shouldThrowException = false;
             try
             {

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Publishing_To_Multiple_Subscribers_Should_Aggregate_Exceptions_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Publishing_To_Multiple_Subscribers_Should_Aggregate_Exceptions_Async.cs
@@ -39,8 +39,8 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
     public class PublishingToMultipleSubscribersAsyncTests : IDisposable
     {
         private readonly CommandProcessor _commandProcessor;
-        private readonly MyEvent _myEvent = new MyEvent();
-        private readonly IDictionary<string, Guid> _receivedMessages = new Dictionary<string, Guid>();
+        private readonly MyEvent _myEvent = new();
+        private readonly IDictionary<string, string> _receivedMessages = new Dictionary<string, string>();
         private Exception _exception;
 
         public PublishingToMultipleSubscribersAsyncTests()

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Sending_A_Command_To_The_Processor_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Sending_A_Command_To_The_Processor_Async.cs
@@ -36,7 +36,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
     public class CommandProcessorSendAsyncTests : IDisposable
     {
         private readonly CommandProcessor _commandProcessor;
-        private readonly IDictionary<string, Guid> _receivedMessages = new Dictionary<string, Guid>();
+        private readonly IDictionary<string, string> _receivedMessages = new Dictionary<string, string>();
         private readonly MyCommand _myCommand = new MyCommand();
 
         public CommandProcessorSendAsyncTests()

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_There_Are_Multiple_Possible_Command_Handlers_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_There_Are_Multiple_Possible_Command_Handlers_Async.cs
@@ -39,7 +39,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
     public class CommandProcessorSendWithMultipleMatchesAsyncTests : IDisposable
     {
         private readonly CommandProcessor _commandProcessor;
-        private readonly IDictionary<string, Guid> _receivedMessages = new Dictionary<string, Guid>();
+        private readonly IDictionary<string, string> _receivedMessages = new Dictionary<string, string>();
         private readonly MyCommand _myCommand = new MyCommand();
         private Exception _exception;
 

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_There_Are_Multiple_Subscribers_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_There_Are_Multiple_Subscribers_Async.cs
@@ -39,7 +39,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
     public class CommandProcessorPublishMultipleMatchesAsyncTests : IDisposable
     {
         private readonly CommandProcessor _commandProcessor;
-        private readonly IDictionary<string, Guid> _receivedMessages = new Dictionary<string, Guid>();
+        private readonly IDictionary<string, string> _receivedMessages = new Dictionary<string, string>();
         private readonly MyEvent _myEvent = new MyEvent();
         private Exception _exception;
 

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_There_Are_No_Subscribers_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_There_Are_No_Subscribers_Async.cs
@@ -37,7 +37,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
     public class CommandProcessorNoMatchingSubcribersAsyncTests : IDisposable
     {
         private readonly CommandProcessor _commandProcessor;
-        private readonly IDictionary<string, Guid> _receivedMessages = new Dictionary<string, Guid>();
+        private readonly IDictionary<string, string> _receivedMessages = new Dictionary<string, string>();
         private readonly MyEvent _myEvent = new MyEvent();
         private Exception _exception;
 

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_publishing_an_event_to_the_processor.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_publishing_an_event_to_the_processor.cs
@@ -35,8 +35,8 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
     public class CommandProcessorPublishEventTests : IDisposable
     {
         private readonly CommandProcessor _commandProcessor;
-        private readonly IDictionary<string, Guid> _receivedMessages = new Dictionary<string, Guid>();
-        private readonly MyEvent _myEvent = new MyEvent();
+        private readonly IDictionary<string, string> _receivedMessages = new Dictionary<string, string>();
+        private readonly MyEvent _myEvent = new();
 
         public CommandProcessorPublishEventTests()
         {

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_publishing_to_multiple_subscribers_should_aggregate_exceptions.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_publishing_to_multiple_subscribers_should_aggregate_exceptions.cs
@@ -38,7 +38,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
     public class PublishingToMultipleSubscribersTests: IDisposable
     {
         private readonly CommandProcessor _commandProcessor;
-        private readonly IDictionary<string, Guid> _receivedMessages = new Dictionary<string, Guid>();
+        private readonly IDictionary<string, string> _receivedMessages = new Dictionary<string, string>();
         private readonly MyEvent _myEvent = new MyEvent();
         private Exception _exception;
 

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_there_are_multiple_subscribers.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_there_are_multiple_subscribers.cs
@@ -38,8 +38,8 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
     public class CommandProcessorPublishMultipleMatchesTests : IDisposable
     {
         private readonly CommandProcessor _commandProcessor;
-        private readonly IDictionary<string, Guid> _receivedMessages = new Dictionary<string, Guid>();
-        private readonly MyEvent _myEvent = new MyEvent();
+        private readonly IDictionary<string, string> _receivedMessages = new Dictionary<string, string>();
+        private readonly MyEvent _myEvent = new();
         private Exception _exception;
 
         public CommandProcessorPublishMultipleMatchesTests()

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_there_are_no_subscribers.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_there_are_no_subscribers.cs
@@ -36,7 +36,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
     public class CommandProcessorNoMatchingSubcribersTests : IDisposable
     {
         private readonly CommandProcessor _commandProcessor;
-        private readonly IDictionary<string, Guid> _receivedMessages = new Dictionary<string, Guid>();
+        private readonly IDictionary<string, string> _receivedMessages = new Dictionary<string, string>();
         private readonly MyEvent _myEvent = new MyEvent();
         private Exception _exception;
 

--- a/tests/Paramore.Brighter.Core.Tests/Compression/When_a_message_compresses_a_large_payload.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Compression/When_a_message_compresses_a_large_payload.cs
@@ -22,7 +22,7 @@ public class CompressLargePayloadTests
         
         _body = DataGenerator.CreateString(6000);
         _message = new Message(
-            new MessageHeader(Guid.NewGuid(), "test_topic", MessageType.MT_EVENT, DateTime.UtcNow),
+            new MessageHeader(Guid.NewGuid().ToString(), "test_topic", MessageType.MT_EVENT, DateTime.UtcNow),
             new MessageBody(_body, MessageBody.APPLICATION_JSON, CharacterEncoding.UTF8));        
     }
 

--- a/tests/Paramore.Brighter.Core.Tests/Compression/When_a_message_compresses_a_large_payload_async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Compression/When_a_message_compresses_a_large_payload_async.cs
@@ -22,7 +22,7 @@ public class AsyncCompressLargePayloadTests
         
         _body = DataGenerator.CreateString(6000);
         _message = new Message(
-            new MessageHeader(Guid.NewGuid(), "test_topic", MessageType.MT_EVENT, DateTime.UtcNow),
+            new MessageHeader(Guid.NewGuid().ToString(), "test_topic", MessageType.MT_EVENT, DateTime.UtcNow),
             new MessageBody(_body, MessageBody.APPLICATION_JSON, CharacterEncoding.UTF8));        
     }
 

--- a/tests/Paramore.Brighter.Core.Tests/Compression/When_a_message_is_not_compressed.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Compression/When_a_message_is_not_compressed.cs
@@ -23,7 +23,7 @@ public class UncompressedPayloadTests
         var body = new MessageBody(smallContent, mimeType);
         
         var message = new Message(
-            new MessageHeader(Guid.NewGuid(), "test_topic", MessageType.MT_EVENT, DateTime.UtcNow, contentType: mimeType),body);
+            new MessageHeader(Guid.NewGuid().ToString(), "test_topic", MessageType.MT_EVENT, DateTime.UtcNow, contentType: mimeType),body);
 
         //act
         var msg = transformer.Unwrap(message);
@@ -46,7 +46,7 @@ public class UncompressedPayloadTests
         var body = new MessageBody(smallContent, mimeType);
         
         var message = new Message(
-            new MessageHeader(Guid.NewGuid(), "test_topic", MessageType.MT_EVENT, DateTime.UtcNow, contentType: mimeType),body);
+            new MessageHeader(Guid.NewGuid().ToString(), "test_topic", MessageType.MT_EVENT, DateTime.UtcNow, contentType: mimeType),body);
         
         //act
         var msg = transformer.Unwrap(message);
@@ -69,7 +69,7 @@ public class UncompressedPayloadTests
         var body = new MessageBody(smallContent, mimeType);
         
         var message = new Message(
-            new MessageHeader(Guid.NewGuid(), "test_topic", MessageType.MT_EVENT, DateTime.UtcNow, contentType: mimeType),body);
+            new MessageHeader(Guid.NewGuid().ToString(), "test_topic", MessageType.MT_EVENT, DateTime.UtcNow, contentType: mimeType),body);
         
         //act
         var msg = transformer.Unwrap(message);

--- a/tests/Paramore.Brighter.Core.Tests/Compression/When_a_message_is_not_compressed_async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Compression/When_a_message_is_not_compressed_async.cs
@@ -23,7 +23,7 @@ public class AsyncUncompressedPayloadTests
         var body = new MessageBody(smallContent, mimeType);
         
         var message = new Message(
-            new MessageHeader(Guid.NewGuid(), "test_topic", MessageType.MT_EVENT, DateTime.UtcNow, contentType: mimeType),body);
+            new MessageHeader(Guid.NewGuid().ToString(), "test_topic", MessageType.MT_EVENT, DateTime.UtcNow, contentType: mimeType),body);
 
         //act
         var msg = await transformer.UnwrapAsync(message);
@@ -46,7 +46,7 @@ public class AsyncUncompressedPayloadTests
         var body = new MessageBody(smallContent, mimeType);
         
         var message = new Message(
-            new MessageHeader(Guid.NewGuid(), "test_topic", MessageType.MT_EVENT, DateTime.UtcNow, contentType: mimeType),body);
+            new MessageHeader(Guid.NewGuid().ToString(), "test_topic", MessageType.MT_EVENT, DateTime.UtcNow, contentType: mimeType),body);
         
         //act
         var msg = await transformer.UnwrapAsync(message);
@@ -69,7 +69,7 @@ public class AsyncUncompressedPayloadTests
         var body = new MessageBody(smallContent, mimeType);
         
         var message = new Message(
-            new MessageHeader(Guid.NewGuid(), "test_topic", MessageType.MT_EVENT, DateTime.UtcNow, contentType: mimeType),body);
+            new MessageHeader(Guid.NewGuid().ToString(), "test_topic", MessageType.MT_EVENT, DateTime.UtcNow, contentType: mimeType),body);
         
         //act
         var msg = await transformer.UnwrapAsync(message);

--- a/tests/Paramore.Brighter.Core.Tests/Compression/When_a_message_is_under_the_threshold.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Compression/When_a_message_is_under_the_threshold.cs
@@ -23,7 +23,7 @@ public class SmallPayloadNotCompressedTests
 
         _body = "small message";
         _message = new Message(
-            new MessageHeader(Guid.NewGuid(), "test_topic", MessageType.MT_EVENT, DateTime.UtcNow, contentType: MessageBody.APPLICATION_JSON),
+            new MessageHeader(Guid.NewGuid().ToString(), "test_topic", MessageType.MT_EVENT, DateTime.UtcNow, contentType: MessageBody.APPLICATION_JSON),
             new MessageBody(_body, MessageBody.APPLICATION_JSON, CharacterEncoding.UTF8));      
     }
     

--- a/tests/Paramore.Brighter.Core.Tests/Compression/When_a_message_is_under_the_threshold_async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Compression/When_a_message_is_under_the_threshold_async.cs
@@ -22,7 +22,7 @@ public class AsyncSmallPayloadNotCompressedTests
 
         _body = "small message";
         _message = new Message(
-            new MessageHeader(Guid.NewGuid(), "test_topic", MessageType.MT_EVENT, DateTime.UtcNow, contentType: MessageBody.APPLICATION_JSON),
+            new MessageHeader(Guid.NewGuid().ToString(), "test_topic", MessageType.MT_EVENT, DateTime.UtcNow, contentType: MessageBody.APPLICATION_JSON),
             new MessageBody(_body, MessageBody.APPLICATION_JSON, CharacterEncoding.UTF8));      
     }
     

--- a/tests/Paramore.Brighter.Core.Tests/Compression/When_decompressing_a_large_payload_in_a_message.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Compression/When_decompressing_a_large_payload_in_a_message.cs
@@ -33,7 +33,7 @@ public class UncompressLargePayloadTests
         var body = new MessageBody(output.ToArray(), mimeType);
         
         var message = new Message(
-            new MessageHeader(Guid.NewGuid(), "test_topic", MessageType.MT_EVENT, DateTime.UtcNow, contentType: mimeType),body);
+            new MessageHeader(Guid.NewGuid().ToString(), "test_topic", MessageType.MT_EVENT, DateTime.UtcNow, contentType: mimeType),body);
         
         message.Header.Bag[CompressPayloadTransformer.ORIGINAL_CONTENTTYPE_HEADER] = MessageBody.APPLICATION_JSON;
         
@@ -68,7 +68,7 @@ public class UncompressLargePayloadTests
         var body = new MessageBody(output.ToArray(), mimeType);
         
         var message = new Message(
-            new MessageHeader(Guid.NewGuid(), "test_topic", MessageType.MT_EVENT, DateTime.UtcNow, contentType: mimeType),body);
+            new MessageHeader(Guid.NewGuid().ToString(), "test_topic", MessageType.MT_EVENT, DateTime.UtcNow, contentType: mimeType),body);
         
         message.Header.Bag[CompressPayloadTransformer.ORIGINAL_CONTENTTYPE_HEADER] = MessageBody.APPLICATION_JSON;
         
@@ -103,7 +103,7 @@ public class UncompressLargePayloadTests
         var body = new MessageBody(output.ToArray(), mimeType);
         
         var message = new Message(
-            new MessageHeader(Guid.NewGuid(), "test_topic", MessageType.MT_EVENT, DateTime.UtcNow, contentType: mimeType),body);
+            new MessageHeader(Guid.NewGuid().ToString(), "test_topic", MessageType.MT_EVENT, DateTime.UtcNow, contentType: mimeType),body);
         
         message.Header.Bag[CompressPayloadTransformerAsync.ORIGINAL_CONTENTTYPE_HEADER] = MessageBody.APPLICATION_JSON;
         

--- a/tests/Paramore.Brighter.Core.Tests/Compression/When_decompressing_a_large_payload_in_a_message_async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Compression/When_decompressing_a_large_payload_in_a_message_async.cs
@@ -33,7 +33,7 @@ public class AsyncUncompressLargePayloadTests
         var body = new MessageBody(output.ToArray(), mimeType);
         
         var message = new Message(
-            new MessageHeader(Guid.NewGuid(), "test_topic", MessageType.MT_EVENT, DateTime.UtcNow, contentType: mimeType),body);
+            new MessageHeader(Guid.NewGuid().ToString(), "test_topic", MessageType.MT_EVENT, DateTime.UtcNow, contentType: mimeType),body);
         
         message.Header.Bag[CompressPayloadTransformerAsync.ORIGINAL_CONTENTTYPE_HEADER] = MessageBody.APPLICATION_JSON;
         
@@ -68,7 +68,7 @@ public class AsyncUncompressLargePayloadTests
         var body = new MessageBody(output.ToArray(), mimeType);
         
         var message = new Message(
-            new MessageHeader(Guid.NewGuid(), "test_topic", MessageType.MT_EVENT, DateTime.UtcNow, contentType: mimeType),body);
+            new MessageHeader(Guid.NewGuid().ToString(), "test_topic", MessageType.MT_EVENT, DateTime.UtcNow, contentType: mimeType),body);
         
         message.Header.Bag[CompressPayloadTransformerAsync.ORIGINAL_CONTENTTYPE_HEADER] = MessageBody.APPLICATION_JSON;
         
@@ -103,7 +103,7 @@ public class AsyncUncompressLargePayloadTests
         var body = new MessageBody(output.ToArray(), mimeType);
         
         var message = new Message(
-            new MessageHeader(Guid.NewGuid(), "test_topic", MessageType.MT_EVENT, DateTime.UtcNow, contentType: mimeType),body);
+            new MessageHeader(Guid.NewGuid().ToString(), "test_topic", MessageType.MT_EVENT, DateTime.UtcNow, contentType: mimeType),body);
         
         message.Header.Bag[CompressPayloadTransformerAsync.ORIGINAL_CONTENTTYPE_HEADER] = MessageBody.APPLICATION_JSON;
         

--- a/tests/Paramore.Brighter.Core.Tests/ControlBus/When_mapping_from_a_configuration_command_from_a_message.cs
+++ b/tests/Paramore.Brighter.Core.Tests/ControlBus/When_mapping_from_a_configuration_command_from_a_message.cs
@@ -41,7 +41,7 @@ namespace Paramore.Brighter.Core.Tests.ControlBus
             _mapper = new ConfigurationCommandMessageMapper();
 
             _message = new Message(
-                new MessageHeader(Guid.NewGuid(), "myTopic", MessageType.MT_COMMAND), 
+                new MessageHeader(Guid.NewGuid().ToString(), "myTopic", MessageType.MT_COMMAND), 
                 new MessageBody(string.Format("{{\"Type\":1,\"SubscriptionName\":\"getallthethings\",\"Id\":\"{0}\"}}", Guid.NewGuid()))
                 );
         }

--- a/tests/Paramore.Brighter.Core.Tests/ControlBus/When_mapping_from_a_heartbeat_reply_to_a_message.cs
+++ b/tests/Paramore.Brighter.Core.Tests/ControlBus/When_mapping_from_a_heartbeat_reply_to_a_message.cs
@@ -37,7 +37,7 @@ namespace Paramore.Brighter.Core.Tests.ControlBus
         private Message _message;
         private readonly HeartbeatReply _request;
         private const string TOPIC = "test.topic";
-        private readonly Guid _correlationId = Guid.NewGuid();
+        private readonly string _correlationId = Guid.NewGuid().ToString();
 
         public HeartbeatReplyToMessageMapperTests()
         {

--- a/tests/Paramore.Brighter.Core.Tests/ControlBus/When_mapping_from_a_heartbeat_request_to_a_message.cs
+++ b/tests/Paramore.Brighter.Core.Tests/ControlBus/When_mapping_from_a_heartbeat_request_to_a_message.cs
@@ -36,7 +36,7 @@ namespace Paramore.Brighter.Core.Tests.ControlBus
         private Message _message;
         private readonly HeartbeatRequest _request;
         private const string TOPIC = "test.topic";
-        private readonly Guid _correlationId = Guid.NewGuid();
+        private readonly string _correlationId = Guid.NewGuid().ToString();
 
         public HearbeatRequestToMessageMapperTests()
         {

--- a/tests/Paramore.Brighter.Core.Tests/ControlBus/When_mapping_from_a_message_to_a_heartbeat_reply.cs
+++ b/tests/Paramore.Brighter.Core.Tests/ControlBus/When_mapping_from_a_message_to_a_heartbeat_reply.cs
@@ -38,12 +38,12 @@ namespace Paramore.Brighter.Core.Tests.ControlBus
         private HeartbeatReply _request;
         private const string MESSAGE_BODY = "{\r\n  \"HostName\": \"Test.Hostname\",\r\n  \"Consumers\": [\r\n    {\r\n      \"ConsumerName\": \"Test.Subscription\",\r\n      \"State\": 1\r\n    },\r\n    {\r\n      \"ConsumerName\": \"More.Consumers\",\r\n      \"State\": 0\r\n    }\r\n  ]\r\n}";
         private const string TOPIC = "test.topic";
-        private readonly Guid _correlationId = Guid.NewGuid();
+        private readonly string _correlationId = Guid.NewGuid().ToString();
 
         public HeartbeatMessageToReplyTests()
         {
             _mapper = new HeartbeatReplyCommandMessageMapper();
-            var header = new MessageHeader(Guid.NewGuid(), TOPIC, MessageType.MT_COMMAND, DateTime.UtcNow, _correlationId);
+            var header = new MessageHeader(Guid.NewGuid().ToString(), TOPIC, MessageType.MT_COMMAND, DateTime.UtcNow, _correlationId);
             var body = new MessageBody(MESSAGE_BODY);
             _message = new Message(header, body);
         }

--- a/tests/Paramore.Brighter.Core.Tests/ControlBus/When_mapping_from_a_message_to_a_heartbeat_request.cs
+++ b/tests/Paramore.Brighter.Core.Tests/ControlBus/When_mapping_from_a_message_to_a_heartbeat_request.cs
@@ -36,14 +36,14 @@ namespace Paramore.Brighter.Core.Tests.ControlBus
         private readonly Message _message;
         private HeartbeatRequest _request;
         private const string TOPIC = "test.topic";
-        private readonly Guid _correlationId = Guid.NewGuid();
-        private readonly Guid _commandId = Guid.NewGuid();
+        private readonly string _correlationId = Guid.NewGuid().ToString();
+        private readonly string _commandId = Guid.NewGuid().ToString();
 
         public HeartbeatMessageToRequestTests()
         {
             _mapper = new HeartbeatRequestCommandMessageMapper();
             var messageHeader = new MessageHeader(
-                Guid.NewGuid(),
+                Guid.NewGuid().ToString(),
                 "Heartbeat",
                 MessageType.MT_COMMAND,
                 DateTime.UtcNow,

--- a/tests/Paramore.Brighter.Core.Tests/ControlBus/When_recieving_a_heartbeat_message.cs
+++ b/tests/Paramore.Brighter.Core.Tests/ControlBus/When_recieving_a_heartbeat_message.cs
@@ -41,7 +41,7 @@ namespace Paramore.Brighter.Core.Tests.ControlBus
         private const string TEST_SECOND_CONNECTION_NAME = "Test.Second.Subscription";
         private const string TEST_ROUTING_KEY = "test.routing.key";
         private readonly SpyCommandProcessor _spyCommandProcessor = new SpyCommandProcessor();
-        private readonly Guid _correlationId = Guid.NewGuid();
+        private readonly string _correlationId = Guid.NewGuid().ToString();
         private readonly HeartbeatRequestCommandHandler _handler;
         private readonly HeartbeatRequest _heartbeatRequest;
         private readonly string _hostName;

--- a/tests/Paramore.Brighter.Core.Tests/MessageDispatch/TestDoubles/MyFailingMapperEvent.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageDispatch/TestDoubles/MyFailingMapperEvent.cs
@@ -9,16 +9,14 @@ internal class MyFailingMapperEvent : IRequest
     /// Gets or sets the identifier.
     /// </summary>
     /// <value>The identifier.</value>
-    public Guid Id { get; set; }
-    public string MissingStringField { get; set; }
-    public int MissingIntField { get; set; }
+    public string Id { get; set; }
         
     /// <summary>
     /// Initializes a new instance of the <see cref="T:System.Object"/> class.
     /// </summary>
     public MyFailingMapperEvent()
     {
-        Id = new Guid();
+        Id = Guid.NewGuid().ToString();
     }
         
     /// <summary>

--- a/tests/Paramore.Brighter.Core.Tests/MessageDispatch/TestDoubles/SpyCommandProcessor.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageDispatch/TestDoubles/SpyCommandProcessor.cs
@@ -57,7 +57,7 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch.TestDoubles
     internal class SpyCommandProcessor : IAmACommandProcessor
     {
         private readonly Queue<IRequest> _requests = new Queue<IRequest>();
-        private readonly Dictionary<Guid, IRequest> _postBox = new Dictionary<Guid, IRequest>();
+        private readonly Dictionary<string, IRequest> _postBox = new();
 
         public IList<CommandType> Commands { get; } = new List<CommandType>();
         public List<ClearParams> ClearParamsList { get; } = new List<ClearParams>();
@@ -123,7 +123,7 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch.TestDoubles
             await completionSource.Task;
         }
 
-        public Guid DepositPost<TRequest>(
+        public string DepositPost<TRequest>(
             TRequest request, 
             Dictionary<string, object> args = null) 
             where TRequest : class, IRequest
@@ -132,7 +132,7 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch.TestDoubles
             return request.Id;
         }
 
-        public Guid DepositPost<TRequest, TTransaction>(
+        public string DepositPost<TRequest, TTransaction>(
             TRequest request,
             IAmABoxTransactionProvider<TTransaction> provider,
             Dictionary<string, object> args = null) 
@@ -142,12 +142,12 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch.TestDoubles
         }
 
 
-        public Guid[] DepositPost<TRequest>(
+        public string[] DepositPost<TRequest>(
             IEnumerable<TRequest> request, 
             Dictionary<string, object> args = null) 
             where TRequest : class, IRequest
         {
-            var ids = new List<Guid>();
+            var ids = new List<string>();
             foreach (TRequest r in request)
             {
                 ids.Add(DepositPost(r));
@@ -156,7 +156,7 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch.TestDoubles
             return ids.ToArray();
         }
 
-        public Guid[] DepositPost<TRequest, TTransaction>(
+        public string[] DepositPost<TRequest, TTransaction>(
             IEnumerable<TRequest> request, 
             IAmABoxTransactionProvider<TTransaction> provider,
             Dictionary<string, object> args = null)
@@ -165,7 +165,7 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch.TestDoubles
             return DepositPost(request);
         }
 
-        public async Task<Guid> DepositPostAsync<TRequest>(
+        public async Task<string> DepositPostAsync<TRequest>(
             TRequest request,
             Dictionary<string, object> args = null,
             bool continueOnCapturedContext = false,
@@ -174,12 +174,12 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch.TestDoubles
         {
             _postBox.Add(request.Id, request);
 
-            var tcs = new TaskCompletionSource<Guid>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
             tcs.SetResult(request.Id);
             return await tcs.Task;
         }
 
-        public async Task<Guid> DepositPostAsync<TRequest, TTransaction>(
+        public async Task<string> DepositPostAsync<TRequest, TTransaction>(
             TRequest request,
             IAmABoxTransactionProvider<TTransaction> provider,
             Dictionary<string, object> args = null,
@@ -189,19 +189,19 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch.TestDoubles
         {
             _postBox.Add(request.Id, request);
 
-            var tcs = new TaskCompletionSource<Guid>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
             tcs.SetResult(request.Id);
             return await tcs.Task;
         }
 
-        public async Task<Guid[]> DepositPostAsync<TRequest>(
+        public async Task<string[]> DepositPostAsync<TRequest>(
             IEnumerable<TRequest> requests,
             Dictionary<string, object> args = null,
             bool continueOnCapturedContext = false,
             CancellationToken cancellationToken = default) 
             where TRequest : class, IRequest
         {
-            var ids = new List<Guid>();
+            var ids = new List<string>();
             foreach (TRequest r in requests)
             {
                 ids.Add(await DepositPostAsync(r, cancellationToken: cancellationToken));
@@ -210,7 +210,7 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch.TestDoubles
             return ids.ToArray();
         }
 
-        public async Task<Guid[]> DepositPostAsync<TRequest, TTransaction>(
+        public async Task<string[]> DepositPostAsync<TRequest, TTransaction>(
             IEnumerable<TRequest> requests,
             IAmABoxTransactionProvider<TTransaction> provider,
             Dictionary<string, object> args = null,
@@ -220,7 +220,7 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch.TestDoubles
             return await DepositPostAsync(requests, cancellationToken: cancellationToken);
         }
 
-        public void ClearOutbox(Guid[] posts, Dictionary<string, object> args = null)
+        public void ClearOutbox(string[] posts, Dictionary<string, object> args = null)
         {
             foreach (var messageId in posts)
             {
@@ -244,7 +244,7 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch.TestDoubles
         }
 
         public async Task ClearOutboxAsync(
-            IEnumerable<Guid> posts, 
+            IEnumerable<string> posts, 
             Dictionary<string, object> args = null,
             bool continueOnCapturedContext = false,
             CancellationToken cancellationToken = default)
@@ -270,7 +270,7 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch.TestDoubles
         }
 
         public Task BulkClearOutboxAsync(
-            IEnumerable<Guid> posts, 
+            IEnumerable<string> posts, 
             bool continueOnCapturedContext = false,
             CancellationToken cancellationToken = default)
         {

--- a/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_a_channel_failure_exception_is_thrown_for_command_should_retry_until_connection_re_established.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_a_channel_failure_exception_is_thrown_for_command_should_retry_until_connection_re_established.cs
@@ -55,13 +55,19 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch
             var command = new MyCommand();
 
             //two command, will be received when subscription restored
-            var message1 = new Message(new MessageHeader(Guid.NewGuid(), "MyTopic", MessageType.MT_COMMAND), new MessageBody(JsonSerializer.Serialize(command, JsonSerialisationOptions.Options)));
-            var message2 = new Message(new MessageHeader(Guid.NewGuid(), "MyTopic", MessageType.MT_COMMAND), new MessageBody(JsonSerializer.Serialize(command, JsonSerialisationOptions.Options)));
+            var message1 = new Message(
+                new MessageHeader(Guid.NewGuid().ToString(), "MyTopic", MessageType.MT_COMMAND), 
+                new MessageBody(JsonSerializer.Serialize(command, JsonSerialisationOptions.Options))
+            );
+            var message2 = new Message(
+                new MessageHeader(Guid.NewGuid().ToString(), "MyTopic", MessageType.MT_COMMAND), 
+                new MessageBody(JsonSerializer.Serialize(command, JsonSerialisationOptions.Options))
+            );
             channel.Enqueue(message1);
             channel.Enqueue(message2);
             
             //end the pump
-            var quitMessage = new Message(new MessageHeader(Guid.Empty, "", MessageType.MT_QUIT), new MessageBody(""));
+            var quitMessage = new Message(new MessageHeader(string.Empty, "", MessageType.MT_QUIT), new MessageBody(""));
             channel.Enqueue(quitMessage);
         }
 

--- a/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_a_channel_failure_exception_is_thrown_for_event_should_retry_until_connection_re_established.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_a_channel_failure_exception_is_thrown_for_event_should_retry_until_connection_re_established.cs
@@ -57,13 +57,19 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch
             var @event = new MyEvent();
 
             //Two events will be received when channel fixed
-            var message1 = new Message(new MessageHeader(Guid.NewGuid(), "MyTopic", MessageType.MT_EVENT), new MessageBody(JsonSerializer.Serialize(@event, JsonSerialisationOptions.Options)));
-            var message2 = new Message(new MessageHeader(Guid.NewGuid(), "MyTopic", MessageType.MT_EVENT), new MessageBody(JsonSerializer.Serialize(@event, JsonSerialisationOptions.Options)));
+            var message1 = new Message(
+                new MessageHeader(Guid.NewGuid().ToString(), "MyTopic", MessageType.MT_EVENT), 
+                new MessageBody(JsonSerializer.Serialize(@event, JsonSerialisationOptions.Options))
+            );
+            var message2 = new Message(
+                new MessageHeader(Guid.NewGuid().ToString(), "MyTopic", MessageType.MT_EVENT), 
+                new MessageBody(JsonSerializer.Serialize(@event, JsonSerialisationOptions.Options))
+            );
             channel.Enqueue(message1);
             channel.Enqueue(message2);
             
             //Quit the message pump
-            var quitMessage = new Message(new MessageHeader(Guid.Empty, "", MessageType.MT_QUIT), new MessageBody(""));
+            var quitMessage = new Message(new MessageHeader(string.Empty, "", MessageType.MT_QUIT), new MessageBody(""));
             channel.Enqueue(quitMessage);
         }
 

--- a/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_a_command_handler_throws_a_defer_message_Then_message_is_requeued_until_rejected.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_a_command_handler_throws_a_defer_message_Then_message_is_requeued_until_rejected.cs
@@ -67,7 +67,7 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch
             var task = Task.Factory.StartNew(() => _messagePump.Run(), TaskCreationOptions.LongRunning);
             await Task.Delay(1000);
 
-            var quitMessage = new Message(new MessageHeader(Guid.Empty, "", MessageType.MT_QUIT), new MessageBody(""));
+            var quitMessage = new Message(new MessageHeader(string.Empty, "", MessageType.MT_QUIT), new MessageBody(""));
             _channel.Enqueue(quitMessage);
 
             await Task.WhenAll(task);

--- a/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_a_command_handler_throws_a_defer_message_Then_message_is_requeued_until_rejectedAsync.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_a_command_handler_throws_a_defer_message_Then_message_is_requeued_until_rejectedAsync.cs
@@ -68,7 +68,7 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch
             var task = Task.Factory.StartNew(() => _messagePump.Run(), TaskCreationOptions.LongRunning);
             await Task.Delay(1000);
 
-            var quitMessage = new Message(new MessageHeader(Guid.Empty, "", MessageType.MT_QUIT), new MessageBody(""));
+            var quitMessage = new Message(new MessageHeader(string.Empty, "", MessageType.MT_QUIT), new MessageBody(""));
             _channel.Enqueue(quitMessage);
 
             await Task.WhenAll(task);

--- a/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_a_command_handler_throws_unhandled_exception_Then_message_is_acked.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_a_command_handler_throws_unhandled_exception_Then_message_is_acked.cs
@@ -71,7 +71,7 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch
                 var task = Task.Factory.StartNew(() => _messagePump.Run(), TaskCreationOptions.LongRunning);
                 await Task.Delay(1000);
 
-                var quitMessage = new Message(new MessageHeader(Guid.Empty, "", MessageType.MT_QUIT),
+                var quitMessage = new Message(new MessageHeader(string.Empty, "", MessageType.MT_QUIT),
                     new MessageBody(""));
                 _channel.Enqueue(quitMessage);
 

--- a/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_a_command_handler_throws_unhandled_exception_Then_message_is_acked_async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_a_command_handler_throws_unhandled_exception_Then_message_is_acked_async.cs
@@ -73,7 +73,7 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch
                 var task = Task.Factory.StartNew(() => _messagePump.Run(), TaskCreationOptions.LongRunning);
                 await Task.Delay(1000);
 
-                var quitMessage = new Message(new MessageHeader(Guid.Empty, "", MessageType.MT_QUIT),
+                var quitMessage = new Message(new MessageHeader(string.Empty, "", MessageType.MT_QUIT),
                     new MessageBody(""));
                 _channel.Enqueue(quitMessage);
 

--- a/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_a_message_fails_to_be_mapped_to_a_request.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_a_message_fails_to_be_mapped_to_a_request.cs
@@ -30,7 +30,10 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch
                 Channel = _channel, TimeoutInMilliseconds = 5000, RequeueCount = 3, UnacceptableMessageLimit = 3
             };
 
-            var unmappableMessage = new Message(new MessageHeader(Guid.NewGuid(), "MyTopic", MessageType.MT_EVENT), new MessageBody("{ \"Id\" : \"48213ADB-A085-4AFF-A42C-CF8209350CF7\" }"));
+            var unmappableMessage = new Message(
+                new MessageHeader(Guid.NewGuid().ToString(), "MyTopic", MessageType.MT_EVENT), 
+                new MessageBody("{ \"Id\" : \"48213ADB-A085-4AFF-A42C-CF8209350CF7\" }")
+                );
 
             _channel.Enqueue(unmappableMessage);
         }

--- a/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_a_message_fails_to_be_mapped_to_a_request_and_the_unacceptable_message_limit_is_reached.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_a_message_fails_to_be_mapped_to_a_request_and_the_unacceptable_message_limit_is_reached.cs
@@ -52,7 +52,10 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch
                 Channel = _channel, TimeoutInMilliseconds = 5000, RequeueCount = 3, UnacceptableMessageLimit = 3
             };
 
-            var unmappableMessage = new Message(new MessageHeader(Guid.NewGuid(), "MyTopic", MessageType.MT_EVENT), new MessageBody("{ \"Id\" : \"48213ADB-A085-4AFF-A42C-CF8209350CF7\" }"));
+            var unmappableMessage = new Message(
+                new MessageHeader(Guid.NewGuid().ToString(), "MyTopic", MessageType.MT_EVENT), 
+                new MessageBody("{ \"Id\" : \"48213ADB-A085-4AFF-A42C-CF8209350CF7\" }")
+            );
 
             _channel.Enqueue(unmappableMessage);
             _channel.Enqueue(unmappableMessage);

--- a/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_a_message_fails_to_be_mapped_to_a_request_and_the_unacceptable_message_limit_is_reached_async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_a_message_fails_to_be_mapped_to_a_request_and_the_unacceptable_message_limit_is_reached_async.cs
@@ -52,7 +52,7 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch
                 Channel = _channel, TimeoutInMilliseconds = 5000, RequeueCount = 3, UnacceptableMessageLimit = 3
             };
 
-            var unmappableMessage = new Message(new MessageHeader(Guid.NewGuid(), "MyTopic", MessageType.MT_EVENT), new MessageBody("{ \"Id\" : \"48213ADB-A085-4AFF-A42C-CF8209350CF7\" }"));
+            var unmappableMessage = new Message(new MessageHeader(Guid.NewGuid().ToString(), "MyTopic", MessageType.MT_EVENT), new MessageBody("{ \"Id\" : \"48213ADB-A085-4AFF-A42C-CF8209350CF7\" }"));
 
             _channel.Enqueue(unmappableMessage);
             _channel.Enqueue(unmappableMessage);

--- a/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_a_message_fails_to_be_mapped_to_a_request_async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_a_message_fails_to_be_mapped_to_a_request_async.cs
@@ -29,7 +29,7 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch
                 Channel = _channel, TimeoutInMilliseconds = 5000, RequeueCount = 3, UnacceptableMessageLimit = 3
             };
 
-            var unmappableMessage = new Message(new MessageHeader(Guid.NewGuid(), "MyTopic", MessageType.MT_EVENT), new MessageBody("{ \"Id\" : \"48213ADB-A085-4AFF-A42C-CF8209350CF7\" }"));
+            var unmappableMessage = new Message(new MessageHeader(Guid.NewGuid().ToString(), "MyTopic", MessageType.MT_EVENT), new MessageBody("{ \"Id\" : \"48213ADB-A085-4AFF-A42C-CF8209350CF7\" }"));
 
             _channel.Enqueue(unmappableMessage);
         }

--- a/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_a_message_is_dispatched_it_should_reach_a_handler.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_a_message_is_dispatched_it_should_reach_a_handler.cs
@@ -38,8 +38,8 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch
     public class MessagePumpDispatchTests
     {
         private readonly IAmAMessagePump _messagePump;
-        private readonly MyEvent _myEvent = new MyEvent();
-        private readonly IDictionary<string, Guid> _receivedMessages = new Dictionary<string, Guid>();
+        private readonly MyEvent _myEvent = new();
+        private readonly IDictionary<string, string> _receivedMessages = new Dictionary<string, string>();
 
         public MessagePumpDispatchTests()
         {
@@ -70,9 +70,12 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch
                 Channel = channel, TimeoutInMilliseconds = 5000
             };
 
-            var message = new Message(new MessageHeader(Guid.NewGuid(), "MyTopic", MessageType.MT_EVENT), new MessageBody(JsonSerializer.Serialize(_myEvent, JsonSerialisationOptions.Options)));
+            var message = new Message(
+                new MessageHeader(Guid.NewGuid().ToString(), "MyTopic", MessageType.MT_EVENT), 
+                new MessageBody(JsonSerializer.Serialize(_myEvent, JsonSerialisationOptions.Options))
+            );
             channel.Enqueue(message);
-            var quitMessage = new Message(new MessageHeader(Guid.Empty, "", MessageType.MT_QUIT), new MessageBody(""));
+            var quitMessage = new Message(new MessageHeader(string.Empty, "", MessageType.MT_QUIT), new MessageBody(""));
             channel.Enqueue(quitMessage);
         }
 

--- a/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_a_message_is_dispatched_it_should_reach_a_handler_async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_a_message_is_dispatched_it_should_reach_a_handler_async.cs
@@ -40,9 +40,9 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch
              _messagePump = new MessagePumpAsync<MyEvent>(commandProcessorProvider, messageMapperRegistry, null) 
                 { Channel = channel, TimeoutInMilliseconds = 5000 };
 
-            var message = new Message(new MessageHeader(Guid.NewGuid(), "MyTopic", MessageType.MT_EVENT), new MessageBody(JsonSerializer.Serialize(_myEvent)));
+            var message = new Message(new MessageHeader(Guid.NewGuid().ToString(), "MyTopic", MessageType.MT_EVENT), new MessageBody(JsonSerializer.Serialize(_myEvent)));
             channel.Enqueue(message);
-            var quitMessage = new Message(new MessageHeader(Guid.Empty, "", MessageType.MT_QUIT), new MessageBody(""));
+            var quitMessage = new Message(new MessageHeader(string.Empty, "", MessageType.MT_QUIT), new MessageBody(""));
             channel.Enqueue(quitMessage);
         }
 

--- a/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_a_requeue_count_threshold_for_commands_has_been_reached.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_a_requeue_count_threshold_for_commands_has_been_reached.cs
@@ -55,8 +55,12 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch
 
             _command = new MyCommand();
 
-            var message1 = new Message(new MessageHeader(Guid.NewGuid(), "MyTopic", MessageType.MT_COMMAND), new MessageBody(JsonSerializer.Serialize(_command, JsonSerialisationOptions.Options)));
-            var message2 = new Message(new MessageHeader(Guid.NewGuid(), "MyTopic", MessageType.MT_COMMAND), new MessageBody(JsonSerializer.Serialize(_command, JsonSerialisationOptions.Options)));
+            var message1 = new Message(new MessageHeader(Guid.NewGuid().ToString(), "MyTopic", MessageType.MT_COMMAND), 
+                new MessageBody(JsonSerializer.Serialize(_command, JsonSerialisationOptions.Options))
+            );
+            var message2 = new Message(new MessageHeader(Guid.NewGuid().ToString(), "MyTopic", MessageType.MT_COMMAND), 
+                new MessageBody(JsonSerializer.Serialize(_command, JsonSerialisationOptions.Options))
+            );
             _channel.Enqueue(message1);
             _channel.Enqueue(message2);
         }
@@ -67,7 +71,7 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch
             var task = Task.Factory.StartNew(() => _messagePump.Run(), TaskCreationOptions.LongRunning);
             await Task.Delay(1000);
 
-            var quitMessage = new Message(new MessageHeader(Guid.Empty, "", MessageType.MT_QUIT), new MessageBody(""));
+            var quitMessage = new Message(new MessageHeader(string.Empty, "", MessageType.MT_QUIT), new MessageBody(""));
             _channel.Enqueue(quitMessage);
 
             await Task.WhenAll(task);

--- a/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_a_requeue_count_threshold_for_events_has_been_reached.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_a_requeue_count_threshold_for_events_has_been_reached.cs
@@ -56,8 +56,14 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch
 
             _event = new MyEvent();
 
-            var message1 = new Message(new MessageHeader(Guid.NewGuid(), "MyTopic", MessageType.MT_EVENT), new MessageBody(JsonSerializer.Serialize(_event, JsonSerialisationOptions.Options)));
-            var message2 = new Message(new MessageHeader(Guid.NewGuid(), "MyTopic", MessageType.MT_EVENT), new MessageBody(JsonSerializer.Serialize(_event, JsonSerialisationOptions.Options)));
+            var message1 = new Message(
+                new MessageHeader(Guid.NewGuid().ToString(), "MyTopic", MessageType.MT_EVENT), 
+                new MessageBody(JsonSerializer.Serialize(_event, JsonSerialisationOptions.Options))
+            );
+            var message2 = new Message(
+                new MessageHeader(Guid.NewGuid().ToString(), "MyTopic", MessageType.MT_EVENT), 
+                new MessageBody(JsonSerializer.Serialize(_event, JsonSerialisationOptions.Options))
+            );
             _channel.Enqueue(message1);
             _channel.Enqueue(message2);
         }
@@ -68,7 +74,7 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch
             var task = Task.Factory.StartNew(() => _messagePump.Run(), TaskCreationOptions.LongRunning);
             await Task.Delay(1000);
 
-            var quitMessage = new Message(new MessageHeader(Guid.Empty, "", MessageType.MT_QUIT), new MessageBody(""));
+            var quitMessage = new Message(new MessageHeader(string.Empty, "", MessageType.MT_QUIT), new MessageBody(""));
             _channel.Enqueue(quitMessage);
 
             await Task.WhenAll(task);

--- a/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_a_requeue_of_command_exception_is_thrown.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_a_requeue_of_command_exception_is_thrown.cs
@@ -52,11 +52,22 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch
              _messagePump = new MessagePumpBlocking<MyCommand>(provider, messageMapperRegistry, null) 
                 { Channel = _channel, TimeoutInMilliseconds = 5000, RequeueCount = -1 };
 
-            var message1 = new Message(new MessageHeader(Guid.NewGuid(), "MyTopic", MessageType.MT_COMMAND), new MessageBody(JsonSerializer.Serialize(_command, JsonSerialisationOptions.Options)));
-            var message2 = new Message(new MessageHeader(Guid.NewGuid(), "MyTopic", MessageType.MT_COMMAND), new MessageBody(JsonSerializer.Serialize(_command, JsonSerialisationOptions.Options)));
+            var message1 = new Message(
+                new MessageHeader(Guid.NewGuid().ToString(), "MyTopic", MessageType.MT_COMMAND), 
+                new MessageBody(JsonSerializer.Serialize(_command, JsonSerialisationOptions.Options))
+            );
+            
+            var message2 = new Message(
+                new MessageHeader(Guid.NewGuid().ToString(), "MyTopic", MessageType.MT_COMMAND), 
+                new MessageBody(JsonSerializer.Serialize(_command, JsonSerialisationOptions.Options))
+            );
+            
             _channel.Enqueue(message1);
             _channel.Enqueue(message2);
-            var quitMessage = new Message(new MessageHeader(Guid.Empty, "", MessageType.MT_QUIT), new MessageBody(""));
+            var quitMessage = new Message(
+                new MessageHeader(string.Empty, "", MessageType.MT_QUIT), 
+                new MessageBody("")
+            );
             _channel.Enqueue(quitMessage);
         }
 

--- a/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_a_requeue_of_event_exception_is_thrown.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_a_requeue_of_event_exception_is_thrown.cs
@@ -55,11 +55,17 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch
 
             _event = new MyEvent();
 
-            var message1 = new Message(new MessageHeader(Guid.NewGuid(), "MyTopic", MessageType.MT_EVENT), new MessageBody(JsonSerializer.Serialize(_event, JsonSerialisationOptions.Options)));
-            var message2 = new Message(new MessageHeader(Guid.NewGuid(), "MyTopic", MessageType.MT_EVENT), new MessageBody(JsonSerializer.Serialize(_event, JsonSerialisationOptions.Options)));
+            var message1 = new Message(
+                new MessageHeader(Guid.NewGuid().ToString(), "MyTopic", MessageType.MT_EVENT), 
+                new MessageBody(JsonSerializer.Serialize(_event, JsonSerialisationOptions.Options))
+            );
+            var message2 = new Message(
+                new MessageHeader(Guid.NewGuid().ToString(), "MyTopic", MessageType.MT_EVENT), 
+                new MessageBody(JsonSerializer.Serialize(_event, JsonSerialisationOptions.Options))
+            );
             _channel.Enqueue(message1);
             _channel.Enqueue(message2);
-            var quitMessage = new Message(new MessageHeader(Guid.Empty, "", MessageType.MT_QUIT), new MessageBody(""));
+            var quitMessage = new Message(new MessageHeader(string.Empty, "", MessageType.MT_QUIT), new MessageBody(""));
             _channel.Enqueue(quitMessage);
         }
 

--- a/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_an_event_handler_throws_a_defer_message_Then_message_is_requeued_until_rejected.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_an_event_handler_throws_a_defer_message_Then_message_is_requeued_until_rejected.cs
@@ -69,7 +69,7 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch
             var task = Task.Factory.StartNew(() => _messagePump.Run(), TaskCreationOptions.LongRunning);
             await Task.Delay(1000);
 
-            var quitMessage = new Message(new MessageHeader(Guid.Empty, "", MessageType.MT_QUIT), new MessageBody(""));
+            var quitMessage = new Message(new MessageHeader(string.Empty, "", MessageType.MT_QUIT), new MessageBody(""));
             _channel.Enqueue(quitMessage);
 
             await Task.WhenAll(task);

--- a/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_an_event_handler_throws_a_defer_message_Then_message_is_requeued_until_rejectedAsync.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_an_event_handler_throws_a_defer_message_Then_message_is_requeued_until_rejectedAsync.cs
@@ -66,7 +66,7 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch
             var task = Task.Factory.StartNew(() => _messagePump.Run(), TaskCreationOptions.LongRunning);
             await Task.Delay(1000);
 
-            var quitMessage = new Message(new MessageHeader(Guid.Empty, "", MessageType.MT_QUIT), new MessageBody(""));
+            var quitMessage = new Message(new MessageHeader(string.Empty, "", MessageType.MT_QUIT), new MessageBody(""));
             _channel.Enqueue(quitMessage);
 
             await Task.WhenAll(task);

--- a/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_an_event_handler_throws_unhandled_exception_Then_message_is_acked.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_an_event_handler_throws_unhandled_exception_Then_message_is_acked.cs
@@ -73,7 +73,7 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch
                 var task = Task.Factory.StartNew(() => _messagePump.Run(), TaskCreationOptions.LongRunning);
                 await Task.Delay(1000);
 
-                var quitMessage = new Message(new MessageHeader(Guid.Empty, "", MessageType.MT_QUIT),
+                var quitMessage = new Message(new MessageHeader(string.Empty, "", MessageType.MT_QUIT),
                     new MessageBody(""));
                 _channel.Enqueue(quitMessage);
 

--- a/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_an_event_handler_throws_unhandled_exception_Then_message_is_acked_async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_an_event_handler_throws_unhandled_exception_Then_message_is_acked_async.cs
@@ -72,7 +72,7 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch
                 var task = Task.Factory.StartNew(() => _messagePump.Run(), TaskCreationOptions.LongRunning);
                 await Task.Delay(1000);
 
-                var quitMessage = new Message(new MessageHeader(Guid.Empty, "", MessageType.MT_QUIT),
+                var quitMessage = new Message(new MessageHeader(string.Empty, "", MessageType.MT_QUIT),
                     new MessageBody(""));
                 _channel.Enqueue(quitMessage);
 

--- a/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_an_unacceptable_message_is_recieved.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_an_unacceptable_message_is_recieved.cs
@@ -55,7 +55,10 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch
             };
 
             var myMessage = JsonSerializer.Serialize(new MyEvent());
-            var unacceptableMessage = new Message(new MessageHeader(Guid.NewGuid(), "MyTopic", MessageType.MT_UNACCEPTABLE), new MessageBody(myMessage));
+            var unacceptableMessage = new Message(
+                new MessageHeader(Guid.NewGuid().ToString(), "MyTopic", MessageType.MT_UNACCEPTABLE), 
+                new MessageBody(myMessage)
+            );
 
             _channel.Enqueue(unacceptableMessage);
         }
@@ -66,7 +69,7 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch
             var task = Task.Factory.StartNew(() => _messagePump.Run(), TaskCreationOptions.LongRunning);
             await Task.Delay(1000);
 
-            var quitMessage = new Message(new MessageHeader(Guid.Empty, "", MessageType.MT_QUIT), new MessageBody(""));
+            var quitMessage = new Message(new MessageHeader(string.Empty, "", MessageType.MT_QUIT), new MessageBody(""));
             _channel.Enqueue(quitMessage);
 
             await Task.WhenAll(new[] { task });

--- a/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_an_unacceptable_message_is_recieved_async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_an_unacceptable_message_is_recieved_async.cs
@@ -55,7 +55,7 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch
             };
 
             var myMessage = JsonSerializer.Serialize(new MyEvent());
-            var unacceptableMessage = new Message(new MessageHeader(Guid.NewGuid(), "MyTopic", MessageType.MT_UNACCEPTABLE), new MessageBody(myMessage));
+            var unacceptableMessage = new Message(new MessageHeader(Guid.NewGuid().ToString(), "MyTopic", MessageType.MT_UNACCEPTABLE), new MessageBody(myMessage));
 
             _channel.Enqueue(unacceptableMessage);
         }
@@ -66,7 +66,10 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch
             var task = Task.Factory.StartNew(() => _messagePump.Run(), TaskCreationOptions.LongRunning);
             await Task.Delay(1000);
 
-            var quitMessage = new Message(new MessageHeader(Guid.Empty, "", MessageType.MT_QUIT), new MessageBody(""));
+            var quitMessage = new Message(
+                new MessageHeader(string.Empty, "", MessageType.MT_QUIT), 
+                new MessageBody("")
+            );
             _channel.Enqueue(quitMessage);
 
             await Task.WhenAll(new[] { task });

--- a/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_an_unacceptable_message_limit_is_reached.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_an_unacceptable_message_limit_is_reached.cs
@@ -54,10 +54,22 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch
                 Channel = _channel, TimeoutInMilliseconds = 5000, RequeueCount = 3, UnacceptableMessageLimit = 3
             };
 
-            var unacceptableMessage1 = new Message(new MessageHeader(Guid.NewGuid(), "MyTopic", MessageType.MT_UNACCEPTABLE), new MessageBody(""));
-            var unacceptableMessage2 = new Message(new MessageHeader(Guid.NewGuid(), "MyTopic", MessageType.MT_UNACCEPTABLE), new MessageBody(""));
-            var unacceptableMessage3 = new Message(new MessageHeader(Guid.NewGuid(), "MyTopic", MessageType.MT_UNACCEPTABLE), new MessageBody(""));
-            var unacceptableMessage4 = new Message(new MessageHeader(Guid.NewGuid(), "MyTopic", MessageType.MT_UNACCEPTABLE), new MessageBody(""));
+            var unacceptableMessage1 = new Message(
+                new MessageHeader(Guid.NewGuid().ToString(), "MyTopic", MessageType.MT_UNACCEPTABLE), 
+                new MessageBody("")
+            );
+            var unacceptableMessage2 = new Message(
+                new MessageHeader(Guid.NewGuid().ToString(), "MyTopic", MessageType.MT_UNACCEPTABLE), 
+                new MessageBody("")
+            );
+            var unacceptableMessage3 = new Message(
+                new MessageHeader(Guid.NewGuid().ToString(), "MyTopic", MessageType.MT_UNACCEPTABLE), 
+                new MessageBody("")
+            );
+            var unacceptableMessage4 = new Message(
+                new MessageHeader(Guid.NewGuid().ToString(), "MyTopic", MessageType.MT_UNACCEPTABLE), 
+                new MessageBody("")
+            );
 
             _channel.Enqueue(unacceptableMessage1);
             _channel.Enqueue(unacceptableMessage2);

--- a/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_an_unacceptable_message_limit_is_reached_async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_an_unacceptable_message_limit_is_reached_async.cs
@@ -54,10 +54,22 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch
                 Channel = _channel, TimeoutInMilliseconds = 5000, RequeueCount = 3, UnacceptableMessageLimit = 3
             };
             
-            var unacceptableMessage1 = new Message(new MessageHeader(Guid.NewGuid(), "MyTopic", MessageType.MT_UNACCEPTABLE), new MessageBody(""));
-            var unacceptableMessage2 = new Message(new MessageHeader(Guid.NewGuid(), "MyTopic", MessageType.MT_UNACCEPTABLE), new MessageBody(""));
-            var unacceptableMessage3 = new Message(new MessageHeader(Guid.NewGuid(), "MyTopic", MessageType.MT_UNACCEPTABLE), new MessageBody(""));
-            var unacceptableMessage4 = new Message(new MessageHeader(Guid.NewGuid(), "MyTopic", MessageType.MT_UNACCEPTABLE), new MessageBody(""));
+            var unacceptableMessage1 = new Message(
+                new MessageHeader(Guid.NewGuid().ToString(), "MyTopic", MessageType.MT_UNACCEPTABLE), 
+                new MessageBody("")                                
+            );
+            var unacceptableMessage2 = new Message(
+                new MessageHeader(Guid.NewGuid().ToString(), "MyTopic", MessageType.MT_UNACCEPTABLE), 
+                new MessageBody("")
+            );
+            var unacceptableMessage3 = new Message(
+                new MessageHeader(Guid.NewGuid().ToString(), "MyTopic", MessageType.MT_UNACCEPTABLE), 
+                new MessageBody("")
+            );
+            var unacceptableMessage4 = new Message(
+                new MessageHeader(Guid.NewGuid().ToString(), "MyTopic", MessageType.MT_UNACCEPTABLE), 
+                new MessageBody("")
+            );
 
             _channel.Enqueue(unacceptableMessage1);
             _channel.Enqueue(unacceptableMessage2);

--- a/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_reading_a_message_from_a_channel_pump_out_to_command_processor.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_reading_a_message_from_a_channel_pump_out_to_command_processor.cs
@@ -55,9 +55,9 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch
 
             _event = new MyEvent();
 
-            var message = new Message(new MessageHeader(Guid.NewGuid(), "MyTopic", MessageType.MT_EVENT), new MessageBody(JsonSerializer.Serialize(_event, JsonSerialisationOptions.Options)));
+            var message = new Message(new MessageHeader(Guid.NewGuid().ToString(), "MyTopic", MessageType.MT_EVENT), new MessageBody(JsonSerializer.Serialize(_event, JsonSerialisationOptions.Options)));
             _channel.Enqueue(message);
-            var quitMessage = new Message(new MessageHeader(Guid.Empty, "", MessageType.MT_QUIT), new MessageBody(""));
+            var quitMessage = new Message(new MessageHeader(string.Empty, "", MessageType.MT_QUIT), new MessageBody(""));
             _channel.Enqueue(quitMessage);
         }
 

--- a/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_reading_a_message_from_a_channel_pump_out_to_command_processor_async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_reading_a_message_from_a_channel_pump_out_to_command_processor_async.cs
@@ -56,9 +56,9 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch
 
             _event = new MyEvent();
 
-            var message = new Message(new MessageHeader(Guid.NewGuid(), "MyTopic", MessageType.MT_EVENT), new MessageBody(JsonSerializer.Serialize(_event, JsonSerialisationOptions.Options)));
+            var message = new Message(new MessageHeader(Guid.NewGuid().ToString(), "MyTopic", MessageType.MT_EVENT), new MessageBody(JsonSerializer.Serialize(_event, JsonSerialisationOptions.Options)));
             _channel.Enqueue(message);
-            var quitMessage = new Message(new MessageHeader(Guid.Empty, "", MessageType.MT_QUIT), new MessageBody(""));
+            var quitMessage = new Message(new MessageHeader(string.Empty, "", MessageType.MT_QUIT), new MessageBody(""));
             _channel.Enqueue(quitMessage);
         }
 

--- a/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_running_a_message_pump_on_a_thread_should_be_able_to_stop.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_running_a_message_pump_on_a_thread_should_be_able_to_stop.cs
@@ -54,7 +54,10 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch
             messagePump.TimeoutInMilliseconds = 5000;
 
             var @event = new MyEvent();
-            var message = new Message(new MessageHeader(Guid.NewGuid(), "MyTopic", MessageType.MT_EVENT), new MessageBody(JsonSerializer.Serialize(@event, JsonSerialisationOptions.Options)));
+            var message = new Message(
+                new MessageHeader(Guid.NewGuid().ToString(), "MyTopic", MessageType.MT_EVENT), 
+                new MessageBody(JsonSerializer.Serialize(@event, JsonSerialisationOptions.Options))
+            );
             _channel.Enqueue(message);
 
             Performer performer = new(_channel, messagePump);

--- a/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_running_a_message_pump_on_a_thread_should_be_able_to_stop_async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageDispatch/When_running_a_message_pump_on_a_thread_should_be_able_to_stop_async.cs
@@ -54,7 +54,10 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch
             messagePump.TimeoutInMilliseconds = 5000;
 
             var @event = new MyEvent();
-            var message = new Message(new MessageHeader(Guid.NewGuid(), "MyTopic", MessageType.MT_EVENT), new MessageBody(JsonSerializer.Serialize(@event, JsonSerialisationOptions.Options)));
+            var message = new Message(
+                new MessageHeader(Guid.NewGuid().ToString(), "MyTopic", MessageType.MT_EVENT), 
+                new MessageBody(JsonSerializer.Serialize(@event, JsonSerialisationOptions.Options))
+            );
             _channel.Enqueue(message);
 
             Performer performer = new(_channel, messagePump);

--- a/tests/Paramore.Brighter.Core.Tests/MessageSerialisation/When_Deserializing_A_Message_Header_Bag.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageSerialisation/When_Deserializing_A_Message_Header_Bag.cs
@@ -17,11 +17,12 @@ namespace Paramore.Brighter.Core.Tests.MessageSerialisation
          {
              //Arrange
              var header = new MessageHeader(
-                 messageId: Guid.NewGuid(),
+                 messageId: Guid.NewGuid().ToString(),
                  topic: "MyTopic",
                  messageType: MessageType.MT_EVENT,
                  timeStamp: DateTime.UtcNow,
-                 correlationId: Guid.NewGuid());
+                 correlationId: Guid.NewGuid().ToString()
+                );
 
              var myGuid = Guid.NewGuid();
              var expectedBag = new Dictionary<string, object>

--- a/tests/Paramore.Brighter.Core.Tests/MessagingGateway/When_a_stop_message_is_added_to_a_channel.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessagingGateway/When_a_stop_message_is_added_to_a_channel.cs
@@ -42,7 +42,7 @@ namespace Paramore.Brighter.Core.Tests.MessagingGateway
             _channel = new Channel("test", _gateway);
 
             _sentMessage = new Message(
-                new MessageHeader(Guid.NewGuid(), "key", MessageType.MT_EVENT),
+                new MessageHeader(Guid.NewGuid().ToString(), "key", MessageType.MT_EVENT),
                 new MessageBody("a test body"));
 
             _channel.Stop();

--- a/tests/Paramore.Brighter.Core.Tests/MessagingGateway/When_acknowledge_is_called_on_a_channel.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessagingGateway/When_acknowledge_is_called_on_a_channel.cs
@@ -41,7 +41,7 @@ namespace Paramore.Brighter.Core.Tests.MessagingGateway
             _channel = new  Channel("test", _gateway);
 
             _receivedMessage = new Message(
-                new MessageHeader(Guid.NewGuid(), "key", MessageType.MT_EVENT),
+                new MessageHeader(Guid.NewGuid().ToString(), "key", MessageType.MT_EVENT),
                 new MessageBody("a test body"));
 
             _receivedMessage.DeliveryTag = 12345UL;

--- a/tests/Paramore.Brighter.Core.Tests/MessagingGateway/When_listening_to_messages_on_a_channel.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessagingGateway/When_listening_to_messages_on_a_channel.cs
@@ -43,7 +43,7 @@ namespace Paramore.Brighter.Core.Tests.MessagingGateway
             _channel = new Channel("test", _gateway);
 
             _sentMessage = new Message(
-                new MessageHeader(Guid.NewGuid(), "key", MessageType.MT_EVENT),
+                new MessageHeader(Guid.NewGuid().ToString(), "key", MessageType.MT_EVENT),
                 new MessageBody("a test body"));
 
             A.CallTo(() => _gateway.Receive(1000)).Returns(new Message[] {_sentMessage});

--- a/tests/Paramore.Brighter.Core.Tests/MessagingGateway/When_no_acknowledge_is_called_on_a_channel.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessagingGateway/When_no_acknowledge_is_called_on_a_channel.cs
@@ -41,7 +41,7 @@ namespace Paramore.Brighter.Core.Tests.MessagingGateway
             _channel = new Channel("test", _gateway);
 
             _receivedMessage = new Message(
-                new MessageHeader(Guid.NewGuid(), "key", MessageType.MT_EVENT),
+                new MessageHeader(Guid.NewGuid().ToString(), "key", MessageType.MT_EVENT),
                 new MessageBody("a test body"));
 
             _receivedMessage.DeliveryTag = 12345UL;

--- a/tests/Paramore.Brighter.Core.Tests/MessagingGateway/When_requeuing_a_message_with_no_delay.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessagingGateway/When_requeuing_a_message_with_no_delay.cs
@@ -24,6 +24,7 @@ THE SOFTWARE. */
 
 using System;
 using FakeItEasy;
+using FluentAssertions;
 using Xunit;
 
 namespace Paramore.Brighter.Core.Tests.MessagingGateway
@@ -41,7 +42,7 @@ namespace Paramore.Brighter.Core.Tests.MessagingGateway
             _channel = new Channel("test", _consumer);
 
             _requeueMessage = new Message(
-                new MessageHeader(Guid.NewGuid(), "key", MessageType.MT_EVENT),
+                new MessageHeader(Guid.NewGuid().ToString(), "key", MessageType.MT_EVENT),
                 new MessageBody("a test body"));
         }
 

--- a/tests/Paramore.Brighter.Core.Tests/MessagingGateway/When_the_buffer_is_not_empty_read_from_that_before_receiving.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessagingGateway/When_the_buffer_is_not_empty_read_from_that_before_receiving.cs
@@ -21,11 +21,11 @@ namespace Paramore.Brighter.Core.Tests.MessagingGateway
             _channel = new Channel("test", _gateway, BufferLimit);
 
             _messageOne = new Message(
-                new MessageHeader(Guid.NewGuid(), "key", MessageType.MT_EVENT),
+                new MessageHeader(Guid.NewGuid().ToString(), "key", MessageType.MT_EVENT),
                 new MessageBody("FirstMessage"));
            
             _messageTwo = new Message(
-                new MessageHeader(Guid.NewGuid(), "key", MessageType.MT_EVENT),
+                new MessageHeader(Guid.NewGuid().ToString(), "key", MessageType.MT_EVENT),
                 new MessageBody("SecondMessage"));
 
         }
@@ -36,7 +36,7 @@ namespace Paramore.Brighter.Core.Tests.MessagingGateway
             _channel.Enqueue(_messageOne, _messageTwo);
              
             _messageThree = new Message(
-                new MessageHeader(Guid.NewGuid(), "key", MessageType.MT_EVENT),
+                new MessageHeader(Guid.NewGuid().ToString(), "key", MessageType.MT_EVENT),
                 new MessageBody("ThirdMessage"));
             
             A.CallTo(() => _gateway.Receive(10)).Returns(new Message[] {_messageThree});
@@ -55,19 +55,19 @@ namespace Paramore.Brighter.Core.Tests.MessagingGateway
         {
             //put BufferLimit messages on the queue first
             var messageOne = new Message(
-                new MessageHeader(Guid.NewGuid(), "key", MessageType.MT_EVENT),
+                new MessageHeader(Guid.NewGuid().ToString(), "key", MessageType.MT_EVENT),
                 new MessageBody("FirstMessage"));
             
             var messageTwo = new Message(
-                new MessageHeader(Guid.NewGuid(), "key", MessageType.MT_EVENT),
+                new MessageHeader(Guid.NewGuid().ToString(), "key", MessageType.MT_EVENT),
                 new MessageBody("SecondMessage"));
             
             var messageThree = new Message(
-                new MessageHeader(Guid.NewGuid(), "key", MessageType.MT_EVENT),
+                new MessageHeader(Guid.NewGuid().ToString(), "key", MessageType.MT_EVENT),
                 new MessageBody("ThirdMessage"));
             
             var messageFour = new Message(
-                new MessageHeader(Guid.NewGuid(), "key", MessageType.MT_EVENT),
+                new MessageHeader(Guid.NewGuid().ToString(), "key", MessageType.MT_EVENT),
                 new MessageBody("FourthMessage"));
             
 

--- a/tests/Paramore.Brighter.Core.Tests/OnceOnly/When_Handling_A_Command_With_A_Inbox_Enabled.cs
+++ b/tests/Paramore.Brighter.Core.Tests/OnceOnly/When_Handling_A_Command_With_A_Inbox_Enabled.cs
@@ -79,7 +79,7 @@ namespace Paramore.Brighter.Core.Tests.OnceOnly
         [Fact]
         public void Command_Is_Not_Stored_If_The_Handler_Is_Not_Successful()
         {
-            Guid id = Guid.NewGuid();
+            string id = Guid.NewGuid().ToString();
 
             Assert.Throws<NotImplementedException>(() => _commandProcessor.Send(new MyCommandToFail { Id = id}));
 

--- a/tests/Paramore.Brighter.Core.Tests/OnceOnly/When_Handling_A_Command_With_A_Inbox_Enabled_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/OnceOnly/When_Handling_A_Command_With_A_Inbox_Enabled_Async.cs
@@ -56,7 +56,7 @@ namespace Paramore.Brighter.Core.Tests.OnceOnly
         [Fact]
         public async Task Command_Is_Not_Stored_If_The_Handler_Is_Not_Successful()
         {
-            Guid id = Guid.NewGuid();
+            string id = Guid.NewGuid().ToString();
             await Catch.ExceptionAsync(async () =>await _commandProcessor.SendAsync(new MyCommandToFail { Id = id }));
 
             var exists = await _inbox.ExistsAsync<MyCommandToFail>(id, typeof(MyStoredCommandToFailHandlerAsync).FullName);

--- a/tests/Paramore.Brighter.DynamoDB.Tests/Inbox/When_checking_for_existing_command.cs
+++ b/tests/Paramore.Brighter.DynamoDB.Tests/Inbox/When_checking_for_existing_command.cs
@@ -43,7 +43,7 @@ namespace Paramore.Brighter.DynamoDB.Tests.Inbox
         [Fact]
         public void When_checking_a_command_does_not_exist()
         {
-            var commandExists = _dynamoDbInbox.Exists<MyCommand>(string.Empty, _contextKey);
+            var commandExists = _dynamoDbInbox.Exists<MyCommand>(Guid.NewGuid().ToString(), _contextKey);
 
             commandExists.Should().BeFalse("because the command doesn't exists.", commandExists);
         }

--- a/tests/Paramore.Brighter.DynamoDB.Tests/Inbox/When_checking_for_existing_command.cs
+++ b/tests/Paramore.Brighter.DynamoDB.Tests/Inbox/When_checking_for_existing_command.cs
@@ -12,12 +12,11 @@ namespace Paramore.Brighter.DynamoDB.Tests.Inbox
         private readonly MyCommand _command;
 
         private readonly DynamoDbInbox _dynamoDbInbox;
-        private readonly Guid _guid = Guid.NewGuid();
         private string _contextKey;
 
         public DynamoDbCommandExistsTests()
         {
-            _command = new MyCommand { Id = _guid, Value = "Test Earliest"};
+            _command = new MyCommand { Id = Guid.NewGuid().ToString(), Value = "Test Earliest"};
             _contextKey = "test-context-key";
 
             _dynamoDbInbox = new DynamoDbInbox(Client, new DynamoDbInboxConfiguration());
@@ -44,7 +43,7 @@ namespace Paramore.Brighter.DynamoDB.Tests.Inbox
         [Fact]
         public void When_checking_a_command_does_not_exist()
         {
-            var commandExists = _dynamoDbInbox.Exists<MyCommand>(Guid.Empty, _contextKey);
+            var commandExists = _dynamoDbInbox.Exists<MyCommand>(string.Empty, _contextKey);
 
             commandExists.Should().BeFalse("because the command doesn't exists.", commandExists);
         }

--- a/tests/Paramore.Brighter.DynamoDB.Tests/Inbox/When_checking_for_existing_command_async.cs
+++ b/tests/Paramore.Brighter.DynamoDB.Tests/Inbox/When_checking_for_existing_command_async.cs
@@ -12,12 +12,11 @@ namespace Paramore.Brighter.DynamoDB.Tests.Inbox
     {
         private readonly MyCommand _command;
         private readonly DynamoDbInbox _dynamoDbInbox;
-        private readonly Guid _guid = Guid.NewGuid();
         private readonly string _contextKey;
 
         public DynamoDbCommandExistsAsyncTests()
         {
-            _command = new MyCommand { Id = _guid, Value = "Test Earliest"};
+            _command = new MyCommand { Id = Guid.NewGuid().ToString(), Value = "Test Earliest"};
             _contextKey = "test-context-key";
 
             _dynamoDbInbox = new DynamoDbInbox(Client, new DynamoDbInboxConfiguration());
@@ -44,7 +43,7 @@ namespace Paramore.Brighter.DynamoDB.Tests.Inbox
         [Fact]
         public async Task When_checking_a_command_does_not_exist()
         {
-            var commandExists = await _dynamoDbInbox.ExistsAsync<MyCommand>(Guid.Empty, _contextKey);
+            var commandExists = await _dynamoDbInbox.ExistsAsync<MyCommand>(string.Empty, _contextKey);
 
             commandExists.Should().BeFalse("because the command doesn't exists.", commandExists);
         }

--- a/tests/Paramore.Brighter.DynamoDB.Tests/Inbox/When_checking_for_existing_command_async.cs
+++ b/tests/Paramore.Brighter.DynamoDB.Tests/Inbox/When_checking_for_existing_command_async.cs
@@ -43,9 +43,9 @@ namespace Paramore.Brighter.DynamoDB.Tests.Inbox
         [Fact]
         public async Task When_checking_a_command_does_not_exist()
         {
-            var commandExists = await _dynamoDbInbox.ExistsAsync<MyCommand>(string.Empty, _contextKey);
+            var commandExists = await _dynamoDbInbox.ExistsAsync<MyCommand>(Guid.NewGuid().ToString(), _contextKey);
 
-            commandExists.Should().BeFalse("because the command doesn't exists.", commandExists);
+            commandExists.Should().BeFalse("because the command doesn't exist.", commandExists);
         }
     }
 }

--- a/tests/Paramore.Brighter.DynamoDB.Tests/Inbox/When_there_is_no_message_in_the_dynamo_inbox.cs
+++ b/tests/Paramore.Brighter.DynamoDB.Tests/Inbox/When_there_is_no_message_in_the_dynamo_inbox.cs
@@ -44,7 +44,7 @@ namespace Paramore.Brighter.DynamoDB.Tests.Inbox
         [Fact]
         public void When_There_Is_No_Message_In_The_Inbox()
         {
-            var exception = Catch.Exception(() => _dynamoDbInbox.Get<MyCommand>(Guid.NewGuid(), "some key"));
+            var exception = Catch.Exception(() => _dynamoDbInbox.Get<MyCommand>(Guid.NewGuid().ToString(), "some key"));
             AssertionExtensions.Should(exception).BeOfType<RequestNotFoundException<MyCommand>>();
         }
     }

--- a/tests/Paramore.Brighter.DynamoDB.Tests/Inbox/When_there_is_no_message_in_the_dynamo_inbox_async.cs
+++ b/tests/Paramore.Brighter.DynamoDB.Tests/Inbox/When_there_is_no_message_in_the_dynamo_inbox_async.cs
@@ -46,7 +46,7 @@ namespace Paramore.Brighter.DynamoDB.Tests.Inbox
         public async void When_There_Is_No_Message_In_The_Sql_Inbox()
         {
             var exception =
-                await Catch.ExceptionAsync(() => _dynamoDbInbox.GetAsync<MyCommand>(Guid.NewGuid(), "some key"));
+                await Catch.ExceptionAsync(() => _dynamoDbInbox.GetAsync<MyCommand>(Guid.NewGuid().ToString(), "some key"));
             AssertionExtensions.Should(exception).BeOfType<RequestNotFoundException<MyCommand>>();
         }
     }

--- a/tests/Paramore.Brighter.DynamoDB.Tests/Outbox/When_deleting_a_message_in_the_outbox.cs
+++ b/tests/Paramore.Brighter.DynamoDB.Tests/Outbox/When_deleting_a_message_in_the_outbox.cs
@@ -13,12 +13,15 @@ public class DynamoDbOutboxDeleteMessageTests : DynamoDBOutboxBaseTest
     public void When_deleting_a_message_in_the_outbox()
     {
         // arrange
-        var message = new Message(new MessageHeader(Guid.NewGuid(), "test_topic", MessageType.MT_DOCUMENT), new MessageBody("message body"));
+        var message = new Message(
+            new MessageHeader(Guid.NewGuid().ToString(), "test_topic", MessageType.MT_DOCUMENT), 
+            new MessageBody("message body")
+            );
         var dynamoDbOutbox = new DynamoDbOutbox(Client, new DynamoDbConfiguration(OutboxTableName));
         dynamoDbOutbox.Add(message);
 
         // act
-        dynamoDbOutbox.Delete(new Guid[] {message.Id});
+        dynamoDbOutbox.Delete([message.Id]);
 
         // assert
         var foundMessage = dynamoDbOutbox.Get(message.Id);
@@ -29,12 +32,12 @@ public class DynamoDbOutboxDeleteMessageTests : DynamoDBOutboxBaseTest
     public async Task When_deleting_a_message_in_the_outbox_async()
     {
         // arrange
-        var message = new Message(new MessageHeader(Guid.NewGuid(), "test_topic", MessageType.MT_DOCUMENT), new MessageBody("message body"));
+        var message = new Message(new MessageHeader(Guid.NewGuid().ToString(), "test_topic", MessageType.MT_DOCUMENT), new MessageBody("message body"));
         var dynamoDbOutbox = new DynamoDbOutbox(Client, new DynamoDbConfiguration(OutboxTableName));
         await dynamoDbOutbox.AddAsync(message);
 
         // act
-        await dynamoDbOutbox.DeleteAsync(new Guid[] {message.Id});
+        await dynamoDbOutbox.DeleteAsync([message.Id]);
 
         // assert
         var foundMessage = await dynamoDbOutbox.GetAsync(message.Id);

--- a/tests/Paramore.Brighter.DynamoDB.Tests/Outbox/When_marking_a_message_as_dispatched_in_the_outbox.cs
+++ b/tests/Paramore.Brighter.DynamoDB.Tests/Outbox/When_marking_a_message_as_dispatched_in_the_outbox.cs
@@ -17,7 +17,10 @@ public class DynamoDbOutboxMessageDispatchTests : DynamoDBOutboxBaseTest
 
     public DynamoDbOutboxMessageDispatchTests()
     {
-        _message = new Message(new MessageHeader(Guid.NewGuid(), "test_topic", MessageType.MT_DOCUMENT), new MessageBody("message body"));
+        _message = new Message(
+            new MessageHeader(Guid.NewGuid().ToString(), "test_topic", MessageType.MT_DOCUMENT), 
+            new MessageBody("message body")
+        );
         _dynamoDbOutbox = new DynamoDbOutbox(Client, new DynamoDbConfiguration(OutboxTableName));
     }
 

--- a/tests/Paramore.Brighter.DynamoDB.Tests/Outbox/When_the_message_is_already_in_the_outbox.cs
+++ b/tests/Paramore.Brighter.DynamoDB.Tests/Outbox/When_the_message_is_already_in_the_outbox.cs
@@ -40,7 +40,10 @@ namespace Paramore.Brighter.DynamoDB.Tests.Outbox
 
         public DynamoDbOutboxMessageAlreadyExistsTests()
         {
-            _messageEarliest = new Message(new MessageHeader(Guid.NewGuid(), "test_topic", MessageType.MT_DOCUMENT), new MessageBody("message body"));
+            _messageEarliest = new Message(
+                new MessageHeader(Guid.NewGuid().ToString(), "test_topic", MessageType.MT_DOCUMENT), 
+                new MessageBody("message body")
+            );
             _dynamoDbOutbox = new DynamoDbOutbox(Client, new DynamoDbConfiguration(OutboxTableName));
 
             _dynamoDbOutbox.AddAsync(_messageEarliest).Wait();

--- a/tests/Paramore.Brighter.DynamoDB.Tests/Outbox/When_the_message_is_already_in_the_outbox_async.cs
+++ b/tests/Paramore.Brighter.DynamoDB.Tests/Outbox/When_the_message_is_already_in_the_outbox_async.cs
@@ -41,7 +41,10 @@ namespace Paramore.Brighter.DynamoDB.Tests.Outbox
 
         public DynamoDbOutboxMessageAlreadyExistsAsyncTests()
         {
-            _messageEarliest = new Message(new MessageHeader(Guid.NewGuid(), "test_topic", MessageType.MT_DOCUMENT), new MessageBody("message body"));
+            _messageEarliest = new Message(
+                new MessageHeader(Guid.NewGuid().ToString(), "test_topic", MessageType.MT_DOCUMENT), 
+                new MessageBody("message body")
+                );
             _dynamoDbOutbox = new DynamoDbOutbox(Client, new DynamoDbConfiguration(OutboxTableName));
         }
 

--- a/tests/Paramore.Brighter.DynamoDB.Tests/Outbox/When_there_are_outstanding_messages_in_the_outbox.cs
+++ b/tests/Paramore.Brighter.DynamoDB.Tests/Outbox/When_there_are_outstanding_messages_in_the_outbox.cs
@@ -17,7 +17,10 @@ public class DynamoDbOutboxOutstandingMessageTests : DynamoDBOutboxBaseTest
 
     public DynamoDbOutboxOutstandingMessageTests()
     {
-        _message = new Message(new MessageHeader(Guid.NewGuid(), "test_topic", MessageType.MT_DOCUMENT), new MessageBody("message body"));
+        _message = new Message(
+            new MessageHeader(Guid.NewGuid().ToString(), "test_topic", MessageType.MT_DOCUMENT), 
+            new MessageBody("message body")
+        );
         _dynamoDbOutbox = new DynamoDbOutbox(Client, new DynamoDbConfiguration(OutboxTableName));
     }
 

--- a/tests/Paramore.Brighter.DynamoDB.Tests/Outbox/When_there_is_a_transaction_between_outbox_and_entity.cs
+++ b/tests/Paramore.Brighter.DynamoDB.Tests/Outbox/When_there_is_a_transaction_between_outbox_and_entity.cs
@@ -54,13 +54,13 @@ public class DynamoDbOutboxTransactionTests : DynamoDBOutboxBaseTest
         var myItem = new MyEntity { Id = Guid.NewGuid().ToString(), Value = "Test Value for Transaction Checking" };
         var attributes = context.ToDocument(myItem).ToAttributeMap();
         var myMessageHeader = new MessageHeader(
-            messageId: Guid.NewGuid(),
+            messageId: Guid.NewGuid().ToString(),
             topic: "test_topic",
             messageType: MessageType.MT_DOCUMENT,
             timeStamp: DateTime.UtcNow.AddDays(-1),
             handledCount: 5,
             delayedMilliseconds: 5,
-            correlationId: Guid.NewGuid(),
+            correlationId: Guid.NewGuid().ToString(),
             replyTo: "ReplyAddress",
             contentType: "text/plain");
 

--- a/tests/Paramore.Brighter.DynamoDB.Tests/Outbox/When_there_is_no_message_in_the_dynamo_db_outbox.cs
+++ b/tests/Paramore.Brighter.DynamoDB.Tests/Outbox/When_there_is_no_message_in_the_dynamo_db_outbox.cs
@@ -40,7 +40,10 @@ namespace Paramore.Brighter.DynamoDB.Tests.Outbox
 
         public DynamoDbOutboxEmptyStoreTests()
         {
-            _messageEarliest = new Message(new MessageHeader(Guid.NewGuid(), "test_topic", MessageType.MT_DOCUMENT), new MessageBody("message body"));
+            _messageEarliest = new Message(
+                new MessageHeader(Guid.NewGuid().ToString(), "test_topic", MessageType.MT_DOCUMENT), 
+                new MessageBody("message body")
+            );
             _dynamoDbOutbox = new DynamoDbOutbox(Client, new DynamoDbConfiguration(OutboxTableName));
         }
 

--- a/tests/Paramore.Brighter.DynamoDB.Tests/Outbox/When_there_is_no_message_in_the_dynamo_db_outbox_async.cs
+++ b/tests/Paramore.Brighter.DynamoDB.Tests/Outbox/When_there_is_no_message_in_the_dynamo_db_outbox_async.cs
@@ -40,7 +40,10 @@ namespace Paramore.Brighter.DynamoDB.Tests.Outbox
 
         public DynamoDbOutboxEmptyStoreAsyncTests()
         {
-            _messageEarliest = new Message(new MessageHeader(Guid.NewGuid(), "test_topic", MessageType.MT_DOCUMENT), new MessageBody("message body"));
+            _messageEarliest = new Message(
+                new MessageHeader(Guid.NewGuid().ToString(), "test_topic", MessageType.MT_DOCUMENT), 
+                new MessageBody("message body")
+            );
             _dynamoDbOutbox = new DynamoDbOutbox(Client, new DynamoDbConfiguration(OutboxTableName));
         }
 

--- a/tests/Paramore.Brighter.DynamoDB.Tests/Outbox/When_writing_a_raw_message_to_the_outbox.cs
+++ b/tests/Paramore.Brighter.DynamoDB.Tests/Outbox/When_writing_a_raw_message_to_the_outbox.cs
@@ -54,13 +54,13 @@ namespace Paramore.Brighter.DynamoDB.Tests.Outbox
             var serdesBody = payload.Concat(Encoding.ASCII.GetBytes(body)).ToArray();
 
             var messageHeader = new MessageHeader(
-                messageId: Guid.NewGuid(),
+                messageId: Guid.NewGuid().ToString(),
                 topic: "test_topic",
                 messageType: MessageType.MT_DOCUMENT,
                 timeStamp: DateTime.UtcNow.AddDays(-1),
                 handledCount: 5,
                 delayedMilliseconds: 5,
-                correlationId: Guid.NewGuid(),
+                correlationId: Guid.NewGuid().ToString(),
                 replyTo: "ReplyAddress",
                 contentType: "text/plain");
 

--- a/tests/Paramore.Brighter.DynamoDB.Tests/Outbox/When_writing_a_utf8_message_to_the_outbox.cs
+++ b/tests/Paramore.Brighter.DynamoDB.Tests/Outbox/When_writing_a_utf8_message_to_the_outbox.cs
@@ -46,7 +46,7 @@ namespace Paramore.Brighter.DynamoDB.Tests.Outbox
         private readonly string _value2 = "value2";
         private readonly int _value3 = 123;
         private readonly DateTime _value4 = DateTime.UtcNow;
-        private readonly string _value5 = Guid.NewGuid().ToString();
+        private readonly Guid _value5 = Guid.NewGuid();
         private Message _storedMessage;
         private readonly DynamoDbOutbox _dynamoDbOutbox;
 

--- a/tests/Paramore.Brighter.DynamoDB.Tests/Outbox/When_writing_a_utf8_message_to_the_outbox.cs
+++ b/tests/Paramore.Brighter.DynamoDB.Tests/Outbox/When_writing_a_utf8_message_to_the_outbox.cs
@@ -46,7 +46,7 @@ namespace Paramore.Brighter.DynamoDB.Tests.Outbox
         private readonly string _value2 = "value2";
         private readonly int _value3 = 123;
         private readonly DateTime _value4 = DateTime.UtcNow;
-        private readonly Guid _value5 = new Guid();
+        private readonly string _value5 = Guid.NewGuid().ToString();
         private Message _storedMessage;
         private readonly DynamoDbOutbox _dynamoDbOutbox;
 
@@ -56,13 +56,13 @@ namespace Paramore.Brighter.DynamoDB.Tests.Outbox
             var body = JsonSerializer.Serialize(command, JsonSerialisationOptions.Options);
 
             var messageHeader = new MessageHeader(
-                messageId: Guid.NewGuid(),
+                messageId: Guid.NewGuid().ToString(),
                 topic: "test_topic",
                 messageType: MessageType.MT_DOCUMENT,
                 timeStamp: DateTime.UtcNow.AddDays(-1),
                 handledCount: 5,
                 delayedMilliseconds: 5,
-                correlationId: Guid.NewGuid(),
+                correlationId: Guid.NewGuid().ToString(),
                 replyTo: "ReplyAddress",
                 contentType: "text/plain");
             messageHeader.Bag.Add(_key1, _value1);

--- a/tests/Paramore.Brighter.DynamoDB.Tests/Outbox/When_writing_a_utf8_message_to_the_outbox_async.cs
+++ b/tests/Paramore.Brighter.DynamoDB.Tests/Outbox/When_writing_a_utf8_message_to_the_outbox_async.cs
@@ -58,13 +58,13 @@ namespace Paramore.Brighter.DynamoDB.Tests.Outbox
             var body = JsonSerializer.Serialize(command, JsonSerialisationOptions.Options);
 
             var messageHeader = new MessageHeader(
-                messageId: Guid.NewGuid(),
+                messageId: Guid.NewGuid().ToString(),
                 topic: "test_topic",
                 messageType: MessageType.MT_DOCUMENT,
                 timeStamp: DateTime.UtcNow.AddDays(-1),
                 handledCount: 5,
                 delayedMilliseconds: 5,
-                correlationId: Guid.NewGuid(),
+                correlationId: Guid.NewGuid().ToString(),
                 replyTo: "ReplyAddress",
                 contentType: "text/plain");
             messageHeader.Bag.Add(_key1, _value1);

--- a/tests/Paramore.Brighter.InMemory.Tests/Builders/MessageTestDataBuilder.cs
+++ b/tests/Paramore.Brighter.InMemory.Tests/Builders/MessageTestDataBuilder.cs
@@ -14,11 +14,11 @@ namespace Paramore.Brighter.InMemory.Tests.Builders
 
         public MessageTestDataBuilder()
         {
-            _specification.Header = new MessageHeader(Guid.NewGuid(), "test_topic", MessageType.MT_DOCUMENT); 
+            _specification.Header = new MessageHeader(Guid.NewGuid().ToString(), "test_topic", MessageType.MT_DOCUMENT); 
             _specification.Body = new MessageBody("message body");
         }
 
-        public MessageTestDataBuilder WithId(Guid id)
+        public MessageTestDataBuilder WithId(string id)
         {
             _specification.Header = new MessageHeader(id, _specification.Header.Topic, _specification.Header.MessageType);
             return this;

--- a/tests/Paramore.Brighter.InMemory.Tests/Inbox/When_storing_items_in_inbox.cs
+++ b/tests/Paramore.Brighter.InMemory.Tests/Inbox/When_storing_items_in_inbox.cs
@@ -152,7 +152,7 @@ namespace Paramore.Brighter.InMemory.Tests.Inbox
             }
              
             //Act
-            var firstCommandExists = inbox.Exists<SimpleCommand>(Guid.NewGuid(), contextKey);
+            var firstCommandExists = inbox.Exists<SimpleCommand>(Guid.NewGuid().ToString(), contextKey);
  
             //Assert
             firstCommandExists.Should().BeFalse();

--- a/tests/Paramore.Brighter.InMemory.Tests/Outbox/When_controlling_cache_size.cs
+++ b/tests/Paramore.Brighter.InMemory.Tests/Outbox/When_controlling_cache_size.cs
@@ -71,7 +71,7 @@ namespace Paramore.Brighter.InMemory.Tests.Outbox
                 CompactionPercentage = 0.5
             };
 
-            var messageIds = new Guid[] {Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid()};
+            var messageIds = new string[] {Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), Guid.NewGuid().ToString()};
 
             for (int i = 0; i <= limit - 1; i++)
             {

--- a/tests/Paramore.Brighter.InMemory.Tests/Outbox/When_expiring_message_in_outbox.cs
+++ b/tests/Paramore.Brighter.InMemory.Tests/Outbox/When_expiring_message_in_outbox.cs
@@ -44,7 +44,7 @@ namespace Paramore.Brighter.InMemory.Tests.Outbox
                 ExpirationScanInterval = TimeSpan.FromMilliseconds(100)
             };
             
-            var messageId = Guid.NewGuid();
+            var messageId = Guid.NewGuid().ToString();
             var messageToAdd = new Message(
                 new MessageHeader(messageId, "test_topic", MessageType.MT_DOCUMENT), 
                 new MessageBody("message body"));
@@ -77,7 +77,7 @@ namespace Paramore.Brighter.InMemory.Tests.Outbox
                    ExpirationScanInterval = TimeSpan.FromMilliseconds(10000)
                };
                
-               var messageId = Guid.NewGuid();
+               var messageId = Guid.NewGuid().ToString();
                var messageToAdd = new Message(
                    new MessageHeader(messageId, "test_topic", MessageType.MT_DOCUMENT), 
                    new MessageBody("message body"));

--- a/tests/Paramore.Brighter.InMemory.Tests/Outbox/When_storing_message_in_outbox.cs
+++ b/tests/Paramore.Brighter.InMemory.Tests/Outbox/When_storing_message_in_outbox.cs
@@ -42,7 +42,7 @@ namespace Paramore.Brighter.InMemory.Tests.Outbox
             //Arrange
             var outbox = new InMemoryOutbox();
             
-            var messageId = Guid.NewGuid();
+            var messageId = Guid.NewGuid().ToString();
             var messageToAdd = new Message(
                 new MessageHeader(messageId, "test_topic", MessageType.MT_DOCUMENT), 
                 new MessageBody("message body"));
@@ -68,7 +68,7 @@ namespace Paramore.Brighter.InMemory.Tests.Outbox
             //Arrange
             var outbox = new InMemoryOutbox();
             
-            var messageId = Guid.NewGuid();
+            var messageId = Guid.NewGuid().ToString();
             var messageToAdd = new Message(
                 new MessageHeader(messageId, "test_topic", MessageType.MT_DOCUMENT), 
                 new MessageBody("message body"));
@@ -93,7 +93,7 @@ namespace Paramore.Brighter.InMemory.Tests.Outbox
             //Arrange
             var outbox = new InMemoryOutbox();
             
-            var messageId = Guid.NewGuid();
+            var messageId = Guid.NewGuid().ToString();
             var messageToAdd = new Message(
                 new MessageHeader(messageId, "test_topic", MessageType.MT_DOCUMENT), 
                 new MessageBody("message body"));
@@ -116,7 +116,7 @@ namespace Paramore.Brighter.InMemory.Tests.Outbox
             //Arrange
             var outbox = new InMemoryOutbox();
 
-            var messageIds = new Guid[] { Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), };
+            var messageIds = new string[] { Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), };
             for(int i =0; i <= 4; i++)
                 outbox.Add(new MessageTestDataBuilder().WithId(messageIds[i]));
 
@@ -133,7 +133,7 @@ namespace Paramore.Brighter.InMemory.Tests.Outbox
             //Arrange
             var outbox = new InMemoryOutbox();
 
-            var messageIds = new Guid[] { Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), };
+            var messageIds = new string[] { Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), };
             for(int i =0; i <= 4; i++)
                 outbox.Add(new MessageTestDataBuilder().WithId(messageIds[i]));
 

--- a/tests/Paramore.Brighter.InMemory.Tests/TestDoubles/FakeCommandProcessor.cs
+++ b/tests/Paramore.Brighter.InMemory.Tests/TestDoubles/FakeCommandProcessor.cs
@@ -16,7 +16,7 @@ namespace Paramore.Brighter.InMemory.Tests.TestDoubles
         /// <summary>
         /// Message has been dispatched (to the bus or directly to the handler)
         /// </summary>
-        public readonly ConcurrentDictionary<Guid, IRequest> Dispatched = new ConcurrentDictionary<Guid, IRequest>();
+        public readonly ConcurrentDictionary<string, IRequest> Dispatched = new ConcurrentDictionary<string, IRequest>();
         /// <summary>
         /// Message has been placed into the outbox but not sent or dispatched
         /// </summary>
@@ -73,13 +73,13 @@ namespace Paramore.Brighter.InMemory.Tests.TestDoubles
               return tcs.Task;
         }
         
-        public Guid DepositPost<T>(T request, Dictionary<string, object> args = null) where T : class, IRequest
+        public string DepositPost<T>(T request, Dictionary<string, object> args = null) where T : class, IRequest
         {
             Deposited.Enqueue(new DepositedMessage(request));
             return request.Id;
         }
         
-        public Guid DepositPost<T, TTransaction>(
+        public string DepositPost<T, TTransaction>(
             T request, 
             IAmABoxTransactionProvider<TTransaction> provider,
             Dictionary<string, object> args = null) where T : class, IRequest
@@ -87,9 +87,9 @@ namespace Paramore.Brighter.InMemory.Tests.TestDoubles
             return DepositPost(request);
         }
 
-        public Guid[] DepositPost<T>(IEnumerable<T> request, Dictionary<string, object> args = null) where T : class, IRequest
+        public string[] DepositPost<T>(IEnumerable<T> request, Dictionary<string, object> args = null) where T : class, IRequest
         {
-            var ids = new List<Guid>();
+            var ids = new List<string>();
             foreach (T r in request)
             {
                 ids.Add(DepositPost(r, (IAmABoxTransactionProvider<Transaction>)null, args));
@@ -98,7 +98,7 @@ namespace Paramore.Brighter.InMemory.Tests.TestDoubles
             return ids.ToArray();
         }
         
-        public Guid[] DepositPost<T, TTransaction>(
+        public string[] DepositPost<T, TTransaction>(
             IEnumerable<T> request, 
             IAmABoxTransactionProvider<TTransaction> provider, 
             Dictionary<string, object> args = null) 
@@ -107,14 +107,14 @@ namespace Paramore.Brighter.InMemory.Tests.TestDoubles
             return DepositPost(request, args);
         }
 
-        public Task<Guid> DepositPostAsync<T>(
+        public Task<string> DepositPostAsync<T>(
             T request, 
             Dictionary<string, object> args = null,
             bool continueOnCapturedContext = false, 
             CancellationToken cancellationToken = default) 
             where T : class, IRequest
         {
-            var tcs = new TaskCompletionSource<Guid>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
             
             if(cancellationToken.IsCancellationRequested)
                 tcs.SetCanceled(cancellationToken);
@@ -127,7 +127,7 @@ namespace Paramore.Brighter.InMemory.Tests.TestDoubles
 
         }
         
-        public Task<Guid> DepositPostAsync<T, TTransaction>(
+        public Task<string> DepositPostAsync<T, TTransaction>(
             T request,
             IAmABoxTransactionProvider<TTransaction> provider, 
             Dictionary<string, object> args = null,
@@ -138,13 +138,13 @@ namespace Paramore.Brighter.InMemory.Tests.TestDoubles
             return DepositPostAsync(request, args, continueOnCapturedContext, cancellationToken);
         }
 
-        public async Task<Guid[]> DepositPostAsync<T>(
+        public async Task<string[]> DepositPostAsync<T>(
             IEnumerable<T> requests,
             Dictionary<string, object> args = null,
             bool continueOnCapturedContext = false,
             CancellationToken cancellationToken = default) where T : class, IRequest
         {
-            var ids = new List<Guid>();
+            var ids = new List<string>();
             foreach (T r in requests)
             {
                 ids.Add(await DepositPostAsync(r, cancellationToken: cancellationToken));
@@ -153,7 +153,7 @@ namespace Paramore.Brighter.InMemory.Tests.TestDoubles
             return ids.ToArray();
         }
         
-        public async Task<Guid[]> DepositPostAsync<T, TTransaction>(
+        public async Task<string[]> DepositPostAsync<T, TTransaction>(
             IEnumerable<T> requests, 
             IAmABoxTransactionProvider<TTransaction> provider, 
             Dictionary<string, object> args = null,
@@ -163,7 +163,7 @@ namespace Paramore.Brighter.InMemory.Tests.TestDoubles
             return await DepositPostAsync(requests, args, continueOnCapturedContext, cancellationToken);
         }
 
-        public void ClearOutbox(Guid[] posts, Dictionary<string, object> args = null)
+        public void ClearOutbox(string[] posts, Dictionary<string, object> args = null)
         {
             foreach (var post in posts)
             {
@@ -185,19 +185,19 @@ namespace Paramore.Brighter.InMemory.Tests.TestDoubles
         }
 
         public Task ClearOutboxAsync(
-            IEnumerable<Guid> posts, 
+            IEnumerable<string> posts, 
             Dictionary<string, object> args = null, 
             bool continueOnCapturedContext = false, 
             CancellationToken cancellationToken = default)
         {
-            var tcs = new TaskCompletionSource<Guid>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
             
             if(cancellationToken.IsCancellationRequested)
                 tcs.SetCanceled(cancellationToken);
 
             ClearOutbox(posts.ToArray());
 
-            tcs.SetResult(Guid.Empty);
+            tcs.SetResult(string.Empty);
             
             return tcs.Task;
         }
@@ -212,7 +212,7 @@ namespace Paramore.Brighter.InMemory.Tests.TestDoubles
         }
 
         public Task BulkClearOutboxAsync(
-            IEnumerable<Guid> posts, 
+            IEnumerable<string> posts, 
             bool continueOnCapturedContext = false,
             CancellationToken cancellationToken = default)
         {

--- a/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/When_a_message_is_acknowledged_update_offset.cs
+++ b/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/When_a_message_is_acknowledged_update_offset.cs
@@ -50,10 +50,10 @@ namespace Paramore.Brighter.Kafka.Tests.MessagingGateway
             var groupId = Guid.NewGuid().ToString();
             
             //send x messages to Kafka
-            var sentMessages = new Guid[10];
+            var sentMessages = new string[10];
             for (int i = 0; i < 10; i++)
             {
-                var msgId = Guid.NewGuid();
+                var msgId = Guid.NewGuid().ToString();
                 SendMessage(msgId);
                 sentMessages[i] = msgId;
             }
@@ -81,11 +81,14 @@ namespace Paramore.Brighter.Kafka.Tests.MessagingGateway
             }
         }
 
-        private void SendMessage(Guid messageId)
+        private void SendMessage(string messageId)
         {
-            ((IAmAMessageProducerSync)_producerRegistry.LookupBy(_topic)).Send(new Message(
-                new MessageHeader(messageId, _topic, MessageType.MT_COMMAND) {PartitionKey = _partitionKey},
-                new MessageBody($"test content [{_queueName}]")));
+            ((IAmAMessageProducerSync)_producerRegistry.LookupBy(_topic)).Send(
+                new Message(
+                    new MessageHeader(messageId, _topic, MessageType.MT_COMMAND) {PartitionKey = _partitionKey},
+                    new MessageBody($"test content [{_queueName}]")
+                )
+            );
         }
 
         private Message[] ConsumeMessages(string groupId, int batchLimit)

--- a/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/When_a_set_of_messages_is_sent_preserve_order.cs
+++ b/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/When_a_set_of_messages_is_sent_preserve_order.cs
@@ -88,16 +88,19 @@ namespace Paramore.Brighter.Kafka.Tests.MessagingGateway
             }
         }
 
-        private Guid SendMessage()
+        private string SendMessage()
         {
-            var messageId = Guid.NewGuid();
+            var messageId = Guid.NewGuid().ToString();
 
-            ((IAmAMessageProducerSync)_producerRegistry.LookupBy(_topic)).Send(new Message(
-                new MessageHeader(messageId, _topic, MessageType.MT_COMMAND)
-                {
-                    PartitionKey = _partitionKey
-                },
-                new MessageBody($"test content [{_queueName}]")));
+            ((IAmAMessageProducerSync)_producerRegistry.LookupBy(_topic)).Send(
+                new Message(
+                    new MessageHeader(messageId, _topic, MessageType.MT_COMMAND)
+                    {
+                        PartitionKey = _partitionKey
+                    },
+                    new MessageBody($"test content [{_queueName}]")
+                )
+            );
 
             return messageId;
         }

--- a/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/When_a_set_of_messages_is_sent_preserve_order_on_a_confluent_cluster.cs
+++ b/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/When_a_set_of_messages_is_sent_preserve_order_on_a_confluent_cluster.cs
@@ -109,16 +109,19 @@ namespace Paramore.Brighter.Kafka.Tests.MessagingGateway
             }
         }
 
-        private Guid SendMessage()
+        private string SendMessage()
         {
-            var messageId = Guid.NewGuid();
+            var messageId = Guid.NewGuid().ToString();
 
-            ((IAmAMessageProducerSync)_producerRegistry.LookupBy(_topic)).Send(new Message(
-                new MessageHeader(messageId, _topic, MessageType.MT_COMMAND)
-                {
-                    PartitionKey = _partitionKey
-                },
-                new MessageBody($"test content [{_queueName}]")));
+            ((IAmAMessageProducerSync)_producerRegistry.LookupBy(_topic)).Send(
+                new Message(
+                    new MessageHeader(messageId, _topic, MessageType.MT_COMMAND)
+                    {
+                        PartitionKey = _partitionKey
+                    },
+                    new MessageBody($"test content [{_queueName}]")
+                    )
+            );
 
             return messageId;
         }

--- a/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/When_consumer_assumes_topic_but_missing.cs
+++ b/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/When_consumer_assumes_topic_but_missing.cs
@@ -75,16 +75,17 @@ namespace Paramore.Brighter.Kafka.Tests.MessagingGateway
         public void When_a_consumer_declares_topics()
         {
             var message = new Message(
-                new MessageHeader(Guid.NewGuid(), _topic, MessageType.MT_COMMAND)
+                new MessageHeader(Guid.NewGuid().ToString(), _topic, MessageType.MT_COMMAND)
                 {
                     PartitionKey = _partitionKey
                 },
-                new MessageBody($"test content [{_queueName}]"));
+                new MessageBody($"test content [{_queueName}]")
+            );
             
             bool messagePublished = false;
             var producer = _producerRegistry.LookupBy(_topic);
             var producerConfirm = producer as ISupportPublishConfirmation;
-            producerConfirm.OnMessagePublished += delegate(bool success, Guid id)
+            producerConfirm.OnMessagePublished += delegate(bool success, string id)
             {
                 if (success) messagePublished = true;
             };

--- a/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/When_consumer_assumes_topic_but_missing_on_a_confluent_cluster.cs
+++ b/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/When_consumer_assumes_topic_but_missing_on_a_confluent_cluster.cs
@@ -96,18 +96,19 @@ namespace Paramore.Brighter.Kafka.Tests.MessagingGateway
         public void When_a_consumer_declares_topics_on_a_confluent_cluster()
         {
             var message = new Message(
-                new MessageHeader(Guid.NewGuid(), _topic, MessageType.MT_COMMAND)
+                new MessageHeader(Guid.NewGuid().ToString(), _topic, MessageType.MT_COMMAND)
                 {
                     PartitionKey = _partitionKey
                 },
-                new MessageBody($"test content [{_queueName}]"));
+                new MessageBody($"test content [{_queueName}]")
+            );
 
             bool messagePublished = false;
             
             
             var producer = _producerRegistry.LookupBy(_topic);
             var producerConfirm = producer as ISupportPublishConfirmation;
-            producerConfirm.OnMessagePublished += delegate(bool success, Guid id)
+            producerConfirm.OnMessagePublished += delegate(bool success, string id)
             {
                 if (success) messagePublished = true;
             };

--- a/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/When_consumer_declares_topic.cs
+++ b/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/When_consumer_declares_topic.cs
@@ -87,11 +87,12 @@ namespace Paramore.Brighter.Kafka.Tests.MessagingGateway
         public async Task When_a_consumer_declares_topics()
         {
             var message = new Message(
-                new MessageHeader(Guid.NewGuid(), _topic, MessageType.MT_COMMAND)
+                new MessageHeader(Guid.NewGuid().ToString(), _topic, MessageType.MT_COMMAND)
                 {
                     PartitionKey = _partitionKey
                 },
-                new MessageBody($"test content [{_queueName}]"));
+                new MessageBody($"test content [{_queueName}]")
+            );
             
             //This should fail, if consumer can't create the topic as set to Assume
             ((IAmAMessageProducerSync)_producerRegistry.LookupBy(_topic)).Send(message);

--- a/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/When_consumer_declares_topic_on_a_confluent_cluster.cs
+++ b/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/When_consumer_declares_topic_on_a_confluent_cluster.cs
@@ -121,7 +121,7 @@ namespace Paramore.Brighter.Kafka.Tests.MessagingGateway
         public async Task When_a_consumer_declares_topics_on_a_confluent_cluster()
         {
             var message = new Message(
-                new MessageHeader(Guid.NewGuid(), _topic, MessageType.MT_COMMAND)
+                new MessageHeader(Guid.NewGuid().ToString(), _topic, MessageType.MT_COMMAND)
                 {
                     PartitionKey = _partitionKey
                 },

--- a/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/When_converting_brighterheader_to_kafkaheader.cs
+++ b/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/When_converting_brighterheader_to_kafkaheader.cs
@@ -18,11 +18,11 @@ public class KafkaDefaultMessageHeaderBuilderTests
         //arrange
         var message = new Message(
             new MessageHeader(
-                messageId: Guid.NewGuid(),
+                messageId: Guid.NewGuid().ToString(),
                 topic: "test",
                 messageType: MessageType.MT_COMMAND,
                 timeStamp: DateTime.UtcNow,
-                correlationId: Guid.NewGuid(),
+                correlationId: Guid.NewGuid().ToString(),
                 replyTo: "test",
                 contentType: "application/octet",
                 partitionKey: "mykey"

--- a/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/When_converting_kafkaheader_to_brighterheader.cs
+++ b/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/When_converting_kafkaheader_to_brighterheader.cs
@@ -17,11 +17,11 @@ public class KafkaHeaderToBrighterTests
         
         var message = new Message(
             new MessageHeader(
-                messageId: Guid.NewGuid(),
+                messageId: Guid.NewGuid().ToString(),
                 topic: "test",
                 messageType: MessageType.MT_COMMAND,
                 timeStamp: DateTime.UtcNow,
-                correlationId: Guid.NewGuid(),
+                correlationId: Guid.NewGuid().ToString(),
                 replyTo: "test",
                 contentType: "application/octet",
                 partitionKey: "mykey"
@@ -33,7 +33,7 @@ public class KafkaHeaderToBrighterTests
         message.Header.HandledCount = 2;
 
         Dictionary<string,object> bag = message.Header.Bag;
-        bag.Add("myguid", Guid.NewGuid());
+        bag.Add("myguid", Guid.NewGuid().ToString());
         bag.Add("mystring", "string value");
         bag.Add("myint", 7);
         bag.Add("mydouble", 3.56);

--- a/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/When_offsets_awaiting_next_acknowledge_sweep_them.cs
+++ b/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/When_offsets_awaiting_next_acknowledge_sweep_them.cs
@@ -69,10 +69,10 @@ namespace Paramore.Brighter.Kafka.Tests.MessagingGateway
             var groupId = Guid.NewGuid().ToString();
             
             //send x messages to Kafka
-            var sentMessages = new Guid[10];
+            var sentMessages = new string[10];
             for (int i = 0; i < 10; i++)
             {
-                var msgId = Guid.NewGuid();
+                var msgId = Guid.NewGuid().ToString();
                 SendMessage(msgId);
                 sentMessages[i] = msgId;
             }
@@ -129,7 +129,7 @@ namespace Paramore.Brighter.Kafka.Tests.MessagingGateway
             }
         }
 
-        private void SendMessage(Guid messageId)
+        private void SendMessage(string messageId)
         {
             ((IAmAMessageProducerSync)_producerRegistry.LookupBy(_topic)).Send(new Message(
                 new MessageHeader(messageId, _topic, MessageType.MT_COMMAND) {PartitionKey = _partitionKey},

--- a/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/When_posting_a_message.cs
+++ b/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/When_posting_a_message.cs
@@ -96,13 +96,13 @@ namespace Paramore.Brighter.Kafka.Tests.MessagingGateway
             var body = JsonSerializer.Serialize(command, JsonSerialisationOptions.Options);
 
             var message = new Message(
-                new MessageHeader(Guid.NewGuid(), _topic, MessageType.MT_COMMAND)
+                new MessageHeader(Guid.NewGuid().ToString(), _topic, MessageType.MT_COMMAND)
                 {
                     PartitionKey = _partitionKey,
                     ContentType = "application/json",
                     Bag = new Dictionary<string, object>{{"Test Header", "Test Value"},},
                     ReplyTo = "com.brightercommand.replyto",
-                    CorrelationId = Guid.NewGuid(),
+                    CorrelationId = Guid.NewGuid().ToString(),
                     DelayedMilliseconds = 10,
                     HandledCount = 2,
                     TimeStamp = DateTime.UtcNow

--- a/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/When_posting_a_message_to_a_confluent_cluster.cs
+++ b/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/When_posting_a_message_to_a_confluent_cluster.cs
@@ -117,7 +117,7 @@ namespace Paramore.Brighter.Kafka.Tests.MessagingGateway
         public async Task When_posting_a_message_to_a_confluent_cluster()
         {
             var message = new Message(
-                new MessageHeader(Guid.NewGuid(), _topic, MessageType.MT_COMMAND)
+                new MessageHeader(Guid.NewGuid().ToString(), _topic, MessageType.MT_COMMAND)
                 {
                     PartitionKey = _partitionKey
                 },

--- a/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/When_posting_a_message_with_header_bytes.cs
+++ b/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/When_posting_a_message_with_header_bytes.cs
@@ -114,7 +114,7 @@ namespace Paramore.Brighter.Kafka.Tests.MessagingGateway
             var schemaId = IPAddress.NetworkToHostOrder(BitConverter.ToInt32(body.Skip(1).Take(4).ToArray()));
 
             var sent = new Message(
-                new MessageHeader(Guid.NewGuid(), _topic, MessageType.MT_COMMAND)
+                new MessageHeader(Guid.NewGuid().ToString(), _topic, MessageType.MT_COMMAND)
                 {
                     PartitionKey = _partitionKey
                 },

--- a/tests/Paramore.Brighter.MSSQL.Tests/Inbox/When_there_Is_no_message_in_the_sql_inbox_async.cs
+++ b/tests/Paramore.Brighter.MSSQL.Tests/Inbox/When_there_Is_no_message_in_the_sql_inbox_async.cs
@@ -49,7 +49,7 @@ namespace Paramore.Brighter.MSSQL.Tests.Inbox
         [Fact]
         public async Task When_There_Is_No_Message_In_The_Sql_Inbox_And_I_Get_Async()
         {
-            Guid commandId = Guid.NewGuid();
+            string commandId = Guid.NewGuid().ToString();
             var exception = await Catch.ExceptionAsync(() => _sqlInbox.GetAsync<MyCommand>(commandId, "some-key"));
             AssertionExtensions.Should(exception).BeOfType<RequestNotFoundException<MyCommand>>();
         }
@@ -57,7 +57,7 @@ namespace Paramore.Brighter.MSSQL.Tests.Inbox
         [Fact]
         public async Task When_There_Is_No_Message_In_The_Sql_Inbox_And_I_Check_Exists_Async()
         {
-            Guid commandId = Guid.NewGuid();
+            string commandId = Guid.NewGuid().ToString();
             bool exists = await _sqlInbox.ExistsAsync<MyCommand>(commandId, "some-key");
             exists.Should().BeFalse();
         }

--- a/tests/Paramore.Brighter.MSSQL.Tests/Inbox/When_there_is_no_message_in_the_sql_inbox.cs
+++ b/tests/Paramore.Brighter.MSSQL.Tests/Inbox/When_there_is_no_message_in_the_sql_inbox.cs
@@ -37,7 +37,6 @@ namespace Paramore.Brighter.MSSQL.Tests.Inbox
         private readonly MsSqlTestHelper _msSqlTestHelper;
         private readonly MsSqlInbox _sqlInbox;
         private readonly string _contextKey;
-        private MyCommand _storedCommand;
 
         public SqlInboxEmptyWhenSearchedTests()
         {
@@ -51,8 +50,8 @@ namespace Paramore.Brighter.MSSQL.Tests.Inbox
         [Fact]
         public void When_There_Is_No_Message_In_The_Sql_Inbox_And_Call_Get()
         {
-            Guid commandId = Guid.NewGuid();
-            var exception = Catch.Exception(() => _storedCommand = _sqlInbox.Get<MyCommand>(commandId, _contextKey));
+            string commandId = Guid.NewGuid().ToString();
+            var exception = Catch.Exception(() => _sqlInbox.Get<MyCommand>(commandId, _contextKey));
 
             AssertionExtensions.Should(exception).BeOfType<RequestNotFoundException<MyCommand>>();
         }
@@ -60,7 +59,7 @@ namespace Paramore.Brighter.MSSQL.Tests.Inbox
         [Fact]
         public void When_There_Is_No_Message_In_The_Sql_Inbox_And_Call_Exists()
         {
-            Guid commandId = Guid.NewGuid();
+            string commandId = Guid.NewGuid().ToString();
             _sqlInbox.Exists<MyCommand>(commandId, _contextKey).Should().BeFalse();
         }
 

--- a/tests/Paramore.Brighter.MSSQL.Tests/MessagingGateway/When_a_message_is_sent_keep_order.cs
+++ b/tests/Paramore.Brighter.MSSQL.Tests/MessagingGateway/When_a_message_is_sent_keep_order.cs
@@ -67,9 +67,9 @@ namespace Paramore.Brighter.MSSQL.Tests.MessagingGateway
             }
         }
 
-        private Guid SendMessage()
+        private string SendMessage()
         {
-            var messageId = Guid.NewGuid();
+            var messageId = Guid.NewGuid().ToString();
 
             ((IAmAMessageProducerSync)_producerRegistry.LookupBy(_topic)).Send(new Message(
                 new MessageHeader(messageId, _topic, MessageType.MT_COMMAND),

--- a/tests/Paramore.Brighter.MSSQL.Tests/MessagingGateway/When_queue_is_Purged.cs
+++ b/tests/Paramore.Brighter.MSSQL.Tests/MessagingGateway/When_queue_is_Purged.cs
@@ -64,9 +64,9 @@ namespace Paramore.Brighter.MSSQL.Tests.MessagingGateway
             }
         }
 
-        private Guid SendMessage()
+        private string SendMessage()
         {
-            var messageId = Guid.NewGuid();
+            var messageId = Guid.NewGuid().ToString();
 
             ((IAmAMessageProducerSync)_producerRegistry.LookupBy(_topic)).Send(new Message(
                 new MessageHeader(messageId, _topic, MessageType.MT_COMMAND),
@@ -107,7 +107,7 @@ namespace Paramore.Brighter.MSSQL.Tests.MessagingGateway
 
         public ExampleCommand()
         {
-            Id = new Guid();
+            Id = Guid.NewGuid().ToString();
         }
         
         /// <summary>

--- a/tests/Paramore.Brighter.MSSQL.Tests/MessagingGateway/When_queue_is_Purged.cs
+++ b/tests/Paramore.Brighter.MSSQL.Tests/MessagingGateway/When_queue_is_Purged.cs
@@ -103,7 +103,7 @@ namespace Paramore.Brighter.MSSQL.Tests.MessagingGateway
     public class ExampleCommand : ICommand
     {
 
-        public Guid Id { get; set; }
+        public string Id { get; set; }
 
         public ExampleCommand()
         {

--- a/tests/Paramore.Brighter.MSSQL.Tests/MessagingGateway/When_requeueing_a_message.cs
+++ b/tests/Paramore.Brighter.MSSQL.Tests/MessagingGateway/When_requeueing_a_message.cs
@@ -19,7 +19,7 @@ namespace Paramore.Brighter.MSSQL.Tests.MessagingGateway
         public MsSqlMessageConsumerRequeueTests()
         {
             var myCommand = new MyCommand { Value = "Test" };
-            Guid correlationId = Guid.NewGuid();
+            string correlationId = Guid.NewGuid().ToString();
             string replyTo = "http:\\queueUrl";
             string contentType = "text\\plain";
             var channelName = $"Consumer-Requeue-Tests-{Guid.NewGuid()}";

--- a/tests/Paramore.Brighter.MSSQL.Tests/Outbox/When_Retrieving_Messages_To_Archive.cs
+++ b/tests/Paramore.Brighter.MSSQL.Tests/Outbox/When_Retrieving_Messages_To_Archive.cs
@@ -23,11 +23,11 @@ public class MsSqlArchiveFetchTests : IDisposable
         _msSqlTestHelper.SetupMessageDb();
 
         _sqlOutbox = new MsSqlOutbox(_msSqlTestHelper.OutboxConfiguration);
-        _messageEarliest = new Message(new MessageHeader(Guid.NewGuid(), "test_topic", MessageType.MT_DOCUMENT),
+        _messageEarliest = new Message(new MessageHeader(Guid.NewGuid().ToString(), "test_topic", MessageType.MT_DOCUMENT),
             new MessageBody("message body"));
-        _messageDispatched = new Message(new MessageHeader(Guid.NewGuid(), "test_topic", MessageType.MT_DOCUMENT),
+        _messageDispatched = new Message(new MessageHeader(Guid.NewGuid().ToString(), "test_topic", MessageType.MT_DOCUMENT),
             new MessageBody("message body"));
-        _messageUnDispatched = new Message(new MessageHeader(Guid.NewGuid(), "test_topic", MessageType.MT_DOCUMENT),
+        _messageUnDispatched = new Message(new MessageHeader(Guid.NewGuid().ToString(), "test_topic", MessageType.MT_DOCUMENT),
             new MessageBody("message body"));
     }
     

--- a/tests/Paramore.Brighter.MSSQL.Tests/Outbox/When_removing_messages_from_the_message_store.cs
+++ b/tests/Paramore.Brighter.MSSQL.Tests/Outbox/When_removing_messages_from_the_message_store.cs
@@ -50,9 +50,18 @@ namespace Paramore.Brighter.MSSQL.Tests.Outbox
 
             _outbox = new MsSqlOutbox(_msSqlTestHelper.OutboxConfiguration);
             
-            _firstMessage = new Message(new MessageHeader(Guid.NewGuid(), "Test", MessageType.MT_COMMAND, DateTime.UtcNow.AddHours(-3)), new MessageBody("Body"));
-            _secondMessage = new Message(new MessageHeader(Guid.NewGuid(), "Test2", MessageType.MT_COMMAND, DateTime.UtcNow.AddHours(-2)), new MessageBody("Body2"));
-            _thirdMessage = new Message(new MessageHeader(Guid.NewGuid(), "Test3", MessageType.MT_COMMAND, DateTime.UtcNow.AddHours(-1)), new MessageBody("Body3"));
+            _firstMessage = new Message(
+                new MessageHeader(Guid.NewGuid().ToString(), "Test", MessageType.MT_COMMAND, DateTime.UtcNow.AddHours(-3)), 
+                new MessageBody("Body")
+            );
+            _secondMessage = new Message(
+                new MessageHeader(Guid.NewGuid().ToString(), "Test2", MessageType.MT_COMMAND, DateTime.UtcNow.AddHours(-2)), 
+                new MessageBody("Body2")
+            );
+            _thirdMessage = new Message(
+                new MessageHeader(Guid.NewGuid().ToString(), "Test3", MessageType.MT_COMMAND, DateTime.UtcNow.AddHours(-1)), 
+                new MessageBody("Body3")
+            );
             
             _outbox.Add(_firstMessage);
             _outbox.Add(_secondMessage);
@@ -62,7 +71,7 @@ namespace Paramore.Brighter.MSSQL.Tests.Outbox
         [Fact]
         public void When_Removing_Messages_From_The_Outbox()
         {
-            _outbox.Delete(new Guid[]{_firstMessage.Id});
+            _outbox.Delete([_firstMessage.Id]);
 
             var remainingMessages = _outbox.OutstandingMessages(0);
 
@@ -80,7 +89,7 @@ namespace Paramore.Brighter.MSSQL.Tests.Outbox
         [Fact]
         public async Task When_Removing_Messages_From_The_OutboxAsync()
         {
-            await _outbox.DeleteAsync(new Guid[] {_firstMessage.Id}, cancellationToken: CancellationToken.None);
+            await _outbox.DeleteAsync([_firstMessage.Id], cancellationToken: CancellationToken.None);
 
             var remainingMessages = await _outbox.OutstandingMessagesAsync(0);
 

--- a/tests/Paramore.Brighter.MSSQL.Tests/Outbox/When_the_message_is_already_in_the_message_store_async.cs
+++ b/tests/Paramore.Brighter.MSSQL.Tests/Outbox/When_the_message_is_already_in_the_message_store_async.cs
@@ -45,7 +45,10 @@ namespace Paramore.Brighter.MSSQL.Tests.Outbox
             _msSqlTestHelper.SetupMessageDb();
 
             _sqlOutbox = new MsSqlOutbox(_msSqlTestHelper.OutboxConfiguration);
-            _messageEarliest = new Message(new MessageHeader(Guid.NewGuid(), "test_topic", MessageType.MT_DOCUMENT), new MessageBody("message body"));
+            _messageEarliest = new Message(
+                new MessageHeader(Guid.NewGuid().ToString(), "test_topic", MessageType.MT_DOCUMENT), 
+                new MessageBody("message body")
+            );
         }
 
         [Fact]

--- a/tests/Paramore.Brighter.MSSQL.Tests/Outbox/When_the_message_is_already_in_the_outbox.cs
+++ b/tests/Paramore.Brighter.MSSQL.Tests/Outbox/When_the_message_is_already_in_the_outbox.cs
@@ -44,7 +44,10 @@ namespace Paramore.Brighter.MSSQL.Tests.Outbox
             _msSqlTestHelper.SetupMessageDb();
 
             _sqlOutbox = new MsSqlOutbox(_msSqlTestHelper.OutboxConfiguration);
-            _messageEarliest = new Message(new MessageHeader(Guid.NewGuid(), "test_topic", MessageType.MT_DOCUMENT), new MessageBody("message body"));
+            _messageEarliest = new Message(
+                new MessageHeader(Guid.NewGuid().ToString(), "test_topic", MessageType.MT_DOCUMENT), 
+                new MessageBody("message body")
+            );
             _sqlOutbox.Add(_messageEarliest);
         }
 

--- a/tests/Paramore.Brighter.MSSQL.Tests/Outbox/When_there_is_an_outstanding_message_in_the_outbox.cs
+++ b/tests/Paramore.Brighter.MSSQL.Tests/Outbox/When_there_is_an_outstanding_message_in_the_outbox.cs
@@ -20,7 +20,7 @@ namespace Paramore.Brighter.MSSQL.Tests.Outbox
             _msSqlTestHelper.SetupMessageDb();
 
             _sqlOutbox = new MsSqlOutbox(_msSqlTestHelper.OutboxConfiguration);
-            _dispatchedMessage = new Message(new MessageHeader(Guid.NewGuid(), "test_topic", MessageType.MT_DOCUMENT), new MessageBody("message body"));
+            _dispatchedMessage = new Message(new MessageHeader(Guid.NewGuid().ToString(), "test_topic", MessageType.MT_DOCUMENT), new MessageBody("message body"));
             _sqlOutbox.Add(_dispatchedMessage);
 
             //wait to create an outstanding period

--- a/tests/Paramore.Brighter.MSSQL.Tests/Outbox/When_there_is_no_message_in_the_sql_message_store.cs
+++ b/tests/Paramore.Brighter.MSSQL.Tests/Outbox/When_there_is_no_message_in_the_sql_message_store.cs
@@ -44,7 +44,7 @@ namespace Paramore.Brighter.MSSQL.Tests.Outbox
             _msSqlTestHelper.SetupMessageDb();
 
             _sqlOutbox = new MsSqlOutbox(_msSqlTestHelper.OutboxConfiguration);
-            _messageEarliest = new Message(new MessageHeader(Guid.NewGuid(), "test_topic", MessageType.MT_DOCUMENT), new MessageBody("message body"));
+            _messageEarliest = new Message(new MessageHeader(Guid.NewGuid().ToString(), "test_topic", MessageType.MT_DOCUMENT), new MessageBody("message body"));
         }
 
         [Fact]

--- a/tests/Paramore.Brighter.MSSQL.Tests/Outbox/When_there_is_no_message_in_the_sql_message_store_async.cs
+++ b/tests/Paramore.Brighter.MSSQL.Tests/Outbox/When_there_is_no_message_in_the_sql_message_store_async.cs
@@ -45,7 +45,10 @@ namespace Paramore.Brighter.MSSQL.Tests.Outbox
             _msSqlTestHelper.SetupMessageDb();
 
             _sqlOutbox = new MsSqlOutbox(_msSqlTestHelper.OutboxConfiguration);
-            _messageEarliest = new Message(new MessageHeader(Guid.NewGuid(), "test_topic", MessageType.MT_DOCUMENT), new MessageBody("message body"));
+            _messageEarliest = new Message(
+                new MessageHeader(Guid.NewGuid().ToString(), "test_topic", MessageType.MT_DOCUMENT), 
+                new MessageBody("message body")
+            );
         }
 
         [Fact]

--- a/tests/Paramore.Brighter.MSSQL.Tests/Outbox/When_writing_a_message_to_a_binary_body_message_store.cs
+++ b/tests/Paramore.Brighter.MSSQL.Tests/Outbox/When_writing_a_message_to_a_binary_body_message_store.cs
@@ -31,13 +31,13 @@ namespace Paramore.Brighter.MSSQL.Tests.Outbox
 
             _sqlOutbox = new MsSqlOutbox(_msSqlTestHelper.OutboxConfiguration);
             _messageHeader = new MessageHeader(
-                messageId: Guid.NewGuid(),
+                messageId: Guid.NewGuid().ToString(),
                 topic: "test_topic",
                 messageType: MessageType.MT_DOCUMENT,
                 timeStamp: DateTime.UtcNow.AddDays(-1),
                 handledCount: 5,
                 delayedMilliseconds: 5,
-                correlationId: Guid.NewGuid(),
+                correlationId: Guid.NewGuid().ToString(),
                 replyTo: "ReplyAddress",
                 contentType: "application/octet-stream",
                 partitionKey: "123456789");

--- a/tests/Paramore.Brighter.MSSQL.Tests/Outbox/When_writing_a_message_to_the_message_store.cs
+++ b/tests/Paramore.Brighter.MSSQL.Tests/Outbox/When_writing_a_message_to_the_message_store.cs
@@ -56,13 +56,13 @@ namespace Paramore.Brighter.MSSQL.Tests.Outbox
 
             _sqlOutbox = new MsSqlOutbox(_msSqlTestHelper.OutboxConfiguration);
             _messageHeader = new MessageHeader(
-                messageId:Guid.NewGuid(),
+                messageId:Guid.NewGuid().ToString(),
                 topic: "test_topic", 
                 messageType: MessageType.MT_DOCUMENT, 
                 timeStamp: DateTime.UtcNow.AddDays(-1), 
                 handledCount:5, 
                 delayedMilliseconds:5,
-                correlationId: Guid.NewGuid(),
+                correlationId: Guid.NewGuid().ToString(),
                 replyTo: "ReplyAddress",
                 contentType: "text/plain",
                 partitionKey: Guid.NewGuid().ToString());

--- a/tests/Paramore.Brighter.MSSQL.Tests/Outbox/When_writing_a_message_to_the_message_store_async.cs
+++ b/tests/Paramore.Brighter.MSSQL.Tests/Outbox/When_writing_a_message_to_the_message_store_async.cs
@@ -44,7 +44,7 @@ namespace Paramore.Brighter.MSSQL.Tests.Outbox
         private readonly string _value1 = "value1";
         private readonly string _value2 = "value2";
         private readonly int _value3 = 123;
-        private readonly string _value4 = Guid.NewGuid().ToString();
+        private readonly Guid _value4 = Guid.NewGuid();
         private readonly DateTime _value5 = DateTime.UtcNow;
         private readonly MsSqlTestHelper _msSqlTestHelper;
 

--- a/tests/Paramore.Brighter.MSSQL.Tests/Outbox/When_writing_a_message_to_the_message_store_async.cs
+++ b/tests/Paramore.Brighter.MSSQL.Tests/Outbox/When_writing_a_message_to_the_message_store_async.cs
@@ -44,7 +44,7 @@ namespace Paramore.Brighter.MSSQL.Tests.Outbox
         private readonly string _value1 = "value1";
         private readonly string _value2 = "value2";
         private readonly int _value3 = 123;
-        private readonly Guid _value4 = Guid.NewGuid();
+        private readonly string _value4 = Guid.NewGuid().ToString();
         private readonly DateTime _value5 = DateTime.UtcNow;
         private readonly MsSqlTestHelper _msSqlTestHelper;
 
@@ -55,13 +55,13 @@ namespace Paramore.Brighter.MSSQL.Tests.Outbox
 
             _sqlOutbox = new MsSqlOutbox(_msSqlTestHelper.OutboxConfiguration);
             var messageHeader = new MessageHeader(
-                messageId:Guid.NewGuid(),
+                messageId:Guid.NewGuid().ToString(),
                 topic: "test_topic", 
                 messageType: MessageType.MT_DOCUMENT, 
                 timeStamp: DateTime.UtcNow.AddDays(-1), 
                 handledCount:5, 
                 delayedMilliseconds:5,
-                correlationId: Guid.NewGuid(),
+                correlationId: Guid.NewGuid().ToString(),
                 replyTo: "ReplyAddress",
                 contentType: "text/plain");
             messageHeader.Bag.Add(_key1, _value1);

--- a/tests/Paramore.Brighter.MySQL.Tests/Inbox/When_there_Is_no_message_in_the_sql_inbox_async.cs
+++ b/tests/Paramore.Brighter.MySQL.Tests/Inbox/When_there_Is_no_message_in_the_sql_inbox_async.cs
@@ -51,7 +51,7 @@ namespace Paramore.Brighter.MySQL.Tests.Inbox
         [Fact]
         public async Task When_There_Is_No_Message_In_The_Sql_Inbox_Get_Async()
         {
-            Guid commandId = Guid.NewGuid();
+            string commandId = Guid.NewGuid().ToString();
             var exception = await Catch.ExceptionAsync(() => _mysqlInbox.GetAsync<MyCommand>(commandId, _contextKey));
             exception.Should().BeOfType<RequestNotFoundException<MyCommand>>();
         }
@@ -59,7 +59,7 @@ namespace Paramore.Brighter.MySQL.Tests.Inbox
         [Fact]
         public async Task When_There_Is_No_Message_In_The_Sql_Inbox_Exists_Async()
         {
-            Guid commandId = Guid.NewGuid();
+            string commandId = Guid.NewGuid().ToString();
             bool exists = await _mysqlInbox.ExistsAsync<MyCommand>(commandId, _contextKey);
             exists.Should().BeFalse();
         }

--- a/tests/Paramore.Brighter.MySQL.Tests/Inbox/When_there_is_no_message_in_the_sql_inbox.cs
+++ b/tests/Paramore.Brighter.MySQL.Tests/Inbox/When_there_is_no_message_in_the_sql_inbox.cs
@@ -50,7 +50,7 @@ namespace Paramore.Brighter.MySQL.Tests.Inbox
         [Fact]
         public void When_There_Is_No_Message_In_The_Sql_Inbox_Get()
         {
-            Guid commandId = Guid.NewGuid();
+            string commandId = Guid.NewGuid().ToString();
             var exception = Catch.Exception(() => _mysqlInBox.Get<MyCommand>(commandId, _contextKey));
             exception.Should().BeOfType<RequestNotFoundException<MyCommand>>();
         }
@@ -58,7 +58,7 @@ namespace Paramore.Brighter.MySQL.Tests.Inbox
         [Fact]
         public void When_There_Is_No_Message_In_The_Sql_Inbox_Exists()
         {
-            Guid commandId = Guid.NewGuid();
+            string commandId = Guid.NewGuid().ToString();
             _mysqlInBox.Exists<MyCommand>(commandId, _contextKey).Should().BeFalse();
         }
 

--- a/tests/Paramore.Brighter.MySQL.Tests/Outbox/When_removing_messages_from_the_outbox.cs
+++ b/tests/Paramore.Brighter.MySQL.Tests/Outbox/When_removing_messages_from_the_outbox.cs
@@ -49,9 +49,18 @@ namespace Paramore.Brighter.MySQL.Tests.Outbox
             _mySqlTestHelper.SetupMessageDb();
             _mySqlOutbox = new MySqlOutbox(_mySqlTestHelper.OutboxConfiguration);
 
-            _firstMessage = new Message(new MessageHeader(Guid.NewGuid(), "Test", MessageType.MT_COMMAND, DateTime.UtcNow.AddHours(-3)), new MessageBody("Body"));
-            _secondMessage = new Message(new MessageHeader(Guid.NewGuid(), "Test2", MessageType.MT_COMMAND, DateTime.UtcNow.AddHours(-2)), new MessageBody("Body2"));
-            _thirdMessage = new Message(new MessageHeader(Guid.NewGuid(), "Test3", MessageType.MT_COMMAND, DateTime.UtcNow.AddHours(-1)), new MessageBody("Body3"));
+            _firstMessage = new Message(
+                new MessageHeader(Guid.NewGuid().ToString(), "Test", MessageType.MT_COMMAND, DateTime.UtcNow.AddHours(-3)), 
+                new MessageBody("Body")
+            );
+            _secondMessage = new Message(
+                new MessageHeader(Guid.NewGuid().ToString(), "Test2", MessageType.MT_COMMAND, DateTime.UtcNow.AddHours(-2)), 
+                new MessageBody("Body2")
+            );
+            _thirdMessage = new Message(
+                new MessageHeader(Guid.NewGuid().ToString(), "Test3", MessageType.MT_COMMAND, DateTime.UtcNow.AddHours(-1)), 
+                new MessageBody("Body3")
+            );
             
         }
 
@@ -62,7 +71,7 @@ namespace Paramore.Brighter.MySQL.Tests.Outbox
             _mySqlOutbox.Add(_secondMessage);
             _mySqlOutbox.Add(_thirdMessage);
             
-            _mySqlOutbox.Delete(new Guid[] {_firstMessage.Id});
+            _mySqlOutbox.Delete([_firstMessage.Id]);
 
             var remainingMessages = _mySqlOutbox.OutstandingMessages(0);
 

--- a/tests/Paramore.Brighter.MySQL.Tests/Outbox/When_the_message_is_already_in_the_outbox.cs
+++ b/tests/Paramore.Brighter.MySQL.Tests/Outbox/When_the_message_is_already_in_the_outbox.cs
@@ -44,7 +44,10 @@ namespace Paramore.Brighter.MySQL.Tests.Outbox
             _mySqlTestHelper.SetupMessageDb();
 
             _mySqlOutbox = new MySqlOutbox(_mySqlTestHelper.OutboxConfiguration);
-            _messageEarliest = new Message(new MessageHeader(Guid.NewGuid(), "test_topic", MessageType.MT_DOCUMENT), new MessageBody("message body"));
+            _messageEarliest = new Message(
+                new MessageHeader(Guid.NewGuid().ToString(), "test_topic", MessageType.MT_DOCUMENT), 
+                new MessageBody("message body")
+            );
             _mySqlOutbox.Add(_messageEarliest);
         }
 

--- a/tests/Paramore.Brighter.MySQL.Tests/Outbox/When_the_message_is_already_in_the_outbox_async.cs
+++ b/tests/Paramore.Brighter.MySQL.Tests/Outbox/When_the_message_is_already_in_the_outbox_async.cs
@@ -45,7 +45,10 @@ namespace Paramore.Brighter.MySQL.Tests.Outbox
             _msSqlTestHelper.SetupMessageDb();
 
             _sqlOutbox = new MySqlOutbox(_msSqlTestHelper.OutboxConfiguration);
-            _messageEarliest = new Message(new MessageHeader(Guid.NewGuid(), "test_topic", MessageType.MT_DOCUMENT), new MessageBody("message body"));
+            _messageEarliest = new Message(
+                new MessageHeader(Guid.NewGuid().ToString(), "test_topic", MessageType.MT_DOCUMENT), 
+                new MessageBody("message body")
+            );
         }
 
         [Fact]

--- a/tests/Paramore.Brighter.MySQL.Tests/Outbox/When_there_are_multiple_messages_and_some_are_receivied_and_Dispatched_bulk_Async.cs
+++ b/tests/Paramore.Brighter.MySQL.Tests/Outbox/When_there_are_multiple_messages_and_some_are_receivied_and_Dispatched_bulk_Async.cs
@@ -27,13 +27,13 @@ namespace Paramore.Brighter.MySQL.Tests.Outbox
             _mySqlTestHelper.SetupMessageDb();
 
             _sqlOutbox = new MySqlOutbox(_mySqlTestHelper.OutboxConfiguration);
-            _message = new Message(new MessageHeader(Guid.NewGuid(), _Topic1, MessageType.MT_COMMAND),
+            _message = new Message(new MessageHeader(Guid.NewGuid().ToString(), _Topic1, MessageType.MT_COMMAND),
                 new MessageBody("message body"));
-            _message1 = new Message(new MessageHeader(Guid.NewGuid(), _Topic2, MessageType.MT_EVENT),
+            _message1 = new Message(new MessageHeader(Guid.NewGuid().ToString(), _Topic2, MessageType.MT_EVENT),
                 new MessageBody("message body2"));
-            _message2 = new Message(new MessageHeader(Guid.NewGuid(), _Topic1, MessageType.MT_COMMAND),
+            _message2 = new Message(new MessageHeader(Guid.NewGuid().ToString(), _Topic1, MessageType.MT_COMMAND),
                 new MessageBody("message body3"));
-            _message3 = new Message(new MessageHeader(Guid.NewGuid(), _Topic2, MessageType.MT_EVENT),
+            _message3 = new Message(new MessageHeader(Guid.NewGuid().ToString(), _Topic2, MessageType.MT_EVENT),
                 new MessageBody("message body4"));
         }
 

--- a/tests/Paramore.Brighter.MySQL.Tests/Outbox/When_there_are_multiple_outstanding_messages_in_the_outbox_and_messages_within_an_interval_are_fetched.cs
+++ b/tests/Paramore.Brighter.MySQL.Tests/Outbox/When_there_are_multiple_outstanding_messages_in_the_outbox_and_messages_within_an_interval_are_fetched.cs
@@ -25,9 +25,18 @@ namespace Paramore.Brighter.MySQL.Tests.Outbox
             _mySqlTestHelper.SetupMessageDb();
             _mySqlOutbox = new MySqlOutbox(_mySqlTestHelper.OutboxConfiguration);
 
-            _messageEarliest = new Message(new MessageHeader(Guid.NewGuid(), _TopicFirstMessage, MessageType.MT_DOCUMENT), new MessageBody("message body"));
-            _message1 = new Message(new MessageHeader(Guid.NewGuid(), "test_topic2", MessageType.MT_DOCUMENT), new MessageBody("message body2"));
-            _message2 = new Message(new MessageHeader(Guid.NewGuid(), _TopicLastMessage, MessageType.MT_DOCUMENT), new MessageBody("message body3"));
+            _messageEarliest = new Message(
+                new MessageHeader(Guid.NewGuid().ToString(), _TopicFirstMessage, MessageType.MT_DOCUMENT), 
+                new MessageBody("message body")
+            );
+            _message1 = new Message(
+                new MessageHeader(Guid.NewGuid().ToString(), "test_topic2", MessageType.MT_DOCUMENT), 
+                new MessageBody("message body2")
+            );
+            _message2 = new Message(
+                new MessageHeader(Guid.NewGuid().ToString(), _TopicLastMessage, MessageType.MT_DOCUMENT), 
+                new MessageBody("message body3")
+            );
             _mySqlOutbox.Add(_messageEarliest);
             Thread.Sleep(100);
             _mySqlOutbox.Add(_message1);

--- a/tests/Paramore.Brighter.MySQL.Tests/Outbox/When_there_is_no_message_in_the_sql_message_store_async.cs
+++ b/tests/Paramore.Brighter.MySQL.Tests/Outbox/When_there_is_no_message_in_the_sql_message_store_async.cs
@@ -44,8 +44,10 @@ namespace Paramore.Brighter.MySQL.Tests.Outbox
             _mySqlTestHelper = new MySqlTestHelper();
             _mySqlTestHelper.SetupMessageDb();
             _mySqlOutbox = new MySqlOutbox(_mySqlTestHelper.OutboxConfiguration);
-            _messageEarliest = new Message(new MessageHeader(Guid.NewGuid(), "test_topic", MessageType.MT_DOCUMENT),
-                new MessageBody("message body"));
+            _messageEarliest = new Message(
+                new MessageHeader(Guid.NewGuid().ToString(), "test_topic", MessageType.MT_DOCUMENT),
+                new MessageBody("message body")
+            );
         }
 
         [Fact]

--- a/tests/Paramore.Brighter.MySQL.Tests/Outbox/When_there_is_no_message_in_the_sql_outbox.cs
+++ b/tests/Paramore.Brighter.MySQL.Tests/Outbox/When_there_is_no_message_in_the_sql_outbox.cs
@@ -43,8 +43,10 @@ namespace Paramore.Brighter.MySQL.Tests.Outbox
             _mySqlTestHelper = new MySqlTestHelper();
             _mySqlTestHelper.SetupMessageDb();
             _mySqlOutbox = new MySqlOutbox(_mySqlTestHelper.OutboxConfiguration);
-            _messageEarliest = new Message(new MessageHeader(Guid.NewGuid(), "test_topic", MessageType.MT_DOCUMENT),
-                new MessageBody("message body"));
+            _messageEarliest = new Message(
+                new MessageHeader(Guid.NewGuid().ToString(), "test_topic", MessageType.MT_DOCUMENT),
+                new MessageBody("message body")
+            );
         }
 
         [Fact]

--- a/tests/Paramore.Brighter.MySQL.Tests/Outbox/When_writing_a_message_to_a_binary_body_outbox.cs
+++ b/tests/Paramore.Brighter.MySQL.Tests/Outbox/When_writing_a_message_to_a_binary_body_outbox.cs
@@ -28,13 +28,13 @@ namespace Paramore.Brighter.MySQL.Tests
             _mySqlTestHelper.SetupMessageDb();
             _mySqlOutbox = new MySqlOutbox(_mySqlTestHelper.OutboxConfiguration);
             var messageHeader = new MessageHeader(
-                messageId: Guid.NewGuid(),
+                messageId: Guid.NewGuid().ToString(),
                 topic: "test_topic",
                 messageType: MessageType.MT_DOCUMENT,
                 timeStamp: DateTime.UtcNow.AddDays(-1),
                 handledCount: 5,
                 delayedMilliseconds: 5,
-                correlationId: new Guid(),
+                correlationId: Guid.NewGuid().ToString(),
                 replyTo: "ReplyTo",
                 contentType: "application/octet-stream",
                 partitionKey: Guid.NewGuid().ToString());

--- a/tests/Paramore.Brighter.MySQL.Tests/Outbox/When_writing_a_message_to_the_message_store_async.cs
+++ b/tests/Paramore.Brighter.MySQL.Tests/Outbox/When_writing_a_message_to_the_message_store_async.cs
@@ -53,7 +53,7 @@ namespace Paramore.Brighter.MySQL.Tests.Outbox
             _mySqlTestHelper.SetupMessageDb();
             _mySqlOutbox = new MySqlOutbox(_mySqlTestHelper.OutboxConfiguration);
 
-            var messageHeader = new MessageHeader(Guid.NewGuid(), "test_topic", MessageType.MT_DOCUMENT,DateTime.UtcNow.AddDays(-1), 5, 5);
+            var messageHeader = new MessageHeader(Guid.NewGuid().ToString(), "test_topic", MessageType.MT_DOCUMENT,DateTime.UtcNow.AddDays(-1), 5, 5);
             messageHeader.Bag.Add(_key1, _value1);
             messageHeader.Bag.Add(_key2, _value2);
             messageHeader.Bag.Add(_key3, _value3);

--- a/tests/Paramore.Brighter.MySQL.Tests/Outbox/When_writing_a_message_to_the_outbox.cs
+++ b/tests/Paramore.Brighter.MySQL.Tests/Outbox/When_writing_a_message_to_the_outbox.cs
@@ -53,13 +53,13 @@ namespace Paramore.Brighter.MySQL.Tests.Outbox
             _mySqlTestHelper.SetupMessageDb();
             _mySqlOutbox = new MySqlOutbox(_mySqlTestHelper.OutboxConfiguration);
             var messageHeader = new MessageHeader(
-                messageId:Guid.NewGuid(), 
+                messageId:Guid.NewGuid().ToString(), 
                 topic: "test_topic", 
                 messageType: MessageType.MT_DOCUMENT,
                 timeStamp: DateTime.UtcNow.AddDays(-1), 
                 handledCount:5, 
                 delayedMilliseconds: 5,
-                correlationId: new Guid(),
+                correlationId: Guid.NewGuid().ToString(),
                 replyTo: "ReplyTo",
                 contentType: "text/plain",
                 partitionKey: Guid.NewGuid().ToString());

--- a/tests/Paramore.Brighter.PostgresSQL.Tests/Inbox/When_there_Is_no_message_in_the_sql_inbox_async.cs
+++ b/tests/Paramore.Brighter.PostgresSQL.Tests/Inbox/When_there_Is_no_message_in_the_sql_inbox_async.cs
@@ -51,7 +51,7 @@ namespace Paramore.Brighter.PostgresSQL.Tests.Inbox
         [Fact]
         public async Task When_There_Is_No_Message_In_The_Sql_Inbox_And_I_Get_Async()
         {
-            Guid commandId = Guid.NewGuid();
+            string commandId = Guid.NewGuid().ToString();
             var exception = await Catch.ExceptionAsync(() => _sqlSqlInbox.GetAsync<MyCommand>(commandId, "some-key"));
             AssertionExtensions.Should(exception).BeOfType<RequestNotFoundException<MyCommand>>();
         }
@@ -59,7 +59,7 @@ namespace Paramore.Brighter.PostgresSQL.Tests.Inbox
         [Fact]
         public async Task When_There_Is_No_Message_In_The_Sql_Inbox_And_I_Check_Exists_Async()
         {
-            Guid commandId = Guid.NewGuid();
+            string commandId = Guid.NewGuid().ToString();
             bool exists = await _sqlSqlInbox.ExistsAsync<MyCommand>(commandId, "some-key");
             exists.Should().BeFalse();
         }

--- a/tests/Paramore.Brighter.PostgresSQL.Tests/Inbox/When_there_is_no_message_in_the_sql_inbox.cs
+++ b/tests/Paramore.Brighter.PostgresSQL.Tests/Inbox/When_there_is_no_message_in_the_sql_inbox.cs
@@ -53,7 +53,7 @@ namespace Paramore.Brighter.PostgresSQL.Tests.Inbox
         [Fact]
         public void When_There_Is_No_Message_In_The_Sql_Inbox_And_Call_Get()
         {
-            Guid commandId = Guid.NewGuid();
+            string commandId = Guid.NewGuid().ToString();
             var exception = Catch.Exception(() => _storedCommand = _pgSqlInbox.Get<MyCommand>(commandId, _contextKey));
 
             AssertionExtensions.Should(exception).BeOfType<RequestNotFoundException<MyCommand>>();
@@ -62,7 +62,7 @@ namespace Paramore.Brighter.PostgresSQL.Tests.Inbox
         [Fact]
         public void When_There_Is_No_Message_In_The_Sql_Inbox_And_Call_Exists()
         {
-            Guid commandId = Guid.NewGuid();
+            string commandId = Guid.NewGuid().ToString();
             _pgSqlInbox.Exists<MyCommand>(commandId, _contextKey).Should().BeFalse();
         }
 

--- a/tests/Paramore.Brighter.PostgresSQL.Tests/Outbox/When_Removing_Messages_From_The_Outbox.cs
+++ b/tests/Paramore.Brighter.PostgresSQL.Tests/Outbox/When_Removing_Messages_From_The_Outbox.cs
@@ -48,9 +48,9 @@ namespace Paramore.Brighter.PostgresSQL.Tests.Outbox
             _postgresSqlTestHelper.SetupMessageDb();
 
             _sqlOutbox = new PostgreSqlOutbox(_postgresSqlTestHelper.Configuration);
-            _firstMessage = new Message(new MessageHeader(Guid.NewGuid(), "Test", MessageType.MT_COMMAND, DateTime.UtcNow.AddHours(-3)), new MessageBody("Body"));
-            _secondMessage = new Message(new MessageHeader(Guid.NewGuid(), "Test2", MessageType.MT_COMMAND, DateTime.UtcNow.AddHours(-2)), new MessageBody("Body2"));
-            _thirdMessage = new Message(new MessageHeader(Guid.NewGuid(), "Test3", MessageType.MT_COMMAND, DateTime.UtcNow.AddHours(-1)), new MessageBody("Body3"));
+            _firstMessage = new Message(new MessageHeader(Guid.NewGuid().ToString(), "Test", MessageType.MT_COMMAND, DateTime.UtcNow.AddHours(-3)), new MessageBody("Body"));
+            _secondMessage = new Message(new MessageHeader(Guid.NewGuid().ToString(), "Test2", MessageType.MT_COMMAND, DateTime.UtcNow.AddHours(-2)), new MessageBody("Body2"));
+            _thirdMessage = new Message(new MessageHeader(Guid.NewGuid().ToString(), "Test3", MessageType.MT_COMMAND, DateTime.UtcNow.AddHours(-1)), new MessageBody("Body3"));
             
         }
 
@@ -61,7 +61,7 @@ namespace Paramore.Brighter.PostgresSQL.Tests.Outbox
             _sqlOutbox.Add(_secondMessage);
             _sqlOutbox.Add(_thirdMessage);
             
-            _sqlOutbox.Delete(new Guid[]{_firstMessage.Id});
+            _sqlOutbox.Delete([_firstMessage.Id]);
 
             var remainingMessages = _sqlOutbox.OutstandingMessages(0);
 

--- a/tests/Paramore.Brighter.PostgresSQL.Tests/Outbox/When_The_Message_Is_Already_In_The_Outbox.cs
+++ b/tests/Paramore.Brighter.PostgresSQL.Tests/Outbox/When_The_Message_Is_Already_In_The_Outbox.cs
@@ -44,7 +44,10 @@ namespace Paramore.Brighter.PostgresSQL.Tests.Outbox
             _postgresSqlTestHelper.SetupMessageDb();
 
             _sqlOutbox = new PostgreSqlOutbox(_postgresSqlTestHelper.Configuration);
-            _messageEarliest = new Message(new MessageHeader(Guid.NewGuid(), "test_topic", MessageType.MT_DOCUMENT), new MessageBody("message body"));
+            _messageEarliest = new Message(
+                new MessageHeader(Guid.NewGuid().ToString(), "test_topic", MessageType.MT_DOCUMENT), 
+                new MessageBody("message body")
+            );
             _sqlOutbox.Add(_messageEarliest);
         }
 

--- a/tests/Paramore.Brighter.PostgresSQL.Tests/Outbox/When_There_Is_No_Message_In_The_Sql_Outbox.cs
+++ b/tests/Paramore.Brighter.PostgresSQL.Tests/Outbox/When_There_Is_No_Message_In_The_Sql_Outbox.cs
@@ -44,7 +44,10 @@ namespace Paramore.Brighter.PostgresSQL.Tests.Outbox
             _postgresSqlTestHelper.SetupMessageDb();
 
             _sqlOutbox = new PostgreSqlOutbox(_postgresSqlTestHelper.Configuration);
-            _messageEarliest = new Message(new MessageHeader(Guid.NewGuid(), "test_topic", MessageType.MT_DOCUMENT), new MessageBody("message body"));
+            _messageEarliest = new Message(
+                new MessageHeader(Guid.NewGuid().ToString(), "test_topic", MessageType.MT_DOCUMENT), 
+                new MessageBody("message body")
+            );
         }
 
         [Fact]

--- a/tests/Paramore.Brighter.PostgresSQL.Tests/Outbox/When_Writing_A_Message_To_A_Binary_Body_Outbox.cs
+++ b/tests/Paramore.Brighter.PostgresSQL.Tests/Outbox/When_Writing_A_Message_To_A_Binary_Body_Outbox.cs
@@ -30,13 +30,13 @@ namespace Paramore.Brighter.PostgresSQL.Tests.Outbox
 
             _sqlOutbox = new PostgreSqlOutbox(_postgresSqlTestHelper.Configuration);
             var messageHeader = new MessageHeader(
-                messageId: Guid.NewGuid(),
+                messageId: Guid.NewGuid().ToString(),
                 topic: "test_topic",
                 messageType: MessageType.MT_DOCUMENT,
                 timeStamp: DateTime.UtcNow.AddDays(-1),
                 handledCount: 5,
                 delayedMilliseconds: 5,
-                correlationId: Guid.NewGuid(),
+                correlationId: Guid.NewGuid().ToString(),
                 replyTo: "ReplyTo",
                 contentType: "text/plain",
                 partitionKey: Guid.NewGuid().ToString());

--- a/tests/Paramore.Brighter.PostgresSQL.Tests/Outbox/When_Writing_A_Message_To_The_Outbox.cs
+++ b/tests/Paramore.Brighter.PostgresSQL.Tests/Outbox/When_Writing_A_Message_To_The_Outbox.cs
@@ -55,13 +55,13 @@ namespace Paramore.Brighter.PostgresSQL.Tests.Outbox
 
             _sqlOutbox = new PostgreSqlOutbox(_postgresSqlTestHelper.Configuration);
             var messageHeader = new MessageHeader(
-                messageId:Guid.NewGuid(), 
+                messageId:Guid.NewGuid().ToString(), 
                 topic: "test_topic", 
                 messageType: MessageType.MT_DOCUMENT, 
                 timeStamp: DateTime.UtcNow.AddDays(-1), 
                 handledCount:5, 
                 delayedMilliseconds:5,
-                correlationId: Guid.NewGuid(),
+                correlationId: Guid.NewGuid().ToString(),
                 replyTo: "ReplyTo",
                 contentType: "text/plain",
                 partitionKey: Guid.NewGuid().ToString());

--- a/tests/Paramore.Brighter.RMQ.Tests/MessagingGateway/When_a_message_consumer_reads_multiple_messages.cs
+++ b/tests/Paramore.Brighter.RMQ.Tests/MessagingGateway/When_a_message_consumer_reads_multiple_messages.cs
@@ -33,13 +33,13 @@ namespace Paramore.Brighter.RMQ.Tests.MessagingGateway
         public void When_a_message_consumer_reads_multiple_messages()
         {
             //Post one more than batch size messages
-             var messageOne = new Message(new MessageHeader(Guid.NewGuid(), _topic, MessageType.MT_COMMAND), new MessageBody("test content One"));
+             var messageOne = new Message(new MessageHeader(Guid.NewGuid().ToString(), _topic, MessageType.MT_COMMAND), new MessageBody("test content One"));
             _messageProducer.Send(messageOne);
-             var messageTwo= new Message(new MessageHeader(Guid.NewGuid(), _topic, MessageType.MT_COMMAND), new MessageBody("test content Two"));
+             var messageTwo= new Message(new MessageHeader(Guid.NewGuid().ToString(), _topic, MessageType.MT_COMMAND), new MessageBody("test content Two"));
             _messageProducer.Send(messageTwo);
-             var messageThree= new Message(new MessageHeader(Guid.NewGuid(), _topic, MessageType.MT_COMMAND), new MessageBody("test content Three"));
+             var messageThree= new Message(new MessageHeader(Guid.NewGuid().ToString(), _topic, MessageType.MT_COMMAND), new MessageBody("test content Three"));
             _messageProducer.Send(messageThree);
-             var messageFour= new Message(new MessageHeader(Guid.NewGuid(), _topic, MessageType.MT_COMMAND), new MessageBody("test content Four"));
+             var messageFour= new Message(new MessageHeader(Guid.NewGuid().ToString(), _topic, MessageType.MT_COMMAND), new MessageBody("test content Four"));
             _messageProducer.Send(messageFour);
             
             //let them arrive

--- a/tests/Paramore.Brighter.RMQ.Tests/MessagingGateway/When_a_message_consumer_throws_an_already_closed_exception_when_connecting.cs
+++ b/tests/Paramore.Brighter.RMQ.Tests/MessagingGateway/When_a_message_consumer_throws_an_already_closed_exception_when_connecting.cs
@@ -42,7 +42,7 @@ namespace Paramore.Brighter.RMQ.Tests.MessagingGateway
 
         public RmqMessageConsumerConnectionClosedTests()
         {
-            var messageHeader = new MessageHeader(Guid.NewGuid(),  Guid.NewGuid().ToString(), MessageType.MT_COMMAND);
+            var messageHeader = new MessageHeader(Guid.NewGuid().ToString(),  Guid.NewGuid().ToString(), MessageType.MT_COMMAND);
 
             messageHeader.UpdateHandledCount();
             _sentMessage = new Message(messageHeader, new MessageBody("test content"));

--- a/tests/Paramore.Brighter.RMQ.Tests/MessagingGateway/When_a_message_consumer_throws_an_not_supported_exception_when_connecting.cs
+++ b/tests/Paramore.Brighter.RMQ.Tests/MessagingGateway/When_a_message_consumer_throws_an_not_supported_exception_when_connecting.cs
@@ -41,7 +41,7 @@ namespace Paramore.Brighter.RMQ.Tests.MessagingGateway
 
         public RmqMessageConsumerChannelFailureTests()
         {
-            var messageHeader = new MessageHeader(Guid.NewGuid(), Guid.NewGuid().ToString(), MessageType.MT_COMMAND);
+            var messageHeader = new MessageHeader(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), MessageType.MT_COMMAND);
 
             messageHeader.UpdateHandledCount();
             _sentMessage = new Message(messageHeader, new MessageBody("test content"));

--- a/tests/Paramore.Brighter.RMQ.Tests/MessagingGateway/When_a_message_consumer_throws_an_operation_interrupted_exception_when_connecting.cs
+++ b/tests/Paramore.Brighter.RMQ.Tests/MessagingGateway/When_a_message_consumer_throws_an_operation_interrupted_exception_when_connecting.cs
@@ -43,7 +43,7 @@ namespace Paramore.Brighter.RMQ.Tests.MessagingGateway
 
         public RmqMessageConsumerOperationInterruptedTests()
         {
-            var messageHeader = new MessageHeader(Guid.NewGuid(), Guid.NewGuid().ToString(), MessageType.MT_COMMAND);
+            var messageHeader = new MessageHeader(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), MessageType.MT_COMMAND);
 
             messageHeader.UpdateHandledCount();
             _sentMessage = new Message(messageHeader, new MessageBody("test content"));

--- a/tests/Paramore.Brighter.RMQ.Tests/MessagingGateway/When_binding_a_channel_to_multiple_topics.cs
+++ b/tests/Paramore.Brighter.RMQ.Tests/MessagingGateway/When_binding_a_channel_to_multiple_topics.cs
@@ -16,10 +16,10 @@ namespace Paramore.Brighter.RMQ.Tests.MessagingGateway
         public RmqMessageConsumerMultipleTopicTests()
         {
             _messageTopic1 = new Message(
-                new MessageHeader(Guid.NewGuid(), Guid.NewGuid().ToString(), MessageType.MT_COMMAND), 
+                new MessageHeader(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), MessageType.MT_COMMAND), 
                 new MessageBody("test content for topic test 1"));
             _messageTopic2 = new Message(
-                new MessageHeader(Guid.NewGuid(), Guid.NewGuid().ToString(), MessageType.MT_COMMAND), 
+                new MessageHeader(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), MessageType.MT_COMMAND), 
                 new MessageBody("test content for topic test 2"));
 
             var rmqConnection = new RmqMessagingGatewayConnection

--- a/tests/Paramore.Brighter.RMQ.Tests/MessagingGateway/When_confirming_posting_a_message_via_the_messaging_gateway.cs
+++ b/tests/Paramore.Brighter.RMQ.Tests/MessagingGateway/When_confirming_posting_a_message_via_the_messaging_gateway.cs
@@ -41,7 +41,7 @@ namespace Paramore.Brighter.RMQ.Tests.MessagingGateway
         public RmqMessageProducerConfirmationsSendMessageTests ()
         {
             _message = new Message(
-                new MessageHeader(Guid.NewGuid(), Guid.NewGuid().ToString(), MessageType.MT_COMMAND), 
+                new MessageHeader(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), MessageType.MT_COMMAND), 
                 new MessageBody("test content"));
 
             var rmqConnection = new RmqMessagingGatewayConnection

--- a/tests/Paramore.Brighter.RMQ.Tests/MessagingGateway/When_confirming_posting_a_message_via_the_messaging_gateway_async.cs
+++ b/tests/Paramore.Brighter.RMQ.Tests/MessagingGateway/When_confirming_posting_a_message_via_the_messaging_gateway_async.cs
@@ -41,7 +41,7 @@ namespace Paramore.Brighter.RMQ.Tests.MessagingGateway
         public RmqMessageProducerConfirmationsSendMessageAsyncTests()
         {
             _message = new Message(
-                new MessageHeader(Guid.NewGuid(), Guid.NewGuid().ToString(), MessageType.MT_COMMAND), 
+                new MessageHeader(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), MessageType.MT_COMMAND), 
                 new MessageBody("test content"));
 
             var rmqConnection = new RmqMessagingGatewayConnection

--- a/tests/Paramore.Brighter.RMQ.Tests/MessagingGateway/When_infrastructure_exists_can_assert.cs
+++ b/tests/Paramore.Brighter.RMQ.Tests/MessagingGateway/When_infrastructure_exists_can_assert.cs
@@ -14,7 +14,7 @@ namespace Paramore.Brighter.RMQ.Tests.MessagingGateway
         public RmqAssumeExistingInfrastructureTests() 
         {
             _message = new Message(
-                new MessageHeader(Guid.NewGuid(), Guid.NewGuid().ToString(), MessageType.MT_COMMAND), 
+                new MessageHeader(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), MessageType.MT_COMMAND), 
                 new MessageBody("test content"));
 
             var rmqConnection = new RmqMessagingGatewayConnection

--- a/tests/Paramore.Brighter.RMQ.Tests/MessagingGateway/When_infrastructure_exists_can_validate.cs
+++ b/tests/Paramore.Brighter.RMQ.Tests/MessagingGateway/When_infrastructure_exists_can_validate.cs
@@ -14,7 +14,7 @@ namespace Paramore.Brighter.RMQ.Tests.MessagingGateway
         public RmqValidateExistingInfrastructureTests() 
         {
             _message = new Message(
-                new MessageHeader(Guid.NewGuid(), Guid.NewGuid().ToString(), MessageType.MT_COMMAND), 
+                new MessageHeader(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), MessageType.MT_COMMAND), 
                 new MessageBody("test content"));
 
             var rmqConnection = new RmqMessagingGatewayConnection

--- a/tests/Paramore.Brighter.RMQ.Tests/MessagingGateway/When_multiple_threads_try_to_post_a_message_at_the_same_time.cs
+++ b/tests/Paramore.Brighter.RMQ.Tests/MessagingGateway/When_multiple_threads_try_to_post_a_message_at_the_same_time.cs
@@ -40,7 +40,7 @@ namespace Paramore.Brighter.RMQ.Tests.MessagingGateway
         public RmqMessageProducerSupportsMultipleThreadsTests()
         {
             _message = new Message(
-                new MessageHeader(Guid.NewGuid(), "nonexistenttopic", MessageType.MT_COMMAND), 
+                new MessageHeader(Guid.NewGuid().ToString(), "nonexistenttopic", MessageType.MT_COMMAND), 
                 new MessageBody("test content"));
 
             var rmqConnection = new RmqMessagingGatewayConnection

--- a/tests/Paramore.Brighter.RMQ.Tests/MessagingGateway/When_posting_a_message_but_no_broker_created.cs
+++ b/tests/Paramore.Brighter.RMQ.Tests/MessagingGateway/When_posting_a_message_but_no_broker_created.cs
@@ -12,7 +12,7 @@ namespace Paramore.Brighter.RMQ.Tests.MessagingGateway
         public RmqBrokerNotPreCreatedTests()
         {
             _message = new Message(
-                new MessageHeader(Guid.NewGuid(), Guid.NewGuid().ToString(), MessageType.MT_COMMAND), 
+                new MessageHeader(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), MessageType.MT_COMMAND), 
                 new MessageBody("test content"));
 
             var rmqConnection = new RmqMessagingGatewayConnection

--- a/tests/Paramore.Brighter.RMQ.Tests/MessagingGateway/When_posting_a_message_to_persist_via_the_messaging_gateway.cs
+++ b/tests/Paramore.Brighter.RMQ.Tests/MessagingGateway/When_posting_a_message_to_persist_via_the_messaging_gateway.cs
@@ -16,7 +16,7 @@ namespace Paramore.Brighter.RMQ.Tests.MessagingGateway
         public RmqMessageProducerSendPersistentMessageTests()
         {
             _message = new Message(
-                new MessageHeader(Guid.NewGuid(), Guid.NewGuid().ToString(), MessageType.MT_COMMAND),
+                new MessageHeader(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), MessageType.MT_COMMAND),
                 new MessageBody("test content"));
 
             var rmqConnection = new RmqMessagingGatewayConnection

--- a/tests/Paramore.Brighter.RMQ.Tests/MessagingGateway/When_posting_a_message_via_the_messaging_gateway.cs
+++ b/tests/Paramore.Brighter.RMQ.Tests/MessagingGateway/When_posting_a_message_via_the_messaging_gateway.cs
@@ -40,7 +40,7 @@ namespace Paramore.Brighter.RMQ.Tests.MessagingGateway
         public RmqMessageProducerSendMessageTests()
         {
             _message = new Message(
-                new MessageHeader(Guid.NewGuid(), Guid.NewGuid().ToString(), MessageType.MT_COMMAND), 
+                new MessageHeader(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), MessageType.MT_COMMAND), 
                 new MessageBody("test content"));
 
             var rmqConnection = new RmqMessagingGatewayConnection

--- a/tests/Paramore.Brighter.RMQ.Tests/MessagingGateway/When_queue_length_causes_a_message_to_be_rejected.cs
+++ b/tests/Paramore.Brighter.RMQ.Tests/MessagingGateway/When_queue_length_causes_a_message_to_be_rejected.cs
@@ -43,11 +43,11 @@ namespace Paramore.Brighter.RMQ.Tests.MessagingGateway
         public RmqMessageProducerQueueLengthTests()
         {
            _messageOne = new Message(
-                new MessageHeader(Guid.NewGuid(), Guid.NewGuid().ToString(), MessageType.MT_COMMAND), 
+                new MessageHeader(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), MessageType.MT_COMMAND), 
                 new MessageBody("test content"));
            
            _messageTwo = new Message(
-               new MessageHeader(Guid.NewGuid(), Guid.NewGuid().ToString(), MessageType.MT_COMMAND), 
+               new MessageHeader(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), MessageType.MT_COMMAND), 
                new MessageBody("test content"));
 
              var rmqConnection = new RmqMessagingGatewayConnection

--- a/tests/Paramore.Brighter.RMQ.Tests/MessagingGateway/When_reading_a_delayed_message_via_the_messaging_gateway.cs
+++ b/tests/Paramore.Brighter.RMQ.Tests/MessagingGateway/When_reading_a_delayed_message_via_the_messaging_gateway.cs
@@ -39,7 +39,7 @@ namespace Paramore.Brighter.RMQ.Tests.MessagingGateway
 
         public RmqMessageProducerDelayedMessageTests()
         {
-            var header = new MessageHeader(Guid.NewGuid(), Guid.NewGuid().ToString(), MessageType.MT_COMMAND);
+            var header = new MessageHeader(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), MessageType.MT_COMMAND);
             var originalMessage = new Message(header, new MessageBody("test3 content"));
 
             var mutatedHeader = new MessageHeader(header.Id, Guid.NewGuid().ToString(), MessageType.MT_COMMAND);

--- a/tests/Paramore.Brighter.RMQ.Tests/MessagingGateway/When_rejecting_a_message_to_a_dead_letter_queue.cs
+++ b/tests/Paramore.Brighter.RMQ.Tests/MessagingGateway/When_rejecting_a_message_to_a_dead_letter_queue.cs
@@ -41,7 +41,7 @@ namespace Paramore.Brighter.RMQ.Tests.MessagingGateway
         public RmqMessageProducerDLQTests()
         {
            _message = new Message(
-                new MessageHeader(Guid.NewGuid(), Guid.NewGuid().ToString(), MessageType.MT_COMMAND), 
+                new MessageHeader(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), MessageType.MT_COMMAND), 
                 new MessageBody("test content"));
 
             var deadLetterQueueName = $"{_message.Header.Topic}.DLQ";

--- a/tests/Paramore.Brighter.RMQ.Tests/MessagingGateway/When_retry_limits_force_a_message_onto_the_DLQ.cs
+++ b/tests/Paramore.Brighter.RMQ.Tests/MessagingGateway/When_retry_limits_force_a_message_onto_the_DLQ.cs
@@ -27,7 +27,7 @@ namespace Paramore.Brighter.RMQ.Tests.MessagingGateway
 
         public RMQMessageConsumerRetryDLQTests()
         {
-            Guid correlationId = Guid.NewGuid();
+            string correlationId = Guid.NewGuid().ToString();
             string contentType = "text\\plain";
             var channelName = $"Requeue-Limit-Tests-{Guid.NewGuid().ToString()}";
             _topicName = $"Requeue-Limit-Tests-{Guid.NewGuid().ToString()}";
@@ -123,7 +123,7 @@ namespace Paramore.Brighter.RMQ.Tests.MessagingGateway
             await Task.Delay(20000);
 
             //send a quit message to the pump to terminate it 
-            var quitMessage = new Message(new MessageHeader(Guid.Empty, "", MessageType.MT_QUIT), new MessageBody(""));
+            var quitMessage = new Message(new MessageHeader(string.Empty, "", MessageType.MT_QUIT), new MessageBody(""));
             _channel.Enqueue(quitMessage);
 
             //wait for the pump to stop once it gets a quit message

--- a/tests/Paramore.Brighter.RMQ.Tests/MessagingGateway/When_ttl_causes_a_message_to_expire.cs
+++ b/tests/Paramore.Brighter.RMQ.Tests/MessagingGateway/When_ttl_causes_a_message_to_expire.cs
@@ -43,11 +43,11 @@ namespace Paramore.Brighter.RMQ.Tests.MessagingGateway
         public RmqMessageProducerTTLTests ()
         {
            _messageOne = new Message(
-                new MessageHeader(Guid.NewGuid(), Guid.NewGuid().ToString(), MessageType.MT_COMMAND), 
+                new MessageHeader(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), MessageType.MT_COMMAND), 
                 new MessageBody("test content"));
            
            _messageTwo = new Message(
-               new MessageHeader(Guid.NewGuid(), Guid.NewGuid().ToString(), MessageType.MT_COMMAND), 
+               new MessageHeader(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), MessageType.MT_COMMAND), 
                new MessageBody("test content"));
 
              var rmqConnection = new RmqMessagingGatewayConnection

--- a/tests/Paramore.Brighter.Redis.Tests/MessagingGateway/When_parsing_a_good_redis_message_to_brighter.cs
+++ b/tests/Paramore.Brighter.Redis.Tests/MessagingGateway/When_parsing_a_good_redis_message_to_brighter.cs
@@ -19,13 +19,13 @@ namespace Paramore.Brighter.Redis.Tests.MessagingGateway
             
             Message message = redisMessageCreator.CreateMessage(GoodMessage);
 
-            message.Id.Should().Be(Guid.Parse("18669550-2069-48c5-923d-74a2e79c0748"));
+            message.Id.Should().Be("18669550-2069-48c5-923d-74a2e79c0748");
             message.Header.TimeStamp.Should().Be(DateTime.Parse("2018-02-07T09:38:36Z"));
             message.Header.Topic.Should().Be("test");
             message.Header.MessageType.Should().Be(MessageType.MT_COMMAND);
             message.Header.HandledCount.Should().Be(3);
             message.Header.DelayedMilliseconds.Should().Be(200);
-            message.Header.CorrelationId.Should().Be(Guid.Parse("0AF88BBC-07FD-4FC3-9CA7-BF68415A2535"));
+            message.Header.CorrelationId.Should().Be("0AF88BBC-07FD-4FC3-9CA7-BF68415A2535");
             message.Header.ContentType.Should().Be("text/plain");
             message.Header.ReplyTo.Should().Be("reply.queue");
         }

--- a/tests/Paramore.Brighter.Redis.Tests/MessagingGateway/When_posting_a_message_via_the_messaging_gateway.cs
+++ b/tests/Paramore.Brighter.Redis.Tests/MessagingGateway/When_posting_a_message_via_the_messaging_gateway.cs
@@ -17,7 +17,7 @@ namespace Paramore.Brighter.Redis.Tests.MessagingGateway
             const string topic = "test";
             _redisFixture = redisFixture;
             _message = new Message(
-                new MessageHeader(Guid.NewGuid(), topic, MessageType.MT_COMMAND), 
+                new MessageHeader(Guid.NewGuid().ToString(), topic, MessageType.MT_COMMAND), 
                 new MessageBody("test content")
                 );
         }

--- a/tests/Paramore.Brighter.Redis.Tests/MessagingGateway/When_posting_multiple_messages_via_the_messaging_gateway.cs
+++ b/tests/Paramore.Brighter.Redis.Tests/MessagingGateway/When_posting_multiple_messages_via_the_messaging_gateway.cs
@@ -18,12 +18,12 @@ namespace Paramore.Brighter.Redis.Tests.MessagingGateway
              const string topic = "test";
             _redisFixture = redisFixture;
             _messageOne = new Message(
-                new MessageHeader(Guid.NewGuid(), topic, MessageType.MT_COMMAND), 
+                new MessageHeader(Guid.NewGuid().ToString(), topic, MessageType.MT_COMMAND), 
                 new MessageBody("test content")
                 );
             
             _messageTwo = new Message(
-                new MessageHeader(Guid.NewGuid(), topic, MessageType.MT_COMMAND), 
+                new MessageHeader(Guid.NewGuid().ToString(), topic, MessageType.MT_COMMAND), 
                 new MessageBody("more test content")
                  );
         }

--- a/tests/Paramore.Brighter.Redis.Tests/MessagingGateway/When_requeing_a_failed_message.cs
+++ b/tests/Paramore.Brighter.Redis.Tests/MessagingGateway/When_requeing_a_failed_message.cs
@@ -20,12 +20,12 @@ namespace Paramore.Brighter.Redis.Tests.MessagingGateway
             const string topic = "test";
             _redisFixture = redisFixture;
             _messageOne = new Message(
-                new MessageHeader(Guid.NewGuid(), topic, MessageType.MT_COMMAND),
+                new MessageHeader(Guid.NewGuid().ToString(), topic, MessageType.MT_COMMAND),
                 new MessageBody("test content")
             );
 
             _messageTwo = new Message(
-                new MessageHeader(Guid.NewGuid(), topic, MessageType.MT_COMMAND),
+                new MessageHeader(Guid.NewGuid().ToString(), topic, MessageType.MT_COMMAND),
                 new MessageBody("more test content")
             );
 

--- a/tests/Paramore.Brighter.Redis.Tests/MessagingGateway/When_requeing_a_failed_message_with_delay.cs
+++ b/tests/Paramore.Brighter.Redis.Tests/MessagingGateway/When_requeing_a_failed_message_with_delay.cs
@@ -17,7 +17,7 @@ namespace Paramore.Brighter.Redis.Tests.MessagingGateway
             const string topic = "test";
             _redisFixture = redisFixture;
             _messageOne = new Message(
-                new MessageHeader(Guid.NewGuid(), topic, MessageType.MT_COMMAND),
+                new MessageHeader(Guid.NewGuid().ToString(), topic, MessageType.MT_COMMAND),
                 new MessageBody("test content")
             );
         }

--- a/tests/Paramore.Brighter.Sqlite.Tests/Inbox/When_there_is_no_message_in_the_sql_inbox.cs
+++ b/tests/Paramore.Brighter.Sqlite.Tests/Inbox/When_there_is_no_message_in_the_sql_inbox.cs
@@ -50,7 +50,7 @@ namespace Paramore.Brighter.Sqlite.Tests.Inbox
         [Fact]
         public void When_There_Is_No_Message_In_The_Sql_Inbox_Get()
         {
-            Guid commandId = Guid.NewGuid();
+            string commandId = Guid.NewGuid().ToString();
             var exception = Catch.Exception(() => _sqlInbox.Get<MyCommand>(commandId, _contextKey));
             AssertionExtensions.Should(exception).BeOfType<RequestNotFoundException<MyCommand>>();
         }
@@ -58,7 +58,7 @@ namespace Paramore.Brighter.Sqlite.Tests.Inbox
         [Fact]
         public void When_There_Is_No_Message_In_The_Sql_Inbox_Exists()
         {
-            Guid commandId = Guid.NewGuid();
+            string commandId = Guid.NewGuid().ToString();
             AssertionExtensions.Should(_sqlInbox.Exists<MyCommand>(commandId, _contextKey)).BeFalse();
         }
 

--- a/tests/Paramore.Brighter.Sqlite.Tests/Inbox/When_there_is_no_message_in_the_sql_inbox_async.cs
+++ b/tests/Paramore.Brighter.Sqlite.Tests/Inbox/When_there_is_no_message_in_the_sql_inbox_async.cs
@@ -51,7 +51,7 @@ namespace Paramore.Brighter.Sqlite.Tests.Inbox
         [Fact]
         public async Task When_There_Is_No_Message_In_The_Sql_Inbox_Get_Async()
         {
-            Guid commandId = Guid.NewGuid();
+            string commandId = Guid.NewGuid().ToString();
             var exception = await Catch.ExceptionAsync(() => _sqlInbox.GetAsync<MyCommand>(commandId, _contextKey));
             AssertionExtensions.Should(exception).BeOfType<RequestNotFoundException<MyCommand>>();
         }
@@ -59,7 +59,7 @@ namespace Paramore.Brighter.Sqlite.Tests.Inbox
         [Fact]
         public async Task When_There_Is_No_Message_In_The_Sql_Inbox_Exists_Async()
         {
-            Guid commandId = Guid.NewGuid();
+            string commandId = Guid.NewGuid().ToString();
             bool exists = await _sqlInbox.ExistsAsync<MyCommand>(commandId, _contextKey);
             exists.Should().BeFalse();
         }

--- a/tests/Paramore.Brighter.Sqlite.Tests/Outbox/SQlOutboxMigrationTests.cs
+++ b/tests/Paramore.Brighter.Sqlite.Tests/Outbox/SQlOutboxMigrationTests.cs
@@ -46,7 +46,7 @@ namespace Paramore.Brighter.Sqlite.Tests.Outbox
             _sqliteTestHelper.SetupMessageDb();
             _sqlOutbox  = new SqliteOutbox(new RelationalDatabaseConfiguration(_sqliteTestHelper.ConnectionString, _sqliteTestHelper.OutboxTableName));
 
-            _message = new Message(new MessageHeader(Guid.NewGuid(), "test_topic", MessageType.MT_DOCUMENT), new MessageBody("message body"));
+            _message = new Message(new MessageHeader(Guid.NewGuid().ToString(), "test_topic", MessageType.MT_DOCUMENT), new MessageBody("message body"));
             AddHistoricMessage(_message);
         }
 

--- a/tests/Paramore.Brighter.Sqlite.Tests/Outbox/When_Removing_Messages_From_The_Outbox.cs
+++ b/tests/Paramore.Brighter.Sqlite.Tests/Outbox/When_Removing_Messages_From_The_Outbox.cs
@@ -50,15 +50,15 @@ namespace Paramore.Brighter.Sqlite.Tests.Outbox
 
             _firstMessage =
                 new Message(
-                    new MessageHeader(Guid.NewGuid(), "Test", MessageType.MT_COMMAND, DateTime.UtcNow.AddHours(-3)),
+                    new MessageHeader(Guid.NewGuid().ToString(), "Test", MessageType.MT_COMMAND, DateTime.UtcNow.AddHours(-3)),
                     new MessageBody("Body"));
             _secondMessage =
                 new Message(
-                    new MessageHeader(Guid.NewGuid(), "Test2", MessageType.MT_COMMAND, DateTime.UtcNow.AddHours(-2)),
+                    new MessageHeader(Guid.NewGuid().ToString(), "Test2", MessageType.MT_COMMAND, DateTime.UtcNow.AddHours(-2)),
                     new MessageBody("Body2"));
             _thirdMessage =
                 new Message(
-                    new MessageHeader(Guid.NewGuid(), "Test3", MessageType.MT_COMMAND, DateTime.UtcNow.AddHours(-1)),
+                    new MessageHeader(Guid.NewGuid().ToString(), "Test3", MessageType.MT_COMMAND, DateTime.UtcNow.AddHours(-1)),
                     new MessageBody("Body3"));
         }
 
@@ -69,13 +69,13 @@ namespace Paramore.Brighter.Sqlite.Tests.Outbox
             _outbox.Add(_secondMessage);
             _outbox.Add(_thirdMessage);
 
-            _outbox.Delete(new Guid[] { _firstMessage.Id, _thirdMessage.Id });
+            _outbox.Delete([_firstMessage.Id, _thirdMessage.Id]);
 
             _outbox.Get(_secondMessage.Id).Header.MessageType.Should().Be(MessageType.MT_COMMAND);
             _outbox.Get(_firstMessage.Id).Header.MessageType.Should().Be(MessageType.MT_NONE);
             _outbox.Get(_thirdMessage.Id).Header.MessageType.Should().Be(MessageType.MT_NONE);
-
-            _outbox.Delete(new Guid[] { _secondMessage.Id });
+            
+            _outbox.Delete([_secondMessage.Id]);
 
             var messages = _outbox.Get(_secondMessage.Id).Should().NotBeNull();
         }

--- a/tests/Paramore.Brighter.Sqlite.Tests/Outbox/When_The_Message_Is_Already_In_The_Outbox.cs
+++ b/tests/Paramore.Brighter.Sqlite.Tests/Outbox/When_The_Message_Is_Already_In_The_Outbox.cs
@@ -44,7 +44,7 @@ namespace Paramore.Brighter.Sqlite.Tests.Outbox
             _sqliteTestHelper = new SqliteTestHelper();
             _sqliteTestHelper.SetupMessageDb();
             _sqlOutbox = new SqliteOutbox(_sqliteTestHelper.OutboxConfiguration);
-            _messageEarliest = new Message(new MessageHeader(Guid.NewGuid(), "test_topic", MessageType.MT_DOCUMENT),
+            _messageEarliest = new Message(new MessageHeader(Guid.NewGuid().ToString(), "test_topic", MessageType.MT_DOCUMENT),
                 new MessageBody("message body"));
             _sqlOutbox.Add(_messageEarliest);
         }

--- a/tests/Paramore.Brighter.Sqlite.Tests/Outbox/When_The_Message_Is_Already_In_The_Outbox_Async.cs
+++ b/tests/Paramore.Brighter.Sqlite.Tests/Outbox/When_The_Message_Is_Already_In_The_Outbox_Async.cs
@@ -46,7 +46,7 @@ namespace Paramore.Brighter.Sqlite.Tests.Outbox
             _sqlOutbox = new SqliteOutbox(_sqliteTestHelper.OutboxConfiguration);
             _messageEarliest = new Message(
                 new MessageHeader(
-                    Guid.NewGuid(), 
+                    Guid.NewGuid().ToString(), 
                     "test_topic", 
                     MessageType.MT_DOCUMENT), 
                 new MessageBody("message body"));

--- a/tests/Paramore.Brighter.Sqlite.Tests/Outbox/When_There_Is_No_Message_In_The_Sql_Outbox.cs
+++ b/tests/Paramore.Brighter.Sqlite.Tests/Outbox/When_There_Is_No_Message_In_The_Sql_Outbox.cs
@@ -44,7 +44,7 @@ namespace Paramore.Brighter.Sqlite.Tests.Outbox
             _sqliteTestHelper = new SqliteTestHelper();
             _sqliteTestHelper.SetupMessageDb();
             _sqlOutbox = new SqliteOutbox(_sqliteTestHelper.OutboxConfiguration);
-            _messageEarliest = new Message(new MessageHeader(Guid.NewGuid(), "test_topic", MessageType.MT_DOCUMENT),
+            _messageEarliest = new Message(new MessageHeader(Guid.NewGuid().ToString(), "test_topic", MessageType.MT_DOCUMENT),
                 new MessageBody("message body"));
         }
 

--- a/tests/Paramore.Brighter.Sqlite.Tests/Outbox/When_There_Is_No_Message_In_The_Sql_Outbox_Async.cs
+++ b/tests/Paramore.Brighter.Sqlite.Tests/Outbox/When_There_Is_No_Message_In_The_Sql_Outbox_Async.cs
@@ -44,7 +44,7 @@ namespace Paramore.Brighter.Sqlite.Tests.Outbox
             _sqliteTestHelper = new SqliteTestHelper();
             _sqliteTestHelper.SetupMessageDb();
             _sqlOutbox = new SqliteOutbox(_sqliteTestHelper.OutboxConfiguration);
-            _messageEarliest = new Message(new MessageHeader(Guid.NewGuid(), "test_topic", MessageType.MT_DOCUMENT),
+            _messageEarliest = new Message(new MessageHeader(Guid.NewGuid().ToString(), "test_topic", MessageType.MT_DOCUMENT),
                 new MessageBody("message body"));
         }
 

--- a/tests/Paramore.Brighter.Sqlite.Tests/Outbox/When_Writing_A_Message_To_A_Binary_Body_Outbox.cs
+++ b/tests/Paramore.Brighter.Sqlite.Tests/Outbox/When_Writing_A_Message_To_A_Binary_Body_Outbox.cs
@@ -56,13 +56,13 @@ namespace Paramore.Brighter.Sqlite.Tests.Outbox
             _sqliteTestHelper.SetupMessageDb();
             _sqlOutbox = new SqliteOutbox(_sqliteTestHelper.OutboxConfiguration);
             var messageHeader = new MessageHeader(
-                messageId:Guid.NewGuid(),
+                messageId:Guid.NewGuid().ToString(),
                 topic: "test_topic", 
                 messageType:MessageType.MT_DOCUMENT,
                 timeStamp: DateTime.UtcNow.AddDays(-1), 
                 handledCount:5,
                 delayedMilliseconds:5,
-                correlationId: Guid.NewGuid(),
+                correlationId: Guid.NewGuid().ToString(),
                 replyTo: "ReplyTo",
                 contentType: "application/octet-stream",
                 partitionKey: "123456789");

--- a/tests/Paramore.Brighter.Sqlite.Tests/Outbox/When_Writing_A_Message_To_The_Outbox.cs
+++ b/tests/Paramore.Brighter.Sqlite.Tests/Outbox/When_Writing_A_Message_To_The_Outbox.cs
@@ -55,13 +55,13 @@ namespace Paramore.Brighter.Sqlite.Tests.Outbox
             _sqliteTestHelper.SetupMessageDb();
             _sqlOutbox = new SqliteOutbox(_sqliteTestHelper.OutboxConfiguration);
             var messageHeader = new MessageHeader(
-                messageId:Guid.NewGuid(),
+                messageId:Guid.NewGuid().ToString(),
                 topic: "test_topic", 
                 messageType:MessageType.MT_DOCUMENT,
                 timeStamp: DateTime.UtcNow.AddDays(-1), 
                 handledCount:5,
                 delayedMilliseconds:5,
-                correlationId: Guid.NewGuid(),
+                correlationId: Guid.NewGuid().ToString(),
                 replyTo: "ReplyTo",
                 contentType: "text/plain",
                 partitionKey: Guid.NewGuid().ToString());

--- a/tests/Paramore.Brighter.Sqlite.Tests/Outbox/When_Writing_A_Message_To_The_Outbox_Async.cs
+++ b/tests/Paramore.Brighter.Sqlite.Tests/Outbox/When_Writing_A_Message_To_The_Outbox_Async.cs
@@ -55,7 +55,7 @@ namespace Paramore.Brighter.Sqlite.Tests.Outbox
             _sqlOutbox = new SqliteOutbox(_sqliteTestHelper.OutboxConfiguration);
  
             var messageHeader = new MessageHeader(
-                Guid.NewGuid(), 
+                Guid.NewGuid().ToString(), 
                 "test_topic", 
                 MessageType.MT_DOCUMENT,
                 DateTime.UtcNow.AddDays(-1), 5, 5);

--- a/tests/Paramore.Brighter.Sqlite.Tests/Outbox/When_there_are_multiple_messages_and_some_are_received_and_Dispatched_bulk_Async.cs
+++ b/tests/Paramore.Brighter.Sqlite.Tests/Outbox/When_there_are_multiple_messages_and_some_are_received_and_Dispatched_bulk_Async.cs
@@ -26,13 +26,13 @@ namespace Paramore.Brighter.Sqlite.Tests.Outbox
             _sqliteTestHelper.SetupMessageDb();
             _sqlOutbox = new SqliteOutbox(_sqliteTestHelper.OutboxConfiguration);
  
-            _message = new Message(new MessageHeader(Guid.NewGuid(), _Topic1, MessageType.MT_COMMAND),
+            _message = new Message(new MessageHeader(Guid.NewGuid().ToString(), _Topic1, MessageType.MT_COMMAND),
                 new MessageBody("message body"));
-            _message1 = new Message(new MessageHeader(Guid.NewGuid(), _Topic2, MessageType.MT_EVENT),
+            _message1 = new Message(new MessageHeader(Guid.NewGuid().ToString(), _Topic2, MessageType.MT_EVENT),
                 new MessageBody("message body2"));
-            _message2 = new Message(new MessageHeader(Guid.NewGuid(), _Topic1, MessageType.MT_COMMAND),
+            _message2 = new Message(new MessageHeader(Guid.NewGuid().ToString(), _Topic1, MessageType.MT_COMMAND),
                 new MessageBody("message body3"));
-            _message3 = new Message(new MessageHeader(Guid.NewGuid(), _Topic2, MessageType.MT_EVENT),
+            _message3 = new Message(new MessageHeader(Guid.NewGuid().ToString(), _Topic2, MessageType.MT_EVENT),
                 new MessageBody("message body4"));
         }
 


### PR DESCRIPTION
Historically we used a GUID to uniquely identify a request and a message. Whilst this strategy worked, it is less helpful for interop with other platforms that use other identifiers. More than this it is not compatible with Cloud Events. 

Given out goal to support Cloud Events properly in V10, (see #2130) this forms a necessary step in that journey.

This is a breaking change, though we do try to limit the damage by defaultint to Guid.NewGuid().ToString to initialize the string where the id is not provided.

