### PR TITLE
Fix how we set up the event bus in V10

### DIFF
--- a/.idea/.idea.Brighter/.idea/httpRequests/http-requests-log.http
+++ b/.idea/.idea.Brighter/.idea/httpRequests/http-requests-log.http
@@ -1,3 +1,17 @@
+DELETE http://localhost:5000/People/Tyrion
+Connection: Keep-Alive
+User-Agent: Apache-HttpClient/4.5.14 (Java/17.0.10)
+Accept-Encoding: br,deflate,gzip,x-gzip
+
+###
+
+DELETE http://localhost:5000/People/Tyrion
+Connection: Keep-Alive
+User-Agent: Apache-HttpClient/4.5.14 (Java/17.0.10)
+Accept-Encoding: br,deflate,gzip,x-gzip
+
+###
+
 POST http://localhost:5000/Greetings/Tyrion/new
 Content-Type: application/json
 Content-Length: 47
@@ -637,24 +651,6 @@ Accept-Encoding: br,deflate,gzip,x-gzip
 }
 
 <> 2023-07-07T190352.200.json
-
-###
-
-GET http://localhost:5000/People/Tyrion
-Connection: Keep-Alive
-User-Agent: Apache-HttpClient/4.5.14 (Java/17.0.6)
-Accept-Encoding: br,deflate,gzip,x-gzip
-
-<> 2023-07-07T190349.200.json
-
-###
-
-GET http://localhost:5000/Greetings/Tyrion
-Connection: Keep-Alive
-User-Agent: Apache-HttpClient/4.5.14 (Java/17.0.6)
-Accept-Encoding: br,deflate,gzip,x-gzip
-
-<> 2023-07-07T165603.200.json
 
 ###
 

--- a/src/Paramore.Brighter.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Paramore.Brighter.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -323,7 +323,7 @@ namespace Paramore.Brighter.Extensions.DependencyInjection
             return (IAmAnExternalBusService)Activator.CreateInstance(busType,
                 busConfiguration.ProducerRegistry,
                 policyRegistry,
-                busConfiguration.MessageMapperRegistry,
+                MessageMapperRegistry(serviceProvider),
                 TransformFactory(serviceProvider),
                 TransformFactoryAsync(serviceProvider),
                 outbox,

--- a/src/Paramore.Brighter.ServiceActivator/ControlBus/ControlBusReceiverBuilder.cs
+++ b/src/Paramore.Brighter.ServiceActivator/ControlBus/ControlBusReceiverBuilder.cs
@@ -155,14 +155,20 @@ namespace Paramore.Brighter.ServiceActivator.ControlBus
             var outbox = new SinkOutboxSync();
             
             CommandProcessor commandProcessor = null;
-            var externalBusConfiguration = new ExternalBusConfiguration();
-            externalBusConfiguration.ProducerRegistry = producerRegistry;
-            externalBusConfiguration.MessageMapperRegistry = outgoingMessageMapperRegistry;
+            
+            var externalBus = new ExternalBusService<Message, CommittableTransaction>(
+                producerRegistry: producerRegistry,
+                policyRegistry: new DefaultPolicy(),
+                mapperRegistry: outgoingMessageMapperRegistry,
+                messageTransformerFactory: new EmptyMessageTransformerFactory(),
+                messageTransformerFactoryAsync: new EmptyMessageTransformerFactoryAsync(),
+                outbox: outbox
+            );  
             
             commandProcessor = CommandProcessorBuilder.With()
                 .Handlers(new HandlerConfiguration(subscriberRegistry, new ControlBusHandlerFactorySync(_dispatcher, () => commandProcessor)))
                 .Policies(policyRegistry)
-                .ExternalBusCreate(externalBusConfiguration, outbox, new CommittableTransactionProvider())
+                .ExternalBus(ExternalBusType.FireAndForget, externalBus)
                 .RequestContextFactory(new InMemoryRequestContextFactory())
                 .Build();
             

--- a/src/Paramore.Brighter/CommandProcessorBuilder.cs
+++ b/src/Paramore.Brighter/CommandProcessorBuilder.cs
@@ -193,39 +193,6 @@ namespace Paramore.Brighter
         }
         
         /// <summary>
