### PR TITLE
Use Default Synchronization Context 

### DIFF
--- a/src/Paramore.Brighter/CommandProcessor.cs
+++ b/src/Paramore.Brighter/CommandProcessor.cs
@@ -267,7 +267,7 @@ namespace Paramore.Brighter
         public async Task SendAsync<T>(
             T command, 
             RequestContext requestContext = null, 
-            bool continueOnCapturedContext = false, 
+            bool continueOnCapturedContext = true, 
             CancellationToken cancellationToken = default
         )
             where T : class, IRequest
@@ -381,7 +381,7 @@ namespace Paramore.Brighter
         public async Task PublishAsync<T>(
             T @event,
             RequestContext requestContext = null,
-            bool continueOnCapturedContext = false,
+            bool continueOnCapturedContext = true,
             CancellationToken cancellationToken = default)
             where T : class, IRequest
         {
@@ -486,7 +486,7 @@ namespace Paramore.Brighter
             TRequest request,
             RequestContext requestContext = null,
             Dictionary<string, object> args = null,
-            bool continueOnCapturedContext = false,
+            bool continueOnCapturedContext = true,
             CancellationToken cancellationToken = default
             )
             where TRequest : class, IRequest
@@ -683,7 +683,7 @@ namespace Paramore.Brighter
             TRequest request,
             RequestContext requestContext = null,
             Dictionary<string, object> args = null,
