### PR TITLE
Kafka  Bug Fixes

### DIFF
--- a/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaSubscription.cs
+++ b/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaSubscription.cs
@@ -156,7 +156,7 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
             OnMissingChannel makeChannels = OnMissingChannel.Create,
             int emptyChannelDelay = 500,
             int channelFailureDelay = 1000,
-            PartitionAssignmentStrategy partitionAssignmentStrategy = PartitionAssignmentStrategy.CooperativeSticky) 
+            PartitionAssignmentStrategy partitionAssignmentStrategy = PartitionAssignmentStrategy.RoundRobin) 
             : base(dataType, name, channelName, routingKey, bufferSize, noOfPerformers, timeoutInMilliseconds, requeueCount, 
                 requeueDelayInMilliseconds, unacceptableMessageLimit, runAsync, channelFactory, makeChannels, emptyChannelDelay, channelFailureDelay)
         {
@@ -170,6 +170,10 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
             NumPartitions = numOfPartitions;
             ReplicationFactor = replicationFactor;
             PartitionAssignmentStrategy = partitionAssignmentStrategy;
+            
+            if (PartitionAssignmentStrategy == PartitionAssignmentStrategy.CooperativeSticky)
+                throw new ArgumentOutOfRangeException("partitionAssignmentStrategy",
+                    "CooperativeSticky is not supported for with manual commits, see https://github.com/confluentinc/librdkafka/issues/4059");
         }
     }
 
@@ -226,7 +230,7 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
             OnMissingChannel makeChannels = OnMissingChannel.Create,
             int emptyChannelDelay = 500,
             int channelFailureDelay = 1000,
-            PartitionAssignmentStrategy partitionAssignmentStrategy = PartitionAssignmentStrategy.CooperativeSticky) 
+            PartitionAssignmentStrategy partitionAssignmentStrategy = PartitionAssignmentStrategy.RoundRobin) 
             : base(typeof(T), name, channelName, routingKey, groupId, bufferSize, noOfPerformers, timeoutInMilliseconds, 
                 requeueCount, requeueDelayInMilliseconds, unacceptableMessageLimit, offsetDefault, commitBatchSize, 
                 sessionTimeoutMs, maxPollIntervalMs, sweepUncommittedOffsetsIntervalMs, isolationLevel, runAsync, 


### PR DESCRIPTION
Fixes from V9

- Drops support for Co-operative Sticky rebalancing for now. (Defaults to Round Robin and gives an exception if you try to set co-operative).  There is an issue around this you can track: https://github.com/BrighterCommand/Brighter/issues/3056 . It may take some thought because we need to know if we are rebalancing when we try to commit an offset.
- Removed a spurious call to StoreOffset. As we have our own offset store this was not being used.