### PR TITLE
Add the ability to use ASB Queues #2262

### DIFF
--- a/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusConsumerFactory.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusConsumerFactory.cs
@@ -45,8 +45,19 @@ namespace Paramore.Brighter.MessagingGateway.AzureServiceBus
             
             if (subscription is AzureServiceBusSubscription sub) 
                 config = sub.Configuration;
-
-            return new AzureServiceBusConsumer(
+            
+            return config.UseServiceBusQueue ? new AzureServiceBusConsumer(
+                subscription.RoutingKey, 
+                new AzureServiceBusMessageProducer(
+                    nameSpaceManagerWrapper,
+                    new ServiceBusSenderProvider(_clientProvider), 
+                    new AzureServiceBusPublication{MakeChannels = subscription.MakeChannels}), 
+                nameSpaceManagerWrapper,
+                new ServiceBusReceiverProvider(_clientProvider),
+                makeChannels: subscription.MakeChannels,
+                receiveMode: _ackOnRead ? ServiceBusReceiveMode.ReceiveAndDelete : ServiceBusReceiveMode.PeekLock,
+                batchSize: subscription.BufferSize,
+                subscriptionConfiguration: config) : new AzureServiceBusConsumer(
                 subscription.RoutingKey, 
                 subscription.ChannelName,
                 new AzureServiceBusMessageProducer(

--- a/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusMessageProducer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusMessageProducer.cs
@@ -252,7 +252,7 @@ namespace Paramore.Brighter.MessagingGateway.AzureServiceBus
 
             try
             {
-                if (_administrationClientWrapper.TopicExists(topic))
+                if (_administrationClientWrapper.TopicOrQueueExists(topic, _publication.UseServiceBusQueue))
                 {
                     _topicCreated = true;
                     return;
@@ -262,8 +262,8 @@ namespace Paramore.Brighter.MessagingGateway.AzureServiceBus
                 {
                     throw new ChannelFailureException($"Topic {topic} does not exist and missing channel mode set to Validate.");
                 }
-
-                _administrationClientWrapper.CreateTopic(topic);
+                
+                _administrationClientWrapper.CreateChannel(topic, _publication.UseServiceBusQueue);
                 _topicCreated = true;
             }
             catch (Exception e)

--- a/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusPublication.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusPublication.cs
@@ -3,5 +3,10 @@
     public class AzureServiceBusPublication : Publication
     {
         //TODO: Placeholder for producer specific properties if required
+        
+        /// <summary>
+        /// Use a Service Bus Queue instead of a Topic
+        /// </summary>
+        public bool UseServiceBusQueue = false;
     }
 }

--- a/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusSubscriptionConfiguration.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusSubscriptionConfiguration.cs
@@ -39,5 +39,10 @@ namespace Paramore.Brighter.MessagingGateway.AzureServiceBus
         /// A Sql Filter to apply to the subscription
         /// </summary>
         public string SqlFilter = String.Empty;
+
+        /// <summary>
+        /// Use a Service Bus Queue instead of a Topic
+        /// </summary>
+        public bool UseServiceBusQueue = false;
     }
 }

--- a/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusWrappers/AdministrationClientWrapper.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusWrappers/AdministrationClientWrapper.cs
@@ -39,31 +39,33 @@ namespace Paramore.Brighter.MessagingGateway.AzureServiceBus.AzureServiceBusWrap
         /// <summary>
         /// Check if a Topic exists
         /// </summary>
-        /// <param name="topic">The name of the Topic.</param>
-        /// <returns>True if the Topic exists.</returns>
-        public bool TopicExists(string topic)
+        /// <param name="topicOrQueue">The name of the Topic or Queue.</param>
+        /// <param name="useQueue">Use a Queue instead of a Topic</param>
+        /// <returns>True if the Channel exists.</returns>
+        public bool TopicOrQueueExists(string topicOrQueue, bool useQueue)
         {
-            s_logger.LogDebug("Checking if topic {Topic} exists...", topic);
+            s_logger.LogDebug("Checking if topic {Topic} exists...", topicOrQueue);
 
             bool result;
 
             try
             {
-                result = _administrationClient.TopicExistsAsync(topic).GetAwaiter().GetResult();
+                result = useQueue ? _administrationClient.QueueExistsAsync(topicOrQueue).GetAwaiter().GetResult(): 
+                _administrationClient.TopicExistsAsync(topicOrQueue).GetAwaiter().GetResult();
             }
             catch (Exception e)
             {
-                s_logger.LogError(e,"Failed to check if topic {Topic} exists.", topic);
+                s_logger.LogError(e,"Failed to check if topic {Topic} exists.", topicOrQueue);
                 throw;
             }
 
             if (result)
             {
-                s_logger.LogDebug("Topic {Topic} exists.", topic);
+                s_logger.LogDebug("Topic {Topic} exists.", topicOrQueue);
             }
             else
             {
-                s_logger.LogWarning("Topic {Topic} does not exist.", topic);
+                s_logger.LogWarning("Topic {Topic} does not exist.", topicOrQueue);
             }
 
             return result;
@@ -72,43 +74,53 @@ namespace Paramore.Brighter.MessagingGateway.AzureServiceBus.AzureServiceBusWrap
         /// <summary>
         /// Create a Topic
         /// </summary>
-        /// <param name="topic">The name of the Topic</param>
+        /// <param name="topicOrQueue"></param>
+        /// <param name="useQueues"></param>
         /// <param name="autoDeleteOnIdle">Number of minutes before an ideal queue will be deleted</param>
-        public void CreateTopic(string topic, TimeSpan? autoDeleteOnIdle = null)
+        public void CreateChannel(string topicOrQueue, bool useQueues, TimeSpan? autoDeleteOnIdle = null)
         {
-            s_logger.LogInformation("Creating topic {Topic}...", topic);
+            s_logger.LogInformation("Creating topic {Topic}...", topicOrQueue);
 
             try
             {
-                _administrationClient.CreateTopicAsync(new CreateTopicOptions(topic)
+                if(useQueues)
+                    _administrationClient.CreateQueueAsync(new CreateQueueOptions(topicOrQueue){
+                        AutoDeleteOnIdle = autoDeleteOnIdle ?? TimeSpan.MaxValue
+                    }).GetAwaiter().GetResult();
+                else
+                    _administrationClient.CreateTopicAsync(new CreateTopicOptions(topicOrQueue)
                 {
                     AutoDeleteOnIdle = autoDeleteOnIdle ?? TimeSpan.MaxValue
                 }).GetAwaiter().GetResult();
             }
             catch (Exception e)
             {
-                s_logger.LogError(e,"Failed to create topic {Topic}.", topic);
+                s_logger.LogError(e,"Failed to create topic {Topic}.", topicOrQueue);
                 throw;
             }
 
-            s_logger.LogInformation("Topic {Topic} created.", topic);
+            s_logger.LogInformation("Topic {Topic} created.", topicOrQueue);
         }
 
         /// <summary>
         /// Delete a Topic.
         /// </summary>
-        /// <param name="topic">The name of the Topic.</param>
-        public async Task DeleteTopicAsync(string topic)
+        /// <param name="topicOrQueue"></param>
+        /// <param name="useQueues"></param>
+        public async Task DeleteChannelAsync(string topicOrQueue, bool useQueues)
         {
-            s_logger.LogInformation("Deleting topic {Topic}...", topic);
+            s_logger.LogInformation("Deleting topic {Topic}...", topicOrQueue);
             try
             {
-                await _administrationClient.DeleteTopicAsync(topic);
-                s_logger.LogInformation("Topic {Topic} successfully deleted", topic);
+                if(useQueues)
+                    await _administrationClient.DeleteQueueAsync(topicOrQueue);
+                else
+                    await _administrationClient.DeleteTopicAsync(topicOrQueue);
+                s_logger.LogInformation("Topic {Topic} successfully deleted", topicOrQueue);
             }
             catch (Exception e)
             {
-                s_logger.LogError(e,"Failed to delete Topic {Topic}", topic);
+                s_logger.LogError(e,"Failed to delete Topic {Topic}", topicOrQueue);
             }
         }
 
@@ -190,9 +202,9 @@ namespace Paramore.Brighter.MessagingGateway.AzureServiceBus.AzureServiceBusWrap
         {
             s_logger.LogInformation("Creating subscription {ChannelName} for topic {Topic}...", subscriptionName, topicName);
 
-            if (!TopicExists(topicName))
+            if (!TopicOrQueueExists(topicName, false))
             {
-                CreateTopic(topicName, subscriptionConfiguration.QueueIdleBeforeDelete);
+                CreateChannel(topicName, false, subscriptionConfiguration.QueueIdleBeforeDelete);
             }
 
             var subscriptionOptions = new CreateSubscriptionOptions(topicName, subscriptionName)

--- a/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusWrappers/IAdministrationClientWrapper.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusWrappers/IAdministrationClientWrapper.cs
@@ -13,21 +13,25 @@ namespace Paramore.Brighter.MessagingGateway.AzureServiceBus.AzureServiceBusWrap
         /// <summary>
         /// Check if a Topic exists
         /// </summary>
-        /// <param name="topic">The name of the Topic.</param>
+        /// <param name="topic">The name of the Topic or Queue.</param>
+        /// <param name="useQueue">Use a Queue instead of a Topic</param>
         /// <returns>True if the Topic exists.</returns>
-        bool TopicExists(string topic);
+        bool TopicOrQueueExists(string topic, bool useQueue);
 
         /// /// <summary>
-        /// Create a Topic
+        /// Create a Channel
         /// </summary>
-        /// <param name="topic">The name of the Topic</param>
-        void CreateTopic(string topic, TimeSpan? autoDeleteOnIdle = null);
+        /// <param name="topicOrQueue">The Name of the Topic or Queue</param>
+        /// <param name="useQueues">If True a Queue will be created otherwise a Topic will be used</param>
+        /// <param name="autoDeleteOnIdle"></param>
+        void CreateChannel(string topicOrQueue, bool useQueues, TimeSpan? autoDeleteOnIdle = null);
 
         /// <summary>
         /// Delete a Topic.
         /// </summary>
-        /// <param name="topic">The name of the Topic.</param>
-        Task DeleteTopicAsync(string topic);
+        /// <param name="topicOrQueue"></param>
+        /// <param name="useQueues"></param>
+        Task DeleteChannelAsync(string topicOrQueue, bool useQueues);
 
         /// <summary>
         /// Check if a Subscription Exists for a Topic.

--- a/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusWrappers/IServiceBusReceiverProvider.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusWrappers/IServiceBusReceiverProvider.cs
@@ -8,7 +8,16 @@ namespace Paramore.Brighter.MessagingGateway.AzureServiceBus.AzureServiceBusWrap
     public interface IServiceBusReceiverProvider
     {
         /// <summary>
-        /// Gets a <see cref="IServiceBusReceiverWrapper"/>
+        /// Gets a <see cref="IServiceBusReceiverWrapper"/> for a Service Bus Queue
+        /// </summary>
+        /// <param name="queueName">The name of the Topic.</param>
+        /// <param name="receiveMode">The Receive Mode.</param>
+        /// <param name="sessionEnabled">Use Sessions for Processing</param>
+        /// <returns>A ServiceBusReceiverWrapper.</returns>
+        IServiceBusReceiverWrapper Get(string queueName, ServiceBusReceiveMode receiveMode, bool sessionEnabled);
+        
+        /// <summary>
+        /// Gets a <see cref="IServiceBusReceiverWrapper"/> for a Service Bus Topic
         /// </summary>
         /// <param name="topicName">The name of the Topic.</param>
         /// <param name="subscriptionName">The name of the Subscription on the Topic.</param>

--- a/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusWrappers/IServiceBusSenderProvider.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusWrappers/IServiceBusSenderProvider.cs
@@ -8,8 +8,8 @@
         /// <summary>
         /// Get a ServiceBusSenderWrapper for a Topic.
         /// </summary>
-        /// <param name="topic">The name of the Topic.</param>
+        /// <param name="topicOrQueueName">The name of the Topic.</param>
         /// <returns>A ServiceBusSenderWrapper for the given Topic.</returns>
-        IServiceBusSenderWrapper Get(string topic);
+        IServiceBusSenderWrapper Get(string topicOrQueueName);
     }
 }

--- a/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusWrappers/ServiceBusReceiverProvider.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusWrappers/ServiceBusReceiverProvider.cs
@@ -12,7 +12,49 @@ namespace Paramore.Brighter.MessagingGateway.AzureServiceBus.AzureServiceBusWrap
         {
             _client = clientProvider.GetServiceBusClient();
         }
+        
+        /// <summary>
+        /// Gets a <see cref="IServiceBusReceiverWrapper"/> for a Service Bus Queue
+        /// </summary>
+        /// <param name="queueName">The name of the Topic.</param>
+        /// <param name="receiveMode">The Receive Mode.</param>
+        /// <param name="sessionEnabled">Use Sessions for Processing</param>
+        /// <returns>A ServiceBusReceiverWrapper.</returns>
+        public IServiceBusReceiverWrapper Get(string queueName, ServiceBusReceiveMode receiveMode, bool sessionEnabled)
+        {
+            if (sessionEnabled)
+            {
+                try
+                {
+                    return new ServiceBusReceiverWrapper(_client.AcceptNextSessionAsync(queueName,
+                        new ServiceBusSessionReceiverOptions() {ReceiveMode = receiveMode}).GetAwaiter().GetResult());
+                }
+                catch (ServiceBusException e)
+                {
+                    if (e.Reason == ServiceBusFailureReason.ServiceTimeout)
+                    {
+                        //No session available
+                        return null;
+                    }
 
+                    throw;
+                }
+            }
+            else
+            {
+                return new ServiceBusReceiverWrapper(_client.CreateReceiver(queueName,
+                    new ServiceBusReceiverOptions { ReceiveMode = receiveMode, }));
+            }
+        }
+
+        /// <summary>
+        /// Gets a <see cref="IServiceBusReceiverWrapper"/> for a Service Bus Topic
+        /// </summary>
+        /// <param name="topicName">The name of the Topic.</param>
+        /// <param name="subscriptionName">The name of the Subscription on the Topic.</param>
+        /// <param name="receiveMode">The Receive Mode.</param>
+        /// <param name="sessionEnabled">Use Sessions for Processing</param>
+        /// <returns>A ServiceBusReceiverWrapper.</returns>
         public IServiceBusReceiverWrapper Get(string topicName, string subscriptionName, ServiceBusReceiveMode receiveMode, bool sessionEnabled)
         {
             if (sessionEnabled)

--- a/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusWrappers/ServiceBusSenderProvider.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusWrappers/ServiceBusSenderProvider.cs
@@ -12,9 +12,9 @@ namespace Paramore.Brighter.MessagingGateway.AzureServiceBus.AzureServiceBusWrap
             _client = clientProvider.GetServiceBusClient();
         }
 
-        public IServiceBusSenderWrapper Get(string topic)
+        public IServiceBusSenderWrapper Get(string topicOrQueueName)
         {
-            return new ServiceBusSenderWrapper(_client.CreateSender(topic));
+            return new ServiceBusSenderWrapper(_client.CreateSender(topicOrQueueName));
         }
     }
 }

--- a/tests/Paramore.Brighter.AzureServiceBus.Tests/AzureServiceBusMessageProducerTests.cs
+++ b/tests/Paramore.Brighter.AzureServiceBus.Tests/AzureServiceBusMessageProducerTests.cs
@@ -16,6 +16,7 @@ namespace Paramore.Brighter.AzureServiceBus.Tests
         private readonly IServiceBusSenderProvider _topicClientProvider;
         private readonly IServiceBusSenderWrapper _topicClient;
         private readonly AzureServiceBusMessageProducer _producer;
+        private readonly AzureServiceBusMessageProducer _queueProducer;
 
         public AzureServiceBusMessageProducerTests()
         {
@@ -28,6 +29,12 @@ namespace Paramore.Brighter.AzureServiceBus.Tests
                 _topicClientProvider, 
                 new AzureServiceBusPublication{MakeChannels = OnMissingChannel.Create}
             );
+            
+            _queueProducer = new AzureServiceBusMessageProducer(
+                _nameSpaceManagerWrapper, 
+                _topicClientProvider, 
+                new AzureServiceBusPublication{MakeChannels = OnMissingChannel.Create, UseServiceBusQueue = true}
+            );
         }
 
         [Fact]
