### PR TITLE
Add MQTT Gateway Support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,31 @@ jobs:
         run: dotnet restore
       - name: Redis Transport Tests
         run: dotnet test ./tests/Paramore.Brighter.Redis.Tests/Paramore.Brighter.Redis.Tests.csproj --filter "Fragile!=CI" --configuration Release --logger "console;verbosity=normal" --blame -v n
-  
+
+  mqtt-ci:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: [build]
+    
+    services:
+      mosquitto:  
+        image: efrecon/mosquitto:latest
+        ports:
+        - 1883:1883
+      
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Setup dotnet 6
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: |
+            6.0.x
+      - name: Install dependencies
+        run: dotnet restore
+      - name: MQTT Transport Tests
+        run: dotnet test ./tests/Paramore.Brighter.MQTT.Tests/Paramore.Brighter.MQTT.Tests.csproj --filter "Category=MQTT&Fragile!=CI" --configuration Release --logger "console;verbosity=normal" --blame -v n
+
   rabbitmq-ci:
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/Brighter.sln
+++ b/Brighter.sln
@@ -317,21 +317,25 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GreetingsSender", "samples\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GreetingsReceiverConsole", "samples\AWSTransfomers\Compression\GreetingsReceiverConsole\GreetingsReceiverConsole.csproj", "{18742337-075A-40D6-B67F-91F5894A50C3}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Paramore.Brighter.Transformers.Azure", "src\Paramore.Brighter.Transformers.Azure\Paramore.Brighter.Transformers.Azure.csproj", "{29FAAF3E-504D-472F-91F6-14A41B897912}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Paramore.Brighter.Transformers.Azure", "src\Paramore.Brighter.Transformers.Azure\Paramore.Brighter.Transformers.Azure.csproj", "{29FAAF3E-504D-472F-91F6-14A41B897912}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Paramore.Brighter.Azure.Tests", "tests\Paramore.Brighter.Azure.Tests\Paramore.Brighter.Azure.Tests.csproj", "{AA2AA086-9B8A-4910-A793-E92B1E352351}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Paramore.Brighter.Azure.Tests", "tests\Paramore.Brighter.Azure.Tests\Paramore.Brighter.Azure.Tests.csproj", "{AA2AA086-9B8A-4910-A793-E92B1E352351}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Paramore.Brighter.Archive.Azure", "src\Paramore.Brighter.Archive.Azure\Paramore.Brighter.Archive.Azure.csproj", "{F329B6C6-40C2-45BA-A2A8-276ACAFA1867}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Paramore.Brighter.Archive.Azure", "src\Paramore.Brighter.Archive.Azure\Paramore.Brighter.Archive.Azure.csproj", "{F329B6C6-40C2-45BA-A2A8-276ACAFA1867}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Paramore.Brighter.ServiceActivator.Control", "src\Paramore.Brighter.ServiceActivator.Control\Paramore.Brighter.ServiceActivator.Control.csproj", "{4ACA8480-16A0-4BC8-8401-4A27E5AEC1BE}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Paramore.Brighter.ServiceActivator.Control", "src\Paramore.Brighter.ServiceActivator.Control\Paramore.Brighter.ServiceActivator.Control.csproj", "{4ACA8480-16A0-4BC8-8401-4A27E5AEC1BE}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Paramore.Brighter.ServiceActivator.Control.Api", "src\Paramore.Brighter.ServiceActivator.Control.Api\Paramore.Brighter.ServiceActivator.Control.Api.csproj", "{397F8496-6916-43EF-AEB2-5D84048DE357}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Paramore.Brighter.ServiceActivator.Control.Api", "src\Paramore.Brighter.ServiceActivator.Control.Api\Paramore.Brighter.ServiceActivator.Control.Api.csproj", "{397F8496-6916-43EF-AEB2-5D84048DE357}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Paramore.Brighter.Sqlite.Dapper", "src\Paramore.Brighter.Sqlite.Dapper\Paramore.Brighter.Sqlite.Dapper.csproj", "{3384FBF0-5DCB-452D-8288-FAD1D0023089}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Paramore.Brighter.Sqlite.Dapper", "src\Paramore.Brighter.Sqlite.Dapper\Paramore.Brighter.Sqlite.Dapper.csproj", "{3384FBF0-5DCB-452D-8288-FAD1D0023089}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Paramore.Brighter.Locking.Azure", "src\Paramore.Brighter.Locking.Azure\Paramore.Brighter.Locking.Azure.csproj", "{021F3B51-A640-4C0D-9B47-FB4E32DF6715}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Paramore.Brighter.Locking.Azure", "src\Paramore.Brighter.Locking.Azure\Paramore.Brighter.Locking.Azure.csproj", "{021F3B51-A640-4C0D-9B47-FB4E32DF6715}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Paramore.Brighter.Extensions.Diagnostics", "src\Paramore.Brighter.Extensions.Diagnostics\Paramore.Brighter.Extensions.Diagnostics.csproj", "{7FD4C263-74DA-4648-AD2A-7EB34FCBE18E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Paramore.Brighter.Extensions.Diagnostics", "src\Paramore.Brighter.Extensions.Diagnostics\Paramore.Brighter.Extensions.Diagnostics.csproj", "{7FD4C263-74DA-4648-AD2A-7EB34FCBE18E}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Paramore.Brighter.MQTT.Tests", "tests\Paramore.Brighter.MQTT.Tests\Paramore.Brighter.MQTT.Tests.csproj", "{F5B8D15A-22CC-4A73-A941-6AD34D0BDEA3}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Paramore.Brighter.MessagingGateway.MQTT", "src\Paramore.Brighter.MessagingGateway.MQTT\Paramore.Brighter.MessagingGateway.MQTT.csproj", "{6B2250DD-4123-40D2-87C5-4C29D452C114}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -1783,30 +1787,6 @@ Global
 		{18742337-075A-40D6-B67F-91F5894A50C3}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{18742337-075A-40D6-B67F-91F5894A50C3}.Release|x86.ActiveCfg = Release|Any CPU
 		{18742337-075A-40D6-B67F-91F5894A50C3}.Release|x86.Build.0 = Release|Any CPU
-		{F329B6C6-40C2-45BA-A2A8-276ACAFA1867}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{F329B6C6-40C2-45BA-A2A8-276ACAFA1867}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{F329B6C6-40C2-45BA-A2A8-276ACAFA1867}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{F329B6C6-40C2-45BA-A2A8-276ACAFA1867}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
-		{F329B6C6-40C2-45BA-A2A8-276ACAFA1867}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{F329B6C6-40C2-45BA-A2A8-276ACAFA1867}.Debug|x86.Build.0 = Debug|Any CPU
-		{F329B6C6-40C2-45BA-A2A8-276ACAFA1867}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{F329B6C6-40C2-45BA-A2A8-276ACAFA1867}.Release|Any CPU.Build.0 = Release|Any CPU
-		{F329B6C6-40C2-45BA-A2A8-276ACAFA1867}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
-		{F329B6C6-40C2-45BA-A2A8-276ACAFA1867}.Release|Mixed Platforms.Build.0 = Release|Any CPU
-		{F329B6C6-40C2-45BA-A2A8-276ACAFA1867}.Release|x86.ActiveCfg = Release|Any CPU
-		{F329B6C6-40C2-45BA-A2A8-276ACAFA1867}.Release|x86.Build.0 = Release|Any CPU
-		{3BCE9BD6-B5A7-4962-8A95-7B83B458458A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{3BCE9BD6-B5A7-4962-8A95-7B83B458458A}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{3BCE9BD6-B5A7-4962-8A95-7B83B458458A}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{3BCE9BD6-B5A7-4962-8A95-7B83B458458A}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
-		{3BCE9BD6-B5A7-4962-8A95-7B83B458458A}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{3BCE9BD6-B5A7-4962-8A95-7B83B458458A}.Debug|x86.Build.0 = Debug|Any CPU
-		{3BCE9BD6-B5A7-4962-8A95-7B83B458458A}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{3BCE9BD6-B5A7-4962-8A95-7B83B458458A}.Release|Any CPU.Build.0 = Release|Any CPU
-		{3BCE9BD6-B5A7-4962-8A95-7B83B458458A}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
-		{3BCE9BD6-B5A7-4962-8A95-7B83B458458A}.Release|Mixed Platforms.Build.0 = Release|Any CPU
-		{3BCE9BD6-B5A7-4962-8A95-7B83B458458A}.Release|x86.ActiveCfg = Release|Any CPU
-		{3BCE9BD6-B5A7-4962-8A95-7B83B458458A}.Release|x86.Build.0 = Release|Any CPU
 		{29FAAF3E-504D-472F-91F6-14A41B897912}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{29FAAF3E-504D-472F-91F6-14A41B897912}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{29FAAF3E-504D-472F-91F6-14A41B897912}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
@@ -1831,18 +1811,18 @@ Global
 		{AA2AA086-9B8A-4910-A793-E92B1E352351}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{AA2AA086-9B8A-4910-A793-E92B1E352351}.Release|x86.ActiveCfg = Release|Any CPU
 		{AA2AA086-9B8A-4910-A793-E92B1E352351}.Release|x86.Build.0 = Release|Any CPU
-		{EC046F36-F93F-447A-86EA-F60585232867}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{EC046F36-F93F-447A-86EA-F60585232867}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{EC046F36-F93F-447A-86EA-F60585232867}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{EC046F36-F93F-447A-86EA-F60585232867}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
-		{EC046F36-F93F-447A-86EA-F60585232867}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{EC046F36-F93F-447A-86EA-F60585232867}.Debug|x86.Build.0 = Debug|Any CPU
-		{EC046F36-F93F-447A-86EA-F60585232867}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{EC046F36-F93F-447A-86EA-F60585232867}.Release|Any CPU.Build.0 = Release|Any CPU
-		{EC046F36-F93F-447A-86EA-F60585232867}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
-		{EC046F36-F93F-447A-86EA-F60585232867}.Release|Mixed Platforms.Build.0 = Release|Any CPU
-		{EC046F36-F93F-447A-86EA-F60585232867}.Release|x86.ActiveCfg = Release|Any CPU
-		{EC046F36-F93F-447A-86EA-F60585232867}.Release|x86.Build.0 = Release|Any CPU
+		{F329B6C6-40C2-45BA-A2A8-276ACAFA1867}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F329B6C6-40C2-45BA-A2A8-276ACAFA1867}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F329B6C6-40C2-45BA-A2A8-276ACAFA1867}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{F329B6C6-40C2-45BA-A2A8-276ACAFA1867}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{F329B6C6-40C2-45BA-A2A8-276ACAFA1867}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F329B6C6-40C2-45BA-A2A8-276ACAFA1867}.Debug|x86.Build.0 = Debug|Any CPU
+		{F329B6C6-40C2-45BA-A2A8-276ACAFA1867}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F329B6C6-40C2-45BA-A2A8-276ACAFA1867}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F329B6C6-40C2-45BA-A2A8-276ACAFA1867}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{F329B6C6-40C2-45BA-A2A8-276ACAFA1867}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{F329B6C6-40C2-45BA-A2A8-276ACAFA1867}.Release|x86.ActiveCfg = Release|Any CPU
+		{F329B6C6-40C2-45BA-A2A8-276ACAFA1867}.Release|x86.Build.0 = Release|Any CPU
 		{4ACA8480-16A0-4BC8-8401-4A27E5AEC1BE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{4ACA8480-16A0-4BC8-8401-4A27E5AEC1BE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4ACA8480-16A0-4BC8-8401-4A27E5AEC1BE}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
@@ -1903,6 +1883,30 @@ Global
 		{7FD4C263-74DA-4648-AD2A-7EB34FCBE18E}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{7FD4C263-74DA-4648-AD2A-7EB34FCBE18E}.Release|x86.ActiveCfg = Release|Any CPU
 		{7FD4C263-74DA-4648-AD2A-7EB34FCBE18E}.Release|x86.Build.0 = Release|Any CPU
+		{F5B8D15A-22CC-4A73-A941-6AD34D0BDEA3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F5B8D15A-22CC-4A73-A941-6AD34D0BDEA3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F5B8D15A-22CC-4A73-A941-6AD34D0BDEA3}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{F5B8D15A-22CC-4A73-A941-6AD34D0BDEA3}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{F5B8D15A-22CC-4A73-A941-6AD34D0BDEA3}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F5B8D15A-22CC-4A73-A941-6AD34D0BDEA3}.Debug|x86.Build.0 = Debug|Any CPU
+		{F5B8D15A-22CC-4A73-A941-6AD34D0BDEA3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F5B8D15A-22CC-4A73-A941-6AD34D0BDEA3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F5B8D15A-22CC-4A73-A941-6AD34D0BDEA3}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{F5B8D15A-22CC-4A73-A941-6AD34D0BDEA3}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{F5B8D15A-22CC-4A73-A941-6AD34D0BDEA3}.Release|x86.ActiveCfg = Release|Any CPU
+		{F5B8D15A-22CC-4A73-A941-6AD34D0BDEA3}.Release|x86.Build.0 = Release|Any CPU
+		{6B2250DD-4123-40D2-87C5-4C29D452C114}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6B2250DD-4123-40D2-87C5-4C29D452C114}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6B2250DD-4123-40D2-87C5-4C29D452C114}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{6B2250DD-4123-40D2-87C5-4C29D452C114}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{6B2250DD-4123-40D2-87C5-4C29D452C114}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6B2250DD-4123-40D2-87C5-4C29D452C114}.Debug|x86.Build.0 = Debug|Any CPU
+		{6B2250DD-4123-40D2-87C5-4C29D452C114}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6B2250DD-4123-40D2-87C5-4C29D452C114}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6B2250DD-4123-40D2-87C5-4C29D452C114}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{6B2250DD-4123-40D2-87C5-4C29D452C114}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{6B2250DD-4123-40D2-87C5-4C29D452C114}.Release|x86.ActiveCfg = Release|Any CPU
+		{6B2250DD-4123-40D2-87C5-4C29D452C114}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -2014,6 +2018,7 @@ Global
 		{D7361C21-AB4D-4E82-8094-FB86C2ED1800} = {65F8C2DE-0CB6-4102-8187-A247F1D5D3D7}
 		{18742337-075A-40D6-B67F-91F5894A50C3} = {65F8C2DE-0CB6-4102-8187-A247F1D5D3D7}
 		{AA2AA086-9B8A-4910-A793-E92B1E352351} = {329736D2-BF92-4D06-A7BF-19F4B6B64EDD}