-            bool continueOnCapturedContext = false,
+            bool continueOnCapturedContext = true,
             CancellationToken cancellationToken = default) where TRequest : class, IRequest
         {
             return await DepositPostAsync<TRequest, CommittableTransaction>(
@@ -718,7 +718,7 @@ namespace Paramore.Brighter
             IAmABoxTransactionProvider<TTransaction> transactionProvider,
             RequestContext requestContext = null,
             Dictionary<string, object> args = null,
-            bool continueOnCapturedContext = false,
+            bool continueOnCapturedContext = true,
             CancellationToken cancellationToken = default,
             string batchId = null) where TRequest : class, IRequest
         {
@@ -765,7 +765,7 @@ namespace Paramore.Brighter
             IEnumerable<TRequest> requests,
             RequestContext requestContext = null,
             Dictionary<string, object> args = null,
-            bool continueOnCapturedContext = false,
+            bool continueOnCapturedContext = true,
             CancellationToken cancellationToken = default) where TRequest : class, IRequest
         {
             return await DepositPostAsync<TRequest, CommittableTransaction>(
@@ -798,7 +798,7 @@ namespace Paramore.Brighter
             IAmABoxTransactionProvider<TTransaction> transactionProvider,
             RequestContext requestContext = null,
             Dictionary<string, object> args = null,
-            bool continueOnCapturedContext = false,
+            bool continueOnCapturedContext = true,
             CancellationToken cancellationToken = default) where TRequest : class, IRequest
         {
             
@@ -901,7 +901,7 @@ namespace Paramore.Brighter
             IEnumerable<string> posts,
             RequestContext requestContext = null,
             Dictionary<string, object> args = null,
-            bool continueOnCapturedContext = false,
+            bool continueOnCapturedContext = true,
             CancellationToken cancellationToken = default)
         {
             var span = _tracer?.CreateClearSpan(CommandProcessorSpanOperation.Create, requestContext?.Span, options: _instrumentationOptions);

--- a/src/Paramore.Brighter/ControlBusSender.cs
+++ b/src/Paramore.Brighter/ControlBusSender.cs
@@ -72,7 +72,7 @@ namespace Paramore.Brighter
 
         public async Task PostAsync<TRequest>(
             TRequest request,
-            bool continueOnCapturedContext = false,
+            bool continueOnCapturedContext = true,
             CancellationToken cancellationToken = default)
             where TRequest : class, IRequest
         {

--- a/src/Paramore.Brighter/ExternalBusService.cs
+++ b/src/Paramore.Brighter/ExternalBusService.cs
@@ -159,7 +159,7 @@ namespace Paramore.Brighter
             TMessage message,
             RequestContext requestContext,
             IAmABoxTransactionProvider<TTransaction> overridingTransactionProvider = null,
-            bool continueOnCapturedContext = false,
+            bool continueOnCapturedContext = true,
             CancellationToken cancellationToken = default,
             string batchId = null) 
         {
@@ -379,7 +379,7 @@ namespace Paramore.Brighter
         public async Task ClearOutboxAsync(
             IEnumerable<string> posts,
             RequestContext requestContext,
-            bool continueOnCapturedContext = false,
+            bool continueOnCapturedContext = true,
             Dictionary<string, object> args = null,
             CancellationToken cancellationToken = default
         )
@@ -1106,7 +1106,7 @@ namespace Paramore.Brighter
         private async Task<bool> RetryAsync(
             Func<CancellationToken, Task> send, 
             RequestContext requestContext,
-            bool continueOnCapturedContext = false,
+            bool continueOnCapturedContext = true,
             CancellationToken cancellationToken = default)
         {
             var result = await _policyRegistry.Get<AsyncPolicy>(CommandProcessor.RETRYPOLICYASYNC)

--- a/src/Paramore.Brighter/IAmACommandProcessor.cs
+++ b/src/Paramore.Brighter/IAmACommandProcessor.cs
@@ -55,7 +55,7 @@ namespace Paramore.Brighter
         /// <param name="requestContext">The context of the request; if null we will start one via a <see cref="RequestContextFactory"/> </param>        /// <param name="continueOnCapturedContext">Should we use the calling thread's synchronization context when continuing or a default thread synchronization context. Defaults to false</param>
         /// <param name="cancellationToken">Allows the sender to cancel the request pipeline. Optional</param>
         /// <returns>awaitable <see cref="Task"/>.</returns>
-        Task SendAsync<TRequest>(TRequest command, RequestContext requestContext = null, bool continueOnCapturedContext = false, CancellationToken cancellationToken = default) where TRequest : class, IRequest;
+        Task SendAsync<TRequest>(TRequest command, RequestContext requestContext = null, bool continueOnCapturedContext = true, CancellationToken cancellationToken = default) where TRequest : class, IRequest;
 
         /// <summary>
         /// Publishes the specified event. Throws an aggregate exception on failure of a pipeline but executes remaining
@@ -76,7 +76,7 @@ namespace Paramore.Brighter
         Task PublishAsync<TRequest>(
             TRequest @event, 
             RequestContext requestContext = null,
-            bool continueOnCapturedContext = false, 
+            bool continueOnCapturedContext = true, 
             CancellationToken cancellationToken = default
             ) where TRequest : class, IRequest;
 
@@ -103,7 +103,7 @@ namespace Paramore.Brighter
             TRequest request, 
             RequestContext requestContext = null,
             Dictionary<string, object> args = null,
-            bool continueOnCapturedContext = false, 
+            bool continueOnCapturedContext = true, 
             CancellationToken cancellationToken = default
         ) where TRequest : class, IRequest;
 
@@ -197,7 +197,7 @@ namespace Paramore.Brighter
             TRequest request,
             RequestContext requestContext = null,
             Dictionary<string, object> args = null,
-            bool continueOnCapturedContext = false,
+            bool continueOnCapturedContext = true,
             CancellationToken cancellationToken = default
             ) where TRequest : class, IRequest;
 
@@ -224,7 +224,7 @@ namespace Paramore.Brighter
             IAmABoxTransactionProvider<TTransaction> transactionProvider,
             RequestContext requestContext = null,
             Dictionary<string, object> args = null,
-            bool continueOnCapturedContext = false,
+            bool continueOnCapturedContext = true,
             CancellationToken cancellationToken = default,
             string batchId = null
             ) where T : class, IRequest;
@@ -248,7 +248,7 @@ namespace Paramore.Brighter
             IEnumerable<TRequest> requests,
             RequestContext requestContext = null,
             Dictionary<string, object> args = null,
-            bool continueOnCapturedContext = false,
+            bool continueOnCapturedContext = true,
             CancellationToken cancellationToken = default
             ) where TRequest : class, IRequest;
 
@@ -273,7 +273,7 @@ namespace Paramore.Brighter
             IAmABoxTransactionProvider<TTransaction> transactionProvider,
             RequestContext requestContext = null,
             Dictionary<string, object> args = null,
-            bool continueOnCapturedContext = false,
+            bool continueOnCapturedContext = true,
             CancellationToken cancellationToken = default
             ) where T : class, IRequest;
 