@@ -36,7 +43,7 @@ namespace Paramore.Brighter.AzureServiceBus.Tests
             ServiceBusMessage sentMessage = null;
             var messageBody = Encoding.UTF8.GetBytes("A message body");
 
-            A.CallTo(() => _nameSpaceManagerWrapper.TopicExists("topic")).Returns(true);
+            A.CallTo(() => _nameSpaceManagerWrapper.TopicOrQueueExists("topic", false)).Returns(true);
             A.CallTo(() => _topicClientProvider.Get("topic")).Returns(_topicClient);
             A.CallTo(() => _topicClient.SendAsync(A<ServiceBusMessage>.Ignored, CancellationToken.None)).ReturnsLazily((ServiceBusMessage g, CancellationToken ct) => Task.FromResult(sentMessage = g));
 
@@ -50,17 +57,21 @@ namespace Paramore.Brighter.AzureServiceBus.Tests
             A.CallTo(() => _topicClient.CloseAsync()).MustHaveHappenedOnceExactly();
         }
 
-        [Fact]
-        public void When_sending_a_command_message_type_message_with_no_delay_it_should_set_the_correct_messagetype_property()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void When_sending_a_command_message_type_message_with_no_delay_it_should_set_the_correct_messagetype_property(bool useQueues)
         {
             ServiceBusMessage sentMessage = null;
             var messageBody = Encoding.UTF8.GetBytes("A message body");
 
-            A.CallTo(() => _nameSpaceManagerWrapper.TopicExists("topic")).Returns(true);
+            A.CallTo(() => _nameSpaceManagerWrapper.TopicOrQueueExists("topic", useQueues)).Returns(true);
             A.CallTo(() => _topicClientProvider.Get("topic")).Returns(_topicClient);
             A.CallTo(() => _topicClient.SendAsync(A<ServiceBusMessage>.Ignored, CancellationToken.None)).ReturnsLazily((ServiceBusMessage g, CancellationToken ct) => Task.FromResult(sentMessage = g));
 
-            _producer.Send(new Message(
+            var producer = useQueues ? _queueProducer : _producer;
+            
+            producer.Send(new Message(
                 new MessageHeader(Guid.NewGuid().ToString(), "topic", MessageType.MT_COMMAND), 
                 new MessageBody(messageBody, "JSON"))
             );
@@ -70,35 +81,43 @@ namespace Paramore.Brighter.AzureServiceBus.Tests
             A.CallTo(() => _topicClient.CloseAsync()).MustHaveHappenedOnceExactly();
         }
 
-        [Fact]
-        public void When_the_topic_does_not_exist_it_should_be_created_and_the_message_is_sent_to_the_correct_topicclient()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void When_the_topic_does_not_exist_it_should_be_created_and_the_message_is_sent_to_the_correct_topicclient(bool useQueues)
         {
             ServiceBusMessage sentMessage = null;
             var messageBody = Encoding.UTF8.GetBytes("A message body");
 
-            A.CallTo(() => _nameSpaceManagerWrapper.TopicExists("topic")).Returns(false);
+            A.CallTo(() => _nameSpaceManagerWrapper.TopicOrQueueExists("topic",useQueues)).Returns(false);
             A.CallTo(() => _topicClientProvider.Get("topic")).Returns(_topicClient);
             A.CallTo(() => _topicClient.SendAsync(A<ServiceBusMessage>.Ignored, CancellationToken.None)).ReturnsLazily((ServiceBusMessage g, CancellationToken ct) => Task.FromResult(sentMessage = g));
 
-            _producer.Send(new Message(
+            var producer = useQueues ? _queueProducer : _producer;
+            
+            producer.Send(new Message(
                 new MessageHeader(Guid.NewGuid().ToString(), "topic", MessageType.MT_NONE), 
                 new MessageBody(messageBody, "JSON")));
 
-            A.CallTo(() => _nameSpaceManagerWrapper.CreateTopic("topic", null)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => _nameSpaceManagerWrapper.CreateChannel("topic", useQueues, null)).MustHaveHappenedOnceExactly();
             Assert.Equal(messageBody, sentMessage.Body.ToArray());
         }
 
-        [Fact]
-        public void When_a_message_is_send_and_an_exception_occurs_close_is_still_called()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void When_a_message_is_send_and_an_exception_occurs_close_is_still_called(bool useQueues)
         {
-            A.CallTo(() => _nameSpaceManagerWrapper.TopicExists("topic")).Returns(true);
+            A.CallTo(() => _nameSpaceManagerWrapper.TopicOrQueueExists("topic", useQueues)).Returns(true);
             A.CallTo(() => _topicClientProvider.Get("topic")).Returns(_topicClient);
 
             A.CallTo(() => _topicClient.SendAsync(A<ServiceBusMessage>.Ignored, CancellationToken.None)).Throws(new Exception("Failed"));
 
             try
             {
-                _producer.Send(new Message(
+                var producer = useQueues ? _queueProducer : _producer;
+                
+                producer.Send(new Message(
                     new MessageHeader(Guid.NewGuid().ToString(), "topic", MessageType.MT_NONE), 
                     new MessageBody("Message", "JSON")));
             }
@@ -110,21 +129,25 @@ namespace Paramore.Brighter.AzureServiceBus.Tests
             A.CallTo(() => _topicClient.CloseAsync()).MustHaveHappenedOnceExactly();
         }
 
-        [Fact]
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
         public void
-            When_the_topic_exists_and_sending_a_message_with_a_delay_it_should_send_the_message_to_the_correct_topicclient()
+            When_the_topic_exists_and_sending_a_message_with_a_delay_it_should_send_the_message_to_the_correct_topicclient(bool useQueues)
         {
             ServiceBusMessage sentMessage = null;
             var messageBody = Encoding.UTF8.GetBytes("A message body");
 
-            A.CallTo(() => _nameSpaceManagerWrapper.TopicExists("topic")).Returns(true);
+            A.CallTo(() => _nameSpaceManagerWrapper.TopicOrQueueExists("topic", useQueues)).Returns(true);
             A.CallTo(() => _topicClientProvider.Get("topic")).Returns(_topicClient);
 
             A.CallTo(() => _topicClient.ScheduleMessageAsync(A<ServiceBusMessage>.Ignored, A<DateTimeOffset>.Ignored,
                 CancellationToken.None)).ReturnsLazily((ServiceBusMessage g, DateTimeOffset t, CancellationToken ct) =>
                 Task.FromResult(sentMessage = g));
 
-            _producer.SendWithDelay(
+            var producer = useQueues ? _queueProducer : _producer;
+            
+            producer.SendWithDelay(
                 new Message(
                     new MessageHeader(Guid.NewGuid().ToString(), "topic", MessageType.MT_EVENT),
                     new MessageBody(messageBody, "JSON")), 1);
@@ -134,20 +157,27 @@ namespace Paramore.Brighter.AzureServiceBus.Tests
             A.CallTo(() => _topicClient.CloseAsync()).MustHaveHappenedOnceExactly();
         }
 
-        [Fact]
-        public void When_sending_a_command_message_type_message_with_delay_it_should_set_the_correct_messagetype_property()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void
+            When_sending_a_command_message_type_message_with_delay_it_should_set_the_correct_messagetype_property(
+                bool useQueues)
         {
             ServiceBusMessage sentMessage = null;
             var messageBody = Encoding.UTF8.GetBytes("A message body");
 
-            A.CallTo(() => _nameSpaceManagerWrapper.TopicExists("topic")).Returns(true);
+            A.CallTo(() => _nameSpaceManagerWrapper.TopicOrQueueExists("topic", useQueues)).Returns(true);
             A.CallTo(() => _topicClientProvider.Get("topic")).Returns(_topicClient);
-            
-                A.CallTo(() => _topicClient.ScheduleMessageAsync(A<ServiceBusMessage>.Ignored, A<DateTimeOffset>.Ignored,
-                    CancellationToken.None)).ReturnsLazily((ServiceBusMessage g, DateTimeOffset t, CancellationToken ct) => Task.FromResult(sentMessage = g));
 
-            _producer.SendWithDelay(new Message(
-                new MessageHeader(Guid.NewGuid().ToString(), "topic", MessageType.MT_COMMAND), 
+            A.CallTo(() => _topicClient.ScheduleMessageAsync(A<ServiceBusMessage>.Ignored, A<DateTimeOffset>.Ignored,
+                CancellationToken.None)).ReturnsLazily((ServiceBusMessage g, DateTimeOffset t, CancellationToken ct) =>
+                Task.FromResult(sentMessage = g));
+
+            var producer = useQueues ? _queueProducer : _producer;
+
+            producer.SendWithDelay(new Message(
+                new MessageHeader(Guid.NewGuid().ToString(), "topic", MessageType.MT_COMMAND),
                 new MessageBody(messageBody, "JSON")), 1);
 
             Assert.Equal(messageBody, sentMessage.Body.ToArray());
@@ -155,60 +185,72 @@ namespace Paramore.Brighter.AzureServiceBus.Tests
             A.CallTo(() => _topicClient.CloseAsync()).MustHaveHappenedOnceExactly();
         }
 
-        [Fact]
-        public void When_the_topic_does_not_exist_and_sending_a_message_with_a_delay_it_should_send_the_message_to_the_correct_topicclient()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void When_the_topic_does_not_exist_and_sending_a_message_with_a_delay_it_should_send_the_message_to_the_correct_topicclient(bool useQueues)
         {
             ServiceBusMessage sentMessage = null;
             var messageBody = Encoding.UTF8.GetBytes("A message body");
 
-            A.CallTo(() => _nameSpaceManagerWrapper.TopicExists("topic")).Returns(false);
+            A.CallTo(() => _nameSpaceManagerWrapper.TopicOrQueueExists("topic", useQueues)).Returns(false);
             A.CallTo(() => _topicClientProvider.Get("topic")).Returns(_topicClient);
             
                 A.CallTo(() => _topicClient.ScheduleMessageAsync(A<ServiceBusMessage>.Ignored, A<DateTimeOffset>.Ignored,
                     CancellationToken.None)).ReturnsLazily((ServiceBusMessage g, DateTimeOffset t , CancellationToken ct) => Task.FromResult(sentMessage = g));
 
-            _producer.SendWithDelay(new Message(
+                var producer = useQueues ? _queueProducer : _producer;
+                
+                producer.SendWithDelay(new Message(
                 new MessageHeader(Guid.NewGuid().ToString(), "topic", MessageType.MT_NONE), 
                 new MessageBody(messageBody, "JSON")), 1);
 
-            A.CallTo(() => _nameSpaceManagerWrapper.CreateTopic("topic", null)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => _nameSpaceManagerWrapper.CreateChannel("topic", useQueues, null)).MustHaveHappenedOnceExactly();
             Assert.Equal(messageBody, sentMessage.Body.ToArray());
             A.CallTo(() => _topicClient.CloseAsync()).MustHaveHappenedOnceExactly();
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void Once_the_topic_is_created_it_then_does_not_check_if_it_exists_every_time(bool topicExists)
+        [InlineData(true, true)]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        [InlineData(false, false)]
+        public void Once_the_topic_is_created_it_then_does_not_check_if_it_exists_every_time(bool topicExists, bool useQueues)
         {
             var messageBody = Encoding.UTF8.GetBytes("A message body");
 
-            A.CallTo(() => _nameSpaceManagerWrapper.TopicExists("topic")).Returns(topicExists);
+            A.CallTo(() => _nameSpaceManagerWrapper.TopicOrQueueExists("topic", useQueues)).Returns(topicExists);
             A.CallTo(() => _topicClientProvider.Get("topic")).Returns(_topicClient);
 
-            _producer.SendWithDelay(new Message(
+            var producer = useQueues ? _queueProducer : _producer;
+            
+            producer.SendWithDelay(new Message(
                 new MessageHeader(Guid.NewGuid().ToString(), "topic", MessageType.MT_NONE), 
                 new MessageBody(messageBody, "JSON")), 1);
-            _producer.SendWithDelay(new Message(
+            producer.SendWithDelay(new Message(
                 new MessageHeader(Guid.NewGuid().ToString(), "topic", MessageType.MT_NONE), 
                 new MessageBody(messageBody, "JSON")), 1);
 
             if (topicExists == false)
             {
-                A.CallTo(() => _nameSpaceManagerWrapper.CreateTopic("topic", null)).MustHaveHappenedOnceExactly();
+                A.CallTo(() => _nameSpaceManagerWrapper.CreateChannel("topic", useQueues, null)).MustHaveHappenedOnceExactly();
             }
 
-            A.CallTo(() => _nameSpaceManagerWrapper.TopicExists("topic")).MustHaveHappenedOnceExactly();
+            A.CallTo(() => _nameSpaceManagerWrapper.TopicOrQueueExists("topic", useQueues)).MustHaveHappenedOnceExactly();
         }
 
-        [Fact]
-        public async Task When_there_is_an_error_talking_to_servicebus_when_creating_the_topic_the_ManagementClientWrapper_is_reinitilised()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task When_there_is_an_error_talking_to_servicebus_when_creating_the_topic_the_ManagementClientWrapper_is_reinitilised(bool useQueues)
         {
             var messageBody = Encoding.UTF8.GetBytes("A message body");
 
-            A.CallTo(() => _nameSpaceManagerWrapper.TopicExists("topic")).Throws(new Exception());
+            A.CallTo(() => _nameSpaceManagerWrapper.TopicOrQueueExists("topic", useQueues)).Throws(new Exception());
 
-            await Assert.ThrowsAsync<Exception>(() => _producer.SendWithDelayAsync(
+            var producer = useQueues ? _queueProducer : _producer;
+            
+            await Assert.ThrowsAsync<Exception>(() => producer.SendWithDelayAsync(
                 new Message(
                     new MessageHeader(Guid.NewGuid().ToString(), "topic", MessageType.MT_NONE), 
                     new MessageBody(messageBody, "JSON")), 1)
@@ -217,16 +259,20 @@ namespace Paramore.Brighter.AzureServiceBus.Tests
         }
 
 
-        [Fact]
-        public void When_there_is_an_error_getting_a_topic_client_the_connection_for_topic_client_is_retried()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void When_there_is_an_error_getting_a_topic_client_the_connection_for_topic_client_is_retried(bool useQueues)
         {
             var messageBody = Encoding.UTF8.GetBytes("A message body");
 
-            A.CallTo(() => _nameSpaceManagerWrapper.TopicExists("topic")).Returns(true);
+            A.CallTo(() => _nameSpaceManagerWrapper.TopicOrQueueExists("topic", useQueues)).Returns(true);
 
             A.CallTo(() => _topicClientProvider.Get("topic")).Throws(new Exception()).Once().Then.Returns(_topicClient);
 
-           _producer.SendWithDelay(new Message(
+            var producer = useQueues ? _queueProducer : _producer;
+            
+            producer.SendWithDelay(new Message(
                new MessageHeader(Guid.NewGuid().ToString(), "topic", MessageType.MT_NONE), 
                new MessageBody(messageBody, "JSON"))
            );

--- a/tests/Paramore.Brighter.AzureServiceBus.Tests/MessagingGateway/When_consuming_a_message_via_the_consumer.cs
+++ b/tests/Paramore.Brighter.AzureServiceBus.Tests/MessagingGateway/When_consuming_a_message_via_the_consumer.cs
@@ -155,7 +155,7 @@ namespace Paramore.Brighter.AzureServiceBus.Tests.MessagingGateway
 
         public void Dispose()
         {
-            _administrationClient.DeleteTopicAsync(_topicName).GetAwaiter().GetResult();
+            _administrationClient.DeleteChannelAsync(_topicName, false).GetAwaiter().GetResult();
             _channel?.Dispose();
             _producerRegistry?.Dispose();
         }

--- a/tests/Paramore.Brighter.AzureServiceBus.Tests/MessagingGateway/When_posting_a_message_via_the_producer.cs
+++ b/tests/Paramore.Brighter.AzureServiceBus.Tests/MessagingGateway/When_posting_a_message_via_the_producer.cs
@@ -13,13 +13,14 @@ namespace Paramore.Brighter.AzureServiceBus.Tests.MessagingGateway
     [Trait("Fragile", "CI")]
     public class ASBProducerTests : IDisposable
     {
-        private readonly Message _message;
-        private readonly IAmAChannel _channel;
+        private readonly IAmAChannel _topicChannel;
+        private readonly IAmAChannel _queueChannel;
         private readonly IAmAProducerRegistry _producerRegistry;
         private readonly ASBTestCommand _command;
         private readonly string _correlationId;
         private readonly string _contentType;
         private readonly string _topicName;
+        private readonly string _queueName;
         private readonly IAdministrationClientWrapper _administrationClient;
 
         public ASBProducerTests()
@@ -40,15 +41,23 @@ namespace Paramore.Brighter.AzureServiceBus.Tests.MessagingGateway
                 channelName: new ChannelName(channelName),
                 routingKey: routingKey
             );
+            
+            var queueChannelName = $"Producer-queue-Send-Tests-{Guid.NewGuid()}".Truncate(50);
+            _queueName = $"Producer-queue-Send-Tests-{Guid.NewGuid()}";
+            var queueRoutingKey = new RoutingKey(_queueName);
+            
+            AzureServiceBusSubscription<ASBTestCommand> queueSubscription = new(
+                name: new SubscriptionName(queueChannelName),
+                channelName: new ChannelName(queueChannelName),
+                routingKey: queueRoutingKey,
+                subscriptionConfiguration : new AzureServiceBusSubscriptionConfiguration()
+                {
+                    UseServiceBusQueue = true
+                }
+            );
+            
 
             _contentType = "application/json";
-
-            _message = new Message(
-                new MessageHeader(_command.Id, _topicName, MessageType.MT_COMMAND, correlationId:_correlationId, 
-                    contentType: _contentType
-                ),
-                new MessageBody(JsonSerializer.Serialize(_command, JsonSerialisationOptions.Options))
-            );
 
             var clientProvider = ASBCreds.ASBClientProvider;
             _administrationClient = new AdministrationClientWrapper(clientProvider);
@@ -56,41 +65,48 @@ namespace Paramore.Brighter.AzureServiceBus.Tests.MessagingGateway
 
             var channelFactory =
                 new AzureServiceBusChannelFactory(new AzureServiceBusConsumerFactory(clientProvider, false));
-            _channel = channelFactory.CreateChannel(subscription);
+            _topicChannel = channelFactory.CreateChannel(subscription);
+            _queueChannel = channelFactory.CreateChannel(queueSubscription);
 
             _producerRegistry = new AzureServiceBusProducerRegistryFactory(
                 clientProvider,
                 new AzureServiceBusPublication[]
                     {
-                        new AzureServiceBusPublication { Topic = new RoutingKey(_topicName) }
+                        new AzureServiceBusPublication { Topic = new RoutingKey(_topicName) },
+                        new AzureServiceBusPublication { Topic = new RoutingKey(_queueName), UseServiceBusQueue = true}
                     }
                 )
                 .Create();
         }
 
-        [Fact]
-        public async Task When_posting_a_message_via_the_producer()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task When_posting_a_message_via_the_producer(bool testQueues)
         {
             //arrange
             string testHeader = "TestHeader";
             string testHeaderValue = "Blah!!!";
-            _message.Header.Bag.Add(testHeader, testHeaderValue);
+            var commandMessage = GenerateMessage(testQueues ? _queueName : _topicName);
+            commandMessage.Header.Bag.Add(testHeader, testHeaderValue);
             
-            var producer = _producerRegistry.LookupBy(_topicName) as IAmAMessageProducerAsync;
+            var producer = _producerRegistry.LookupBy(testQueues ? _queueName : _topicName) as IAmAMessageProducerAsync;
            
-            await producer.SendAsync(_message);
+            await producer.SendAsync(commandMessage);
 
-            var message = _channel.Receive(5000);
+            var channel = testQueues ? _queueChannel : _topicChannel;
+            
+            var message = channel.Receive(5000);
 
             //clear the queue
-            _channel.Acknowledge(message);
+            channel.Acknowledge(message);
 
             message.Header.MessageType.Should().Be(MessageType.MT_COMMAND);
 
             message.Id.Should().Be(_command.Id);
             message.Redelivered.Should().BeFalse();
             message.Header.Id.Should().Be(_command.Id);
-            message.Header.Topic.Should().Contain(_topicName);
+            message.Header.Topic.Should().Contain(testQueues ? _queueName : _topicName);
             message.Header.CorrelationId.Should().Be(_correlationId);
             message.Header.ContentType.Should().Be(_contentType);
             message.Header.HandledCount.Should().Be(0);
@@ -98,13 +114,21 @@ namespace Paramore.Brighter.AzureServiceBus.Tests.MessagingGateway
             message.Header.TimeStamp.Should().BeAfter(RoundToSeconds(DateTime.UtcNow.AddMinutes(-1)));
             message.Header.DelayedMilliseconds.Should().Be(0);
             //{"Id":"cd581ced-c066-4322-aeaf-d40944de8edd","Value":"Test","WasCancelled":false,"TaskCompleted":false}
-            message.Body.Value.Should().Be(_message.Body.Value);
+            message.Body.Value.Should().Be(commandMessage.Body.Value);
             message.Header.Bag.Should().Contain(testHeader, testHeaderValue);
         }
+        
+        private Message GenerateMessage(string topicName) => new Message(
+            new MessageHeader(_command.Id, topicName, MessageType.MT_COMMAND, correlationId:_correlationId, 
+                contentType: _contentType
+            ),
+            new MessageBody(JsonSerializer.Serialize(_command, JsonSerialisationOptions.Options))
+        );
 
         public void Dispose()
         {
-            _administrationClient.DeleteTopicAsync(_topicName).GetAwaiter().GetResult();
+            _administrationClient.DeleteChannelAsync(_topicName, false).GetAwaiter().GetResult();
+            _administrationClient.DeleteChannelAsync(_queueName, true).GetAwaiter().GetResult();
         }
 
         private DateTime RoundToSeconds(DateTime dateTime)


### PR DESCRIPTION
This Pull request gives the ability to configure Service bus to use a Queue instead of a Topic.

At this point in time you will have to set the configuration in both the `Publication` and `Subscription` to `UseServiceBusQueue=true` (Currently defaulted to False)