+		{F5B8D15A-22CC-4A73-A941-6AD34D0BDEA3} = {329736D2-BF92-4D06-A7BF-19F4B6B64EDD}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8B7C7E31-2E32-4E0D-9426-BC9AF22E9F4C}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -46,6 +46,7 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.6.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageVersion Include="MQTTnet" Version="3.1.2"/>
     <PackageVersion Include="MySqlConnector" Version="2.3.7" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="NJsonSchema" Version="10.9.0" />

--- a/docker-compose-mqtt.yaml
+++ b/docker-compose-mqtt.yaml
@@ -1,0 +1,7 @@
+version: '3'
+
+services:
+  mosquitto:
+    image: efrecon/mosquitto
+    ports:
+      - 1883:1883

--- a/src/Paramore.Brighter.MessagingGateway.MQTT/MQTTMessageConsumer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.MQTT/MQTTMessageConsumer.cs
@@ -1,0 +1,161 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using MQTTnet;
+using MQTTnet.Client;
+using MQTTnet.Client.Options;
+using MQTTnet.Client.Receiving;
+using MQTTnet.Protocol;
+using Paramore.Brighter.Logging;
+
+namespace Paramore.Brighter.MessagingGateway.MQTT
+{
+    /// <summary>
+    /// Class MQTTMessageConsumer.
+    /// The <see cref="MQTTMessageConsumer"/> is used on the server to receive messages from the broker. It abstracts away the details of 
+    /// inter-process communication tasks from the server. It handles subscription establishment, request reception and dispatching.
+    /// </summary>
+    public class MQTTMessageConsumer : IAmAMessageConsumer
+    {
+        private readonly string _topic;
+        private readonly Queue<Message> _messageQueue = new Queue<Message>();
+        private static readonly ILogger s_logger = ApplicationLogging.CreateLogger<MQTTMessageConsumer>();
+        private readonly Message _noopMessage = new Message();
+        private readonly IMqttClientOptions _mqttClientOptions;
+        private readonly IMqttClient _mqttClient;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MQTTMessageConsumer" /> class.
+        /// </summary>
+        /// <param name="configuration"></param>
+        public MQTTMessageConsumer(MQTTMessagingGatewayConsumerConfiguration configuration)
+        {
+            _topic = $"{configuration.TopicPrefix}/#" ?? throw new ArgumentNullException(nameof(configuration.TopicPrefix));
+            
+            MqttClientOptionsBuilder mqttClientOptionsBuilder = new MqttClientOptionsBuilder()
+               .WithTcpServer(configuration.Hostname)
+               .WithCleanSession(configuration.CleanSession);
+
+            if (!string.IsNullOrEmpty(configuration.ClientID))
+            {
+                mqttClientOptionsBuilder = mqttClientOptionsBuilder.WithClientId($"{configuration.ClientID}");
+            }
+
+            if (!string.IsNullOrEmpty(configuration.Username))
+            {
+                mqttClientOptionsBuilder = mqttClientOptionsBuilder.WithCredentials(configuration.Username, configuration.Password);
+            }
+
+            _mqttClientOptions = mqttClientOptionsBuilder.Build();
+
+            _mqttClient = new MqttFactory().CreateMqttClient();
+
+            _mqttClient.ApplicationMessageReceivedHandler = new MqttApplicationMessageReceivedHandlerDelegate(e =>
+            {
+                s_logger.LogInformation("MQTTMessageConsumer: Received message from queue {TopicPrefix}", configuration.TopicPrefix);
+                string message = Encoding.UTF8.GetString(e.ApplicationMessage.Payload);
+                _messageQueue.Enqueue(JsonSerializer.Deserialize<Message>(message));
+            });
+
+            Task connectTask = Connect(configuration.ConnectionAttempts);
+            connectTask.Wait();
+        }
+
+        /// <summary>
+        /// Not implemented Acknowledge Method.
+        /// </summary>
+        /// <param name="message"></param>
+        public void Acknowledge(Message message)
+        {
+            return;
+        }
+
+        public void Dispose()
+        {
+            _mqttClient.Dispose();
+        }
+
+        /// <summary>
+        /// Clears the internal Queue buffer.
+        /// </summary>
+        public void Purge()
+        {
+            _messageQueue.Clear();
+        }
+
+        /// <summary>
+        /// Retrieves the current recieved messages from the internal buffer.
+        /// </summary>
+        /// <param name="timeoutInMilliseconds"></param>
+        public Message[] Receive(int timeoutInMilliseconds)
+        {
+            if (_messageQueue.Count==0)
+                return new Message[] { _noopMessage };
+
+            List<Message> messages = new List<Message>();
+
+            using (CancellationTokenSource cts = new CancellationTokenSource(timeoutInMilliseconds))
+            {
+                cts.Token.Register(() => { throw new TimeoutException(); });
+                while (!cts.IsCancellationRequested && _messageQueue.Count > 0)
+                {
+                    try
+                    {
+                        Message message = _messageQueue.Dequeue();
+                        messages.Add(message);
+                    }
+                    catch (TimeoutException)
+                    {
+                        s_logger.LogWarning("MQTTMessageConsumer: Timed out retrieving messages.  Queue length: {QueueLength}", _messageQueue.Count);
+                    }
+                }
+            }
+
+            return messages.ToArray();
+        }
+
+        /// <summary>
+        /// Not implemented Reject Method.
+        /// </summary>
+        /// <param name="message"></param>
+        public void Reject(Message message)
+        {
+            return;
+        }
+
+        /// <summary>
+        /// Not implemented Requeue Method.
+        /// </summary>
+        /// <param name="message"></param>
+        /// <param name="delayMilliseconds"></param>
+        public bool Requeue(Message message, int delayMilliseconds)
+        {
+            return false;
+        }
+
+        private async Task Connect(int connectionAttempts)
+        {
+            for (int i = 0; i < connectionAttempts; i++)
+            {
+                try
+                {
+                    await _mqttClient.ConnectAsync(_mqttClientOptions, CancellationToken.None);
+                    s_logger.LogInformation("MQTT Consumer Client Connected");
+
+                    await _mqttClient.SubscribeAsync(new MqttTopicFilter { Topic = _topic, QualityOfServiceLevel = MqttQualityOfServiceLevel.AtLeastOnce });
+                    s_logger.LogInformation("Subscribed to {Topic}", _topic);
+
+                    return;
+                }
+                catch (Exception)
+                {
+                    s_logger.LogError("Unable to connect MQTT Consumer Client");
+                }
+            }
+        }
+    }
+}

