### PR TITLE
Backport Dynamo DB distributed locking provider to v9

### DIFF
--- a/Brighter.sln
+++ b/Brighter.sln
@@ -335,17 +335,17 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GreetingsSender", "samples\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GreetingsReceiverConsole", "samples\AWSTransfomers\Compression\GreetingsReceiverConsole\GreetingsReceiverConsole.csproj", "{18742337-075A-40D6-B67F-91F5894A50C3}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Paramore.Brighter.Transformers.Azure", "src\Paramore.Brighter.Transformers.Azure\Paramore.Brighter.Transformers.Azure.csproj", "{29FAAF3E-504D-472F-91F6-14A41B897912}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Paramore.Brighter.Transformers.Azure", "src\Paramore.Brighter.Transformers.Azure\Paramore.Brighter.Transformers.Azure.csproj", "{29FAAF3E-504D-472F-91F6-14A41B897912}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Paramore.Brighter.Azure.Tests", "tests\Paramore.Brighter.Azure.Tests\Paramore.Brighter.Azure.Tests.csproj", "{AA2AA086-9B8A-4910-A793-E92B1E352351}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Paramore.Brighter.Azure.Tests", "tests\Paramore.Brighter.Azure.Tests\Paramore.Brighter.Azure.Tests.csproj", "{AA2AA086-9B8A-4910-A793-E92B1E352351}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Paramore.Brighter.Archive.Azure", "src\Paramore.Brighter.Archive.Azure\Paramore.Brighter.Archive.Azure.csproj", "{F329B6C6-40C2-45BA-A2A8-276ACAFA1867}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Paramore.Brighter.Archive.Azure", "src\Paramore.Brighter.Archive.Azure\Paramore.Brighter.Archive.Azure.csproj", "{F329B6C6-40C2-45BA-A2A8-276ACAFA1867}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Paramore.Brighter.ServiceActivator.Control", "src\Paramore.Brighter.ServiceActivator.Control\Paramore.Brighter.ServiceActivator.Control.csproj", "{4ACA8480-16A0-4BC8-8401-4A27E5AEC1BE}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Paramore.Brighter.ServiceActivator.Control", "src\Paramore.Brighter.ServiceActivator.Control\Paramore.Brighter.ServiceActivator.Control.csproj", "{4ACA8480-16A0-4BC8-8401-4A27E5AEC1BE}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Paramore.Brighter.ServiceActivator.Control.Api", "src\Paramore.Brighter.ServiceActivator.Control.Api\Paramore.Brighter.ServiceActivator.Control.Api.csproj", "{397F8496-6916-43EF-AEB2-5D84048DE357}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Paramore.Brighter.ServiceActivator.Control.Api", "src\Paramore.Brighter.ServiceActivator.Control.Api\Paramore.Brighter.ServiceActivator.Control.Api.csproj", "{397F8496-6916-43EF-AEB2-5D84048DE357}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Paramore.Brighter.Locking.Azure", "Paramore.Brighter.Locking.Azure\Paramore.Brighter.Locking.Azure.csproj", "{021F3B51-A640-4C0D-9B47-FB4E32DF6715}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Paramore.Brighter.Locking.Azure", "Paramore.Brighter.Locking.Azure\Paramore.Brighter.Locking.Azure.csproj", "{021F3B51-A640-4C0D-9B47-FB4E32DF6715}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Paramore.Brighter.Locking.DynamoDB", "src\Paramore.Brighter.Locking.DynamoDB\Paramore.Brighter.Locking.DynamoDB.csproj", "{CBF99394-E332-439B-8632-ABDE06F6E343}"
 EndProject
@@ -1907,30 +1907,6 @@ Global
 		{18742337-075A-40D6-B67F-91F5894A50C3}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{18742337-075A-40D6-B67F-91F5894A50C3}.Release|x86.ActiveCfg = Release|Any CPU
 		{18742337-075A-40D6-B67F-91F5894A50C3}.Release|x86.Build.0 = Release|Any CPU
