### PR TITLE
Use Time Provider to fix time related tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
         run: |
           dotnet test tests/Paramore.Brighter.Core.Tests/Paramore.Brighter.Core.Tests.csproj --filter "Fragile!=CI" -c Release --no-restore --no-build --verbosity d
           dotnet test tests/Paramore.Brighter.Extensions.Tests/Paramore.Brighter.Extensions.Tests.csproj -c Release --no-restore --no-build --verbosity d
+          dotnet test tests/Paramore.Brighter.InMemory.Tests/Paramore.Brighter.InMemory.Tests.csproj -c Release --no-restore --no-build --verbosity d
       - name: Upload packages as artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -30,6 +30,7 @@
     <PackageVersion Include="FluentMigrator" Version="5.2.0" />
     <PackageVersion Include="FluentMigrator.Runner" Version="5.2.0" />
     <PackageVersion Include="MessagePack" Version="2.5.140" />
+    <PackageVersion Include="Microsoft.Bcl.TimeProvider" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.2.0" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="8.0.4" />
     <PackageVersion Include="Microsoft.Data.Sqlite.Core" Version="8.0.4" />
@@ -43,6 +44,7 @@
     <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.4.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageVersion Include="MySqlConnector" Version="2.3.6" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />

--- a/src/Paramore.Brighter.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Paramore.Brighter.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -182,7 +182,7 @@ namespace Paramore.Brighter.Extensions.DependencyInjection
             var outbox = busConfiguration.Outbox;
             if (outbox == null)
             {
-                outbox = new InMemoryOutbox();
+                outbox = new InMemoryOutbox(TimeProvider.System);
             }
 
             //we create the outbox from interfaces from the determined transaction type to prevent the need

--- a/src/Paramore.Brighter/ExternalBusService.cs
+++ b/src/Paramore.Brighter/ExternalBusService.cs
@@ -97,7 +97,7 @@ namespace Paramore.Brighter
             _transformPipelineBuilderAsync = new TransformPipelineBuilderAsync(mapperRegistryAsync, messageTransformerFactoryAsync);
 
             //default to in-memory; expectation for a in memory box is Message and CommittableTransaction
-            if (outbox is null) outbox = new InMemoryOutbox();
+            if (outbox is null) outbox = new InMemoryOutbox(TimeProvider.System);
             if (outbox is IAmAnOutboxSync<TMessage, TTransaction> syncOutbox) _outBox = syncOutbox;
             if (outbox is IAmAnOutboxAsync<TMessage, TTransaction> asyncOutbox) _asyncOutbox = asyncOutbox;
             

--- a/src/Paramore.Brighter/InboxConfiguration.cs
+++ b/src/Paramore.Brighter/InboxConfiguration.cs
@@ -51,7 +51,7 @@ namespace Paramore.Brighter
             OnceOnlyAction actionOnExists = OnceOnlyAction.Throw, 
             Func<Type, string> context = null)
         {
-            Inbox = inbox ?? new InMemoryInbox(); 
+            Inbox = inbox ?? new InMemoryInbox(TimeProvider.System); 
             
             Scope = scope;
             Context = context;

--- a/src/Paramore.Brighter/Paramore.Brighter.csproj
+++ b/src/Paramore.Brighter/Paramore.Brighter.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Bcl.TimeProvider" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="NJsonSchema" />

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Building_A_Pipeline_With_Global_Inbox.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Building_A_Pipeline_With_Global_Inbox.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using FluentAssertions;
 using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Time.Testing;
 using Paramore.Brighter.Extensions.DependencyInjection;
 using Xunit;
 using Paramore.Brighter.Inbox.Handlers;
@@ -18,14 +19,14 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
 
         public PipelineGlobalInboxTests()
         {
-            IAmAnInboxSync inbox = new InMemoryInbox();
+            IAmAnInboxSync inbox = new InMemoryInbox(new FakeTimeProvider());
             
             var registry = new SubscriberRegistry();
             registry.Register<MyCommand, MyCommandHandler>();
             
             var container = new ServiceCollection();
             container.AddTransient<MyCommandHandler>();
-            container.AddSingleton<IAmAnInboxSync>(inbox);
+            container.AddSingleton(inbox);
             container.AddTransient<UseInboxHandler<MyCommand>>();
             container.AddSingleton<IBrighterOptions>(new BrighterOptions {HandlerLifetime = ServiceLifetime.Transient});
  
@@ -33,7 +34,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
             
             _requestContext = new RequestContext();
             
-            InboxConfiguration inboxConfiguration = new InboxConfiguration();
+            InboxConfiguration inboxConfiguration = new();
 
             _chainBuilder = new PipelineBuilder<MyCommand>(registry, (IAmAHandlerFactorySync)handlerFactory, inboxConfiguration);
             PipelineBuilder<MyCommand>.ClearPipelineCache(); 

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Building_A_Pipeline_With_Global_Inbox_And_NoInbox_Attribute_Async .cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Building_A_Pipeline_With_Global_Inbox_And_NoInbox_Attribute_Async .cs
@@ -3,6 +3,7 @@ using System.Linq;
 using FluentAssertions;
 using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Time.Testing;
 using Paramore.Brighter.Extensions.DependencyInjection;
 using Xunit;
 
@@ -14,29 +15,27 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
         private readonly PipelineBuilder<MyCommand> _chainBuilder;
         private AsyncPipelines<MyCommand> _chainOfResponsibility;
         private readonly RequestContext _requestContext;
-        private readonly InboxConfiguration _inboxConfiguration;
-        private IAmAnInboxSync _inbox;
 
 
         public PipelineGlobalInboxNoInboxAttributeAsyncTests()
         {
-            _inbox = new InMemoryInbox();
+            IAmAnInboxSync inbox = new InMemoryInbox(new FakeTimeProvider());
             
             var registry = new SubscriberRegistry();
             registry.RegisterAsync<MyCommand, MyNoInboxCommandHandlerAsync>();
             
             var container = new ServiceCollection();
             container.AddTransient<MyNoInboxCommandHandlerAsync>();
-            container.AddSingleton<IAmAnInboxSync>(_inbox);
+            container.AddSingleton(inbox);
             container.AddSingleton<IBrighterOptions>(new BrighterOptions {HandlerLifetime = ServiceLifetime.Transient});
  
             var handlerFactory = new ServiceProviderHandlerFactory(container.BuildServiceProvider());
 
             _requestContext = new RequestContext();
             
-            _inboxConfiguration = new InboxConfiguration();
+            InboxConfiguration inboxConfiguration = new();
 
-            _chainBuilder = new PipelineBuilder<MyCommand>(registry, (IAmAHandlerFactoryAsync)handlerFactory, _inboxConfiguration);
+            _chainBuilder = new PipelineBuilder<MyCommand>(registry, (IAmAHandlerFactoryAsync)handlerFactory, inboxConfiguration);
             
         }
 

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Calling_A_Server_Via_The_Command_Processor.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Calling_A_Server_Via_The_Command_Processor.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using System.Transactions;
 using FluentAssertions;
+using Microsoft.Extensions.Time.Testing;
 using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
 using Paramore.Brighter.ServiceActivator.TestHelpers;
 using Polly;
@@ -88,7 +89,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
                 messageMapperRegistry,
                 new EmptyMessageTransformerFactory(),
                 new EmptyMessageTransformerFactoryAsync(),
-                new InMemoryOutbox());
+                new InMemoryOutbox(new FakeTimeProvider()));
         
             CommandProcessor.ClearServiceBus();
             _commandProcessor = new CommandProcessor(

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Calling_A_Server_Via_The_Command_Processor_With_No_In_Mapper.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Calling_A_Server_Via_The_Command_Processor_With_No_In_Mapper.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Transactions;
 using FluentAssertions;
+using Microsoft.Extensions.Time.Testing;
 using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
 using Paramore.Brighter.Core.Tests.TestHelpers;
 using Paramore.Brighter.ServiceActivator.TestHelpers;
@@ -63,7 +64,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
                 messageMapperRegistry,
                 new EmptyMessageTransformerFactory(),
                 new EmptyMessageTransformerFactoryAsync(),
-                new InMemoryOutbox()
+                new InMemoryOutbox(new FakeTimeProvider())
                 );
         
             CommandProcessor.ClearServiceBus();

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Calling_A_Server_Via_The_Command_Processor_With_No_Out_Mapper.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Calling_A_Server_Via_The_Command_Processor_With_No_Out_Mapper.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Transactions;
 using FluentAssertions;