--- a/src/Paramore.Brighter.MessagingGateway.MQTT/MQTTMessageProducer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.MQTT/MQTTMessageProducer.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading.Tasks;
+
+namespace Paramore.Brighter.MessagingGateway.MQTT
+{
+    /// <summary>
+    /// Class ClientRequestHandler .
+    /// The <see cref="MQTTMessageProducer"/> is used by a client to talk to a server and abstracts the infrastructure for inter-process communication away from clients.
+    /// It handles subscription establishment, request sending and error handling
+    /// </summary>
+    public class MQTTMessageProducer : IAmAMessageProducer, IAmAMessageProducerAsync, IAmAMessageProducerSync
+    {
+        public int MaxOutStandingMessages { get; set; } = -1;
+        public int MaxOutStandingCheckIntervalMilliSeconds { get; set; } = 0;
+        public Dictionary<string, object> OutBoxBag { get; set; } = new Dictionary<string, object>();
+
+        public Publication Publication { get; set; }
+
+        public Activity Span { get; set; }
+
+        private MQTTMessagePublisher _mqttMessagePublisher;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MQTTMessageProducer" /> class.
+        /// </summary>
+        /// <param name="mqttMessagePublisher">The publisher used to send messages</param>
+        public MQTTMessageProducer(MQTTMessagePublisher mqttMessagePublisher)
+        {
+            _mqttMessagePublisher = mqttMessagePublisher;
+        }
+
+        public void Dispose()
+        {
+            _mqttMessagePublisher = null;
+        }
+
+        /// <summary>
+        /// Sends the specified message.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        public void Send(Message message)
+        {
+            if (message == null)
+                throw new ArgumentNullException(nameof(message));
+
+            _mqttMessagePublisher.PublishMessage(message);
+        }
+
+        /// <summary>
+        /// Sends the specified message asynchronously.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        /// <returns>Task.</returns>
+        public async Task SendAsync(Message message)
+        {
+            if (message == null)
+                throw new ArgumentNullException(nameof(message));
+
+            await _mqttMessagePublisher.PublishMessageAsync(message);
+        }
+
+
+        /// <summary>
+        /// Sends the specified message.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        /// <param name="delayMilliseconds">Number of milliseconds to delay delivery of the message.</param>
+        public void SendWithDelay(Message message, int delayMilliseconds = 0)
+        {
+            Task.Delay(delayMilliseconds);
+            Send(message);
+        }
+    }
+}