-        /// The <see cref="CommandProcessor"/> wants to support <see cref="CommandProcessor.Post{TRequest}"/> or <see cref="CommandProcessor.Repost"/> using an external bus.
-        /// You need to provide a policy to specify how QoS issues, specifically <see cref="CommandProcessor.RETRYPOLICY "/> or <see cref="CommandProcessor.CIRCUITBREAKER "/> 
-        /// are handled by adding appropriate <see cref="Policies"/> when choosing this option.
-        /// 
-        /// </summary>
-        /// <param name="configuration">The Task Queues configuration.</param>
-        /// <param name="outbox">The Outbox.</param>
-        /// <param name="transactionProvider"></param>
-        /// <returns>INeedARequestContext.</returns>
-        public INeedARequestContext ExternalBusCreate<TTransaction>(
-            ExternalBusConfiguration configuration, 
-            IAmAnOutbox outbox,
-            IAmABoxTransactionProvider<TTransaction> transactionProvider)
-        {
-            _responseChannelFactory = configuration.ResponseChannelFactory;
-            
-            _bus = new ExternalBusService<Message, TTransaction>(
-                configuration.ProducerRegistry,
-                _policyRegistry,
-                configuration.MessageMapperRegistry,
-                new EmptyMessageTransformerFactory(),
-                new EmptyMessageTransformerFactoryAsync(),
-                outbox, 
-                configuration.OutboxBulkChunkSize,
-                configuration.OutboxTimeout,
-                configuration.MaxOutStandingMessages,
-                configuration.MaxOutStandingCheckIntervalMilliSeconds,
-                configuration.OutBoxBag);
-            
-            return this;
-        }
-
-        /// <summary>
         /// Use to indicate that you are not using Task Queues.
         /// </summary>
         /// <returns>INeedARequestContext.</returns>
@@ -360,21 +327,6 @@ namespace Paramore.Brighter
         /// </summary>
         /// <returns>INeedARequestContext.</returns>
         INeedARequestContext NoExternalBus();
-
-        /// <summary>
-        /// The <see cref="CommandProcessor"/> wants to support <see cref="CommandProcessor.Post{TRequest}"/> or <see cref="CommandProcessor.Repost"/> using an external bus.
-        /// You need to provide a policy to specify how QoS issues, specifically <see cref="CommandProcessor.RETRYPOLICY "/> or <see cref="CommandProcessor.CIRCUITBREAKER "/> 
-        /// are handled by adding appropriate <see cref="CommandProcessorBuilder.Policies"/> when choosing this option.
-        /// 
-        /// </summary>
-        /// <param name="configuration">The Task Queues configuration.</param>
-        /// <param name="outbox">The Outbox.</param>
-        /// <param name="transactionProvider"></param>
-        /// <returns>INeedARequestContext.</returns>
-        INeedARequestContext ExternalBusCreate<TTransaction>(
-            ExternalBusConfiguration configuration, 
-            IAmAnOutbox outbox,
-            IAmABoxTransactionProvider<TTransaction> transactionProvider);
     }
 
     /// <summary>

--- a/src/Paramore.Brighter/ExternalBusConfiguration.cs
+++ b/src/Paramore.Brighter/ExternalBusConfiguration.cs
@@ -38,6 +38,7 @@ namespace Paramore.Brighter
 
         /// <summary>
         /// Gets the message mapper registry.
+        /// You can set this, but you will not need to if you are using the AutoFromAssemblies extension method
         /// </summary>
         /// <value>The message mapper registry.</value>
         IAmAMessageMapperRegistry MessageMapperRegistry { get; set; }
@@ -127,6 +128,7 @@ namespace Paramore.Brighter
 
         /// <summary>
         /// Gets the message mapper registry.
+        /// You can set this, but you will not need to if you are using the AutoFromAssemblies extension method
         /// </summary>
         /// <value>The message mapper registry.</value>
         public IAmAMessageMapperRegistry MessageMapperRegistry { get; set; }
@@ -179,6 +181,12 @@ namespace Paramore.Brighter
         /// </summary>
         public IAmAChannelFactory ResponseChannelFactory { get; set; }
         
+        /// <summary>
+        /// Sets up a transform factory. We need this if you have transforms applied to your MapToMessage or MapToRequest methods
+        /// of your MessageMappers
+        /// You can set this, but you will not need to if you are using the AutoFromAssemblies extension method
+        /// </summary>
+        public IAmAMessageTransformerFactory TransformerFactory { get; set; }
         
         /// <summary>
         /// The transaction provider for the outbox


### PR DESCRIPTION
The Event Bus was not working when used with the samples in V10, due to the changed way that we set up the message mapper registry. This fixes that.