@@ -299,7 +299,7 @@ namespace Paramore.Brighter
             IEnumerable<string> posts,
             RequestContext requestContext = null,
             Dictionary<string, object> args = null,
-            bool continueOnCapturedContext = false,
+            bool continueOnCapturedContext = true,
             CancellationToken cancellationToken = default);
         
         /// <summary>

--- a/src/Paramore.Brighter/IAmAControlBusSender.cs
+++ b/src/Paramore.Brighter/IAmAControlBusSender.cs
@@ -69,7 +69,7 @@ namespace Paramore.Brighter
         /// <returns>awaitable <see cref="Task"/>.</returns>
         Task PostAsync<TRequest>(
             TRequest request, 
-            bool continueOnCapturedContext = false, 
+            bool continueOnCapturedContext = true, 
             CancellationToken cancellationToken = default
             ) where TRequest : class, IRequest;
         

--- a/src/Paramore.Brighter/IAmAnExternalBusService.cs
+++ b/src/Paramore.Brighter/IAmAnExternalBusService.cs
@@ -60,7 +60,7 @@ namespace Paramore.Brighter
         Task ClearOutboxAsync(
             IEnumerable<string> posts,
             RequestContext requestContext,
-            bool continueOnCapturedContext = false,
+            bool continueOnCapturedContext = true,
             Dictionary<string, object> args = null,
             CancellationToken cancellationToken = default
         );
@@ -136,7 +136,7 @@ namespace Paramore.Brighter
             TMessage message,
             RequestContext requestContext,
             IAmABoxTransactionProvider<TTransaction> overridingTransactionProvider = null,
-            bool continueOnCapturedContext = false,
+            bool continueOnCapturedContext = true,
             CancellationToken cancellationToken = default,
             string batchId = null);
 