+using Microsoft.Extensions.Time.Testing;
 using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
 using Paramore.Brighter.Core.Tests.TestHelpers;
 using Paramore.Brighter.ServiceActivator.TestHelpers;
@@ -65,7 +66,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
                 messageMapperRegistry,
                 new EmptyMessageTransformerFactory(),
                 new EmptyMessageTransformerFactoryAsync(),
-                new InMemoryOutbox()
+                new InMemoryOutbox(new FakeTimeProvider())
             );
         
             CommandProcessor.ClearServiceBus();

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Calling_A_Server_Via_The_Command_Processor_With_No_Timeout.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Calling_A_Server_Via_The_Command_Processor_With_No_Timeout.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Transactions;
 using FluentAssertions;
+using Microsoft.Extensions.Time.Testing;
 using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
 using Paramore.Brighter.Core.Tests.TestHelpers;
 using Paramore.Brighter.ServiceActivator.TestHelpers;
@@ -69,7 +70,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
                 messageMapperRegistry,
                 new EmptyMessageTransformerFactory(),
                 new EmptyMessageTransformerFactoryAsync(),
-                new InMemoryOutbox()
+                new InMemoryOutbox(new FakeTimeProvider())
             );
 
             CommandProcessor.ClearServiceBus();

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Inserting_A_Default_Inbox_Into_The_Publish_Pipeline.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Inserting_A_Default_Inbox_Into_The_Publish_Pipeline.cs
@@ -6,6 +6,7 @@ using Paramore.Brighter.Inbox;
 using Polly;
 using Polly.Registry;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Time.Testing;
 using Paramore.Brighter.Extensions.DependencyInjection;
 using Paramore.Brighter.Inbox.Handlers;
 using Xunit;