--- a/src/Paramore.Brighter.MessagingGateway.MQTT/MQTTMessagingGatewayConfiguration.cs
+++ b/src/Paramore.Brighter.MessagingGateway.MQTT/MQTTMessagingGatewayConfiguration.cs
@@ -1,0 +1,44 @@
+﻿namespace Paramore.Brighter.MessagingGateway.MQTT
+{
+    public class MQTTMessagingGatewayConfiguration : IAmGatewayConfiguration
+    {
+        /// <summary>
+        /// Sets the MQTT ClientID.
+        /// </summary>
+        public string ClientID { get; set; }
+        
+        /// <summary>
+        /// Sets the MQTT Username
+        /// </summary>
+        public string Username { get; set; }
+
+        /// <summary>
+        /// Sets the MQTT Password
+        /// </summary>
+        public string Password { get; set; }
+
+        /// <summary>
+        /// Sets the CleanSession flag
+        /// </summary>
+        public bool CleanSession { get; set; }
+
+        /// <summary>
+        /// Sets the Server Hostname
+        /// </summary>
+        public string Hostname { get; set; }
+
+        /// <summary>
+        /// Sets the Topic Prefix
+        /// </summary>
+        public object TopicPrefix { get; set; }
+
+        /// <summary>
+        /// Sets the Connection Attempts
+        /// </summary>
+        public int ConnectionAttempts { get; internal set; } = 1;
+    }
+
+
+    public class MQTTMessagingGatewayProducerConfiguration : MQTTMessagingGatewayConfiguration{}
+    public class MQTTMessagingGatewayConsumerConfiguration : MQTTMessagingGatewayConfiguration{}
+}