--- a/tests/Paramore.Brighter.Core.Tests/MessageDispatch/TestDoubles/SpyCommandProcessor.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageDispatch/TestDoubles/SpyCommandProcessor.cs
@@ -71,7 +71,7 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch.TestDoubles
         public virtual async Task SendAsync<TRequest>(
             TRequest command, 
             RequestContext requestContext = null,
-            bool continueOnCapturedContext = false,
+            bool continueOnCapturedContext = true,
             CancellationToken cancellationToken = default) 
             where TRequest : class, IRequest
         {
@@ -91,7 +91,7 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch.TestDoubles
         public virtual async Task PublishAsync<TRequest>(
             TRequest @event, 
             RequestContext requestContext = null,
-            bool continueOnCapturedContext = false,
+            bool continueOnCapturedContext = true,
             CancellationToken cancellationToken = default) 
             where TRequest : class, IRequest
         {
@@ -114,7 +114,7 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch.TestDoubles
             TRequest request, 
             RequestContext requestContext = null,
             Dictionary<string, object> args = null,
-            bool continueOnCapturedContext = false,
+            bool continueOnCapturedContext = true,
             CancellationToken cancellationToken = default) 
             where TRequest : class, IRequest
         {
@@ -177,7 +177,7 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch.TestDoubles
             TRequest request,
             RequestContext requestContext = null,
             Dictionary<string, object> args = null,
-            bool continueOnCapturedContext = false,
+            bool continueOnCapturedContext = true,
             CancellationToken cancellationToken = default) 
             where TRequest : class, IRequest
         {
@@ -193,7 +193,7 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch.TestDoubles
             IAmABoxTransactionProvider<TTransaction> provider,
             RequestContext requestContext = null,
             Dictionary<string, object> args = null,
-            bool continueOnCapturedContext = false, 
+            bool continueOnCapturedContext = true, 
             CancellationToken cancellationToken = default,
             string batchId = null)
             where TRequest : class, IRequest
@@ -209,7 +209,7 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch.TestDoubles
             IEnumerable<TRequest> requests,
             RequestContext requestContext = null,
             Dictionary<string, object> args = null,
-            bool continueOnCapturedContext = false,
+            bool continueOnCapturedContext = true,
             CancellationToken cancellationToken = default) 
             where TRequest : class, IRequest
         {
@@ -227,7 +227,7 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch.TestDoubles
             IAmABoxTransactionProvider<TTransaction> provider,
             RequestContext requestContext = null,
             Dictionary<string, object> args = null,
-            bool continueOnCapturedContext = false,
+            bool continueOnCapturedContext = true,
             CancellationToken cancellationToken = default) where TRequest : class, IRequest
         {
             return await DepositPostAsync(requests, cancellationToken: cancellationToken);
@@ -248,7 +248,7 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch.TestDoubles
             IEnumerable<string> posts, 
             RequestContext requestContext = null,
             Dictionary<string, object> args = null,
-            bool continueOnCapturedContext = false,
+            bool continueOnCapturedContext = true,
             CancellationToken cancellationToken = default)
         {
             var completionSource = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -327,7 +327,7 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch.TestDoubles
         public override async Task SendAsync<T>(
             T command, 
             RequestContext requestContext = null,
-            bool continueOnCapturedContext = false,
+            bool continueOnCapturedContext = true,
             CancellationToken cancellationToken = default
             )
         {
@@ -339,7 +339,7 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch.TestDoubles
         public override async Task PublishAsync<T>(
             T @event, 
             RequestContext requestContext = null,
-            bool continueOnCapturedContext = false,
+            bool continueOnCapturedContext = true,
             CancellationToken cancellationToken = default
             )
         {
@@ -380,14 +380,14 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch.TestDoubles
 
             throw new AggregateException("Failed to publish to one more handlers successfully, see inner exceptions for details", exceptions);
         }
-        public override async Task SendAsync<T>(T command, RequestContext requestContext = null, bool continueOnCapturedContext = false, CancellationToken cancellationToken = default)
+        public override async Task SendAsync<T>(T command, RequestContext requestContext = null, bool continueOnCapturedContext = true, CancellationToken cancellationToken = default)
         {
             await base.SendAsync(command, requestContext, continueOnCapturedContext, cancellationToken);
             SendCount++;
             throw new Exception();
         }
 
-        public override async Task PublishAsync<T>(T @event, RequestContext requestContext = null, bool continueOnCapturedContext = false, CancellationToken cancellationToken = default)
+        public override async Task PublishAsync<T>(T @event, RequestContext requestContext = null, bool continueOnCapturedContext = true, CancellationToken cancellationToken = default)
         {
             await base.PublishAsync(@event, requestContext, continueOnCapturedContext, cancellationToken);
             PublishCount++;

--- a/tests/Paramore.Brighter.Core.Tests/Monitoring/TestDoubles/SpyControlBusSender.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Monitoring/TestDoubles/SpyControlBusSender.cs
@@ -44,7 +44,7 @@ namespace Paramore.Brighter.Core.Tests.Monitoring.TestDoubles
             return (T) _requests.Dequeue();
         }
 
-        public async Task PostAsync<T>(T request, bool continueOnCapturedContext = false, CancellationToken cancellationToken = default) where T : class, IRequest
+        public async Task PostAsync<T>(T request, bool continueOnCapturedContext = true, CancellationToken cancellationToken = default) where T : class, IRequest
         {
             await Task.Delay(5, cancellationToken); 
             Post(request);

--- a/tests/Paramore.Brighter.InMemory.Tests/TestDoubles/FakeCommandProcessor.cs
+++ b/tests/Paramore.Brighter.InMemory.Tests/TestDoubles/FakeCommandProcessor.cs
@@ -27,7 +27,7 @@ namespace Paramore.Brighter.InMemory.Tests.TestDoubles
             Dispatched.TryAdd(command.Id, command);
         }
 
-        public Task SendAsync<T>(T command, RequestContext requestContext = null, bool continueOnCapturedContext = false, CancellationToken cancellationToken = default) where T : class, IRequest
+        public Task SendAsync<T>(T command, RequestContext requestContext = null, bool continueOnCapturedContext = true, CancellationToken cancellationToken = default) where T : class, IRequest
         {
             var tcs = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
             
@@ -44,7 +44,7 @@ namespace Paramore.Brighter.InMemory.Tests.TestDoubles
             Dispatched.TryAdd(@event.Id, @event);
         }
 
-        public Task PublishAsync<T>(T @event, RequestContext requestContext = null, bool continueOnCapturedContext = false, CancellationToken cancellationToken = default) where T : class, IRequest
+        public Task PublishAsync<T>(T @event, RequestContext requestContext = null, bool continueOnCapturedContext = true, CancellationToken cancellationToken = default) where T : class, IRequest
         {
               var tcs = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
               
@@ -62,7 +62,7 @@ namespace Paramore.Brighter.InMemory.Tests.TestDoubles
             ClearOutbox([post], requestContext, args);
         }
         
-        public Task PostAsync<T>(T request, RequestContext requestContext = null, Dictionary<string, object> args = null, bool continueOnCapturedContext = false, CancellationToken cancellationToken = default) where T : class, IRequest
+        public Task PostAsync<T>(T request, RequestContext requestContext = null, Dictionary<string, object> args = null, bool continueOnCapturedContext = true, CancellationToken cancellationToken = default) where T : class, IRequest
         {
               var tcs = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
               
@@ -115,7 +115,7 @@ namespace Paramore.Brighter.InMemory.Tests.TestDoubles
             T request,
             RequestContext requestContext = null,
             Dictionary<string, object> args = null,
-            bool continueOnCapturedContext = false, 
+            bool continueOnCapturedContext = true, 
             CancellationToken cancellationToken = default) 
             where T : class, IRequest
         {
@@ -137,7 +137,7 @@ namespace Paramore.Brighter.InMemory.Tests.TestDoubles
             IAmABoxTransactionProvider<TTransaction> provider, 
             RequestContext requestContext = null,
             Dictionary<string, object> args = null,
-            bool continueOnCapturedContext = false, 
+            bool continueOnCapturedContext = true, 
             CancellationToken cancellationToken = default,
             string batchId = null) 
             where T : class, IRequest
@@ -149,7 +149,7 @@ namespace Paramore.Brighter.InMemory.Tests.TestDoubles
             IEnumerable<T> requests,
             RequestContext requestContext = null,
             Dictionary<string, object> args = null,
-            bool continueOnCapturedContext = false,
+            bool continueOnCapturedContext = true,
             CancellationToken cancellationToken = default) where T : class, IRequest
         {
             var ids = new List<string>();
@@ -166,7 +166,7 @@ namespace Paramore.Brighter.InMemory.Tests.TestDoubles
             IAmABoxTransactionProvider<TTransaction> provider, 
             RequestContext requestContext = null,
             Dictionary<string, object> args = null,
-            bool continueOnCapturedContext = false,
+            bool continueOnCapturedContext = true,
             CancellationToken cancellationToken = default) where T : class, IRequest
         {
             return await DepositPostAsync(requests, requestContext, args, continueOnCapturedContext, cancellationToken);
@@ -185,7 +185,7 @@ namespace Paramore.Brighter.InMemory.Tests.TestDoubles
             IEnumerable<string> posts, 
             RequestContext requestContext = null,
             Dictionary<string, object> args = null, 
-            bool continueOnCapturedContext = false, 
+            bool continueOnCapturedContext = true, 
             CancellationToken cancellationToken = default)
         {
             var tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);


### PR DESCRIPTION
# Issue
We set continueOnCapturedContext to false by default in CommandProcessor, which results in us setting .ConfigureAwait(continueOnCapturedContext). By default we should use true here, because we want you to use the SynchronizationContext that has been set.

# Context

According to the [ConfigureAwait FAQ](https://devblogs.microsoft.com/dotnet/configureawait-faq/) this is the wrong choice as we should default to true, to chose the default model of respecting the synchronizationcontext. The advice we have followed from here previously is to default to ConfigureAwait(false) in a generate purpose library so as to get a performance benefit from not forcing the call back onto the original context. But in our case we supply a SynchronizationContext for use with our message pump, where we want to force you back onto the context.

When we supported async and brought in our own synchronizationcontext we should probably have updated our default to true.

# Fix

We change the default for ContinueOnCapturedContext to true, and a user should pass false if they want to avoid using our context.