@@ -16,7 +17,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
     public class CommandProcessorBuildDefaultInboxPublishTests : IDisposable
     {
         private readonly CommandProcessor _commandProcessor;
-        private readonly InMemoryInbox _inbox = new InMemoryInbox();
+        private readonly InMemoryInbox _inbox = new InMemoryInbox(new FakeTimeProvider());
 
         public CommandProcessorBuildDefaultInboxPublishTests()
         {
@@ -27,7 +28,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
             subscriberRegistry.Add(typeof(MyEvent), typeof(MyGlobalInboxEventHandler));
 
             var container = new ServiceCollection();
-            container.AddSingleton<MyGlobalInboxEventHandler>(handler);
+            container.AddSingleton(handler);
             container.AddSingleton<IAmAnInboxSync>(_inbox);
             container.AddSingleton<UseInboxHandler<MyEvent>>();
             container.AddSingleton<IBrighterOptions>(new BrighterOptions {HandlerLifetime = ServiceLifetime.Transient});

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Inserting_A_Default_Inbox_Into_The_Send_Pipeline.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Inserting_A_Default_Inbox_Into_The_Send_Pipeline.cs
@@ -5,6 +5,7 @@ using Paramore.Brighter.Inbox;
 using Polly;
 using Polly.Registry;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Time.Testing;
 using Paramore.Brighter.Extensions.DependencyInjection;
 using Xunit;
 using Paramore.Brighter.Inbox.Handlers;
@@ -41,7 +42,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
                 .CircuitBreaker(1, TimeSpan.FromMilliseconds(1));
 
             var inboxConfiguration = new InboxConfiguration(
-                new InMemoryInbox(),
+                new InMemoryInbox(new FakeTimeProvider()),
                 InboxScope.All, //grab all the events
                 onceOnly: true, //only allow once
                 actionOnExists: OnceOnlyAction.Throw //throw on duplicates (we should  be the only entry after)

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Inserting_A_Default_Inbox_Into_The_Send_Pipeline.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Inserting_A_Default_Inbox_Into_The_Send_Pipeline.cs
@@ -26,7 +26,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
 
             var container = new ServiceCollection();
             container.AddTransient<MyCommandHandler>();
-            container.AddSingleton<IAmAnInboxSync, InMemoryInbox>();
+            container.AddSingleton<IAmAnInboxSync>(new InMemoryInbox(new FakeTimeProvider()));
             container.AddTransient<UseInboxHandler<MyCommand>>();
             container.AddSingleton<IBrighterOptions>(new BrighterOptions {HandlerLifetime = ServiceLifetime.Transient});
 

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Posting_Fails_Limit_Total_Writes_To_OutBox_In_Window.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Posting_Fails_Limit_Total_Writes_To_OutBox_In_Window.cs
@@ -39,7 +39,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
     {
         private readonly CommandProcessor _commandProcessor;
         private readonly InMemoryOutbox _outbox;
-        private readonly TimeProvider _timeProvider;
+        private readonly FakeTimeProvider _timeProvider;
 
         public PostFailureLimitCommandTests()
         {
@@ -90,9 +90,11 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
                     var command = new MyCommand{Value = $"Hello World: {sentList.Count() + 1}"};
                     _commandProcessor.Post(command);
                     sentList.Add(command.Id);
+                    
+                    _timeProvider.Advance(TimeSpan.FromMilliseconds(500));
 
                     //We need to wait for the sweeper thread to check the outstanding in the outbox
-                    await _timeProvider.Delay(TimeSpan.FromMilliseconds(50));
+                    await Task.Delay(50);
 
                 } while (sentList.Count < 10);
             }

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Posting_Via_A_Control_Bus_Sender_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Posting_Via_A_Control_Bus_Sender_Async.cs
@@ -29,6 +29,7 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using System.Transactions;
 using FluentAssertions;
+using Microsoft.Extensions.Time.Testing;
 using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
 using Polly;
 using Polly.Registry;
@@ -50,7 +51,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
         {
             _myCommand.Value = "Hello World";
 
-            _outbox = new InMemoryOutbox();
+            _outbox = new InMemoryOutbox(new FakeTimeProvider());
             _fakeMessageProducerWithPublishConfirmation = new FakeMessageProducerWithPublishConfirmation();
 
             const string topic = "MyCommand";

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Posting_With_An_In_Memory_Message_Store.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Posting_With_An_In_Memory_Message_Store.cs
@@ -27,6 +27,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using System.Transactions;
 using FluentAssertions;
+using Microsoft.Extensions.Time.Testing;
 using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
 using Polly;
 using Polly.Registry;
@@ -40,7 +41,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
         private readonly CommandProcessor _commandProcessor;
         private readonly MyCommand _myCommand = new MyCommand();
         private readonly Message _message;
-        private readonly InMemoryOutbox _outbox = new InMemoryOutbox();
+        private readonly InMemoryOutbox _outbox = new InMemoryOutbox(new FakeTimeProvider());
         private readonly FakeMessageProducerWithPublishConfirmation _producer; 
 
         public CommandProcessorWithInMemoryOutboxTests()

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Posting_With_An_In_Memory_Message_Store_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_Posting_With_An_In_Memory_Message_Store_Async.cs
@@ -28,6 +28,7 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using System.Transactions;
 using FluentAssertions;
+using Microsoft.Extensions.Time.Testing;
 using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
 using Polly;
 using Polly.Registry;
@@ -49,7 +50,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors
             const string topic = "MyCommand";
             _myCommand.Value = "Hello World";
 
-            _outbox = new InMemoryOutbox();
+            _outbox = new InMemoryOutbox(new FakeTimeProvider());
             _producer = new FakeMessageProducerWithPublishConfirmation{Publication = {Topic = new RoutingKey(topic), RequestType = typeof(MyCommand)}};
 
             _message = new Message(

--- a/tests/Paramore.Brighter.Core.Tests/Observability/When_Implicitly_Clearing_The_Outbox_A_Span_Is_Exported.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Observability/When_Implicitly_Clearing_The_Outbox_A_Span_Is_Exported.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using System.Transactions;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Time.Testing;
 using OpenTelemetry;
 using OpenTelemetry.Trace;
 using Paramore.Brighter.Core.Tests.Observability.TestDoubles;
@@ -21,12 +22,14 @@ public class ImplicitClearingObservabilityTests : IDisposable
     private readonly MyEvent _event;
     private readonly TracerProvider _traceProvider;
     private readonly List<Activity> _exportedActivities;
+    private readonly TimeProvider _timeProvider;
 
     public ImplicitClearingObservabilityTests()
     {
         const string topic = "MyEvent";
-        
-        IAmAnOutboxSync<Message, CommittableTransaction> outbox = new InMemoryOutbox();
+
+        _timeProvider = new FakeTimeProvider();
+        IAmAnOutboxSync<Message, CommittableTransaction> outbox = new InMemoryOutbox(_timeProvider);
         _event = new MyEvent("TestEvent");
 
         var registry = new SubscriberRegistry();
@@ -90,8 +93,7 @@ public class ImplicitClearingObservabilityTests : IDisposable
             _commandProcessor.ClearOutbox(10, 0);
         }
 
-        //wait for Background Process
-        await Task.Delay(100);
+        await _timeProvider.Delay(TimeSpan.FromMilliseconds(100)); //Allow time for clear to run
 
         _traceProvider.ForceFlush();
         

--- a/tests/Paramore.Brighter.Core.Tests/Observability/When_Implicitly_Clearing_The_Outbox_A_Span_Is_Exported.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Observability/When_Implicitly_Clearing_The_Outbox_A_Span_Is_Exported.cs
@@ -93,7 +93,7 @@ public class ImplicitClearingObservabilityTests : IDisposable
             _commandProcessor.ClearOutbox(10, 0);
         }
 
-        await _timeProvider.Delay(TimeSpan.FromMilliseconds(100)); //Allow time for clear to run
+        await Task.Delay(100); //Allow time for clear to run
 
         _traceProvider.ForceFlush();
         

--- a/tests/Paramore.Brighter.Core.Tests/Observability/When_Implicitly_Clearing_The_Outbox_async_A_Span_Is_Exported.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Observability/When_Implicitly_Clearing_The_Outbox_async_A_Span_Is_Exported.cs
@@ -97,7 +97,7 @@ public class ImplicitClearingAsyncObservabilityTests : IDisposable
             _commandProcessor.ClearAsyncOutbox(10, 0);
         }
 
-        await _timeProvider.Delay(TimeSpan.FromMilliseconds(100)); //Allow time for clear to run
+        await Task.Delay(100); //Allow time for clear to run 
 
         _traceProvider.ForceFlush();
 

--- a/tests/Paramore.Brighter.Core.Tests/OnceOnly/When_Handling_A_Command_Once_Only_With_Inbox_Enabled.cs
+++ b/tests/Paramore.Brighter.Core.Tests/OnceOnly/When_Handling_A_Command_Once_Only_With_Inbox_Enabled.cs
@@ -4,6 +4,7 @@ using Paramore.Brighter.Core.Tests.OnceOnly.TestDoubles;
 using Paramore.Brighter.Inbox.Exceptions;
 using Polly.Registry;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Time.Testing;
 using Paramore.Brighter.Extensions.DependencyInjection;
 using Xunit;
 using Paramore.Brighter.Inbox.Handlers;
@@ -19,7 +20,7 @@ namespace Paramore.Brighter.Core.Tests.OnceOnly
         
         public OnceOnlyAttributeTests()
         {
-            _inbox = new InMemoryInbox();
+            _inbox = new InMemoryInbox(new FakeTimeProvider());
             
             var registry = new SubscriberRegistry();
             registry.Register<MyCommand, MyStoredCommandHandler>();

--- a/tests/Paramore.Brighter.Core.Tests/OnceOnly/When_Handling_A_Command_Once_Only_With_Inbox_Enabled_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/OnceOnly/When_Handling_A_Command_Once_Only_With_Inbox_Enabled_Async.cs
@@ -5,6 +5,7 @@ using Paramore.Brighter.Core.Tests.OnceOnly.TestDoubles;
 using Paramore.Brighter.Inbox.Exceptions;
 using Polly.Registry;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Time.Testing;
 using Paramore.Brighter.Extensions.DependencyInjection;
 using Xunit;
 using Paramore.Brighter.Inbox.Handlers;
@@ -22,7 +23,7 @@ namespace Paramore.Brighter.Core.Tests.OnceOnly
         
         public OnceOnlyAttributeAsyncTests()
         {
-            _inbox = new InMemoryInbox();
+            _inbox = new InMemoryInbox(new FakeTimeProvider());
 
             var registry = new SubscriberRegistry();
             registry.RegisterAsync<MyCommand, MyStoredCommandHandlerAsync>();

--- a/tests/Paramore.Brighter.Core.Tests/OnceOnly/When_Handling_A_Command_Once_Only_With_Throw_Enabled.cs
+++ b/tests/Paramore.Brighter.Core.Tests/OnceOnly/When_Handling_A_Command_Once_Only_With_Throw_Enabled.cs
@@ -28,6 +28,7 @@ using Paramore.Brighter.Core.Tests.OnceOnly.TestDoubles;
 using Paramore.Brighter.Inbox.Exceptions;
 using Polly.Registry;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Time.Testing;
 using Paramore.Brighter.Extensions.DependencyInjection;
 using Xunit;
 using Paramore.Brighter.Inbox.Handlers;
@@ -43,7 +44,7 @@ namespace Paramore.Brighter.Core.Tests.OnceOnly
 
         public OnceOnlyAttributeWithThrowExceptionTests()
         {
-            _inbox = new InMemoryInbox();
+            _inbox = new InMemoryInbox(new FakeTimeProvider());
             
             var registry = new SubscriberRegistry();
             registry.Register<MyCommand, MyStoredCommandToThrowHandler>();

--- a/tests/Paramore.Brighter.Core.Tests/OnceOnly/When_Handling_A_Command_Once_Only_With_Throw_Enabled_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/OnceOnly/When_Handling_A_Command_Once_Only_With_Throw_Enabled_Async.cs
@@ -30,6 +30,7 @@ using Paramore.Brighter.Inbox.Exceptions;
 using Paramore.Brighter.Inbox.Handlers;
 using Polly.Registry;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Time.Testing;
 using Paramore.Brighter.Extensions.DependencyInjection;
 using Xunit;
 
@@ -45,7 +46,7 @@ namespace Paramore.Brighter.Core.Tests.OnceOnly
 
         public OnceOnlyAttributeWithThrowExceptionAsyncTests()
         {
-            _inbox = new InMemoryInbox();
+            _inbox = new InMemoryInbox(new FakeTimeProvider());
             
             var registry = new SubscriberRegistry();
             registry.RegisterAsync<MyCommand, MyStoredCommandToThrowHandlerAsync>();

--- a/tests/Paramore.Brighter.Core.Tests/OnceOnly/When_Handling_A_Command_Once_Only_With_Warn_Enabled.cs
+++ b/tests/Paramore.Brighter.Core.Tests/OnceOnly/When_Handling_A_Command_Once_Only_With_Warn_Enabled.cs
@@ -28,6 +28,7 @@ using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
 using Paramore.Brighter.Core.Tests.OnceOnly.TestDoubles;
 using Polly.Registry;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Time.Testing;
 using Paramore.Brighter.Extensions.DependencyInjection;
 using Xunit;
 using Paramore.Brighter.Inbox.Handlers;
@@ -43,7 +44,7 @@ namespace Paramore.Brighter.Core.Tests.OnceOnly
 
         public OnceOnlyAttributeWithWarnExceptionTests()
         {
-            _inbox = new InMemoryInbox();
+            _inbox = new InMemoryInbox(new FakeTimeProvider());
             
             var registry = new SubscriberRegistry();
             registry.Register<MyCommand, MyStoredCommandToWarnHandler>();

--- a/tests/Paramore.Brighter.Core.Tests/OnceOnly/When_Handling_A_Command_Once_Only_With_Warn_Enabled_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/OnceOnly/When_Handling_A_Command_Once_Only_With_Warn_Enabled_Async.cs
@@ -29,6 +29,7 @@ using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
 using Paramore.Brighter.Core.Tests.OnceOnly.TestDoubles;
 using Polly.Registry;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Time.Testing;
 using Paramore.Brighter.Extensions.DependencyInjection;
 using Xunit;
 using Paramore.Brighter.Inbox.Handlers;
@@ -40,19 +41,18 @@ namespace Paramore.Brighter.Core.Tests.OnceOnly
     public class OnceOnlyAttributeWithWarnExceptionAsyncTests : IDisposable
     {
         private readonly MyCommand _command;
-        private readonly IAmAnInboxAsync _inbox;
         private readonly IAmACommandProcessor _commandProcessor;
 
         public OnceOnlyAttributeWithWarnExceptionAsyncTests()
         {
-            _inbox = new InMemoryInbox();
+            IAmAnInboxAsync inbox = new InMemoryInbox(new FakeTimeProvider());
             
             var registry = new SubscriberRegistry();
             registry.RegisterAsync<MyCommand, MyStoredCommandToWarnHandlerAsync>();
 
             var container = new ServiceCollection();
             container.AddTransient<MyStoredCommandToWarnHandlerAsync>();
-            container.AddSingleton(_inbox);
+            container.AddSingleton(inbox);
             container.AddTransient<UseInboxHandlerAsync<MyCommand>>();
             container.AddSingleton<IBrighterOptions>(new BrighterOptions {HandlerLifetime = ServiceLifetime.Transient});
 

--- a/tests/Paramore.Brighter.Core.Tests/OnceOnly/When_Handling_A_Command_With_A_Inbox_Enabled.cs
+++ b/tests/Paramore.Brighter.Core.Tests/OnceOnly/When_Handling_A_Command_With_A_Inbox_Enabled.cs
@@ -28,6 +28,7 @@ using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
 using Paramore.Brighter.Core.Tests.OnceOnly.TestDoubles;
 using Polly.Registry;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Time.Testing;
 using Paramore.Brighter.Extensions.DependencyInjection;
 using Xunit;
 using Paramore.Brighter.Inbox.Handlers;
@@ -44,7 +45,7 @@ namespace Paramore.Brighter.Core.Tests.OnceOnly
 
         public CommandProcessorUsingInboxTests()
         {
-            _inbox = new InMemoryInbox();
+            _inbox = new InMemoryInbox(new FakeTimeProvider());
 
             var registry = new SubscriberRegistry();
             registry.Register<MyCommand, MyStoredCommandHandler>();

--- a/tests/Paramore.Brighter.Core.Tests/OnceOnly/When_Handling_A_Command_With_A_Inbox_Enabled_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/OnceOnly/When_Handling_A_Command_With_A_Inbox_Enabled_Async.cs
@@ -5,6 +5,7 @@ using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
 using Paramore.Brighter.Core.Tests.OnceOnly.TestDoubles;
 using Polly.Registry;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Time.Testing;
 using Paramore.Brighter.Core.Tests.TestHelpers;
 using Paramore.Brighter.Extensions.DependencyInjection;
 using Xunit;
@@ -23,7 +24,7 @@ namespace Paramore.Brighter.Core.Tests.OnceOnly
 
         public CommandProcessorUsingInboxAsyncTests()
         {
-            _inbox = new InMemoryInbox();
+            _inbox = new InMemoryInbox(new FakeTimeProvider());
 
             var registry = new SubscriberRegistry();
             registry.RegisterAsync<MyCommand, MyStoredCommandHandlerAsync>();

--- a/tests/Paramore.Brighter.Core.Tests/Paramore.Brighter.Core.Tests.csproj
+++ b/tests/Paramore.Brighter.Core.Tests/Paramore.Brighter.Core.Tests.csproj
@@ -15,6 +15,7 @@
     </PackageReference>
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="FakeItEasy" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="OpenTelemetry" />
     <PackageReference Include="OpenTelemetry.Exporter.InMemory" />

--- a/tests/Paramore.Brighter.InMemory.Tests/Inbox/When_storing_items_in_inbox.cs
+++ b/tests/Paramore.Brighter.InMemory.Tests/Inbox/When_storing_items_in_inbox.cs
@@ -25,6 +25,7 @@ THE SOFTWARE. */
 
 using System;
 using FluentAssertions;
+using Microsoft.Extensions.Time.Testing;
 using Paramore.Brighter.InMemory.Tests.Data;
 using Xunit;
 
@@ -38,7 +39,7 @@ namespace Paramore.Brighter.InMemory.Tests.Inbox
         public void When_storing_a_seen_message_in_the_inbox()
         {
             //Arrange
-            var inbox = new InMemoryInbox();
+            var inbox = new InMemoryInbox(new FakeTimeProvider());
             const string contextKey = "Developer_Test";
 
             var command = new SimpleCommand();
@@ -58,7 +59,7 @@ namespace Paramore.Brighter.InMemory.Tests.Inbox
         public void When_testing_for_a_message_in_the_inbox()
         {
             //Arrange
-            var inbox = new InMemoryInbox();
+            var inbox = new InMemoryInbox(new FakeTimeProvider());
             const string contextKey = "Developer_Test";
 
             var command = new SimpleCommand();
@@ -76,7 +77,7 @@ namespace Paramore.Brighter.InMemory.Tests.Inbox
         public void When_testing_for_a_missing_command()
         {
             //Arrange
-            var inbox = new InMemoryInbox();
+            var inbox = new InMemoryInbox(new FakeTimeProvider());
             const string contextKey = "Developer_Test";
 
             var command = new SimpleCommand();
@@ -93,7 +94,7 @@ namespace Paramore.Brighter.InMemory.Tests.Inbox
         public void When_storing_multiple_entries_retrieve_the_right_one()
         {
            //Arrange
-           var inbox = new InMemoryInbox();
+           var inbox = new InMemoryInbox(new FakeTimeProvider());
            const string contextKey = "Developer_Test";
 
            var commands = new SimpleCommand[] {new SimpleCommand(), new SimpleCommand(), new SimpleCommand(), new SimpleCommand(), new SimpleCommand()};
@@ -119,7 +120,7 @@ namespace Paramore.Brighter.InMemory.Tests.Inbox
         public void When_storing_multiple_entries_exists_should_find()
         {
             //Arrange
-            var inbox = new InMemoryInbox();
+            var inbox = new InMemoryInbox(new FakeTimeProvider());
             const string contextKey = "Developer_Test";
  
             var commands = new SimpleCommand[] {new SimpleCommand(), new SimpleCommand(), new SimpleCommand(), new SimpleCommand(), new SimpleCommand()};
@@ -142,7 +143,7 @@ namespace Paramore.Brighter.InMemory.Tests.Inbox
         public void When_storing_many_but_not_requested_exists_should_not_find()
         {
             //Arrange
-            var inbox = new InMemoryInbox();
+            var inbox = new InMemoryInbox(new FakeTimeProvider());
             const string contextKey = "Developer_Test";
  
             var commands = new SimpleCommand[] {new SimpleCommand(), new SimpleCommand(), new SimpleCommand(), new SimpleCommand(), new SimpleCommand()};

--- a/tests/Paramore.Brighter.InMemory.Tests/Outbox/When_Retrieving_Messages_based_on_Age.cs
+++ b/tests/Paramore.Brighter.InMemory.Tests/Outbox/When_Retrieving_Messages_based_on_Age.cs
@@ -1,6 +1,8 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Time.Testing;
 using Paramore.Brighter;
 using Paramore.Brighter.InMemory.Tests.Builders;
 using Xunit;
@@ -14,12 +16,13 @@ public class When_Retrieving_Messages_based_on_Age
     public void When_outstanding_in_outbox_they_are_retrieved_correctly()
     {
         var minimumAgeInMs = 500;
-        var outbox = new InMemoryOutbox();
+        var timeProvider = new FakeTimeProvider();
+        var outbox = new InMemoryOutbox(timeProvider);
         
         outbox.Add(new MessageTestDataBuilder());
         outbox.Add(new MessageTestDataBuilder());
         
-        Thread.Sleep(minimumAgeInMs);
+        timeProvider.Advance(TimeSpan.FromMilliseconds(minimumAgeInMs));
         
         outbox.Add(new MessageTestDataBuilder());
         outbox.Add(new MessageTestDataBuilder());
@@ -43,12 +46,13 @@ public class When_Retrieving_Messages_based_on_Age
     public async Task When_outstanding_in_outbox_they_are_retrieved_correctly_async()
     {
         var minimumAgeInMs = 1000;
-        var outbox = new InMemoryOutbox();
+        var timeProvider = new FakeTimeProvider();
+        var outbox = new InMemoryOutbox(timeProvider);
         
         await outbox.AddAsync(new MessageTestDataBuilder());
         await outbox.AddAsync(new MessageTestDataBuilder());
         
-        await Task.Delay(minimumAgeInMs * 2);
+        timeProvider.Advance(TimeSpan.FromMilliseconds(minimumAgeInMs * 2));
         
         await outbox.AddAsync(new MessageTestDataBuilder());
         await outbox.AddAsync(new MessageTestDataBuilder());

--- a/tests/Paramore.Brighter.InMemory.Tests/Outbox/When_controlling_cache_size.cs
+++ b/tests/Paramore.Brighter.InMemory.Tests/Outbox/When_controlling_cache_size.cs
@@ -25,6 +25,7 @@ THE SOFTWARE. */
 using System;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Microsoft.Extensions.Time.Testing;
 using Paramore.Brighter.InMemory.Tests.Builders;
 using Xunit;
 
@@ -39,7 +40,8 @@ namespace Paramore.Brighter.InMemory.Tests.Outbox
             //Arrange
             const int limit = 5;
             
-            var outbox = new InMemoryOutbox
+            var timeProvider = new FakeTimeProvider(); 
+            var outbox = new InMemoryOutbox(timeProvider)
             {
                 EntryLimit = limit,
                 CompactionPercentage = 0.5
@@ -65,7 +67,8 @@ namespace Paramore.Brighter.InMemory.Tests.Outbox
             //Arrange
             const int limit = 5;
             
-            var outbox = new InMemoryOutbox
+            var timeProvider = new FakeTimeProvider();
+            var outbox = new InMemoryOutbox(timeProvider)
             {
                 EntryLimit = limit,
                 CompactionPercentage = 0.5
@@ -76,7 +79,7 @@ namespace Paramore.Brighter.InMemory.Tests.Outbox
             for (int i = 0; i <= limit - 1; i++)
             {
                 outbox.Add(new MessageTestDataBuilder().WithId(messageIds[i]));
-                await Task.Delay(1000);
+                timeProvider.Advance(TimeSpan.FromMilliseconds(1000));
             }
 
             //Act

--- a/tests/Paramore.Brighter.InMemory.Tests/Paramore.Brighter.InMemory.Tests.csproj
+++ b/tests/Paramore.Brighter.InMemory.Tests/Paramore.Brighter.InMemory.Tests.csproj
@@ -11,6 +11,7 @@
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
       <PackageReference Include="FluentAssertions" />
+      <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" />
       <PackageReference Include="System.Text.Json" />
       <PackageReference Include="xunit" />

--- a/tests/Paramore.Brighter.InMemory.Tests/Sweeper/When_sweeping_the_outbox.cs
+++ b/tests/Paramore.Brighter.InMemory.Tests/Sweeper/When_sweeping_the_outbox.cs
@@ -1,7 +1,9 @@
-﻿using System.Globalization;
+﻿using System;
+using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Microsoft.Extensions.Time.Testing;
 using Paramore.Brighter.InMemory.Tests.Builders;
 using Paramore.Brighter.InMemory.Tests.TestDoubles;
 using Xunit;
@@ -11,18 +13,21 @@ namespace Paramore.Brighter.InMemory.Tests.Sweeper
     [Trait("Category", "InMemory")]
     public class SweeperTests
     {
-
         [Fact]
         public async Task When_outstanding_in_outbox_sweep_clears_them()
         {
             //Arrange
             const int milliSecondsSinceSent = 500;
-            
-            var outbox = new InMemoryOutbox();
-            var commandProcessor = new FakeCommandProcessor();
+
+            var timeProvider = new FakeTimeProvider();
+            var outbox = new InMemoryOutbox(timeProvider);
+            var commandProcessor = new FakeCommandProcessor(timeProvider);
             var sweeper = new OutboxSweeper(milliSecondsSinceSent, commandProcessor);
 
-            var messages = new Message[] {new MessageTestDataBuilder(), new MessageTestDataBuilder(), new MessageTestDataBuilder()};
+            var messages = new Message[]
+            {
+                new MessageTestDataBuilder(), new MessageTestDataBuilder(), new MessageTestDataBuilder()
+            };
 
             foreach (var message in messages)
             {
@@ -31,30 +36,33 @@ namespace Paramore.Brighter.InMemory.Tests.Sweeper
             }
 
             //Act
-            await Task.Delay(1000); // -- let the messages expire
-            
+            timeProvider.Advance(TimeSpan.FromMilliseconds(1000)); // -- let the messages expire
+
             sweeper.Sweep();
 
-            Thread.Sleep(200);
+            await Task.Delay(200); //Give the sweep time to run
 
             //Assert
             outbox.EntryCount.Should().Be(3);
             commandProcessor.Dispatched.Count.Should().Be(3);
             commandProcessor.Deposited.Count.Should().Be(3);
-
         }
-        
+
         [Fact]
         public async Task When_outstanding_in_outbox_sweep_clears_them_async()
         {
             //Arrange
             const int milliSecondsSinceSent = 500;
-            
-            var outbox = new InMemoryOutbox();
-            var commandProcessor = new FakeCommandProcessor();
+
+            var timeProvider = new FakeTimeProvider();
+            var outbox = new InMemoryOutbox(timeProvider);
+            var commandProcessor = new FakeCommandProcessor(timeProvider);
             var sweeper = new OutboxSweeper(milliSecondsSinceSent, commandProcessor);
 
-            var messages = new Message[] {new MessageTestDataBuilder(), new MessageTestDataBuilder(), new MessageTestDataBuilder()};
+            var messages = new Message[]
+            {
+                new MessageTestDataBuilder(), new MessageTestDataBuilder(), new MessageTestDataBuilder()
+            };
 
             foreach (var message in messages)
             {
@@ -63,82 +71,89 @@ namespace Paramore.Brighter.InMemory.Tests.Sweeper
             }
 
             //Act
-            await Task.Delay(milliSecondsSinceSent * 2); // -- let the messages expire
-            
+            timeProvider.Advance(TimeSpan.FromMilliseconds(milliSecondsSinceSent * 2)); // -- let the messages expire
+
             sweeper.SweepAsyncOutbox();
 
-            await Task.Delay(200);
+            await Task.Delay(200); //Give the sweep time to run
 
             //Assert
             outbox.EntryCount.Should().Be(3);
             commandProcessor.Dispatched.Count.Should().Be(3);
             commandProcessor.Deposited.Count.Should().Be(3);
-
         }
 
         [Fact]
         public async Task When_too_new_to_sweep_leaves_them()
         {
-             //Arrange
-             const int milliSecondsSinceSent = 500;
-             
-             var commandProcessor = new FakeCommandProcessor();
-             var sweeper = new OutboxSweeper(milliSecondsSinceSent, commandProcessor);
-             
-             Message oldMessage = new MessageTestDataBuilder();
-             commandProcessor.DepositPost(oldMessage.ToStubRequest());
-
-             var messages = new Message[] {new MessageTestDataBuilder(), new MessageTestDataBuilder(), new MessageTestDataBuilder()};
-            
-             Thread.Sleep(milliSecondsSinceSent * 2);
-
-             foreach (var message in messages)
-             {
-                 commandProcessor.DepositPost(message.ToStubRequest());
-             }
-
-             //Act
-             sweeper.Sweep();
-
-             await Task.Delay(200);
-
-            //Assert
-            commandProcessor.Dispatched.Count.Should().Be(1);
-            commandProcessor.Deposited.Count.Should().Be(4);
-           
-        }
-        
-        [Fact]
-        public async Task When_too_new_to_sweep_leaves_them_async()
-        {
             //Arrange
             const int milliSecondsSinceSent = 500;
-            
-            var commandProcessor = new FakeCommandProcessor();
+
+            var timeProvider = new FakeTimeProvider();
+            var commandProcessor = new FakeCommandProcessor(timeProvider);
             var sweeper = new OutboxSweeper(milliSecondsSinceSent, commandProcessor);
- 
+
             Message oldMessage = new MessageTestDataBuilder();
             commandProcessor.DepositPost(oldMessage.ToStubRequest());
-            
-            var messages = new Message[] {new MessageTestDataBuilder(), new MessageTestDataBuilder(), new MessageTestDataBuilder()};
 
-            await Task.Delay(milliSecondsSinceSent * 2);
+            var messages = new Message[]
+            {
+                new MessageTestDataBuilder(), new MessageTestDataBuilder(), new MessageTestDataBuilder()
+            };
+
+            //Thread.Sleep(milliSecondsSinceSent * 2);
+            timeProvider.Advance(
+                TimeSpan.FromMilliseconds(milliSecondsSinceSent * 2)); //-- allow the messages to be old enough to sweep
 
             foreach (var message in messages)
             {
                 commandProcessor.DepositPost(message.ToStubRequest());
             }
- 
+
+            //Act
+            sweeper.Sweep();
+
+            await Task.Delay(200); //Give the sweep time to run
+
+            //Assert
+            commandProcessor.Dispatched.Count.Should().Be(1);
+            commandProcessor.Deposited.Count.Should().Be(4);
+        }
+
+        [Fact]
+        public async Task When_too_new_to_sweep_leaves_them_async()
+        {
+            //Arrange
+            const int milliSecondsSinceSent = 500;
+
+            var timeProvider = new FakeTimeProvider();
+            var commandProcessor = new FakeCommandProcessor(timeProvider);
+            var sweeper = new OutboxSweeper(milliSecondsSinceSent, commandProcessor);
+
+            Message oldMessage = new MessageTestDataBuilder();
+            commandProcessor.DepositPost(oldMessage.ToStubRequest());
+
+            var messages = new Message[]
+            {
+                new MessageTestDataBuilder(), new MessageTestDataBuilder(), new MessageTestDataBuilder()
+            };
+
+            timeProvider.Advance(
+                TimeSpan.FromMilliseconds(milliSecondsSinceSent * 2)); //-- allow the messages to be old enough to sweep
+
+            foreach (var message in messages)
+            {
+                commandProcessor.DepositPost(message.ToStubRequest());
+            }
+
             //Act
             sweeper.SweepAsyncOutbox();
 
-            await Task.Delay(200);
+            await Task.Delay(200); //Give the sweep time to run
 
             //Assert
             commandProcessor.Deposited.Count.Should().Be(4);
             commandProcessor.Dispatched.Count.Should().Be(1);
-
         }
-        
     }
 }

--- a/tests/Paramore.Brighter.InMemory.Tests/TestDoubles/FakeCommandProcessor.cs
+++ b/tests/Paramore.Brighter.InMemory.Tests/TestDoubles/FakeCommandProcessor.cs
@@ -11,7 +11,7 @@ namespace Paramore.Brighter.InMemory.Tests.TestDoubles
     /// <summary>
     /// Used for Sweeper tests, will not clear the message!!!
     /// </summary>
-    public class FakeCommandProcessor : IAmACommandProcessor
+    public class FakeCommandProcessor(TimeProvider timeProvider) : IAmACommandProcessor
     {
         /// <summary>
         /// Message has been dispatched (to the bus or directly to the handler)
@@ -75,7 +75,7 @@ namespace Paramore.Brighter.InMemory.Tests.TestDoubles
         
         public string DepositPost<T>(T request, Dictionary<string, object> args = null) where T : class, IRequest
         {
-            Deposited.Enqueue(new DepositedMessage(request));
+            Deposited.Enqueue(new DepositedMessage(request, timeProvider));
             return request.Id;
         }
         
@@ -175,7 +175,7 @@ namespace Paramore.Brighter.InMemory.Tests.TestDoubles
         public void ClearOutbox(int amountToClear = 100, int minimumAge = 5000, Dictionary<string, object> args = null)
         {
             var depositedMessages = Deposited.Where(m =>
-                m.EnqueuedTime < DateTime.Now.AddMilliseconds(-1 * minimumAge) &&
+                m.EnqueuedTime < timeProvider.GetUtcNow().DateTime.AddMilliseconds(-1 * minimumAge) &&
                 !Dispatched.ContainsKey(m.Request.Id))
                 .Take(amountToClear)
                 .Select(m => m.Request.Id)
@@ -230,10 +230,10 @@ namespace Paramore.Brighter.InMemory.Tests.TestDoubles
         public IRequest Request { get; }
         public DateTime EnqueuedTime { get; }
 
-        public DepositedMessage(IRequest request)
+        public DepositedMessage(IRequest request, TimeProvider timeProvider)
         {
             Request = request;
-            EnqueuedTime = DateTime.UtcNow;
+            EnqueuedTime = timeProvider.GetUtcNow().DateTime;
         }
     }
 }


### PR DESCRIPTION
.NET 8 adds TimeProvider which can be used to provide system time; it also supports FakeTimeProvider which can be used to fake an advancing clock, provide a fake timer etc. There is a backport of the interface and library to netstandard2.0

We have tests that rely on time, specifically where we:

* Clear a cache following expiry of a time period (in memory box)
* Determine if items in an Outbox are outstanding.

Many of these come together in Paramore.Brighter.InMemory.Tests. We stopped running these because they were flaky in contested CI environments as they relied on delaying action/assertion until time had passed.

With this change we use TimeProvider with our InMemoryBox (used by default if you don't provide an out of process alternative). This allows us to advance time for use with the tests around this functionality. The Advance method to set the clock forward works well, and helps with our tests where we want something to expire. 

Note the Delay method doesn’t work as expected where we need to yield to allow another thread to complete. So we continue to use Task.Delay where we need a background thread to run. (It also doesn't seem to play nice with async xunit tests, which seem to spin).