### PR TITLE
Fix v9 Send breaking Open Telemetry

### DIFF
--- a/src/Paramore.Brighter/CommandProcessor.cs
+++ b/src/Paramore.Brighter/CommandProcessor.cs
@@ -345,12 +345,14 @@ namespace Paramore.Brighter
                 }
                 catch (Exception)
                 {
-                    span.span?.SetStatus(ActivityStatusCode.Error);
+                    if (span.created)
+                        span.span?.SetStatus(ActivityStatusCode.Error);
                     throw;
                 }
                 finally
                 {
-                    EndSpan(span.span);
+                    if (span.created)
+                        EndSpan(span.span);
                 }
             }
         }


### PR DESCRIPTION
When running Send Async and there is an error this can cause a Span the be compelted that should not be and then leaks into the  Activity in the higher context which will cause thigns to be related that are not