-		{F329B6C6-40C2-45BA-A2A8-276ACAFA1867}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{F329B6C6-40C2-45BA-A2A8-276ACAFA1867}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{F329B6C6-40C2-45BA-A2A8-276ACAFA1867}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{F329B6C6-40C2-45BA-A2A8-276ACAFA1867}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
-		{F329B6C6-40C2-45BA-A2A8-276ACAFA1867}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{F329B6C6-40C2-45BA-A2A8-276ACAFA1867}.Debug|x86.Build.0 = Debug|Any CPU
-		{F329B6C6-40C2-45BA-A2A8-276ACAFA1867}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{F329B6C6-40C2-45BA-A2A8-276ACAFA1867}.Release|Any CPU.Build.0 = Release|Any CPU
-		{F329B6C6-40C2-45BA-A2A8-276ACAFA1867}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
-		{F329B6C6-40C2-45BA-A2A8-276ACAFA1867}.Release|Mixed Platforms.Build.0 = Release|Any CPU
-		{F329B6C6-40C2-45BA-A2A8-276ACAFA1867}.Release|x86.ActiveCfg = Release|Any CPU
-		{F329B6C6-40C2-45BA-A2A8-276ACAFA1867}.Release|x86.Build.0 = Release|Any CPU
-		{3BCE9BD6-B5A7-4962-8A95-7B83B458458A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{3BCE9BD6-B5A7-4962-8A95-7B83B458458A}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{3BCE9BD6-B5A7-4962-8A95-7B83B458458A}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{3BCE9BD6-B5A7-4962-8A95-7B83B458458A}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
-		{3BCE9BD6-B5A7-4962-8A95-7B83B458458A}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{3BCE9BD6-B5A7-4962-8A95-7B83B458458A}.Debug|x86.Build.0 = Debug|Any CPU
-		{3BCE9BD6-B5A7-4962-8A95-7B83B458458A}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{3BCE9BD6-B5A7-4962-8A95-7B83B458458A}.Release|Any CPU.Build.0 = Release|Any CPU
-		{3BCE9BD6-B5A7-4962-8A95-7B83B458458A}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
-		{3BCE9BD6-B5A7-4962-8A95-7B83B458458A}.Release|Mixed Platforms.Build.0 = Release|Any CPU
-		{3BCE9BD6-B5A7-4962-8A95-7B83B458458A}.Release|x86.ActiveCfg = Release|Any CPU
-		{3BCE9BD6-B5A7-4962-8A95-7B83B458458A}.Release|x86.Build.0 = Release|Any CPU
 		{29FAAF3E-504D-472F-91F6-14A41B897912}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{29FAAF3E-504D-472F-91F6-14A41B897912}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{29FAAF3E-504D-472F-91F6-14A41B897912}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
@@ -1955,18 +1931,18 @@ Global
 		{AA2AA086-9B8A-4910-A793-E92B1E352351}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{AA2AA086-9B8A-4910-A793-E92B1E352351}.Release|x86.ActiveCfg = Release|Any CPU
 		{AA2AA086-9B8A-4910-A793-E92B1E352351}.Release|x86.Build.0 = Release|Any CPU
-		{EC046F36-F93F-447A-86EA-F60585232867}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{EC046F36-F93F-447A-86EA-F60585232867}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{EC046F36-F93F-447A-86EA-F60585232867}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{EC046F36-F93F-447A-86EA-F60585232867}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
-		{EC046F36-F93F-447A-86EA-F60585232867}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{EC046F36-F93F-447A-86EA-F60585232867}.Debug|x86.Build.0 = Debug|Any CPU
-		{EC046F36-F93F-447A-86EA-F60585232867}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{EC046F36-F93F-447A-86EA-F60585232867}.Release|Any CPU.Build.0 = Release|Any CPU
-		{EC046F36-F93F-447A-86EA-F60585232867}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
-		{EC046F36-F93F-447A-86EA-F60585232867}.Release|Mixed Platforms.Build.0 = Release|Any CPU
-		{EC046F36-F93F-447A-86EA-F60585232867}.Release|x86.ActiveCfg = Release|Any CPU
-		{EC046F36-F93F-447A-86EA-F60585232867}.Release|x86.Build.0 = Release|Any CPU
+		{F329B6C6-40C2-45BA-A2A8-276ACAFA1867}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F329B6C6-40C2-45BA-A2A8-276ACAFA1867}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F329B6C6-40C2-45BA-A2A8-276ACAFA1867}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{F329B6C6-40C2-45BA-A2A8-276ACAFA1867}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{F329B6C6-40C2-45BA-A2A8-276ACAFA1867}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F329B6C6-40C2-45BA-A2A8-276ACAFA1867}.Debug|x86.Build.0 = Debug|Any CPU
+		{F329B6C6-40C2-45BA-A2A8-276ACAFA1867}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F329B6C6-40C2-45BA-A2A8-276ACAFA1867}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F329B6C6-40C2-45BA-A2A8-276ACAFA1867}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{F329B6C6-40C2-45BA-A2A8-276ACAFA1867}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{F329B6C6-40C2-45BA-A2A8-276ACAFA1867}.Release|x86.ActiveCfg = Release|Any CPU
+		{F329B6C6-40C2-45BA-A2A8-276ACAFA1867}.Release|x86.Build.0 = Release|Any CPU
 		{4ACA8480-16A0-4BC8-8401-4A27E5AEC1BE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{4ACA8480-16A0-4BC8-8401-4A27E5AEC1BE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4ACA8480-16A0-4BC8-8401-4A27E5AEC1BE}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
@@ -1991,18 +1967,6 @@ Global
 		{397F8496-6916-43EF-AEB2-5D84048DE357}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{397F8496-6916-43EF-AEB2-5D84048DE357}.Release|x86.ActiveCfg = Release|Any CPU
 		{397F8496-6916-43EF-AEB2-5D84048DE357}.Release|x86.Build.0 = Release|Any CPU
-		{3384FBF0-5DCB-452D-8288-FAD1D0023089}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{3384FBF0-5DCB-452D-8288-FAD1D0023089}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{3384FBF0-5DCB-452D-8288-FAD1D0023089}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{3384FBF0-5DCB-452D-8288-FAD1D0023089}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
-		{3384FBF0-5DCB-452D-8288-FAD1D0023089}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{3384FBF0-5DCB-452D-8288-FAD1D0023089}.Debug|x86.Build.0 = Debug|Any CPU
-		{3384FBF0-5DCB-452D-8288-FAD1D0023089}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{3384FBF0-5DCB-452D-8288-FAD1D0023089}.Release|Any CPU.Build.0 = Release|Any CPU
-		{3384FBF0-5DCB-452D-8288-FAD1D0023089}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
-		{3384FBF0-5DCB-452D-8288-FAD1D0023089}.Release|Mixed Platforms.Build.0 = Release|Any CPU
-		{3384FBF0-5DCB-452D-8288-FAD1D0023089}.Release|x86.ActiveCfg = Release|Any CPU
-		{3384FBF0-5DCB-452D-8288-FAD1D0023089}.Release|x86.Build.0 = Release|Any CPU
 		{021F3B51-A640-4C0D-9B47-FB4E32DF6715}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{021F3B51-A640-4C0D-9B47-FB4E32DF6715}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{021F3B51-A640-4C0D-9B47-FB4E32DF6715}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
@@ -2015,6 +1979,18 @@ Global
 		{021F3B51-A640-4C0D-9B47-FB4E32DF6715}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{021F3B51-A640-4C0D-9B47-FB4E32DF6715}.Release|x86.ActiveCfg = Release|Any CPU
 		{021F3B51-A640-4C0D-9B47-FB4E32DF6715}.Release|x86.Build.0 = Release|Any CPU
+		{CBF99394-E332-439B-8632-ABDE06F6E343}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CBF99394-E332-439B-8632-ABDE06F6E343}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CBF99394-E332-439B-8632-ABDE06F6E343}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{CBF99394-E332-439B-8632-ABDE06F6E343}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{CBF99394-E332-439B-8632-ABDE06F6E343}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{CBF99394-E332-439B-8632-ABDE06F6E343}.Debug|x86.Build.0 = Debug|Any CPU
+		{CBF99394-E332-439B-8632-ABDE06F6E343}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CBF99394-E332-439B-8632-ABDE06F6E343}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CBF99394-E332-439B-8632-ABDE06F6E343}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{CBF99394-E332-439B-8632-ABDE06F6E343}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{CBF99394-E332-439B-8632-ABDE06F6E343}.Release|x86.ActiveCfg = Release|Any CPU
+		{CBF99394-E332-439B-8632-ABDE06F6E343}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Brighter.sln
+++ b/Brighter.sln
@@ -347,6 +347,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Paramore.Brighter.ServiceAc
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Paramore.Brighter.Locking.Azure", "Paramore.Brighter.Locking.Azure\Paramore.Brighter.Locking.Azure.csproj", "{021F3B51-A640-4C0D-9B47-FB4E32DF6715}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Paramore.Brighter.Locking.DynamoDB", "src\Paramore.Brighter.Locking.DynamoDB\Paramore.Brighter.Locking.DynamoDB.csproj", "{CBF99394-E332-439B-8632-ABDE06F6E343}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -43,6 +43,7 @@
     <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.7.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageVersion Include="MySqlConnector" Version="2.3.6" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />

