### PR TITLE
Only configure publisher confirmation callbacks once [v9]

### DIFF
--- a/src/Paramore.Brighter/CommandProcessor.cs
+++ b/src/Paramore.Brighter/CommandProcessor.cs
@@ -172,8 +172,6 @@ namespace Paramore.Brighter
             _transformPipelineBuilder = new TransformPipelineBuilder(mapperRegistry, messageTransformerFactory);
 
             InitExtServiceBus(policyRegistry, outBox, outboxTimeout, producerRegistry, outboxBulkChunkSize);
-
-            ConfigureCallbacks(producerRegistry);
         }
 
         /// <summary>
@@ -220,8 +218,6 @@ namespace Paramore.Brighter
             _transformPipelineBuilder = new TransformPipelineBuilder(mapperRegistry, messageTransformerFactory);
 
             InitExtServiceBus(policyRegistry, outBox, outboxTimeout, producerRegistry, outboxBulkChunkSize);
-
-            ConfigureCallbacks(producerRegistry);
         }
 
         /// <summary>
@@ -261,8 +257,6 @@ namespace Paramore.Brighter
             _transformPipelineBuilder = new TransformPipelineBuilder(mapperRegistry, messageTransformerFactory);
 
             InitExtServiceBus(policyRegistry, outBox, outboxTimeout, producerRegistry, outboxBulkChunkSize);
-
-            ConfigureCallbacks(producerRegistry);
         }
 
         /// <summary>
@@ -815,8 +809,7 @@ namespace Paramore.Brighter
                     $"No command handler was found for the typeof command {typeof(T)} - a command should have exactly one handler.");
         }
 
-
-        private void ConfigureCallbacks(IAmAProducerRegistry producerRegistry)
+        private static void ConfigureCallbacks(IAmAProducerRegistry producerRegistry)
         {
             //Only register one, to avoid two callbacks where we support both interfaces on a producer
             foreach (var producer in producerRegistry.Producers)
@@ -871,6 +864,8 @@ namespace Paramore.Brighter
                         _bus.PolicyRegistry = policyRegistry;
                         _bus.ProducerRegistry = producerRegistry;
                         _bus.OutboxBulkChunkSize = outboxBulkChunkSize;
+
+                        ConfigureCallbacks(producerRegistry);
                     }
                 }
             }


### PR DESCRIPTION
This fixes #3246 by ensuring that publish confirmation delegates are only registered once. It does this in a slightly different way than the one that was suggested in the issue, as I noticed that v10 fixes this by moving the callback registration to inside the `ExternalBusServices` constructor. In v9 `ExternalBusServices` doesn't have an explicit constructor, so I've moved the call to `ConfigureCallbacks` to inside the lock where the static instance is initialised in `CommandProcessor`.