--- a/src/Paramore.Brighter.MessagingGateway.MQTT/Paramore.Brighter.MessagingGateway.MQTT.csproj
+++ b/src/Paramore.Brighter.MessagingGateway.MQTT/Paramore.Brighter.MessagingGateway.MQTT.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Description>Provides an implementation of the messaging gateway for decoupled invocation in the Paramore.Brighter pipeline, using MQTT&lt;</Description>
+    <Authors>Tim van Wijk</Authors>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <PackageTags>MQTT;Command;Event;Service Activator;Decoupled;Invocation;Messaging;Remote;Command Dispatcher;Command Processor;Request;Service;Task Queue;Work Queue;Retry;Circuit Breaker;Availability</PackageTags>
+    <SignAssembly>false</SignAssembly>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Paramore.Brighter\Paramore.Brighter.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="MQTTnet" />
+  </ItemGroup>
+</Project>

--- a/tests/Paramore.Brighter.MQTT.Tests/MessagingGateway/When_posting_multiples_message_via_the_messaging_gateway.cs
+++ b/tests/Paramore.Brighter.MQTT.Tests/MessagingGateway/When_posting_multiples_message_via_the_messaging_gateway.cs
@@ -1,0 +1,102 @@
+﻿#region Licence
+/* The MIT License (MIT)
+Copyright © 2014 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Paramore.Brighter.MessagingGateway.MQTT;
+using Xunit;
+
+namespace Paramore.Brighter.MQTT.Tests.MessagingGateway
+{
+    [Trait("Category", "MQTT")]
+    [Collection("MQTT")]
+    public class MqttMessageProducerSendMessageTests : IDisposable
+    {
+        private const string MqttHost = "localhost";
+        private const string ClientId = "BrighterIntegrationTests-Produce";
+        private readonly IAmAMessageProducerAsync _messageProducer;
+        private readonly IAmAMessageConsumer _messageConsumer;
+        private readonly string _topicPrefix = "BrighterIntegrationTests/ProducerTests";
+
+        public MqttMessageProducerSendMessageTests()
+        {
+            
+            var mqttProducerConfig = new MQTTMessagingGatewayProducerConfiguration 
+            {
+                Hostname = MqttHost,
+                TopicPrefix = _topicPrefix
+            };
+
+            MQTTMessagePublisher mqttMessagePublisher = new(
+                mqttProducerConfig);
+
+            _messageProducer = new MQTTMessageProducer(mqttMessagePublisher);
+
+
+            MQTTMessagingGatewayConsumerConfiguration mqttConsumerConfig = new()
+            {
+                Hostname = MqttHost,
+                TopicPrefix = _topicPrefix,
+                ClientID = ClientId
+            };
+
+            _messageConsumer = new MQTTMessageConsumer(mqttConsumerConfig);
+        }
+
+        [Fact]
+        public void When_posting_multiples_message_via_the_messaging_gateway()
+        {
+            const int messageCount = 1000;
+            List<Message> sentMessages = new();
+
+            for (int i = 0; i < messageCount; i++)
+            {
+                Message _message = new(
+                    new MessageHeader(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), MessageType.MT_COMMAND),
+                    new MessageBody($"test message")
+                );
+
+                Task task = _messageProducer.SendAsync(_message);
+                task.Wait();
+
+                sentMessages.Add(_message);
+            }
+
+            Message[] recievedMessages = _messageConsumer.Receive(100);
+
+            recievedMessages.Should().NotBeEmpty()
+            .And.HaveCount(messageCount)
+            .And.ContainInOrder(sentMessages)
+            .And.ContainItemsAssignableTo<Message>();
+        }
+
+        public void Dispose()
+        {
+            _messageProducer.Dispose();
+            _messageConsumer.Dispose();
+        }
+    }
+}

--- a/tests/Paramore.Brighter.MQTT.Tests/MessagingGateway/When_queue_is_Purged.cs
+++ b/tests/Paramore.Brighter.MQTT.Tests/MessagingGateway/When_queue_is_Purged.cs
@@ -1,0 +1,102 @@
+﻿#region Licence
+/* The MIT License (MIT)
+Copyright © 2014 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Paramore.Brighter.MessagingGateway.MQTT;
+using Xunit;
+
+namespace Paramore.Brighter.MQTT.Tests.MessagingGateway
+{
+    [Trait("Category", "MQTT")]
+    [Collection("MQTT")]
+    public class When_queue_is_Purged : IDisposable
+    {
+        private const string MqttHost = "localhost";
+        private const string ClientId = "BrighterIntegrationTests-Purge";
+        private readonly IAmAMessageProducerAsync _messageProducer;
+        private readonly IAmAMessageConsumer _messageConsumer;
+        private readonly string _topicPrefix = "BrighterIntegrationTests/PurgeTests";
+        private readonly Message _noopMessage = new();
+
+        public When_queue_is_Purged()
+        {
+
+            var mqttProducerConfig = new MQTTMessagingGatewayProducerConfiguration
+            {
+                Hostname = MqttHost,
+                TopicPrefix = _topicPrefix
+            };
+
+            MQTTMessagePublisher mqttMessagePublisher = new(
+                mqttProducerConfig);
+
+            _messageProducer = new MQTTMessageProducer(mqttMessagePublisher);
+
+
+            MQTTMessagingGatewayConsumerConfiguration mqttConsumerConfig = new()
+            {
+                Hostname = MqttHost,
+                TopicPrefix = _topicPrefix,
+                ClientID = ClientId
+            };
+
+            _messageConsumer = new MQTTMessageConsumer(mqttConsumerConfig);
+        }
+
+        [Fact]
+        public void When_purging_the_queue_on_the_messaging_gateway()
+        {
+            for (int i = 0; i < 5; i++)
+            {
+                Message _message = new(
+                    new MessageHeader(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), MessageType.MT_COMMAND),
+                    new MessageBody($"test message")
+                );
+
+                Task task = _messageProducer.SendAsync(_message);
+                task.Wait();
+            }
+
+            Thread.Sleep(100);
+
+            _messageConsumer.Purge();
+
+            Message[] recievedMessages = _messageConsumer.Receive(100);
+
+            recievedMessages.Should().NotBeEmpty()
+            .And.HaveCount(1)
+            .And.ContainInOrder(new[] { _noopMessage })
+            .And.ContainItemsAssignableTo<Message>();
+        }
+
+        public void Dispose()
+        {
+            _messageProducer.Dispose();
+            _messageConsumer.Dispose();
+        }
+    }
+}

--- a/tests/Paramore.Brighter.MQTT.Tests/Paramore.Brighter.MQTT.Tests.csproj
+++ b/tests/Paramore.Brighter.MQTT.Tests/Paramore.Brighter.MQTT.Tests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions"/>
+    <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Paramore.Brighter.Extensions.DependencyInjection\Paramore.Brighter.Extensions.DependencyInjection.csproj" />
+    <ProjectReference Include="..\..\src\Paramore.Brighter.MessagingGateway.MQTT\Paramore.Brighter.MessagingGateway.MQTT.csproj" />
+    <ProjectReference Include="..\..\src\Paramore.Brighter.ServiceActivator\Paramore.Brighter.ServiceActivator.csproj" />
+    <ProjectReference Include="..\..\src\Paramore.Brighter\Paramore.Brighter.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Starter for MQTT Gateway support.

The Consumer Client keeps a local `Systems.Collections.Generic.Queue`, due to MQTT's "push" technology.

Not implemented:
`IAmAMessageConsumer.Acknowledge`
`IAmAMessageConsumer.Reject`
`IAmAMessageConsumer.Requeue`