--- a/src/Paramore.Brighter.Locking.DynamoDB/DynamoDbLockingProvider.cs
+++ b/src/Paramore.Brighter.Locking.DynamoDB/DynamoDbLockingProvider.cs
@@ -1,0 +1,139 @@
+﻿#region Licence
+/* The MIT License (MIT)
+Copyright © 2024 Dominic Hickie <dominichickie@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+#endregion
+using Amazon.DynamoDBv2;
+using Amazon.DynamoDBv2.Model;
+
+namespace Paramore.Brighter.Locking.DynamoDb
+{
+    public class DynamoDbLockingProvider : IDistributedLock
+    {
+        private readonly IAmazonDynamoDB _dynamoDb;
+        private readonly DynamoDbLockingProviderOptions _options;
+        private readonly TimeProvider _timeProvider;
+
+        public DynamoDbLockingProvider(IAmazonDynamoDB dynamoDb, DynamoDbLockingProviderOptions options)
+            :this(dynamoDb, options, TimeProvider.System)
+        {
+        }
+
+        public DynamoDbLockingProvider(IAmazonDynamoDB dynamoDb, DynamoDbLockingProviderOptions options, TimeProvider timeProvider)
+        {
+            _dynamoDb = dynamoDb;
+            _options = options;
+            _timeProvider = timeProvider;
+        }
+
+        /// <summary>
+        /// Attempt to obtain a lock on a resource
+        /// </summary>
+        /// <param name="resource">The name of the resource to Lock</param>
+        /// <param name="cancellationToken">The Cancellation Token</param>
+        /// <returns>The id of the lock that has been acquired or null if no lock was able to be acquired</returns>
+        public async Task<string?> ObtainLockAsync(string resource, CancellationToken cancellationToken = default)
+        {
+            var lockId = Guid.NewGuid().ToString();
+
+            try
+            {
+                await _dynamoDb.PutItemAsync(BuildLockRequest(resource, lockId), cancellationToken);
+            }
+            catch (ConditionalCheckFailedException)
+            {
+                return null;
+            }
+
+            return lockId;
+        }
+
+        /// <summary>
+        /// Release a lock
+        /// </summary>
+        /// <param name="resource">The name of the resource to Lock</param>
+        /// <param name="lockId">The lock Id that was provided when the lock was obtained</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns>Awaitable Task</returns>
+        public async Task ReleaseLockAsync(string resource, string lockId, CancellationToken cancellationToken = default)
+        {
+            if (_options.ManuallyReleaseLock)
+            {
+                try
+                {
+                    await _dynamoDb.DeleteItemAsync(BuildReleaseRequest(resource, lockId), cancellationToken);
+                }
+                catch (ConditionalCheckFailedException)
+                {
+                    // Log that the lease is no longer valid
+                }
+            }
+        }
+
+        private PutItemRequest BuildLockRequest(string resource, string lockId)
+        {
+            var now = _timeProvider.GetUtcNow();
+            var leaseExpiry = now.Add(_options.LeaseValidity);
+
+            return new PutItemRequest
+            {
+                TableName = _options.LockTableName,
+                Item = new Dictionary<string, AttributeValue>
+                {
+                    {"ResourceId", new AttributeValue{ S = $"{_options.LeaseholderGroupId}_{resource}"} },
+                    {"LeaseExpiry", new AttributeValue{ N = leaseExpiry.ToUnixTimeMilliseconds().ToString()} },
+                    {"LockId", new AttributeValue{S = lockId} }
+                },
+                ConditionExpression = "attribute_not_exists(#r) OR (attribute_exists(#r) AND #e <= :t)",
+                ExpressionAttributeNames = new Dictionary<string, string>
+                {
+                    {"#r", "LockId"},
+                    {"#e", "LeaseExpiry"}
+                },
+                ExpressionAttributeValues = new Dictionary<string, AttributeValue>
+                {
+                    {":t", new AttributeValue {N = now.ToUnixTimeMilliseconds().ToString()} }
+                }
+            };
+        }
+
+        private DeleteItemRequest BuildReleaseRequest(string resource, string leaseId)
+        {
+            return new DeleteItemRequest
+            {
+                TableName = _options.LockTableName,
+                Key = new Dictionary<string, AttributeValue>
+                {
+                    {"ResourceId", new AttributeValue{S = $"{_options.LeaseholderGroupId}_{resource}"} }
+                },
+                ConditionExpression = "attribute_exists(#r) AND #l = :l",
+                ExpressionAttributeNames = new Dictionary<string, string>
+                {
+                    {"#r", "ResourceId"},
+                    {"#l", "LockId"}
+                },
+                ExpressionAttributeValues = new Dictionary<string, AttributeValue>
+                {
+                    {":l", new AttributeValue{S = leaseId} }
+                }
+            };
+        }
+    }
+}

--- a/src/Paramore.Brighter.Locking.DynamoDB/DynamoDbLockingProviderOptions.cs
+++ b/src/Paramore.Brighter.Locking.DynamoDB/DynamoDbLockingProviderOptions.cs
@@ -1,0 +1,47 @@
+﻿#region Licence
+/* The MIT License (MIT)
+Copyright © 2024 Dominic Hickie <dominichickie@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+#endregion
+namespace Paramore.Brighter.Locking.DynamoDb
+{
+    public class DynamoDbLockingProviderOptions(string lockTableName, string leaseholderGroupId)
+    {
+        /// <summary>
+        /// The name of the dynamo DB table containing locks
+        /// </summary>
+        public string LockTableName { get; init; } = lockTableName;
+
+        /// <summary>
+        /// The ID of the group of potential leaseholders that share the lock
+        /// </summary>
+        public string LeaseholderGroupId { get; init; } = leaseholderGroupId;
+
+        /// <summary>
+        /// The amount of time before the lease automatically expires
+        /// </summary>
+        public TimeSpan LeaseValidity { get; set; } = TimeSpan.FromMinutes(1);
+
+        /// <summary>
+        /// Whether the lock provider should manually release the lock on completion or simply wait for expiry
+        /// </summary>
+        public bool ManuallyReleaseLock { get; set; } = false;
+    }
+}

--- a/src/Paramore.Brighter.Locking.DynamoDB/LockItem.cs
+++ b/src/Paramore.Brighter.Locking.DynamoDB/LockItem.cs
@@ -1,0 +1,47 @@
+﻿#region Licence
+/* The MIT License (MIT)
+Copyright © 2024 Dominic Hickie <dominichickie@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+#endregion
+using Amazon.DynamoDBv2.DataModel;
+
+namespace Paramore.Brighter.Locking.DynamoDB
+{
+    [DynamoDBTable("brighter_distributed_lock")]
+    public class LockItem
+    {
+        /// <summary>
+        /// The ID of the resource being locked
+        /// </summary>
+        [DynamoDBHashKey]
+        [DynamoDBProperty]
+        public string? ResourceId { get; init; }
+
+        /// <summary>
+        /// The time at which the lease for the lock expires, as a unix timestamp in milliseconds
+        /// </summary>
+        public long LeaseExpiry { get; init; }
+
+        /// <summary>
+        /// The ID of the lock that has been obtained
+        /// </summary>
+        public string? LockId { get; init; }
+    }
+}

--- a/src/Paramore.Brighter.Locking.DynamoDB/Paramore.Brighter.Locking.DynamoDB.csproj
+++ b/src/Paramore.Brighter.Locking.DynamoDB/Paramore.Brighter.Locking.DynamoDB.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <Title>This is the Dynamo DB Distributed Locking Provider.</Title>
+    <Authors>Dominic Hickie</Authors>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Paramore.Brighter\Paramore.Brighter.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AWSSDK.DynamoDBv2" />
+  </ItemGroup>
+
+</Project>

--- a/src/Paramore.Brighter.Locking.DynamoDB/Paramore.Brighter.Locking.DynamoDB.csproj
+++ b/src/Paramore.Brighter.Locking.DynamoDB/Paramore.Brighter.Locking.DynamoDB.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Paramore.Brighter.Extensions.DependencyInjection\Paramore.Brighter.Extensions.DependencyInjection.csproj" />
     <ProjectReference Include="..\Paramore.Brighter\Paramore.Brighter.csproj" />
   </ItemGroup>
 

--- a/src/Paramore.Brighter.Locking.DynamoDB/ServiceCollectionExtensions.cs
+++ b/src/Paramore.Brighter.Locking.DynamoDB/ServiceCollectionExtensions.cs
@@ -1,0 +1,74 @@
+﻿#region Licence
+/* The MIT License (MIT)
+Copyright © 2024 Dominic Hickie <dominichickie@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+#endregion
+using Amazon.DynamoDBv2;
+using Microsoft.Extensions.DependencyInjection;
+using Paramore.Brighter.Extensions.DependencyInjection;
+using Paramore.Brighter.Locking.DynamoDb;
+
+namespace Paramore.Brighter.Locking.DynamoDB
+{
+    public static class ServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Registers a DynamoDb distributed locking provider. This helper registers
+        ///  - IDistributedLock
+        ///
+        /// You will need to register IAmazonDynamoDb BEFORE calling this extension
+        /// We do not register this, as we assume you will need to register them for your code's access to DynamoDb  
+        /// So we assume that prerequisite has taken place beforehand 
+        /// </summary>
+        /// <param name="configAction">An action for customising the lock config before registering the provider</param>
+        /// <param name="serviceLifetime">The lifetime of the locking provider</param>
+        /// <returns></returns>
+        public static IBrighterBuilder UseDynamoDbDistributedLock(this IBrighterBuilder builder, 
+            string lockTableName,
+            string leaseholderGroupId,
+            Action<DynamoDbLockingProviderOptions>? configAction = null,
+            ServiceLifetime serviceLifetime = ServiceLifetime.Singleton)
+        {
+            var config = new DynamoDbLockingProviderOptions(lockTableName, leaseholderGroupId);
+
+            if (configAction != null)
+            {
+                configAction(config);
+            }
+
+            builder.Services.AddSingleton(config);
+            builder.Services.Add(new ServiceDescriptor(typeof(IDistributedLock), BuildLockingProvider, serviceLifetime));
+
+            return builder;
+        }
+
+        private static DynamoDbLockingProvider BuildLockingProvider(IServiceProvider serviceProvider)
+        {
+            var config = serviceProvider.GetService<DynamoDbLockingProviderOptions>();
+            if (config == null)
+                throw new InvalidOperationException("No service of type DynamoDbLockingProviderOptions could be found, please register before calling this method");
+            var dynamoDb = serviceProvider.GetService<IAmazonDynamoDB>();
+            if (dynamoDb == null)
+                throw new InvalidOperationException("No service of type IAmazonDynamoDb was found. Please register before calling this method");
+
+            return new DynamoDbLockingProvider(dynamoDb, config);
+        }
+    }
+}

--- a/tests/Paramore.Brighter.DynamoDB.Tests/Locking/DynamoDBLockingBaseTest.cs
+++ b/tests/Paramore.Brighter.DynamoDB.Tests/Locking/DynamoDBLockingBaseTest.cs
@@ -1,0 +1,59 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Amazon.DynamoDBv2;
+using Amazon.DynamoDBv2.DataModel;
+using Amazon.DynamoDBv2.Model;
+using Amazon.Runtime;
+using Paramore.Brighter.DynamoDb;
+using Paramore.Brighter.Locking.DynamoDB;
+using Paramore.Brighter.Outbox.DynamoDB;
+
+namespace Paramore.Brighter.DynamoDB.Tests.Locking
+{
+    public class DynamoDBLockingBaseTest
+    {
+        protected DynamoDbTableBuilder DbTableBuilder { get; }
+        protected string LockTableName { get; }
+        protected AWSCredentials Credentials { get; set; }
+        protected IAmazonDynamoDB Client { get; }
+        private DynamoDBContext _dynamoDBContext;
+
+        protected DynamoDBLockingBaseTest()
+        {
+            Client = CreateClient();
+            _dynamoDBContext = new DynamoDBContext(Client);
+            DbTableBuilder = new DynamoDbTableBuilder(Client);
+
+            // Create the lock table
+            var createTableRequest = new DynamoDbTableFactory().GenerateCreateTableRequest<LockItem>(
+                new DynamoDbCreateProvisionedThroughput(
+                    new ProvisionedThroughput { ReadCapacityUnits = 10, WriteCapacityUnits = 10 }
+                ));
+            LockTableName = createTableRequest.TableName;
+
+            (bool exist, IEnumerable<string> _) hasTables = DbTableBuilder.HasTables([LockTableName]).GetAwaiter().GetResult();
+            if (!hasTables.exist)
+            {
+                DbTableBuilder.Build(createTableRequest).GetAwaiter().GetResult();
+                DbTableBuilder.EnsureTablesReady([createTableRequest.TableName], TableStatus.ACTIVE).GetAwaiter().GetResult();
+            }
+        }
+
+        protected async Task<LockItem> GetLockItem(string resourceId)
+        {
+            return await _dynamoDBContext.LoadAsync<LockItem>(resourceId);
+        }
+
+        private IAmazonDynamoDB CreateClient()
+        {
+            Credentials = new BasicAWSCredentials("FakeAccessKey", "FakeSecretKey");
+
+            var clientConfig = new AmazonDynamoDBConfig
+            {
+                ServiceURL = "http://localhost:8000"
+            };
+
+            return new AmazonDynamoDBClient(Credentials, clientConfig);
+        }
+    }
+}

--- a/tests/Paramore.Brighter.DynamoDB.Tests/Locking/When_releasing_a_lock.cs
+++ b/tests/Paramore.Brighter.DynamoDB.Tests/Locking/When_releasing_a_lock.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.Time.Testing;
+using Paramore.Brighter.Locking.DynamoDb;
+using Xunit;
+
+namespace Paramore.Brighter.DynamoDB.Tests.Locking
+{
+    [Trait("Category", "DynamoDB")]
+    public class DynamoDbReleasingLockTests : DynamoDBLockingBaseTest
+    {
+        private readonly DynamoDbLockingProviderOptions _options;
+        private readonly FakeTimeProvider _timeProvider;
+
+        public DynamoDbReleasingLockTests()
+        {
+            _options = new DynamoDbLockingProviderOptions("brighter_distributed_lock", Guid.NewGuid().ToString());
+            _timeProvider = new FakeTimeProvider();
+        }
+
+        [Fact]
+        public async Task When_manual_lock_release_is_enabled()
+        {
+            _options.ManuallyReleaseLock = true;
+            var provider = new DynamoDbLockingProvider(Client, _options, _timeProvider);
+
+            var resource = Guid.NewGuid().ToString();
+            var result = await provider.ObtainLockAsync(resource);
+            result.Should().NotBeNull();
+
+            var lockItem = await GetLockItem($"{_options.LeaseholderGroupId}_{resource}");
+            lockItem.Should().NotBeNull();
+
+            await provider.ReleaseLockAsync(resource, result);
+            lockItem = await GetLockItem($"{_options.LeaseholderGroupId}_{resource}");
+            lockItem.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task When_manual_lock_release_is_disabled()
+        {
+            _options.ManuallyReleaseLock = false;
+            var provider = new DynamoDbLockingProvider(Client, _options, _timeProvider);
+
+            var resource = Guid.NewGuid().ToString();
+            var result = await provider.ObtainLockAsync(resource);
+            result.Should().NotBeNull();
+
+            var lockItem = await GetLockItem($"{_options.LeaseholderGroupId}_{resource}");
+            lockItem.Should().NotBeNull();
+
+            await provider.ReleaseLockAsync(resource, result);
+            lockItem = await GetLockItem($"{_options.LeaseholderGroupId}_{resource}");
+            lockItem.Should().NotBeNull();
+        }
+
+        [Fact]
+        public async Task When_one_of_multiple_locks_is_released()
+        {
+            _options.ManuallyReleaseLock = true;
+            var provider = new DynamoDbLockingProvider(Client, _options, _timeProvider);
+
+            var resourceA = Guid.NewGuid().ToString();
+            var resultA = await provider.ObtainLockAsync(resourceA);
+            resultA.Should().NotBeNull();
+
+            var resourceB = Guid.NewGuid().ToString();
+            var resultB = await provider.ObtainLockAsync(resourceB);
+            resultB.Should().NotBeNull();
+
+            await provider.ReleaseLockAsync(resourceA, resultA);
+            var lockItemA = await GetLockItem($"{_options.LeaseholderGroupId}_{resourceA}");
+            var lockItemB = await GetLockItem($"{_options.LeaseholderGroupId}_{resourceB}");
+            lockItemA.Should().BeNull();
+            lockItemB.Should().NotBeNull();
+        }
+    }
+}

--- a/tests/Paramore.Brighter.DynamoDB.Tests/Locking/When_there_is_an_existing_lock.cs
+++ b/tests/Paramore.Brighter.DynamoDB.Tests/Locking/When_there_is_an_existing_lock.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.Time.Testing;
+using Paramore.Brighter.Locking.DynamoDb;
+using Xunit;
+
+namespace Paramore.Brighter.DynamoDB.Tests.Locking
+{
+    [Trait("Category", "DynamoDB")]
+    public class DynamoDbExistingLockTests : DynamoDBLockingBaseTest
+    {
+        private readonly DynamoDbLockingProvider _provider;
+        private readonly DynamoDbLockingProviderOptions _options;
+        private readonly FakeTimeProvider _timeProvider;
+
+        public DynamoDbExistingLockTests()
+        {
+            _options = new DynamoDbLockingProviderOptions("brighter_distributed_lock", Guid.NewGuid().ToString());
+            _timeProvider = new FakeTimeProvider();
+            _provider = new DynamoDbLockingProvider(Client, _options, _timeProvider);
+        }
+
+        [Fact]
+        public async Task When_there_is_an_existing_lock_for_resource()
+        {
+            var startTime = _timeProvider.GetUtcNow();
+            var resource = Guid.NewGuid().ToString();
+            var resultA = await _provider.ObtainLockAsync(resource);
+            resultA.Should().NotBeNull();
+
+            _timeProvider.Advance(TimeSpan.FromSeconds(30));
+
+            var resultB = await _provider.ObtainLockAsync(resource);
+            resultB.Should().BeNull();
+
+            var lockItem = await GetLockItem($"{_options.LeaseholderGroupId}_{resource}");
+
+            lockItem.Should().NotBeNull();
+            lockItem.LockId.Should().Be(resultA);
+            lockItem.LeaseExpiry.Should().Be(startTime.Add(_options.LeaseValidity).ToUnixTimeMilliseconds());
+        }
+    }
+}

--- a/tests/Paramore.Brighter.DynamoDB.Tests/Locking/When_there_is_no_existing_lock.cs
+++ b/tests/Paramore.Brighter.DynamoDB.Tests/Locking/When_there_is_no_existing_lock.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.Time.Testing;
+using Paramore.Brighter.Locking.DynamoDb;
+using Xunit;
+
+namespace Paramore.Brighter.DynamoDB.Tests.Locking
+{
+    [Trait("Category", "DynamoDB")]
+    public class DynamoDbNoExistingLockTests : DynamoDBLockingBaseTest
+    {
+        private readonly DynamoDbLockingProvider _provider;
+        private readonly DynamoDbLockingProviderOptions _options;
+        private readonly FakeTimeProvider _timeProvider;
+
+        public DynamoDbNoExistingLockTests()
+        {
+            _options = new DynamoDbLockingProviderOptions("brighter_distributed_lock", Guid.NewGuid().ToString());
+            _timeProvider = new FakeTimeProvider();
+            _provider = new DynamoDbLockingProvider(Client, _options, _timeProvider);
+        }
+
+        [Fact]
+        public async Task When_there_is_no_existing_lock_for_resource()
+        {
+            var resource = Guid.NewGuid().ToString();
+            var result = await _provider.ObtainLockAsync(resource);
+
+            result.Should().NotBeNull();
+
+            var lockItem = await GetLockItem($"{_options.LeaseholderGroupId}_{resource}");
+
+            lockItem.Should().NotBeNull();
+            lockItem.LockId.Should().Be(result);
+            lockItem.LeaseExpiry.Should().Be(_timeProvider.GetUtcNow().Add(_options.LeaseValidity).ToUnixTimeMilliseconds());
+        }
+
+        [Fact]
+        public async Task When_there_is_existing_expired_lock_for_resource()
+        {
+            var resource = Guid.NewGuid().ToString();
+            var result = await _provider.ObtainLockAsync(resource);
+            result.Should().NotBeNull();
+
+            _timeProvider.Advance(TimeSpan.FromMinutes(5));
+            result = await _provider.ObtainLockAsync(resource);
+            result.Should().NotBeNull();
+
+            var lockItem = await GetLockItem($"{_options.LeaseholderGroupId}_{resource}");
+
+            lockItem.Should().NotBeNull();
+            lockItem.LockId.Should().Be(result);
+            lockItem.LeaseExpiry.Should().Be(_timeProvider.GetUtcNow().Add(_options.LeaseValidity).ToUnixTimeMilliseconds());
+        }
+
+        [Fact]
+        public async Task When_there_is_existing_lock_for_different_resource()
+        {
+            var resourceA = Guid.NewGuid().ToString();
+            var result = await _provider.ObtainLockAsync(resourceA);
+            result.Should().NotBeNull();
+
+            var resourceB = Guid.NewGuid().ToString();
+            result = await _provider.ObtainLockAsync(resourceB);
+            result.Should().NotBeNull();
+
+            var lockItem = await GetLockItem($"{_options.LeaseholderGroupId}_{resourceB}");
+
+            lockItem.Should().NotBeNull();
+            lockItem.LockId.Should().Be(result);
+            lockItem.LeaseExpiry.Should().Be(_timeProvider.GetUtcNow().Add(_options.LeaseValidity).ToUnixTimeMilliseconds());
+        }
+    }
+}

--- a/tests/Paramore.Brighter.DynamoDB.Tests/Paramore.Brighter.DynamoDB.Tests.csproj
+++ b/tests/Paramore.Brighter.DynamoDB.Tests/Paramore.Brighter.DynamoDB.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
@@ -12,6 +12,7 @@
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
       <PackageReference Include="FluentAssertions" />
+      <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" />
       <PackageReference Include="xunit" />
       <PackageReference Include="xunit.runner.visualstudio">
@@ -22,6 +23,7 @@
 
     <ItemGroup>
       <ProjectReference Include="..\..\src\Paramore.Brighter.Inbox.DynamoDB\Paramore.Brighter.Inbox.DynamoDB.csproj" />
+      <ProjectReference Include="..\..\src\Paramore.Brighter.Locking.DynamoDB\Paramore.Brighter.Locking.DynamoDB.csproj" />
       <ProjectReference Include="..\..\src\Paramore.Brighter.Outbox.DynamoDB\Paramore.Brighter.Outbox.DynamoDB.csproj" />
     </ItemGroup>
 


### PR DESCRIPTION
This backports the implementation of a Dynamo DB distributed locking provider to to the v9 branch.

In addition to the changes made for the v10 version, this also adds an extension method for registering the Dynamo DB locking provider, in line with the pattern used elsewhere, for example when registering the Dynamo DB outbox.