### PR TITLE
Use TimeSpan instead of milliseconds int

### DIFF
--- a/samples/TaskQueue/RMQTaskQueue/GreetingsSender/Program.cs
+++ b/samples/TaskQueue/RMQTaskQueue/GreetingsSender/Program.cs
@@ -79,7 +79,7 @@ namespace GreetingsSender
                 {
                     configure.ProducerRegistry = producerRegistry;
                     configure.MaxOutStandingMessages = 5;
-                    configure.MaxOutStandingCheckIntervalMilliSeconds = 500;
+                    configure.MaxOutStandingCheckInterval = TimeSpan.FromMilliseconds(500);
                 })
                 .AutoFromAssemblies();
 

--- a/samples/WebAPI/WebAPI_Dapper/GreetingsWeb/Startup.cs
+++ b/samples/WebAPI/WebAPI_Dapper/GreetingsWeb/Startup.cs
@@ -112,7 +112,7 @@ public class Startup
                 configure.TransactionProvider = makeOutbox.transactionProvider;
                 configure.ConnectionProvider = makeOutbox.connectionProvider;
                 configure.MaxOutStandingMessages = 5;
-                configure.MaxOutStandingCheckIntervalMilliSeconds = 500;
+                configure.MaxOutStandingCheckInterval = TimeSpan.FromMilliseconds(500);
             })
             .AutoFromAssemblies(typeof(AddPersonHandlerAsync).Assembly);
     }

--- a/samples/WebAPI/WebAPI_Dapper/Greetings_Sweeper/Program.cs
+++ b/samples/WebAPI/WebAPI_Dapper/Greetings_Sweeper/Program.cs
@@ -90,12 +90,12 @@ builder.Services.AddBrighter(options =>
     configure.TransactionProvider = makeOutbox.transactionProvider;
     configure.ConnectionProvider = makeOutbox.connectionProvider;
     configure.MaxOutStandingMessages = 5;
-    configure.MaxOutStandingCheckIntervalMilliSeconds = 500;
+    configure.MaxOutStandingCheckInterval = TimeSpan.FromMilliseconds(500);
 })
 .UseOutboxSweeper(options =>
 {
     options.TimerInterval = 3;
-    options.MinimumMessageAge = 1000;
+    options.MinimumMessageAge = TimeSpan.FromSeconds(1);
     options.BatchSize = 10;
     options.UseBulk = false;
 });

--- a/samples/WebAPI/WebAPI_Dapper/SalutationAnalytics/Program.cs
+++ b/samples/WebAPI/WebAPI_Dapper/SalutationAnalytics/Program.cs
@@ -132,7 +132,7 @@ static void ConfigureBrighter(HostBuilderContext hostContext, IServiceCollection
             config.ConnectionProvider = makeOutbox.connectionProvider;
             config.TransactionProvider = makeOutbox.transactionProvider;
             config.MaxOutStandingMessages = 5;
-            config.MaxOutStandingCheckIntervalMilliSeconds = 500;
+            config.MaxOutStandingCheckInterval = TimeSpan.FromMilliseconds(500);
         })
         .AutoFromAssemblies();
 

--- a/samples/WebAPI/WebAPI_Dapper/Salutation_Sweeper/Program.cs
+++ b/samples/WebAPI/WebAPI_Dapper/Salutation_Sweeper/Program.cs
@@ -88,12 +88,12 @@ builder.Services.AddBrighter(options =>
     configure.TransactionProvider = makeOutbox.transactionProvider;
     configure.ConnectionProvider = makeOutbox.connectionProvider;
     configure.MaxOutStandingMessages = 5;
-    configure.MaxOutStandingCheckIntervalMilliSeconds = 500;
+    configure.MaxOutStandingCheckInterval = TimeSpan.FromMilliseconds(500);
 })
 .UseOutboxSweeper(options =>
 {
     options.TimerInterval = 3;
-    options.MinimumMessageAge = 1000;
+    options.MinimumMessageAge = TimeSpan.FromSeconds(1);
     options.BatchSize = 10;
     options.UseBulk = false;
 });

--- a/samples/WebAPI/WebAPI_Dynamo/GreetingsWeb/Startup.cs
+++ b/samples/WebAPI/WebAPI_Dynamo/GreetingsWeb/Startup.cs
@@ -106,7 +106,7 @@ namespace GreetingsWeb
                  configure.ConnectionProvider = typeof(DynamoDbUnitOfWork);
                  configure.TransactionProvider = typeof(DynamoDbUnitOfWork);
                  configure.MaxOutStandingMessages = 5;
-                 configure.MaxOutStandingCheckIntervalMilliSeconds = 500;
+                 configure.MaxOutStandingCheckInterval = TimeSpan.FromMilliseconds(500);
                  configure.OutBoxBag = new Dictionary<string, object> { { "Topic", "GreetingMade" } };
              })
              .AutoFromAssemblies(typeof(AddPersonHandlerAsync).Assembly);

--- a/samples/WebAPI/WebAPI_Dynamo/Greetings_Sweeper/Program.cs
+++ b/samples/WebAPI/WebAPI_Dynamo/Greetings_Sweeper/Program.cs
@@ -32,7 +32,7 @@ builder.Services.AddBrighter(options =>
     configure.ConnectionProvider = typeof(DynamoDbUnitOfWork);
     configure.TransactionProvider = typeof(DynamoDbUnitOfWork);
     configure.MaxOutStandingMessages = 5;
-    configure.MaxOutStandingCheckIntervalMilliSeconds = 500;
+    configure.MaxOutStandingCheckInterval = TimeSpan.FromMilliseconds(500);
     configure.OutBoxBag = new Dictionary<string, object> { { "Topic", "GreetingMade" } };
 });
 

--- a/samples/WebAPI/WebAPI_Dynamo/SalutationAnalytics/Program.cs
+++ b/samples/WebAPI/WebAPI_Dynamo/SalutationAnalytics/Program.cs
@@ -119,7 +119,7 @@ static void ConfigureBrighter(
                 configure.ConnectionProvider = typeof(DynamoDbUnitOfWork);
                 configure.TransactionProvider = typeof(DynamoDbUnitOfWork);
                 configure.MaxOutStandingMessages = 5;
-                configure.MaxOutStandingCheckIntervalMilliSeconds = 500;
+                configure.MaxOutStandingCheckInterval = TimeSpan.FromMilliseconds(500);
             }
         )
         .AutoFromAssemblies();

--- a/samples/WebAPI/WebAPI_EFCore/GreetingsWeb/Startup.cs
+++ b/samples/WebAPI/WebAPI_EFCore/GreetingsWeb/Startup.cs
@@ -109,7 +109,7 @@ namespace GreetingsWeb
                         configure.TransactionProvider = transactionProvider;
                         configure.ConnectionProvider = connectionProvider;
                         configure.MaxOutStandingMessages = 5;
-                        configure.MaxOutStandingCheckIntervalMilliSeconds = 500;
+                        configure.MaxOutStandingCheckInterval = TimeSpan.FromMilliseconds(500);
                     }
                 )
                 .AutoFromAssemblies();

--- a/samples/WebAPI/WebAPI_EFCore/Greetings_Sweeper/Program.cs
+++ b/samples/WebAPI/WebAPI_EFCore/Greetings_Sweeper/Program.cs
@@ -43,7 +43,7 @@ builder.Services.AddBrighter(options =>
     configure.TransactionProvider = makeOutbox.transactionProvider;
     configure.ConnectionProvider = makeOutbox.connectionProvider;
     configure.MaxOutStandingMessages = 5;
-    configure.MaxOutStandingCheckIntervalMilliSeconds = 500;
+    configure.MaxOutStandingCheckInterval = TimeSpan.FromMilliseconds(500);
 });
 
 WebApplication app = builder.Build();

--- a/samples/WebAPI/WebAPI_EFCore/SalutationAnalytics/Program.cs
+++ b/samples/WebAPI/WebAPI_EFCore/SalutationAnalytics/Program.cs
@@ -131,7 +131,7 @@ static void ConfigureBrighter(HostBuilderContext hostContext, IServiceCollection
             configure.TransactionProvider = makeOutbox.transactionProvider;
             configure.ConnectionProvider = makeOutbox.connectionProvider;
             configure.MaxOutStandingMessages = 5;
-            configure.MaxOutStandingCheckIntervalMilliSeconds = 500;
+            configure.MaxOutStandingCheckInterval = TimeSpan.FromMilliseconds(500);
         })
         .AutoFromAssemblies();
 

--- a/src/Paramore.Brighter.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Paramore.Brighter.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -348,7 +348,7 @@ namespace Paramore.Brighter.Extensions.DependencyInjection
                 RequestContextFactory(serviceProvider),
                 busConfiguration.OutboxTimeout,
                 busConfiguration.MaxOutStandingMessages,
-                TimeSpan.FromMilliseconds(busConfiguration.MaxOutStandingCheckIntervalMilliSeconds),
+                busConfiguration.MaxOutStandingCheckInterval,
                 busConfiguration.OutBoxBag,
                 busConfiguration.ArchiveBatchSize,
                 busConfiguration.InstrumentationOptions);

--- a/src/Paramore.Brighter.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Paramore.Brighter.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -348,7 +348,7 @@ namespace Paramore.Brighter.Extensions.DependencyInjection
                 RequestContextFactory(serviceProvider),
                 busConfiguration.OutboxTimeout,
                 busConfiguration.MaxOutStandingMessages,
-                busConfiguration.MaxOutStandingCheckIntervalMilliSeconds,
+                TimeSpan.FromMilliseconds(busConfiguration.MaxOutStandingCheckIntervalMilliSeconds),
                 busConfiguration.OutBoxBag,
                 busConfiguration.ArchiveBatchSize,
                 busConfiguration.InstrumentationOptions);

--- a/src/Paramore.Brighter.Extensions.Hosting/TimedOutboxArchiver.cs
+++ b/src/Paramore.Brighter.Extensions.Hosting/TimedOutboxArchiver.cs
@@ -99,7 +99,7 @@ namespace Paramore.Brighter.Extensions.Hosting
                 {
                     IAmAnExternalBusService externalBusService = scope.ServiceProvider.GetService<IAmAnExternalBusService>();
                     
-                    await externalBusService.ArchiveAsync(TimeSpan.FromHours(options.MinimumAge),  new RequestContext(), cancellationToken);
+                    await externalBusService.ArchiveAsync(options.MinimumAge,  new RequestContext(), cancellationToken);
                 }
                 catch (Exception e)
                 {

--- a/src/Paramore.Brighter.Extensions.Hosting/TimedOutboxArchiver.cs
+++ b/src/Paramore.Brighter.Extensions.Hosting/TimedOutboxArchiver.cs
@@ -99,7 +99,7 @@ namespace Paramore.Brighter.Extensions.Hosting
                 {
                     IAmAnExternalBusService externalBusService = scope.ServiceProvider.GetService<IAmAnExternalBusService>();
                     
-                    await externalBusService.ArchiveAsync(options.MinimumAge,  new RequestContext(), cancellationToken);
+                    await externalBusService.ArchiveAsync(TimeSpan.FromHours(options.MinimumAge),  new RequestContext(), cancellationToken);
                 }
                 catch (Exception e)
                 {

--- a/src/Paramore.Brighter.Extensions.Hosting/TimedOutboxArchiverOptions.cs
+++ b/src/Paramore.Brighter.Extensions.Hosting/TimedOutboxArchiverOptions.cs
@@ -22,6 +22,8 @@ THE SOFTWARE. */
 
 #endregion
 
+using System;
+
 namespace Paramore.Brighter.Extensions.Hosting
 {
     public class TimedOutboxArchiverOptions
@@ -34,6 +36,6 @@ namespace Paramore.Brighter.Extensions.Hosting
         /// <summary>
         /// The minimum age in hours to Archive
         /// </summary>
-        public int MinimumAge { get; set; } = 24;
+        public TimeSpan MinimumAge { get; set; } = TimeSpan.FromHours(24);
     }
 }

--- a/src/Paramore.Brighter.Extensions.Hosting/TimedOutboxSweeper.cs
+++ b/src/Paramore.Brighter.Extensions.Hosting/TimedOutboxSweeper.cs
@@ -115,7 +115,7 @@ namespace Paramore.Brighter.Extensions.Hosting
                     IAmACommandProcessor commandProcessor = scope.ServiceProvider.GetService<IAmACommandProcessor>();
 
                     var outBoxSweeper = new OutboxSweeper(
-                        timeSinceSent: TimeSpan.FromMilliseconds(_options.MinimumMessageAge),
+                        timeSinceSent: _options.MinimumMessageAge,
                         commandProcessor: commandProcessor,
                         new InMemoryRequestContextFactory(),
                         _options.BatchSize,

--- a/src/Paramore.Brighter.Extensions.Hosting/TimedOutboxSweeper.cs
+++ b/src/Paramore.Brighter.Extensions.Hosting/TimedOutboxSweeper.cs
@@ -115,7 +115,7 @@ namespace Paramore.Brighter.Extensions.Hosting
                     IAmACommandProcessor commandProcessor = scope.ServiceProvider.GetService<IAmACommandProcessor>();
 
                     var outBoxSweeper = new OutboxSweeper(
-                        millisecondsSinceSent: _options.MinimumMessageAge,
+                        timeSinceSent: TimeSpan.FromMilliseconds(_options.MinimumMessageAge),
                         commandProcessor: commandProcessor,
                         new InMemoryRequestContextFactory(),
                         _options.BatchSize,

--- a/src/Paramore.Brighter.Extensions.Hosting/TimedOutboxSweeperOptions.cs
+++ b/src/Paramore.Brighter.Extensions.Hosting/TimedOutboxSweeperOptions.cs
@@ -22,6 +22,7 @@ THE SOFTWARE. */
 
 #endregion
 
+using System;
 using System.Collections.Generic;
 
 namespace Paramore.Brighter.Extensions.Hosting
@@ -38,7 +39,7 @@ namespace Paramore.Brighter.Extensions.Hosting
         /// <summary>
         /// The age a message to pickup by the sweeper in milliseconds.
         /// </summary>
-        public int MinimumMessageAge { get; set; } = 5000;
+        public TimeSpan MinimumMessageAge { get; set; } = TimeSpan.FromSeconds(5);
 
         /// <summary>
         /// The maximum number of messages to dispatch.

--- a/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaDefaultMessageHeaderBuilder.cs
+++ b/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaDefaultMessageHeaderBuilder.cs
@@ -48,7 +48,7 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
             };
 
             if (message.Header.TimeStamp != default)
-                headers.Add(HeaderNames.TIMESTAMP, new DateTimeOffset(message.Header.TimeStamp).ToString().ToByteArray());
+                headers.Add(HeaderNames.TIMESTAMP, message.Header.TimeStamp.ToString().ToByteArray());
             else
                 headers.Add(HeaderNames.TIMESTAMP, DateTimeOffset.UtcNow.ToString().ToByteArray());
             

--- a/src/Paramore.Brighter.MessagingGateway.RMQ/RmqMessagePublisher.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ/RmqMessagePublisher.cs
@@ -177,7 +177,7 @@ internal class RmqMessagePublisher
                 message.Body.Bytes);
         }
 
-        private IBasicProperties CreateBasicProperties(string id, DateTime timeStamp, string type, string contentType,
+        private IBasicProperties CreateBasicProperties(string id, DateTimeOffset timeStamp, string type, string contentType,
             string replyTo, bool persistMessage, IDictionary<string, object> headers = null)
         {
             var basicProperties = _channel.CreateBasicProperties();
@@ -186,7 +186,7 @@ internal class RmqMessagePublisher
             basicProperties.ContentType = contentType;
             basicProperties.Type = type;
             basicProperties.MessageId = id;
-            basicProperties.Timestamp = new AmqpTimestamp(UnixTimestamp.GetUnixTimestampSeconds(timeStamp));
+            basicProperties.Timestamp = new AmqpTimestamp(UnixTimestamp.GetUnixTimestampSeconds(timeStamp.DateTime));
             if (!string.IsNullOrEmpty(replyTo))
                 basicProperties.ReplyTo = replyTo;
 

--- a/src/Paramore.Brighter.Outbox.MsSql/MsSqlOutbox.cs
+++ b/src/Paramore.Brighter.Outbox.MsSql/MsSqlOutbox.cs
@@ -231,7 +231,7 @@ namespace Paramore.Brighter.Outbox.MsSql
                 new SqlParameter
                 {
                     ParameterName = $"{prefix}Timestamp",
-                    DbType = DbType.DateTime,
+                    DbType = DbType.DateTimeOffset,
                     Value = (object)message.Header.TimeStamp.ToUniversalTime() ?? DBNull.Value
                 }, //always store in UTC, as this is how we query messages
                 new SqlParameter

--- a/src/Paramore.Brighter.Outbox.MySql/MySqlOutbox.cs
+++ b/src/Paramore.Brighter.Outbox.MySql/MySqlOutbox.cs
@@ -214,7 +214,7 @@ namespace Paramore.Brighter.Outbox.MySql
                 new MySqlParameter
                 {
                     ParameterName = $"@{prefix}Timestamp",
-                    DbType = DbType.DateTime2,
+                    DbType = DbType.DateTimeOffset,
                     Value = message.Header.TimeStamp.ToUniversalTime()
                 }, //always store in UTC, as this is how we query messages
                 new MySqlParameter

--- a/src/Paramore.Brighter.Outbox.PostgreSql/PostgreSqlOutbox.cs
+++ b/src/Paramore.Brighter.Outbox.PostgreSql/PostgreSqlOutbox.cs
@@ -237,7 +237,7 @@ namespace Paramore.Brighter.Outbox.PostgreSql
                 {
                     ParameterName = $"{prefix}Timestamp",
                     NpgsqlDbType = NpgsqlDbType.TimestampTz,
-                    Value = message.Header.TimeStamp
+                    Value = message.Header.TimeStamp.DateTime.ToUniversalTime()
                 },
                 new NpgsqlParameter
                 {

--- a/src/Paramore.Brighter.ServiceActivator.Control.Api/Responses/GetStatusResponse.cs
+++ b/src/Paramore.Brighter.ServiceActivator.Control.Api/Responses/GetStatusResponse.cs
@@ -44,7 +44,7 @@ public record GetStatusResponse
     /// <summary>
     /// Timestamp of Status Event
     /// </summary>
-    public DateTime TimeStamp { get; } = DateTime.UtcNow;
+    public DateTimeOffset TimeStamp { get; } = DateTimeOffset.Now;
     
     /// <summary>
     /// The version of the running process

--- a/src/Paramore.Brighter.ServiceActivator.Control.Api/Responses/GetStatusResponse.cs
+++ b/src/Paramore.Brighter.ServiceActivator.Control.Api/Responses/GetStatusResponse.cs
@@ -44,7 +44,7 @@ public record GetStatusResponse
     /// <summary>
     /// Timestamp of Status Event
     /// </summary>
-    public DateTimeOffset TimeStamp { get; } = DateTimeOffset.Now;
+    public DateTimeOffset TimeStamp { get; } = DateTimeOffset.UtcNow;
     
     /// <summary>
     /// The version of the running process

--- a/src/Paramore.Brighter.ServiceActivator.Control/Events/NodeStatusEvent.cs
+++ b/src/Paramore.Brighter.ServiceActivator.Control/Events/NodeStatusEvent.cs
@@ -42,7 +42,7 @@ public record NodeStatusEvent : IEvent
     /// <summary>
     /// Timestamp of Status Event
     /// </summary>
-    public DateTimeOffset TimeStamp { get; init; } = DateTimeOffset.Now;
+    public DateTimeOffset TimeStamp { get; init; } = DateTimeOffset.UtcNow;
     
     /// <summary>
     /// The version of the running process

--- a/src/Paramore.Brighter.ServiceActivator.Control/Events/NodeStatusEvent.cs
+++ b/src/Paramore.Brighter.ServiceActivator.Control/Events/NodeStatusEvent.cs
@@ -42,7 +42,7 @@ public record NodeStatusEvent : IEvent
     /// <summary>
     /// Timestamp of Status Event
     /// </summary>
-    public DateTime TimeStamp { get; init; } = DateTime.UtcNow;
+    public DateTimeOffset TimeStamp { get; init; } = DateTimeOffset.Now;
     
     /// <summary>
     /// The version of the running process

--- a/src/Paramore.Brighter.ServiceActivator.Control/NodeStatus.cs
+++ b/src/Paramore.Brighter.ServiceActivator.Control/NodeStatus.cs
@@ -30,7 +30,7 @@ public record NodeStatus
     /// <summary>
     /// Timestamp of Status Event
     /// </summary>
-    public DateTimeOffset TimeStamp { get; } = DateTimeOffset.Now;
+    public DateTimeOffset TimeStamp { get; } = DateTimeOffset.UtcNow;
 
     /// <summary>
     /// The version of the running process

--- a/src/Paramore.Brighter.ServiceActivator.Control/NodeStatus.cs
+++ b/src/Paramore.Brighter.ServiceActivator.Control/NodeStatus.cs
@@ -30,7 +30,7 @@ public record NodeStatus
     /// <summary>
     /// Timestamp of Status Event
     /// </summary>
-    public DateTime TimeStamp { get; } = DateTime.UtcNow;
+    public DateTimeOffset TimeStamp { get; } = DateTimeOffset.Now;
 
     /// <summary>
     /// The version of the running process

--- a/src/Paramore.Brighter.ServiceActivator/ControlBus/ControlBusReceiverBuilder.cs
+++ b/src/Paramore.Brighter.ServiceActivator/ControlBus/ControlBusReceiverBuilder.cs
@@ -228,13 +228,13 @@ namespace Paramore.Brighter.ServiceActivator.ControlBus
                  return null;
             }
 
-            public void MarkDispatched(string id, RequestContext requestContext, DateTime? dispatchedAt = null, Dictionary<string, object> args = null)
+            public void MarkDispatched(string id, RequestContext requestContext, DateTimeOffset? dispatchedAt = null, Dictionary<string, object> args = null)
             {
                 //ignore
             }
 
             public IEnumerable<Message> DispatchedMessages(
-                double millisecondsDispatchedSince, 
+                TimeSpan millisecondsDispatchedSince, 
                 RequestContext requestContext,
                 int pageSize = 100, 
                 int pageNumber = 1,
@@ -246,7 +246,7 @@ namespace Paramore.Brighter.ServiceActivator.ControlBus
             }
 
             public IEnumerable<Message> OutstandingMessages(
-                double millSecondsSinceSent, 
+                TimeSpan dispatchedSince, 
                 RequestContext requestContext,
                 int pageSize = 100, 
                 int pageNumber = 1,
@@ -256,7 +256,7 @@ namespace Paramore.Brighter.ServiceActivator.ControlBus
             }
 
 
-            public IEnumerable<Message> OutstandingMessages(TimeSpan millSecondsSinceSent)
+            public IEnumerable<Message> OutstandingMessages(TimeSpan dispatchedSince)
             {
                return Array.Empty<Message>(); 
             }

--- a/src/Paramore.Brighter/CommandProcessor.cs
+++ b/src/Paramore.Brighter/CommandProcessor.cs
@@ -930,13 +930,13 @@ namespace Paramore.Brighter
         /// Intended for use with the Outbox pattern: http://gistlabs.com/2014/05/the-outbox/ <see cref="DepositPostAsync{TRequest}(TRequest,Paramore.Brighter.RequestContext,System.Collections.Generic.Dictionary{string,object},bool,System.Threading.CancellationToken)"/>
         /// </summary>
         /// <param name="amountToClear">The maximum number to clear.</param>
-        /// <param name="minimumAge">The minimum age to clear in milliseconds.</param>
+        /// <param name="minimumAge">The minimum age to clear (Default 5 second).</param>
         /// <param name="useBulk">Use the bulk send on the producer.</param>
         /// <param name="requestContext">The context of the request; if null we will start one via a <see cref="IAmARequestContextFactory"/> </param>
         /// <param name="args">For transports or outboxes that require additional parameters such as topic, provide an optional arg</param>
         public void ClearOutstandingFromOutbox(
             int amountToClear = 100,
-            int minimumAge = 5000,
+            TimeSpan? minimumAge = null,
             bool useBulk = false,
             RequestContext requestContext = null,
             Dictionary<string, object> args = null
@@ -947,7 +947,8 @@ namespace Paramore.Brighter
 
             try
             {
-                s_bus.ClearOustandingFromOutbox(amountToClear, minimumAge, useBulk, context, args);
+                var minAge = minimumAge ?? TimeSpan.FromMilliseconds(5000);
+                s_bus.ClearOutstandingFromOutbox(amountToClear, minAge, useBulk, context, args);
             }
             finally
             {

--- a/src/Paramore.Brighter/ExternalBusConfiguration.cs
+++ b/src/Paramore.Brighter/ExternalBusConfiguration.cs
@@ -86,9 +86,9 @@ namespace Paramore.Brighter
         /// <summary>
         /// At what interval should we check the number of outstanding messages has not exceeded the limit set in MaxOutStandingMessages
         /// We spin off a thread to check when inserting an item into the outbox, if the interval since the last insertion is greater than this threshold
-        /// If you set MaxOutStandingMessages to -1 or 0 this property is effectively ignored
+        /// If you set MaxOutStandingMessages to 0 this property is effectively ignored
         /// </summary>
-        public int MaxOutStandingCheckIntervalMilliSeconds { get; set; } 
+        public TimeSpan MaxOutStandingCheckInterval { get; set; } 
         
         /// <summary>
         /// An outbox may require additional arguments before it can run its checks. The DynamoDb outbox for example expects there to be a Topic in the args
@@ -186,7 +186,7 @@ namespace Paramore.Brighter
         /// We spin off a thread to check when inserting an item into the outbox, if the interval since the last insertion is greater than this threshold
         /// If you set MaxOutStandingMessages to -1 or 0 this property is effectively ignored
         /// </summary>
-        public int MaxOutStandingCheckIntervalMilliSeconds { get; set; } = 0;
+        public TimeSpan MaxOutStandingCheckInterval { get; set; } = TimeSpan.Zero;
         
         /// <summary>
         /// The Outbox we wish to use for messaging

--- a/src/Paramore.Brighter/ExternalBusService.cs
+++ b/src/Paramore.Brighter/ExternalBusService.cs
@@ -43,13 +43,13 @@ namespace Paramore.Brighter
         //bool should be made thread-safe by locking the object
         private static readonly SemaphoreSlim s_checkOutstandingSemaphoreToken = new(1, 1);
 
-        private DateTime _lastOutStandingMessageCheckAt = DateTime.UtcNow;
+        private DateTimeOffset _lastOutStandingMessageCheckAt = DateTime.UtcNow;
 
         //Uses -1 to indicate no outbox and will thus force a throw on a failed publish
         private int _outStandingCount;
         private bool _disposed;
         private readonly int _maxOutStandingMessages;
-        private readonly double _maxOutStandingCheckIntervalMilliSeconds;
+        private readonly TimeSpan _maxOutStandingCheckInterval;
         private readonly Dictionary<string, object> _outBoxBag;
         private readonly IAmABrighterTracer _tracer;
 
@@ -67,7 +67,7 @@ namespace Paramore.Brighter
         /// <param name="requestContextFactory"></param>
         /// <param name="outboxTimeout">How long to timeout for with an outbox</param>
         /// <param name="maxOutStandingMessages">How many messages can become outstanding in the Outbox before we throw an OutboxLimitReached exception</param>
-        /// <param name="maxOutStandingCheckIntervalMilliSeconds">How long before we check for maxOutStandingMessages</param>
+        /// <param name="maxOutStandingCheckInterval">How long before we check for maxOutStandingMessages</param>
         /// <param name="outBoxBag">An outbox may require additional arguments, such as a topic list to search</param>
         /// <param name="archiveBatchSize">What batch size to use when archiving from the Outbox</param>
         /// <param name="instrumentationOptions">How verbose do we want our instrumentation to be</param>
@@ -83,7 +83,7 @@ namespace Paramore.Brighter
             IAmARequestContextFactory requestContextFactory = null,
             int outboxTimeout = 300,
             int maxOutStandingMessages = -1,
-            int maxOutStandingCheckIntervalMilliSeconds = 1000,
+            TimeSpan? maxOutStandingCheckInterval = null,
             Dictionary<string, object> outBoxBag = null,
             int archiveBatchSize = 100,
             InstrumentationOptions instrumentationOptions = InstrumentationOptions.All)
@@ -119,7 +119,7 @@ namespace Paramore.Brighter
 
             _outboxTimeout = outboxTimeout;
             _maxOutStandingMessages = maxOutStandingMessages;
-            _maxOutStandingCheckIntervalMilliSeconds = maxOutStandingCheckIntervalMilliSeconds;
+            _maxOutStandingCheckInterval = maxOutStandingCheckInterval ?? TimeSpan.FromMilliseconds(1000);
             _outBoxBag = outBoxBag;
             _archiveBatchSize = archiveBatchSize;
             _instrumentationOptions = instrumentationOptions;
@@ -234,14 +234,14 @@ namespace Paramore.Brighter
         /// Archive Message from the outbox to the outbox archive provider
         /// Throws any archiving exception
         /// </summary>
-        /// <param name="millisecondsDispatchedSince">Minimum age in hours</param>
+        /// <param name="dispatchedSince">Minimum age</param>
         /// <param name="requestContext">The request context for the pipeline</param>
-        public void Archive(int millisecondsDispatchedSince, RequestContext requestContext)
+        public void Archive(TimeSpan dispatchedSince, RequestContext requestContext)
         {
             try
             {
                 var messages = _outBox
-                    .DispatchedMessages(millisecondsDispatchedSince, requestContext, _archiveBatchSize)
+                    .DispatchedMessages(dispatchedSince, requestContext, _archiveBatchSize)
                     .ToArray();
 
                 s_logger.LogInformation(
@@ -275,16 +275,16 @@ namespace Paramore.Brighter
         /// Archive Message from the outbox to the outbox archive provider
         /// Throws any archiving exception
         /// </summary>
-        /// <param name="millisecondsDispatchedSince"></param>
+        /// <param name="dispatchedSince"></param>
         /// <param name="requestContext"></param>
         /// <param name="cancellationToken">The Cancellation Token</param>
-        public async Task ArchiveAsync(int millisecondsDispatchedSince, RequestContext requestContext,
+        public async Task ArchiveAsync(TimeSpan dispatchedSince, RequestContext requestContext,
             CancellationToken cancellationToken)
         {
             try
             {
                 var messages = (await _asyncOutbox.DispatchedMessagesAsync(
-                    millisecondsDispatchedSince, requestContext, pageSize: _archiveBatchSize,
+                    dispatchedSince, requestContext, pageSize: _archiveBatchSize,
                     cancellationToken: cancellationToken
                 )).ToArray();
 
@@ -438,12 +438,12 @@ namespace Paramore.Brighter
         /// happened by returning control - that happens in parallel. 
         /// </summary>
         /// <param name="amountToClear">Maximum number to clear.</param>
-        /// <param name="minimumAge">The minimum age of messages to be cleared in milliseconds.</param>
+        /// <param name="minimumAge">The minimum age of messages to be cleared.</param>
         /// <param name="useBulk">Use bulk sending capability of the message producer, this must be paired with useAsync.</param>
         /// <param name="requestContext">The request context for the pipeline</param>
         /// <param name="args">Optional bag of arguments required by an outbox implementation to sweep</param>
-        public void ClearOustandingFromOutbox(int amountToClear,
-            int minimumAge,
+        public void ClearOutstandingFromOutbox(int amountToClear,
+            TimeSpan minimumAge,
             bool useBulk,
             RequestContext requestContext,
             Dictionary<string, object> args = null)
@@ -613,7 +613,7 @@ namespace Paramore.Brighter
 
         private Task BackgroundDispatchUsingSync(
             int amountToClear,
-            int millisecondsSinceSent,
+            TimeSpan timeSinceSent,
             RequestContext requestContext,
             Dictionary<string, object> args
         )
@@ -636,7 +636,7 @@ namespace Paramore.Brighter
                 {
                     requestContext.Span = span;
 
-                    var messages = _outBox.OutstandingMessages(millisecondsSinceSent,
+                    var messages = _outBox.OutstandingMessages(timeSinceSent,
                         requestContext, amountToClear, args: args
                     ).ToArray();
 
@@ -678,7 +678,7 @@ namespace Paramore.Brighter
 
         private async Task BackgroundDispatchUsingAsync(
             int amountToClear,
-            int milliSecondsSinceSent,
+            TimeSpan timeSinceSent,
             bool useBulk,
             RequestContext requestContext,
             Dictionary<string, object> args
@@ -702,7 +702,7 @@ namespace Paramore.Brighter
                     requestContext.Span = span;
 
                     var messages =
-                        (await _asyncOutbox.OutstandingMessagesAsync(milliSecondsSinceSent, requestContext,
+                        (await _asyncOutbox.OutstandingMessagesAsync(timeSinceSent, requestContext,
                             pageSize: amountToClear, args: args)).ToArray();
 
                     BrighterTracer.WriteOutboxEvent(OutboxDbOperation.OutStandingMessages, messages, span, false, true,
@@ -765,9 +765,6 @@ namespace Paramore.Brighter
         private void CheckOutstandingMessages(RequestContext requestContext)
         {
             var now = DateTime.UtcNow;
-            var checkInterval =
-                TimeSpan.FromMilliseconds(_maxOutStandingCheckIntervalMilliSeconds);
-
 
             var timeSinceLastCheck = now - _lastOutStandingMessageCheckAt;
 
@@ -776,7 +773,7 @@ namespace Paramore.Brighter
                 timeSinceLastCheck.TotalSeconds
             );
 
-            if (timeSinceLastCheck < checkInterval)
+            if (timeSinceLastCheck < _maxOutStandingCheckInterval)
             {
                 s_logger.LogDebug($"Check not ready to run yet");
                 return;
@@ -1108,7 +1105,7 @@ namespace Paramore.Brighter
                 {
                     _outStandingCount = _outBox
                         .OutstandingMessages(
-                            _maxOutStandingCheckIntervalMilliSeconds,
+                            _maxOutStandingCheckInterval,
                             requestContext,
                             args: _outBoxBag
                         )

--- a/src/Paramore.Brighter/ExternalBusService.cs
+++ b/src/Paramore.Brighter/ExternalBusService.cs
@@ -43,7 +43,7 @@ namespace Paramore.Brighter
         //bool should be made thread-safe by locking the object
         private static readonly SemaphoreSlim s_checkOutstandingSemaphoreToken = new(1, 1);
 
-        private DateTimeOffset _lastOutStandingMessageCheckAt = DateTime.UtcNow;
+        private DateTimeOffset _lastOutStandingMessageCheckAt = DateTimeOffset.UtcNow;
 
         //Uses -1 to indicate no outbox and will thus force a throw on a failed publish
         private int _outStandingCount;

--- a/src/Paramore.Brighter/IAmACommandProcessor.cs
+++ b/src/Paramore.Brighter/IAmACommandProcessor.cs
@@ -307,13 +307,13 @@ namespace Paramore.Brighter
         /// Intended for use with the Outbox pattern: http://gistlabs.com/2014/05/the-outbox/ <see cref="DepositPostBoxAsync"/>
         /// </summary>
         /// <param name="amountToClear">The maximum number to clear.</param>
-        /// <param name="minimumAge">The minimum age to clear in milliseconds.</param>
+        /// <param name="minimumAge">The minimum age to clear (Default 5 second).</param>
         /// <param name="useBulk">Use the bulk send on the producer.</param>
         /// <param name="requestContext">The context of the request; if null we will start one via a <see cref="RequestContextFactory"/> </param>
         /// <param name="args">For transports or outboxes that require additional parameters such as topic, provide an optional arg</param>
         void ClearOutstandingFromOutbox(
             int amountToClear = 100, 
-            int minimumAge = 5000, 
+            TimeSpan? minimumAge = null, 
             bool useBulk = false, 
             RequestContext requestContext = null,
             Dictionary<string, object> args = null

--- a/src/Paramore.Brighter/IAmAnExternalBusService.cs
+++ b/src/Paramore.Brighter/IAmAnExternalBusService.cs
@@ -15,17 +15,17 @@ namespace Paramore.Brighter
         /// <summary>
         /// Archive Message from the outbox to the outbox archive provider
         /// </summary>
-        /// <param name="millisecondsDispatchedSince">Minimum age in milliseconds</param>
+        /// <param name="dispatchedSince">Minimum age</param>
         /// <param name="requestContext">What is the context for this request; used to access the Span</param>        
-        void Archive(int millisecondsDispatchedSince, RequestContext requestContext);
+        void Archive(TimeSpan dispatchedSince, RequestContext requestContext);
 
         /// <summary>
         /// Archive Message from the outbox to the outbox archive provider
         /// </summary>
-        /// <param name="millisecondsDispatchedSince">How stale is the message that we want to archive</param>
+        /// <param name="dispatchedSince">How stale is the message that we want to archive</param>
         /// <param name="requestContext">The context for the request pipeline; gives us the OTel span for example</param>
         /// <param name="cancellationToken">The Cancellation Token</param>
-        Task ArchiveAsync(int millisecondsDispatchedSince, RequestContext requestContext, CancellationToken cancellationToken);
+        Task ArchiveAsync(TimeSpan dispatchedSince, RequestContext requestContext, CancellationToken cancellationToken);
         
         /// <summary>
         /// Used with RPC to call a remote service via the external bus
@@ -73,8 +73,8 @@ namespace Paramore.Brighter
         /// <param name="useBulk">Use bulk sending capability of the message producer, this must be paired with useAsync.</param>
         /// <param name="requestContext">The context of the request pipeline</param>
         /// <param name="args">Optional bag of arguments required by an outbox implementation to sweep</param>
-        void ClearOustandingFromOutbox(int amountToClear,
-            int minimumAge,
+        void ClearOutstandingFromOutbox(int amountToClear,
+            TimeSpan minimumAge,
             bool useBulk,
             RequestContext requestContext,
             Dictionary<string, object> args = null);

--- a/src/Paramore.Brighter/IAmAnOutboxAsync.cs
+++ b/src/Paramore.Brighter/IAmAnOutboxAsync.cs
@@ -99,7 +99,7 @@ namespace Paramore.Brighter
         /// <summary>
         /// Retrieves messages that have been sent within the window
         /// </summary>
-        /// <param name="millisecondsDispatchedSince"></param>
+        /// <param name="dispatchedSince"></param>
         /// <param name="requestContext">The context for the request pipeline; gives us the OTel span for example</param>
         /// <param name="pageSize">The number of messages to fetch.</param>
         /// <param name="pageNumber">The page number.</param>
@@ -108,7 +108,7 @@ namespace Paramore.Brighter
         /// <param name="cancellationToken">The Cancellation Token</param>
         /// <returns>List of messages that need to be dispatched.</returns>
         Task<IEnumerable<Message>> DispatchedMessagesAsync(
-            double millisecondsDispatchedSince,
+            TimeSpan dispatchedSince,
             RequestContext requestContext,
             int pageSize = 100,
             int pageNumber = 1,
@@ -145,7 +145,7 @@ namespace Paramore.Brighter
         Task MarkDispatchedAsync(
             string id,
             RequestContext requestContext,
-            DateTime? dispatchedAt = null,
+            DateTimeOffset? dispatchedAt = null,
             Dictionary<string, object> args = null,
             CancellationToken cancellationToken = default);
 
@@ -160,14 +160,14 @@ namespace Paramore.Brighter
         Task MarkDispatchedAsync(
             IEnumerable<string> ids,
             RequestContext requestContext,
-            DateTime? dispatchedAt = null,
+            DateTimeOffset? dispatchedAt = null,
             Dictionary<string, object> args = null,
             CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Messages still outstanding in the Outbox because their timestamp
         /// </summary>
-        /// <param name="millSecondsSinceSent">How many seconds since the message was sent do we wait to declare it outstanding</param>
+        /// <param name="dispatchedSince">How long since the message was sent do we wait to declare it outstanding</param>
         /// <param name="requestContext"></param>
         /// <param name="pageSize">The number of messages to fetch.</param>
         /// <param name="pageNumber">The page number.</param>
@@ -175,7 +175,7 @@ namespace Paramore.Brighter
         /// <param name="cancellationToken">Async Cancellation Token</param>
         /// <returns>Outstanding Messages</returns>
         Task<IEnumerable<Message>> OutstandingMessagesAsync(
-            double millSecondsSinceSent,
+            TimeSpan dispatchedSince,
             RequestContext requestContext,
             int pageSize = 100,
             int pageNumber = 1,

--- a/src/Paramore.Brighter/IAmAnOutboxSync.cs
+++ b/src/Paramore.Brighter/IAmAnOutboxSync.cs
@@ -66,7 +66,7 @@ namespace Paramore.Brighter
         /// <summary>
         /// Retrieves messages that have been sent within the window
         /// </summary>
-        /// <param name="millisecondsDispatchedSince"></param>
+        /// <param name="dispatchedSince"></param>
         /// <param name="requestContext">What is the context for this request; used to access the Span</param>
         /// <param name="pageSize">The number of messages to fetch.</param>
         /// <param name="pageNumber">The page number.</param>
@@ -74,7 +74,7 @@ namespace Paramore.Brighter
         /// <param name="args">Additional parameters required for search, if any</param>
         /// <returns>List of messages that need to be dispatched.</returns>
         IEnumerable<Message> DispatchedMessages(
-            double millisecondsDispatchedSince, 
+            TimeSpan dispatchedSince, 
             RequestContext requestContext,
             int pageSize = 100, 
             int pageNumber = 1, 
@@ -98,19 +98,19 @@ namespace Paramore.Brighter
         /// <param name="requestContext">What is the context for this request; used to access the Span</param>
         /// <param name="dispatchedAt">When was the message dispatched, defaults to UTC now</param>
         /// <param name="args">Dictionary to allow platform specific parameters to be passed to the interface</param>
-        void MarkDispatched(string id, RequestContext requestContext, DateTime? dispatchedAt = null, Dictionary<string, object> args = null);
+        void MarkDispatched(string id, RequestContext requestContext, DateTimeOffset? dispatchedAt = null, Dictionary<string, object> args = null);
 
         /// <summary>
         /// Messages still outstanding in the Outbox because their timestamp
         /// </summary>
-        /// <param name="millSecondsSinceSent">How many seconds since the message was sent do we wait to declare it outstanding</param>
+        /// <param name="dispatchedSince">How many seconds since the message was sent do we wait to declare it outstanding</param>
         /// <param name="requestContext">What is the context for this request; used to access the Span</param>
         /// <param name="pageSize">Number of items on the page, default is 100</param>
         /// <param name="pageNumber">Page number of results to return, default is first</param>
         /// <param name="args">Additional parameters required for search, if any</param>
         /// <returns>Outstanding Messages</returns>
         IEnumerable<Message> OutstandingMessages(
-            double millSecondsSinceSent, 
+            TimeSpan dispatchedSince, 
             RequestContext requestContext,
             int pageSize = 100, 
             int pageNumber = 1,

--- a/src/Paramore.Brighter/InMemoryBox.cs
+++ b/src/Paramore.Brighter/InMemoryBox.cs
@@ -15,7 +15,7 @@ namespace Paramore.Brighter
         /// <summary>
         /// When was this item written to the box
         /// </summary>
-        DateTime WriteTime { get; }
+        DateTimeOffset WriteTime { get; }
     }
      
     /// <summary>
@@ -78,7 +78,7 @@ namespace Paramore.Brighter
             _lastScanAt = now;
         }
 
-        private void RemoveExpiredMessages(DateTime now)
+        private void RemoveExpiredMessages(DateTimeOffset now)
         {
             if (Monitor.TryEnter(_cleanupRunningLockObject))
             {

--- a/src/Paramore.Brighter/InMemoryInbox.cs
+++ b/src/Paramore.Brighter/InMemoryInbox.cs
@@ -43,7 +43,7 @@ namespace Paramore.Brighter
         /// <param name="requestBody">The request body.</param>
         /// <param name="writeTime">The request arrived at when.</param>
         /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
-        public InboxItem(Type requestType, string requestBody, DateTime writeTime, string contextKey)
+        public InboxItem(Type requestType, string requestBody, DateTimeOffset writeTime, string contextKey)
         {
             RequestType = requestType;
             RequestBody = requestBody;
@@ -68,7 +68,7 @@ namespace Paramore.Brighter
         /// </summary>
         /// <value>The command when.</value>
 
-        public DateTime WriteTime { get; }
+        public DateTimeOffset WriteTime { get; }
 
         /// <summary>
         /// The Id and the key for the context i.e. message type, that we are looking for

--- a/src/Paramore.Brighter/MessageHeader.cs
+++ b/src/Paramore.Brighter/MessageHeader.cs
@@ -204,7 +204,7 @@ namespace Paramore.Brighter
         /// Internal usage. The date the message was created.
         /// Defaults to now in UTC
         /// </summary>
-        public DateTime TimeStamp { get; set; }
+        public DateTimeOffset TimeStamp { get; set; }
         
         /// <summary>
         /// REQUIRED (for OTel support, OPTIONAL in Cloud Events)

--- a/src/Paramore.Brighter/OutboxArchiver.cs
+++ b/src/Paramore.Brighter/OutboxArchiver.cs
@@ -58,8 +58,8 @@ namespace Paramore.Brighter
         /// Outbox Archiver will swallow any errors during the archive process, but record them. Assumption is
         /// that these are transient errors which can be retried
         /// </summary>
-        /// <param name="millisecondsDispatchedSince">How stale is the message that we want archive</param>
-        public void Archive(int millisecondsDispatchedSince)
+        /// <param name="dispatchedSince">How stale is the message that we want archive</param>
+        public void Archive(TimeSpan dispatchedSince)
         {
             var activity = ApplicationTelemetry.ActivitySource.StartActivity(ARCHIVE_OUTBOX, ActivityKind.Server);
             var requestContext = _requestContextFactory.Create();
@@ -67,7 +67,7 @@ namespace Paramore.Brighter
             
             try
             {
-                _bus.Archive(millisecondsDispatchedSince, requestContext);  
+                _bus.Archive(dispatchedSince, requestContext);  
             }
             catch (Exception e)
             {
@@ -85,17 +85,17 @@ namespace Paramore.Brighter
         /// Outbox Archiver will swallow any errors during the archive process, but record them. Assumption is
         /// that these are transient errors which can be retried       
         /// </summary>
-        /// <param name="millisecondsDispatchedSince">How stale is the message that</param>
+        /// <param name="dispatchedSince">How stale is the message that</param>
         /// <param name="requestContext">The context for the request pipeline; gives us the OTel span for example</param>
         /// <param name="cancellationToken">The Cancellation Token</param>
-        public async Task ArchiveAsync(int millisecondsDispatchedSince, RequestContext requestContext, CancellationToken cancellationToken)
+        public async Task ArchiveAsync(TimeSpan dispatchedSince, RequestContext requestContext, CancellationToken cancellationToken)
         {
             var activity = ApplicationTelemetry.ActivitySource.StartActivity(ARCHIVE_OUTBOX, ActivityKind.Server);
             requestContext.Span = activity;
             
             try
             {
-                await _bus.ArchiveAsync(millisecondsDispatchedSince, requestContext, cancellationToken);
+                await _bus.ArchiveAsync(dispatchedSince, requestContext, cancellationToken);
             }
             catch (Exception e)
             {

--- a/src/Paramore.Brighter/OutboxSweeper.cs
+++ b/src/Paramore.Brighter/OutboxSweeper.cs
@@ -22,6 +22,7 @@ THE SOFTWARE. */
 
 #endregion
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 
@@ -29,7 +30,7 @@ namespace Paramore.Brighter
 {
     public class OutboxSweeper
     {
-        private readonly int _millisecondsSinceSent;
+        private readonly TimeSpan _timeSinceSent;
         private readonly IAmACommandProcessor _commandProcessor;
         private readonly int _batchSize;
         private readonly bool _useBulk;
@@ -41,21 +42,21 @@ namespace Paramore.Brighter
         /// <summary>
         /// This sweeper clears an outbox of any outstanding messages within the time interval
         /// </summary>
-        /// <param name="millisecondsSinceSent">How long can a message sit in the box before we attempt to resend</param>
+        /// <param name="timeSinceSent">How long can a message sit in the box before we attempt to resend</param>
         /// <param name="commandProcessor">Who should post the messages</param>
         /// <param name="requestContextFactory">Allows us to create a request context to pass down the pipeline when clearing the Outbox</param>
         /// <param name="batchSize">The maximum number of messages to dispatch.</param>
         /// <param name="useBulk">Use the producers bulk dispatch functionality.</param>
         /// <param name="args">Optional bag of parameters to pass to the Outbox</param>
         public OutboxSweeper(
-            int millisecondsSinceSent, 
+            TimeSpan timeSinceSent, 
             IAmACommandProcessor commandProcessor, 
             IAmARequestContextFactory requestContextFactory,
             int batchSize = 100,
             bool useBulk = false,
             Dictionary<string, object> args = null)
         {
-            _millisecondsSinceSent = millisecondsSinceSent;
+            _timeSinceSent = timeSinceSent;
             _commandProcessor = commandProcessor;
             _batchSize = batchSize;
             _useBulk = useBulk;
@@ -72,7 +73,7 @@ namespace Paramore.Brighter
             var context = _requestContextFactory.Create();
             context.Span = span;
             
-            _commandProcessor.ClearOutstandingFromOutbox(_batchSize, _millisecondsSinceSent, _useBulk, context, _args);
+            _commandProcessor.ClearOutstandingFromOutbox(_batchSize, _timeSinceSent, _useBulk, context, _args);
         }
 
         /// <summary>
@@ -84,7 +85,7 @@ namespace Paramore.Brighter
             var context = _requestContextFactory.Create();
             context.Span = span;
             
-            _commandProcessor.ClearOutstandingFromOutbox(_batchSize, _millisecondsSinceSent, _useBulk, context, _args);
+            _commandProcessor.ClearOutstandingFromOutbox(_batchSize, _timeSinceSent, _useBulk, context, _args);
         }
     }
 }

--- a/src/Paramore.Brighter/RelationDatabaseOutbox.cs
+++ b/src/Paramore.Brighter/RelationDatabaseOutbox.cs
@@ -360,7 +360,7 @@ namespace Paramore.Brighter
             CancellationToken cancellationToken = default)
         {
             return WriteToStoreAsync(null,
-                connection => InitMarkDispatchedCommand(connection, ids, dispatchedAt ?? DateTimeOffset.Now), null,
+                connection => InitMarkDispatchedCommand(connection, ids, dispatchedAt ?? DateTimeOffset.UtcNow), null,
                 cancellationToken);
         }
 

--- a/src/Paramore.Brighter/RelationDatabaseOutbox.cs
+++ b/src/Paramore.Brighter/RelationDatabaseOutbox.cs
@@ -159,7 +159,7 @@ namespace Paramore.Brighter
         /// <summary>
         /// Retrieves messages that have been sent within the window
         /// </summary>
-        /// <param name="millisecondsDispatchedSince">How long ago would the message have been dispatched in milliseconds</param>
+        /// <param name="dispatchedSince">How long ago would the message have been dispatched in milliseconds</param>
         /// <param name="requestContext">What is the context for this request; used to access the Span</param>
         /// <param name="pageSize">How many messages in a page</param>
         /// <param name="pageNumber">Which page of messages to get</param>
@@ -168,7 +168,7 @@ namespace Paramore.Brighter
         /// <param name="cancellationToken">The Cancellation Token</param>
         /// <returns>A list of dispatched messages</returns>
         public Task<IEnumerable<Message>> DispatchedMessagesAsync(
-            double millisecondsDispatchedSince,
+            TimeSpan dispatchedSince,
             RequestContext requestContext,
             int pageSize = 100,
             int pageNumber = 1,
@@ -178,14 +178,14 @@ namespace Paramore.Brighter
         {
             return ReadFromStoreAsync(
                 connection =>
-                    CreatePagedDispatchedCommand(connection, millisecondsDispatchedSince, pageSize, pageNumber),
+                    CreatePagedDispatchedCommand(connection, dispatchedSince, pageSize, pageNumber),
                 dr => MapListFunctionAsync(dr, cancellationToken), cancellationToken);
         }
 
         /// <summary>
         /// Retrieves messages that have been sent within the window
         /// </summary>
-        /// <param name="millisecondsDispatchedSince">How long ago would the message have been dispatched in milliseconds</param>
+        /// <param name="dispatchedSince">How long ago would the message have been dispatched in milliseconds</param>
         /// <param name="requestContext">What is the context for this request; used to access the Span</param>        
         /// <param name="pageSize">How many messages in a page</param>
         /// <param name="pageNumber">Which page of messages to get</param>
@@ -193,7 +193,7 @@ namespace Paramore.Brighter
         /// <param name="args">Additional parameters required for search, if any</param>
         /// <returns>A list of dispatched messages</returns>
         public IEnumerable<Message> DispatchedMessages(
-            double millisecondsDispatchedSince,
+            TimeSpan dispatchedSince,
             RequestContext requestContext,
             int pageSize = 100,
             int pageNumber = 1,
@@ -202,7 +202,7 @@ namespace Paramore.Brighter
         {
             return ReadFromStore(
                 connection =>
-                    CreatePagedDispatchedCommand(connection, millisecondsDispatchedSince, pageSize, pageNumber),
+                    CreatePagedDispatchedCommand(connection, dispatchedSince, pageSize, pageNumber),
                 dr => MapListFunction(dr));
         }
         
@@ -335,7 +335,7 @@ namespace Paramore.Brighter
         public Task MarkDispatchedAsync(
             string id,
             RequestContext requestContext,
-            DateTime? dispatchedAt = null,
+            DateTimeOffset? dispatchedAt = null,
             Dictionary<string, object> args = null,
             CancellationToken cancellationToken = default)
         {
@@ -355,12 +355,12 @@ namespace Paramore.Brighter
         public Task MarkDispatchedAsync(
             IEnumerable<string> ids,
             RequestContext requestContext,
-            DateTime? dispatchedAt = null,
+            DateTimeOffset? dispatchedAt = null,
             Dictionary<string, object> args = null,
             CancellationToken cancellationToken = default)
         {
             return WriteToStoreAsync(null,
-                connection => InitMarkDispatchedCommand(connection, ids, dispatchedAt ?? DateTime.UtcNow), null,
+                connection => InitMarkDispatchedCommand(connection, ids, dispatchedAt ?? DateTimeOffset.Now), null,
                 cancellationToken);
         }
 
@@ -371,7 +371,7 @@ namespace Paramore.Brighter
         /// <param name="requestContext">What is the context for this request; used to access the Span</param>        
         /// <param name="dispatchedAt">When was the message dispatched, defaults to UTC now</param>
         /// <param name="args">Allows additional arguments to be provided for specific Outbox Db providers</param>
-        public void MarkDispatched(string id, RequestContext requestContext, DateTime? dispatchedAt = null, Dictionary<string, object> args = null)
+        public void MarkDispatched(string id, RequestContext requestContext, DateTimeOffset? dispatchedAt = null, Dictionary<string, object> args = null)
         {
             WriteToStore(null, connection => InitMarkDispatchedCommand(connection, id, dispatchedAt ?? DateTime.UtcNow),
                 null);
@@ -380,28 +380,28 @@ namespace Paramore.Brighter
         /// <summary>
         /// Messages still outstanding in the Outbox because their timestamp
         /// </summary>
-        /// <param name="millSecondsSinceSent">How many seconds since the message was sent do we wait to declare it outstanding</param>
+        /// <param name="dispatchedSince">How many seconds since the message was sent do we wait to declare it outstanding</param>
         /// <param name="requestContext">What is the context for this request; used to access the Span</param>        
         /// <param name="pageSize">The number of entries on a page</param>
         /// <param name="pageNumber">The page to return</param>
         /// <param name="args">Additional parameters required for search, if any</param>
         /// <returns>Outstanding Messages</returns>
         public IEnumerable<Message> OutstandingMessages(
-            double millSecondsSinceSent,
+            TimeSpan dispatchedSince,
             RequestContext requestContext,
             int pageSize = 100,
             int pageNumber = 1,
             Dictionary<string, object> args = null)
         {
             return ReadFromStore(
-                connection => CreatePagedOutstandingCommand(connection, millSecondsSinceSent, pageSize, pageNumber),
+                connection => CreatePagedOutstandingCommand(connection, dispatchedSince, pageSize, pageNumber),
                 dr => MapListFunction(dr));
         }
 
         /// <summary>
         /// Messages still outstanding in the Outbox because their timestamp
         /// </summary>
-        /// <param name="millSecondsSinceSent">How many seconds since the message was sent do we wait to declare it outstanding</param>
+        /// <param name="dispatchedSince">How many seconds since the message was sent do we wait to declare it outstanding</param>
         /// <param name="requestContext">What is the context for this request; used to access the Span</param>
         /// <param name="pageSize">The number of entries to return in a page</param>
         /// <param name="pageNumber">The page number to return</param>
@@ -409,7 +409,7 @@ namespace Paramore.Brighter
         /// <param name="cancellationToken">Async Cancellation Token</param>
         /// <returns>Outstanding Messages</returns>
         public Task<IEnumerable<Message>> OutstandingMessagesAsync(
-            double millSecondsSinceSent,
+            TimeSpan dispatchedSince,
             RequestContext requestContext,
             int pageSize = 100,
             int pageNumber = 1,
@@ -417,7 +417,7 @@ namespace Paramore.Brighter
             CancellationToken cancellationToken = default)
         {
             return ReadFromStoreAsync(
-                connection => CreatePagedOutstandingCommand(connection, millSecondsSinceSent, pageSize, pageNumber),
+                connection => CreatePagedOutstandingCommand(connection, dispatchedSince, pageSize, pageNumber),
                 dr => MapListFunctionAsync(dr, cancellationToken), cancellationToken);
         }
 
@@ -486,12 +486,12 @@ namespace Paramore.Brighter
 
         private DbCommand CreatePagedDispatchedCommand(
             DbConnection connection, 
-            double millisecondsDispatchedSince,
+            TimeSpan timeDispatchedSince,
             int pageSize, 
             int pageNumber)
             => CreateCommand(connection, GenerateSqlText(queries.PagedDispatchedCommand), 0,
                 CreateSqlParameter("PageNumber", pageNumber), CreateSqlParameter("PageSize", pageSize),
-                CreateSqlParameter("OutstandingSince", -1 * millisecondsDispatchedSince));
+                CreateSqlParameter("OutstandingSince", -1 * timeDispatchedSince.Milliseconds));
         
         private DbCommand CreateDispatchedCommand(DbConnection connection, int hoursDispatchedSince, int pageSize)
             => CreateCommand(connection, GenerateSqlText(queries.DispatchedCommand), 0,
@@ -509,11 +509,11 @@ namespace Paramore.Brighter
 
         private DbCommand CreatePagedOutstandingCommand(
             DbConnection connection, 
-            double milliSecondsSinceAdded,
+            TimeSpan timeSinceAdded,
             int pageSize, 
             int pageNumber)
             => CreateCommand(connection, GenerateSqlText(queries.PagedOutstandingCommand), 0,
-                CreatePagedOutstandingParameters(milliSecondsSinceAdded, pageSize, pageNumber));
+                CreatePagedOutstandingParameters(timeSinceAdded.Milliseconds, pageSize, pageNumber));
         
         private DbCommand CreateRemainingOutstandingCommand(DbConnection connection)
             => CreateCommand(connection, GenerateSqlText(queries.GetNumberOfOutstandingMessagesCommand), 0);
@@ -531,13 +531,13 @@ namespace Paramore.Brighter
                 insertClause.parameters);
         }
 
-        private DbCommand InitMarkDispatchedCommand(DbConnection connection, string messageId, DateTime? dispatchedAt)
+        private DbCommand InitMarkDispatchedCommand(DbConnection connection, string messageId, DateTimeOffset? dispatchedAt)
             => CreateCommand(connection, GenerateSqlText(queries.MarkDispatchedCommand), 0,
                 CreateSqlParameter("MessageId", messageId),
                 CreateSqlParameter("DispatchedAt", dispatchedAt?.ToUniversalTime()));
 
         private DbCommand InitMarkDispatchedCommand(DbConnection connection, IEnumerable<string> messageIds,
-            DateTime? dispatchedAt)
+            DateTimeOffset? dispatchedAt)
         {
             var inClause = GenerateInClauseAndAddParameters(messageIds.ToList());
             return CreateCommand(connection, GenerateSqlText(queries.MarkMultipleDispatchedCommand, inClause.inClause), 0,

--- a/tests/Paramore.Brighter.Azure.Tests/AzureBlobArchiveProviderTests.cs
+++ b/tests/Paramore.Brighter.Azure.Tests/AzureBlobArchiveProviderTests.cs
@@ -88,7 +88,7 @@ public class AzureBlobArchiveProviderTests
         Assert.That(tags["topic"], Is.EqualTo(eventMessage.Header.Topic));
         Assert.That(tags["correlationId"], Is.EqualTo(eventMessage.Header.CorrelationId));
         Assert.That(tags["message_type"], Is.EqualTo(eventMessage.Header.MessageType.ToString()));
-        Assert.That(DateTime.Parse(tags["timestamp"]), Is.EqualTo(eventMessage.Header.TimeStamp));
+        Assert.That(DateTime.Parse(tags["timestamp"]), Is.EqualTo(eventMessage.Header.TimeStamp.DateTime));
         Assert.That(tags["content_type"], Is.EqualTo(eventMessage.Header.ContentType));
     }
 
@@ -206,7 +206,7 @@ public class AzureBlobArchiveProviderTests
         Assert.That(tags["topic"], Is.EqualTo(eventMessage.Header.Topic));
         Assert.That(tags["correlationId"], Is.EqualTo(eventMessage.Header.CorrelationId));
         Assert.That(tags["message_type"], Is.EqualTo(eventMessage.Header.MessageType.ToString()));
-        Assert.That(DateTime.Parse(tags["timestamp"]), Is.EqualTo(eventMessage.Header.TimeStamp));
+        Assert.That(DateTime.Parse(tags["timestamp"]), Is.EqualTo(eventMessage.Header.TimeStamp.DateTime));
         Assert.That(tags["content_type"], Is.EqualTo(eventMessage.Header.ContentType));
     }
 

--- a/tests/Paramore.Brighter.Core.Tests/Archiving/When_Archiving_Old_Messages_From_The_Outbox.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Archiving/When_Archiving_Old_Messages_From_The_Outbox.cs
@@ -84,7 +84,7 @@ public class ServiceBusMessageStoreArchiverTests
         //act
         _outbox.EntryCount.Should().Be(3);
         
-        _bus.Archive(20000, context);
+        _bus.Archive(TimeSpan.FromMilliseconds(20000), context);
         
         //assert
         _outbox.EntryCount.Should().Be(0);
@@ -112,7 +112,7 @@ public class ServiceBusMessageStoreArchiverTests
         //act
         _outbox.EntryCount.Should().Be(3);
         
-        _bus.Archive(20000, context);
+        _bus.Archive(TimeSpan.FromMilliseconds(20000), context);
         
         //assert
         _outbox.EntryCount.Should().Be(1);
@@ -138,7 +138,7 @@ public class ServiceBusMessageStoreArchiverTests
         //act
         _outbox.EntryCount.Should().Be(3);
         
-        _bus.Archive(20000, context);
+        _bus.Archive(TimeSpan.FromMilliseconds(20000), context);
         
         //assert
         _outbox.EntryCount.Should().Be(3);
@@ -151,7 +151,7 @@ public class ServiceBusMessageStoreArchiverTests
     public void When_Archiving_An_Empty_The_Outbox()
     {
         var context = new RequestContext();
-        _bus.Archive(20000, context);
+        _bus.Archive(TimeSpan.FromMilliseconds(20000), context);
         
         //assert
         _outbox.EntryCount.Should().Be(0);

--- a/tests/Paramore.Brighter.Core.Tests/Archiving/When_Archiving_Old_Messages_From_The_Outbox_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Archiving/When_Archiving_Old_Messages_From_The_Outbox_Async.cs
@@ -90,7 +90,7 @@ public class ServiceBusMessageStoreArchiverTestsAsync
         //act
         _outbox.EntryCount.Should().Be(3);
         
-        await _bus.ArchiveAsync(20000, context, new CancellationToken());
+        await _bus.ArchiveAsync(TimeSpan.FromMilliseconds(20000), context, new CancellationToken());
         
         //assert
         _outbox.EntryCount.Should().Be(0);
@@ -118,7 +118,7 @@ public class ServiceBusMessageStoreArchiverTestsAsync
         //act
         _outbox.EntryCount.Should().Be(3);
         
-        await _bus.ArchiveAsync(20000, context, new CancellationToken());
+        await _bus.ArchiveAsync(TimeSpan.FromMilliseconds(20000), context, new CancellationToken());
         
         //assert
         _outbox.EntryCount.Should().Be(1);
@@ -144,7 +144,7 @@ public class ServiceBusMessageStoreArchiverTestsAsync
         //act
         _outbox.EntryCount.Should().Be(3);
         
-        await _bus.ArchiveAsync(20000, context, new CancellationToken());
+        await _bus.ArchiveAsync(TimeSpan.FromMilliseconds(20000), context, new CancellationToken());
         
         //assert
         _outbox.EntryCount.Should().Be(3);
@@ -160,7 +160,7 @@ public class ServiceBusMessageStoreArchiverTestsAsync
         var context = new RequestContext();
         
         //act
-        await _bus.ArchiveAsync(20000, context, new CancellationToken());
+        await _bus.ArchiveAsync(TimeSpan.FromMilliseconds(20000), context, new CancellationToken());
         
         //assert
         _outbox.EntryCount.Should().Be(0);

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Clear/When_Bulk_Clearing_The_PostBox_On_The_Command_Processor_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Clear/When_Bulk_Clearing_The_PostBox_On_The_Command_Processor_Async.cs
@@ -127,7 +127,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.Clear
             await _outbox.AddAsync(_messageOne, context);
             await _outbox.AddAsync(_messageTwo, context);
 
-            _commandProcessor.ClearOutstandingFromOutbox(2, 1);
+            _commandProcessor.ClearOutstandingFromOutbox(2, TimeSpan.FromMilliseconds(1));
 
             await Task.Delay(3000);
 

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Clear/When_Implicit_Clearing_The_PostBox_On_The_Command_Processor.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Clear/When_Implicit_Clearing_The_PostBox_On_The_Command_Processor.cs
@@ -120,7 +120,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.Clear
             _outbox.Add(_message, context);
             _outbox.Add(_message2, context);
 
-            _commandProcessor.ClearOutstandingFromOutbox(1,0);
+            _commandProcessor.ClearOutstandingFromOutbox(1,TimeSpan.Zero);
             
             var topic = new RoutingKey(Topic);
             for (var i = 1; i <= 10; i++)
@@ -136,7 +136,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.Clear
                 if (_bus.Stream(topic).Count() == 2)
                     break;
                 Thread.Sleep(i * 100);
-                _commandProcessor.ClearOutstandingFromOutbox(1, 0);
+                _commandProcessor.ClearOutstandingFromOutbox(1, TimeSpan.Zero);
             }
 
             //_should_send_a_message_via_the_messaging_gateway

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Clear/When_Implicit_Clearing_The_PostBox_On_The_Command_Processor_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Clear/When_Implicit_Clearing_The_PostBox_On_The_Command_Processor_Async.cs
@@ -119,7 +119,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.Clear
             await _outbox.AddAsync(_message, context);
             await _outbox.AddAsync(_message2, context);
 
-            _commandProcessor.ClearOutstandingFromOutbox(1,0);
+            _commandProcessor.ClearOutstandingFromOutbox(1,TimeSpan.Zero);
 
             for (var i = 1; i <= 10; i++)
             {
@@ -127,7 +127,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.Clear
                 await Task.Delay(i * 100);
             }
 
-            _commandProcessor.ClearOutstandingFromOutbox(1, 0);
+            _commandProcessor.ClearOutstandingFromOutbox(1, TimeSpan.Zero);
 
             //Try again and kick off another background thread
             for (var i = 1; i <= 10; i++)
@@ -135,7 +135,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.Clear
                 if (_bus.Stream(new RoutingKey(Topic)).Count() == 2)
                     break;
                 await Task.Delay(i * 100);
-                _commandProcessor.ClearOutstandingFromOutbox(1, 1);
+                _commandProcessor.ClearOutstandingFromOutbox(1, TimeSpan.FromMilliseconds(1));
             }
 
             //_should_send_a_message_via_the_messaging_gateway

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Deposit/When_Depositing_A_Message_In_The_Message_Store.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Deposit/When_Depositing_A_Message_In_The_Message_Store.cs
@@ -106,7 +106,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.Deposit
             depositedPost.Header.MessageType.Should().Be(_message.Header.MessageType);
             
             //message should be marked as outstanding if not sent
-            var outstandingMessages = _fakeOutbox.OutstandingMessages(0, context);
+            var outstandingMessages = _fakeOutbox.OutstandingMessages(TimeSpan.Zero, context);
             var outstandingMessage = outstandingMessages.Single();
             outstandingMessage.Id.Should().Be(_message.Id);
         }

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Deposit/When_Depositing_A_Message_In_The_Message_StoreAsync.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Deposit/When_Depositing_A_Message_In_The_Message_StoreAsync.cs
@@ -100,7 +100,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.Deposit
             
             //message should be in the store
             var depositedPost = _outbox
-                .OutstandingMessages(0, context)
+                .OutstandingMessages(TimeSpan.Zero, context)
                 .SingleOrDefault(msg => msg.Id == _message.Id);
                 
             depositedPost.Should().NotBeNull();
@@ -112,7 +112,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.Deposit
             depositedPost.Header.MessageType.Should().Be(_message.Header.MessageType);
             
             //message should be marked as outstanding if not sent
-            var outstandingMessages = await _outbox.OutstandingMessagesAsync(0, context);
+            var outstandingMessages = await _outbox.OutstandingMessagesAsync(TimeSpan.Zero, context);
             var outstandingMessage = outstandingMessages.Single();
             outstandingMessage.Id.Should().Be(_message.Id);
         }

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Deposit/When_Depositing_A_Message_In_The_Message_StoreAsync_Bulk.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Deposit/When_Depositing_A_Message_In_The_Message_StoreAsync_Bulk.cs
@@ -138,17 +138,17 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.Deposit
             
             //message should be in the store
             var depositedPost = _outbox
-                .OutstandingMessages(0, context)
+                .OutstandingMessages(TimeSpan.Zero, context)
                 .SingleOrDefault(msg => msg.Id == _message.Id);
             
             //message should be in the store
             var depositedPost2 = _outbox
-                .OutstandingMessages(0, context)
+                .OutstandingMessages(TimeSpan.Zero, context)
                 .SingleOrDefault(msg => msg.Id == _message2.Id);
             
             //message should be in the store
             var depositedPost3 = _outbox
-                .OutstandingMessages(0, context)
+                .OutstandingMessages(TimeSpan.Zero, context)
                 .SingleOrDefault(msg => msg.Id == _message3.Id);
 
             depositedPost.Should().NotBeNull();

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Deposit/When_Depositing_A_Message_In_The_Message_Store_Bulk.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Deposit/When_Depositing_A_Message_In_The_Message_Store_Bulk.cs
@@ -147,7 +147,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.Deposit
             depositedPost2.Header.MessageType.Should().Be(_messageTwo.Header.MessageType);
             
             var depositedPost3 = _outbox
-                .OutstandingMessages(0, context)
+                .OutstandingMessages(TimeSpan.Zero, context)
                 .SingleOrDefault(msg => msg.Id == _messageThree.Id);
             //message should correspond to the command
             depositedPost3.Id.Should().Be(_messageThree.Id);
@@ -156,7 +156,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.Deposit
             depositedPost3.Header.MessageType.Should().Be(_messageThree.Header.MessageType);
             
             //message should be marked as outstanding if not sent
-            var outstandingMessages = _outbox.OutstandingMessages(0, context);
+            var outstandingMessages = _outbox.OutstandingMessages(TimeSpan.Zero, context);
             outstandingMessages.Count().Should().Be(3);
         }
         

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Post/When_Posting_Fails_Limit_Total_Writes_To_OutBox_In_Window.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Post/When_Posting_Fails_Limit_Total_Writes_To_OutBox_In_Window.cs
@@ -70,7 +70,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.Post
                 tracer,
                 outbox: _outbox,
                 maxOutStandingMessages:3,
-                maxOutStandingCheckIntervalMilliSeconds:250
+                maxOutStandingCheckInterval: TimeSpan.FromMilliseconds(250)
             );  
             
             _commandProcessor = CommandProcessorBuilder.StartNew()

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Post/When_Posting_Via_A_Control_Bus_Sender.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Post/When_Posting_Via_A_Control_Bus_Sender.cs
@@ -107,7 +107,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.Post
 
             //_should_store_the_message_in_the_sent_command_message_repository
             var message = _outbox
-              .DispatchedMessages(120000, new RequestContext(), 1)
+              .DispatchedMessages(TimeSpan.FromMilliseconds(120000), new RequestContext(), 1)
               .SingleOrDefault();
               
             message.Should().NotBeNull();

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Post/When_Posting_Via_A_Control_Bus_Sender_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Post/When_Posting_Via_A_Control_Bus_Sender_Async.cs
@@ -108,7 +108,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.Post
             
             //_should_store_the_message_in_the_sent_command_message_repository
             var message = _outbox
-              .DispatchedMessages(1200000, new RequestContext(), 1)
+              .DispatchedMessages(TimeSpan.FromMilliseconds(1200000), new RequestContext(), 1)
               .SingleOrDefault();
               
             message.Should().NotBeNull();

--- a/tests/Paramore.Brighter.Core.Tests/MessageDispatch/TestDoubles/SpyCommandProcessor.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageDispatch/TestDoubles/SpyCommandProcessor.cs
@@ -50,7 +50,7 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch.TestDoubles
     public class ClearParams
     {
         public int AmountToClear;
-        public int MinimumAge;
+        public TimeSpan MinimumAge;
         public Dictionary<string, object> Args;
     }
 
@@ -261,7 +261,7 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch.TestDoubles
 
         public void ClearOutstandingFromOutbox(
             int amountToClear = 100, 
-            int minimumAge = 5000, 
+            TimeSpan? minimumAge = null, 
             bool useBulk = false,
             RequestContext requestContext = null,
             Dictionary<string, object> args = null)
@@ -269,7 +269,7 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch.TestDoubles
             Commands.Add(CommandType.Clear);
             ClearParamsList.Add(new ClearParams
             {
-                AmountToClear = amountToClear, MinimumAge = minimumAge, Args = args
+                AmountToClear = amountToClear, MinimumAge = minimumAge ?? TimeSpan.FromMilliseconds(5000), Args = args
             });
         }
 

--- a/tests/Paramore.Brighter.Core.Tests/Observability/CommandProcessor/Clear/When_Clearing_Outstanding_Messages_Spans_Are_Exported.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Observability/CommandProcessor/Clear/When_Clearing_Outstanding_Messages_Spans_Are_Exported.cs
@@ -119,7 +119,7 @@ public class CommandProcessorClearOutstandingObservabilityTests
         //reset the parent span as deposit and clear are siblings
         
         context.Span = parentActivity;
-        _commandProcessor.ClearOutstandingFromOutbox(3, 0, false, context);
+        _commandProcessor.ClearOutstandingFromOutbox(3, TimeSpan.Zero, false, context);
 
         await Task.Delay(3000);     //allow bulk clear to run -- can make test fragile
         

--- a/tests/Paramore.Brighter.Core.Tests/Observability/CommandProcessor/Clear/When_Clearing_Outstanding_Messages_Spans_Are_Exported_Bulk.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Observability/CommandProcessor/Clear/When_Clearing_Outstanding_Messages_Spans_Are_Exported_Bulk.cs
@@ -119,7 +119,7 @@ public class AsyncCommandProcessorBulkClearOutstandingObservabilityTests
         //reset the parent span as deposit and clear are siblings
         
         context.Span = parentActivity;
-        _commandProcessor.ClearOutstandingFromOutbox(3, 0, useBulk: true, requestContext: context);
+        _commandProcessor.ClearOutstandingFromOutbox(3, TimeSpan.Zero, useBulk: true, requestContext: context);
 
         await Task.Delay(3000);     //allow bulk clear to run -- can make test fragile
         

--- a/tests/Paramore.Brighter.Core.Tests/Observability/CommandProcessor/Deposit/When_Depositing_A_Request_A_Span_Is_Exported.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Observability/CommandProcessor/Deposit/When_Depositing_A_Request_A_Span_Is_Exported.cs
@@ -127,7 +127,7 @@ public class CommandProcessorDepositObservabilityTests
         mapperEvent.Tags.Any(a => a.Key == BrighterSemanticConventions.MapperType && (string)a.Value == "sync").Should().BeTrue();
         
         //depositing a message should be an event
-        var message = _outbox.OutstandingMessages(0, context).Single();
+        var message = _outbox.OutstandingMessages(TimeSpan.Zero, context).Single();
         var depositEvent = events.Single(e => e.Name == OutboxDbOperation.Add.ToSpanName());
         depositEvent.Tags.Any(a => a is { Value: not null, Key: BrighterSemanticConventions.OutboxSharedTransaction } && (bool)a.Value == false).Should().BeTrue();
         depositEvent.Tags.Any(a => a.Key == BrighterSemanticConventions.OutboxType && (string)a.Value == "sync" ).Should().BeTrue();

--- a/tests/Paramore.Brighter.Core.Tests/Observability/CommandProcessor/Deposit/When_Depositing_A_Request_A_Span_Is_Exported_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Observability/CommandProcessor/Deposit/When_Depositing_A_Request_A_Span_Is_Exported_Async.cs
@@ -129,7 +129,7 @@ public class AsyncCommandProcessorDepositObservabilityTests
         mapperEvent.Tags.Any(a => a.Key == BrighterSemanticConventions.MapperType && (string)a.Value == "async").Should().BeTrue();
         
         //depositing a message should be an event
-        var message = _outbox.OutstandingMessages(0, context).Single();
+        var message = _outbox.OutstandingMessages(TimeSpan.Zero, context).Single();
         var depositEvent = events.Single(e => e.Name == OutboxDbOperation.Add.ToSpanName());
         depositEvent.Tags.Any(a => a is { Value: not null, Key: BrighterSemanticConventions.OutboxSharedTransaction } && (bool)a.Value == false).Should().BeTrue();
         depositEvent.Tags.Any(a => a.Key == BrighterSemanticConventions.OutboxType && (string)a.Value == "async" ).Should().BeTrue();

--- a/tests/Paramore.Brighter.DynamoDB.Tests/Outbox/When_marking_a_message_as_dispatched_in_the_outbox.cs
+++ b/tests/Paramore.Brighter.DynamoDB.Tests/Outbox/When_marking_a_message_as_dispatched_in_the_outbox.cs
@@ -38,7 +38,7 @@ public class DynamoDbOutboxMessageDispatchTests : DynamoDBOutboxBaseTest
 
         _fakeTimeProvider.Advance(TimeSpan.FromSeconds(1));
 
-        var messages = _dynamoDbOutbox.DispatchedMessages(0, context,100, 1, args:args);
+        var messages = _dynamoDbOutbox.DispatchedMessages(TimeSpan.Zero, context,100, 1, args:args);
         var message = messages.Single(m => m.Id == _message.Id);
         message.Should().NotBeNull();
         message.Body.Value.Should().Be(_message.Body.Value);
@@ -56,7 +56,7 @@ public class DynamoDbOutboxMessageDispatchTests : DynamoDBOutboxBaseTest
 
         _fakeTimeProvider.Advance(TimeSpan.FromSeconds(1));
 
-        var messages = _dynamoDbOutbox.DispatchedMessages(0, context, 100, 1, args:args);
+        var messages = _dynamoDbOutbox.DispatchedMessages(TimeSpan.Zero, context, 100, 1, args:args);
         var message = messages.Single(m => m.Id == _message.Id);
         message.Should().NotBeNull();
         message.Body.Value.Should().Be(_message.Body.Value);

--- a/tests/Paramore.Brighter.DynamoDB.Tests/Outbox/When_there_are_dispatched_messages_in_the_outbox.cs
+++ b/tests/Paramore.Brighter.DynamoDB.Tests/Outbox/When_there_are_dispatched_messages_in_the_outbox.cs
@@ -34,7 +34,7 @@ public class DynamoDbOutboxDispatchedMessageTests : DynamoDBOutboxBaseTest
 
         var args = new Dictionary<string, object> {{"Topic", "test_topic"}};
 
-        var messages = await _dynamoDbOutbox.DispatchedMessagesAsync(0, context, 100, 1, args: args);
+        var messages = await _dynamoDbOutbox.DispatchedMessagesAsync(TimeSpan.Zero, context, 100, 1, args: args);
 
         //Other tests may leave messages, so make sure that we grab ours
         var message = messages.Single(m => m.Id == _message.Id);
@@ -53,7 +53,7 @@ public class DynamoDbOutboxDispatchedMessageTests : DynamoDBOutboxBaseTest
 
         var args = new Dictionary<string, object> {{"Topic", "test_topic"}};
 
-        var messages = _dynamoDbOutbox.DispatchedMessages(0, context, 100, 1, args: args);
+        var messages = _dynamoDbOutbox.DispatchedMessages(TimeSpan.Zero, context, 100, 1, args: args);
 
         //Other tests may leave messages, so make sure that we grab ours
         var message = messages.Single(m => m.Id == _message.Id);
@@ -77,7 +77,7 @@ public class DynamoDbOutboxDispatchedMessageTests : DynamoDBOutboxBaseTest
 
         _fakeTimeProvider.Advance(TimeSpan.FromSeconds(1));
 
-        var dispatchedMessages = await _dynamoDbOutbox.DispatchedMessagesAsync(0, context, 100, 1);
+        var dispatchedMessages = await _dynamoDbOutbox.DispatchedMessagesAsync(TimeSpan.Zero, context, 100, 1);
 
         //Other tests may leave messages, so make sure that we grab ours
         foreach (var message in messages)
@@ -105,7 +105,7 @@ public class DynamoDbOutboxDispatchedMessageTests : DynamoDBOutboxBaseTest
 
         _fakeTimeProvider.Advance(TimeSpan.FromSeconds(1));
 
-        var dispatchedMessages = _dynamoDbOutbox.DispatchedMessages(0, context, 100, 1);
+        var dispatchedMessages = _dynamoDbOutbox.DispatchedMessages(TimeSpan.Zero, context, 100, 1);
 
         //Other tests may leave messages, so make sure that we grab ours
         foreach (var message in messages)
@@ -139,10 +139,10 @@ public class DynamoDbOutboxDispatchedMessageTests : DynamoDBOutboxBaseTest
         var args = new Dictionary<string, object> { { "Topic", "test_topic" } };
 
         // Get the first page
-        var dispatchedMessages = (await _dynamoDbOutbox.DispatchedMessagesAsync(0, context, 5, 1, args: args)).ToList();
+        var dispatchedMessages = (await _dynamoDbOutbox.DispatchedMessagesAsync(TimeSpan.Zero, context, 5, 1, args: args)).ToList();
         dispatchedMessages.Count.Should().Be(5);
         // Get the remainder
-        dispatchedMessages.AddRange(await _dynamoDbOutbox.DispatchedMessagesAsync(0, context, 100, 2, args: args));
+        dispatchedMessages.AddRange(await _dynamoDbOutbox.DispatchedMessagesAsync(TimeSpan.Zero, context, 100, 2, args: args));
 
         //Other tests may leave messages, so make sure that we grab ours
         foreach (var message in messages)
@@ -175,10 +175,10 @@ public class DynamoDbOutboxDispatchedMessageTests : DynamoDBOutboxBaseTest
         var args = new Dictionary<string, object> { { "Topic", "test_topic" } };
 
         // Get the first page
-        var dispatchedMessages = (_dynamoDbOutbox.DispatchedMessages(0, context, 5, 1, args: args)).ToList();
+        var dispatchedMessages = (_dynamoDbOutbox.DispatchedMessages(TimeSpan.Zero, context, 5, 1, args: args)).ToList();
         dispatchedMessages.Count.Should().Be(5);
         // Get the remainder
-        dispatchedMessages.AddRange(_dynamoDbOutbox.DispatchedMessages(0, context, 100, 2, args: args));
+        dispatchedMessages.AddRange(_dynamoDbOutbox.DispatchedMessages(TimeSpan.Zero, context, 100, 2, args: args));
 
         //Other tests may leave messages, so make sure that we grab ours
         foreach (var message in messages)
@@ -218,10 +218,10 @@ public class DynamoDbOutboxDispatchedMessageTests : DynamoDBOutboxBaseTest
         var dispatchedMessages = new List<Message>();
         for (var i = 1; i < 5; i++)
         {
-            dispatchedMessages.AddRange(await _dynamoDbOutbox.DispatchedMessagesAsync(0, context, 5, i));
+            dispatchedMessages.AddRange(await _dynamoDbOutbox.DispatchedMessagesAsync(TimeSpan.Zero, context, 5, i));
         }
         // Do a last page in case other tests have added more messages
-        dispatchedMessages.AddRange(await _dynamoDbOutbox.DispatchedMessagesAsync(0, context, 100, 5));
+        dispatchedMessages.AddRange(await _dynamoDbOutbox.DispatchedMessagesAsync(TimeSpan.Zero, context, 100, 5));
 
         //Other tests may leave messages, so make sure that we grab ours
         foreach (var message in messages)
@@ -262,10 +262,10 @@ public class DynamoDbOutboxDispatchedMessageTests : DynamoDBOutboxBaseTest
         var dispatchedMessages = new List<Message>();
         for (var i = 1; i < 5; i++)
         {
-            dispatchedMessages.AddRange(_dynamoDbOutbox.DispatchedMessages(0, context, 5, i));
+            dispatchedMessages.AddRange(_dynamoDbOutbox.DispatchedMessages(TimeSpan.Zero, context, 5, i));
         }
         // Do a last page in case other tests have added more messages
-        dispatchedMessages.AddRange(_dynamoDbOutbox.DispatchedMessages(0, context, 100, 5));
+        dispatchedMessages.AddRange(_dynamoDbOutbox.DispatchedMessages(TimeSpan.Zero, context, 100, 5));
 
         //Other tests may leave messages, so make sure that we grab ours
         foreach (var message in messages)

--- a/tests/Paramore.Brighter.DynamoDB.Tests/Outbox/When_there_are_outstanding_messages_in_the_outbox.cs
+++ b/tests/Paramore.Brighter.DynamoDB.Tests/Outbox/When_there_are_outstanding_messages_in_the_outbox.cs
@@ -33,7 +33,7 @@ public class DynamoDbOutboxOutstandingMessageTests : DynamoDBOutboxBaseTest
 
         var args = new Dictionary<string, object> {{"Topic", "test_topic"}};
 
-        var messages = await _dynamoDbOutbox.OutstandingMessagesAsync(0, context, 100, 1, args);
+        var messages = await _dynamoDbOutbox.OutstandingMessagesAsync(TimeSpan.Zero, context, 100, 1, args);
 
         //Other tests may leave messages, so make sure that we grab ours
         var message = messages.Single(m => m.Id == _message.Id);
@@ -51,7 +51,7 @@ public class DynamoDbOutboxOutstandingMessageTests : DynamoDBOutboxBaseTest
 
         var args = new Dictionary<string, object> {{"Topic", "test_topic"}};
 
-        var messages =_dynamoDbOutbox.OutstandingMessages(0, context, 100, 1, args);
+        var messages =_dynamoDbOutbox.OutstandingMessages(TimeSpan.Zero, context, 100, 1, args);
 
         //Other tests may leave messages, so make sure that we grab ours
         var message = messages.Single(m => m.Id == _message.Id);
@@ -74,7 +74,7 @@ public class DynamoDbOutboxOutstandingMessageTests : DynamoDBOutboxBaseTest
 
         _fakeTimeProvider.Advance(TimeSpan.FromSeconds(1));
 
-        var outstandingMessages = await _dynamoDbOutbox.OutstandingMessagesAsync(0, context, 100, 1);
+        var outstandingMessages = await _dynamoDbOutbox.OutstandingMessagesAsync(TimeSpan.Zero, context, 100, 1);
 
         //Other tests may leave messages, so make sure that we grab ours
         foreach (var message in messages)
@@ -101,7 +101,7 @@ public class DynamoDbOutboxOutstandingMessageTests : DynamoDBOutboxBaseTest
 
         _fakeTimeProvider.Advance(TimeSpan.FromSeconds(1));
 
-        var outstandingMessages = _dynamoDbOutbox.OutstandingMessages(0, context, 100, 1);
+        var outstandingMessages = _dynamoDbOutbox.OutstandingMessages(TimeSpan.Zero, context, 100, 1);
 
         //Other tests may leave messages, so make sure that we grab ours
         foreach (var message in messages)
@@ -134,10 +134,10 @@ public class DynamoDbOutboxOutstandingMessageTests : DynamoDBOutboxBaseTest
         var args = new Dictionary<string, object> { { "Topic", "test_topic" } };
 
         // Get the first page
-        var outstandingMessages = (await _dynamoDbOutbox.OutstandingMessagesAsync(0, context, 5, 1, args)).ToList();
+        var outstandingMessages = (await _dynamoDbOutbox.OutstandingMessagesAsync(TimeSpan.Zero, context, 5, 1, args)).ToList();
         outstandingMessages.Count.Should().Be(5);
         // Get the remainder
-        outstandingMessages.AddRange(await _dynamoDbOutbox.OutstandingMessagesAsync(0, context, 100, 2, args));
+        outstandingMessages.AddRange(await _dynamoDbOutbox.OutstandingMessagesAsync(TimeSpan.Zero, context, 100, 2, args));
 
         //Other tests may leave messages, so make sure that we grab ours
         foreach (var message in messages)
@@ -169,10 +169,10 @@ public class DynamoDbOutboxOutstandingMessageTests : DynamoDBOutboxBaseTest
         var args = new Dictionary<string, object> { { "Topic", "test_topic" } };
 
         // Get the first page
-        var outstandingMessages = _dynamoDbOutbox.OutstandingMessages(0, context, 5, 1, args).ToList();
+        var outstandingMessages = _dynamoDbOutbox.OutstandingMessages(TimeSpan.Zero, context, 5, 1, args).ToList();
         outstandingMessages.Count.Should().Be(5);
         // Get the remainder
-        outstandingMessages.AddRange(_dynamoDbOutbox.OutstandingMessages(0, context, 100, 2, args));
+        outstandingMessages.AddRange(_dynamoDbOutbox.OutstandingMessages(TimeSpan.Zero, context, 100, 2, args));
 
         //Other tests may leave messages, so make sure that we grab ours
         foreach (var message in messages)
@@ -211,10 +211,10 @@ public class DynamoDbOutboxOutstandingMessageTests : DynamoDBOutboxBaseTest
         var outstandingMessages = new List<Message>();
         for (var i = 1; i < 5; i++)
         {
-            outstandingMessages.AddRange(await _dynamoDbOutbox.OutstandingMessagesAsync(0, context, 5, i));
+            outstandingMessages.AddRange(await _dynamoDbOutbox.OutstandingMessagesAsync(TimeSpan.Zero, context, 5, i));
         }
         // Do a last page in case other tests have added more messages
-        outstandingMessages.AddRange(await _dynamoDbOutbox.OutstandingMessagesAsync(0, context, 100, 5));
+        outstandingMessages.AddRange(await _dynamoDbOutbox.OutstandingMessagesAsync(TimeSpan.Zero, context, 100, 5));
 
         //Other tests may leave messages, so make sure that we grab ours
         foreach (var message in messages)
@@ -254,10 +254,10 @@ public class DynamoDbOutboxOutstandingMessageTests : DynamoDBOutboxBaseTest
         var outstandingMessages = new List<Message>();
         for (var i = 1; i < 5; i++)
         {
-            outstandingMessages.AddRange(_dynamoDbOutbox.OutstandingMessages(0, context, 5, i));
+            outstandingMessages.AddRange(_dynamoDbOutbox.OutstandingMessages(TimeSpan.Zero, context, 5, i));
         }
         // Do a last page in case other tests have added more messages
-        outstandingMessages.AddRange(_dynamoDbOutbox.OutstandingMessages(0, context, 100, 5));
+        outstandingMessages.AddRange(_dynamoDbOutbox.OutstandingMessages(TimeSpan.Zero, context, 100, 5));
 
         //Other tests may leave messages, so make sure that we grab ours
         foreach (var message in messages)

--- a/tests/Paramore.Brighter.InMemory.Tests/Outbox/When_Retrieving_Messages_based_on_Age.cs
+++ b/tests/Paramore.Brighter.InMemory.Tests/Outbox/When_Retrieving_Messages_based_on_Age.cs
@@ -28,15 +28,15 @@ public class When_Retrieving_Messages_based_on_Age
         outbox.Add(new MessageTestDataBuilder(), context);
         outbox.Add(new MessageTestDataBuilder(), context);
 
-        var messagesToDispatch = outbox.OutstandingMessages(2000, context);
-        var allMessages = outbox.OutstandingMessages(0, context).ToArray();
+        var messagesToDispatch = outbox.OutstandingMessages(TimeSpan.FromMilliseconds(2000), context);
+        var allMessages = outbox.OutstandingMessages(TimeSpan.Zero, context).ToArray();
 
         foreach (var message in allMessages)
         {
             outbox.MarkDispatched(message.Id, context);
         }
 
-        var messagesAfterDispatch = outbox.OutstandingMessages(0, context);
+        var messagesAfterDispatch = outbox.OutstandingMessages(TimeSpan.Zero, context);
 
         Assert.Equal(2, messagesToDispatch.Count());
         Assert.Equal(4, allMessages.Count());
@@ -58,15 +58,15 @@ public class When_Retrieving_Messages_based_on_Age
         await outbox.AddAsync(new MessageTestDataBuilder(), context);
         await outbox.AddAsync(new MessageTestDataBuilder(), context);
 
-        var messagesToDispatch = await outbox.OutstandingMessagesAsync(2000, context);
-        var allMessages = (await outbox.OutstandingMessagesAsync(0, context)).ToArray();
+        var messagesToDispatch = await outbox.OutstandingMessagesAsync(TimeSpan.FromMilliseconds(2000), context);
+        var allMessages = (await outbox.OutstandingMessagesAsync(TimeSpan.Zero, context)).ToArray();
 
         foreach (var message in allMessages)
         {
             await outbox.MarkDispatchedAsync(message.Id, context);
         }
 
-        var messagesAfterDispatch = await outbox.OutstandingMessagesAsync(0, context);
+        var messagesAfterDispatch = await outbox.OutstandingMessagesAsync(TimeSpan.Zero, context);
 
         Assert.Equal(2, messagesToDispatch.Count());
         Assert.Equal(4, allMessages.Count());

--- a/tests/Paramore.Brighter.InMemory.Tests/Outbox/When_storing_message_in_outbox.cs
+++ b/tests/Paramore.Brighter.InMemory.Tests/Outbox/When_storing_message_in_outbox.cs
@@ -83,7 +83,7 @@ namespace Paramore.Brighter.InMemory.Tests.Outbox
             var dispatchedAt = DateTime.UtcNow;
             outbox.MarkDispatched(messageId, context, dispatchedAt);
 
-            var dispatchedMessages = outbox.DispatchedMessages(500, context);
+            var dispatchedMessages = outbox.DispatchedMessages(TimeSpan.FromMilliseconds(500), context);
 
             //Assert
             dispatchedMessages.Count().Should().Be(1);
@@ -110,7 +110,7 @@ namespace Paramore.Brighter.InMemory.Tests.Outbox
             
             timeProvider.Advance(TimeSpan.FromMilliseconds(500));
 
-            var outstandingMessages = outbox.OutstandingMessages(0, context);
+            var outstandingMessages = outbox.OutstandingMessages(TimeSpan.Zero, context);
             
             //Assert
             outstandingMessages.Count().Should().Be(1);
@@ -161,8 +161,8 @@ namespace Paramore.Brighter.InMemory.Tests.Outbox
 
             timeProvider.Advance(TimeSpan.FromMilliseconds(500));
 
-            var sentMessages = outbox.DispatchedMessages(5000, context);
-            var outstandingMessages = outbox.OutstandingMessages(0, context);
+            var sentMessages = outbox.DispatchedMessages(TimeSpan.FromMilliseconds(5000), context);
+            var outstandingMessages = outbox.OutstandingMessages(TimeSpan.Zero, context);
 
             //Assert
             sentMessages.Count().Should().Be(2);

--- a/tests/Paramore.Brighter.InMemory.Tests/Sweeper/When_sweeping_the_outbox.cs
+++ b/tests/Paramore.Brighter.InMemory.Tests/Sweeper/When_sweeping_the_outbox.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Globalization;
-using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Extensions.Time.Testing;
@@ -23,7 +21,7 @@ namespace Paramore.Brighter.InMemory.Tests.Sweeper
             var timeProvider = new FakeTimeProvider();
             var outbox = new InMemoryOutbox(timeProvider) { Tracer = new BrighterTracer(timeProvider) };
             var commandProcessor = new FakeCommandProcessor(timeProvider);
-            var sweeper = new OutboxSweeper(milliSecondsSinceSent, commandProcessor, new InMemoryRequestContextFactory());
+            var sweeper = new OutboxSweeper(TimeSpan.FromMilliseconds(milliSecondsSinceSent), commandProcessor, new InMemoryRequestContextFactory());
 
             var messages = new Message[]
             {
@@ -58,7 +56,7 @@ namespace Paramore.Brighter.InMemory.Tests.Sweeper
             var timeProvider = new FakeTimeProvider();
             var outbox = new InMemoryOutbox(timeProvider) { Tracer = new BrighterTracer(timeProvider) };
             var commandProcessor = new FakeCommandProcessor(timeProvider);
-            var sweeper = new OutboxSweeper(milliSecondsSinceSent, commandProcessor, new InMemoryRequestContextFactory());
+            var sweeper = new OutboxSweeper(TimeSpan.FromMilliseconds(milliSecondsSinceSent), commandProcessor, new InMemoryRequestContextFactory());
 
             var messages = new Message[]
             {
@@ -92,7 +90,7 @@ namespace Paramore.Brighter.InMemory.Tests.Sweeper
 
             var timeProvider = new FakeTimeProvider();
             var commandProcessor = new FakeCommandProcessor(timeProvider);
-            var sweeper = new OutboxSweeper(milliSecondsSinceSent, commandProcessor, new InMemoryRequestContextFactory());
+            var sweeper = new OutboxSweeper(TimeSpan.FromMilliseconds(milliSecondsSinceSent), commandProcessor, new InMemoryRequestContextFactory());
 
             Message oldMessage = new MessageTestDataBuilder();
             commandProcessor.DepositPost(oldMessage.ToStubRequest());
@@ -129,7 +127,7 @@ namespace Paramore.Brighter.InMemory.Tests.Sweeper
 
             var timeProvider = new FakeTimeProvider();
             var commandProcessor = new FakeCommandProcessor(timeProvider);
-            var sweeper = new OutboxSweeper(milliSecondsSinceSent, commandProcessor, new InMemoryRequestContextFactory());
+            var sweeper = new OutboxSweeper(TimeSpan.FromMilliseconds(milliSecondsSinceSent), commandProcessor, new InMemoryRequestContextFactory());
 
             Message oldMessage = new MessageTestDataBuilder();
             commandProcessor.DepositPost(oldMessage.ToStubRequest());

--- a/tests/Paramore.Brighter.InMemory.Tests/TestDoubles/FakeCommandProcessor.cs
+++ b/tests/Paramore.Brighter.InMemory.Tests/TestDoubles/FakeCommandProcessor.cs
@@ -202,13 +202,14 @@ namespace Paramore.Brighter.InMemory.Tests.TestDoubles
 
         public void ClearOutstandingFromOutbox(
             int amountToClear = 100, 
-            int minimumAge = 5000, 
+            TimeSpan? minimumAge = null, 
             bool useBulk = false, 
             RequestContext requestContext = null,
             Dictionary<string, object> args = null)
         {
+            var minAge = minimumAge ?? TimeSpan.FromMilliseconds(500);
             var depositedMessages = Deposited.Where(m =>
-                    m.EnqueuedTime < timeProvider.GetUtcNow().DateTime.AddMilliseconds(-1 * minimumAge) &&
+                    m.EnqueuedTime < timeProvider.GetUtcNow() - minAge &&
                     !Dispatched.ContainsKey(m.Request.Id))
                 .Take(amountToClear)
                 .Select(m => m.Request.Id)

--- a/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/When_converting_brighterheader_to_kafkaheader.cs
+++ b/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/When_converting_brighterheader_to_kafkaheader.cs
@@ -51,7 +51,7 @@ public class KafkaDefaultMessageHeaderBuilderTests
         headers.GetLastBytes(HeaderNames.MESSAGE_ID).Should().Equal(message.Header.Id.ToString().ToByteArray());
         headers.GetLastBytes(HeaderNames.TOPIC).Should().Equal(message.Header.Topic.ToByteArray());
         headers.GetLastBytes(HeaderNames.TIMESTAMP).Should()
-            .Equal(new DateTimeOffset(message.Header.TimeStamp).ToUnixTimeMilliseconds().ToString().ToByteArray());
+            .Equal(message.Header.TimeStamp.ToUnixTimeMilliseconds().ToString().ToByteArray());
         headers.GetLastBytes(HeaderNames.CORRELATION_ID).Should()
             .Equal(message.Header.CorrelationId.ToString().ToByteArray());
         headers.GetLastBytes(HeaderNames.PARTITIONKEY).Should().Equal(message.Header.PartitionKey.ToByteArray());

--- a/tests/Paramore.Brighter.MSSQL.Tests/Outbox/When_removing_messages_from_the_message_store.cs
+++ b/tests/Paramore.Brighter.MSSQL.Tests/Outbox/When_removing_messages_from_the_message_store.cs
@@ -81,7 +81,7 @@ namespace Paramore.Brighter.MSSQL.Tests.Outbox
             var context = new RequestContext();
             _outbox.Delete([_firstMessage.Id], context);
 
-            var remainingMessages = _outbox.OutstandingMessages(0, context);
+            var remainingMessages = _outbox.OutstandingMessages(TimeSpan.Zero, context);
 
             remainingMessages.Should().HaveCount(2);
             remainingMessages.Should().Contain(_secondMessage);
@@ -89,7 +89,7 @@ namespace Paramore.Brighter.MSSQL.Tests.Outbox
             
             _outbox.Delete(remainingMessages.Select(m => m.Id).ToArray(), context);
 
-            var messages = _outbox.OutstandingMessages(0, context);
+            var messages = _outbox.OutstandingMessages(TimeSpan.Zero, context);
 
             messages.Should().HaveCount(0);
 
@@ -100,7 +100,7 @@ namespace Paramore.Brighter.MSSQL.Tests.Outbox
             var context = new RequestContext();
             await _outbox.DeleteAsync([_firstMessage.Id], context, cancellationToken: CancellationToken.None);
 
-            var remainingMessages = await _outbox.OutstandingMessagesAsync(0, context);
+            var remainingMessages = await _outbox.OutstandingMessagesAsync(TimeSpan.Zero, context);
 
             remainingMessages.Should().HaveCount(2);
             remainingMessages.Should().Contain(_secondMessage);
@@ -112,7 +112,7 @@ namespace Paramore.Brighter.MSSQL.Tests.Outbox
                 cancellationToken: CancellationToken.None
                 );
 
-            var messages = await _outbox.OutstandingMessagesAsync(0, context);
+            var messages = await _outbox.OutstandingMessagesAsync(TimeSpan.Zero, context);
 
             messages.Should().HaveCount(0);
 

--- a/tests/Paramore.Brighter.MSSQL.Tests/Outbox/When_there_is_an_outstanding_message_in_the_outbox.cs
+++ b/tests/Paramore.Brighter.MSSQL.Tests/Outbox/When_there_is_an_outstanding_message_in_the_outbox.cs
@@ -29,7 +29,7 @@ namespace Paramore.Brighter.MSSQL.Tests.Outbox
         [Fact]
         public void When_there_is_an_outstanding_message_in_the_outbox()
         {
-            var outstandingMessage = _sqlOutbox.OutstandingMessages(100, new RequestContext()).SingleOrDefault();
+            var outstandingMessage = _sqlOutbox.OutstandingMessages(TimeSpan.FromMilliseconds(100), new RequestContext()).SingleOrDefault();
 
             outstandingMessage.Should().NotBeNull();
             outstandingMessage?.Id.Should().Be(_dispatchedMessage.Id);
@@ -38,7 +38,7 @@ namespace Paramore.Brighter.MSSQL.Tests.Outbox
         [Fact]
         public async Task When_there_is_an_outstanding_message_in_the_outbox_async()
         {
-            var outstandingMessage = (await _sqlOutbox.OutstandingMessagesAsync(100, new RequestContext())).SingleOrDefault();
+            var outstandingMessage = (await _sqlOutbox.OutstandingMessagesAsync(TimeSpan.FromMilliseconds(100), new RequestContext())).SingleOrDefault();
 
             outstandingMessage.Should().NotBeNull();
             outstandingMessage?.Id.Should().Be(_dispatchedMessage.Id);

--- a/tests/Paramore.Brighter.MySQL.Tests/Outbox/When_removing_messages_from_the_outbox.cs
+++ b/tests/Paramore.Brighter.MySQL.Tests/Outbox/When_removing_messages_from_the_outbox.cs
@@ -80,7 +80,7 @@ namespace Paramore.Brighter.MySQL.Tests.Outbox
             
             _mySqlOutbox.Delete([_firstMessage.Id], _context);
 
-            var remainingMessages = _mySqlOutbox.OutstandingMessages(0, _context);
+            var remainingMessages = _mySqlOutbox.OutstandingMessages(TimeSpan.Zero, _context);
 
             var msgs = remainingMessages as Message[] ?? remainingMessages.ToArray();
             msgs.Should().HaveCount(2);
@@ -89,7 +89,7 @@ namespace Paramore.Brighter.MySQL.Tests.Outbox
             
             _mySqlOutbox.Delete(new []{_secondMessage.Id, _thirdMessage.Id}, _context);
 
-            var messages = _mySqlOutbox.OutstandingMessages(0, _context);
+            var messages = _mySqlOutbox.OutstandingMessages(TimeSpan.Zero, _context);
 
             messages.Should().HaveCount(0);
         }
@@ -103,7 +103,7 @@ namespace Paramore.Brighter.MySQL.Tests.Outbox
 
             await _mySqlOutbox.DeleteAsync(new []{_firstMessage.Id}, _context, cancellationToken: CancellationToken.None);
 
-            var remainingMessages = await _mySqlOutbox.OutstandingMessagesAsync(0, _context);
+            var remainingMessages = await _mySqlOutbox.OutstandingMessagesAsync(TimeSpan.Zero, _context);
 
             var messages = remainingMessages as Message[] ?? remainingMessages.ToArray();
             messages.Should().HaveCount(2);
@@ -112,7 +112,7 @@ namespace Paramore.Brighter.MySQL.Tests.Outbox
             
             await _mySqlOutbox.DeleteAsync(new []{_secondMessage.Id, _thirdMessage.Id}, _context, cancellationToken: CancellationToken.None);
 
-            var finalMessages = await _mySqlOutbox.OutstandingMessagesAsync(0, _context);
+            var finalMessages = await _mySqlOutbox.OutstandingMessagesAsync(TimeSpan.Zero, _context);
 
             finalMessages.Should().HaveCount(0);
         }

--- a/tests/Paramore.Brighter.MySQL.Tests/Outbox/When_there_are_multiple_messages_and_some_are_receivied_and_Dispatched_bulk_Async.cs
+++ b/tests/Paramore.Brighter.MySQL.Tests/Outbox/When_there_are_multiple_messages_and_some_are_receivied_and_Dispatched_bulk_Async.cs
@@ -53,7 +53,7 @@ namespace Paramore.Brighter.MySQL.Tests.Outbox
 
             await Task.Delay(TimeSpan.FromSeconds(5));
 
-            var undispatchedMessages = await _sqlOutbox.OutstandingMessagesAsync(0, _context);
+            var undispatchedMessages = await _sqlOutbox.OutstandingMessagesAsync(TimeSpan.Zero, _context);
 
             undispatchedMessages.Count().Should().Be(2);
         }

--- a/tests/Paramore.Brighter.MySQL.Tests/Outbox/When_there_are_multiple_outstanding_messages_in_the_outbox_and_messages_within_an_interval_are_fetched.cs
+++ b/tests/Paramore.Brighter.MySQL.Tests/Outbox/When_there_are_multiple_outstanding_messages_in_the_outbox_and_messages_within_an_interval_are_fetched.cs
@@ -49,7 +49,7 @@ namespace Paramore.Brighter.MySQL.Tests.Outbox
         [Fact]
         public void When_there_are_multiple_outstanding_messages_in_the_outbox_and_messages_within_an_interval_are_fetched()
         {
-            var messages = _mySqlOutbox.OutstandingMessages(millSecondsSinceSent: 0, _context);
+            var messages = _mySqlOutbox.OutstandingMessages(dispatchedSince: TimeSpan.Zero, _context);
 
             var msgs = messages as Message[] ?? messages.ToArray();
             msgs.Should().NotBeNullOrEmpty();
@@ -60,7 +60,7 @@ namespace Paramore.Brighter.MySQL.Tests.Outbox
         [Fact]
         public async Task When_there_are_multiple_outstanding_messages_in_the_outbox_and_messages_within_an_interval_are_fetched_async()
         {
-            var messages = await _mySqlOutbox.OutstandingMessagesAsync(millSecondsSinceSent: 0, _context);
+            var messages = await _mySqlOutbox.OutstandingMessagesAsync(dispatchedSince: TimeSpan.Zero, _context);
 
             var msgs = messages as Message[] ?? messages.ToArray();
             msgs.Should().NotBeNullOrEmpty();

--- a/tests/Paramore.Brighter.PostgresSQL.Tests/Outbox/When_Removing_Messages_From_The_Outbox.cs
+++ b/tests/Paramore.Brighter.PostgresSQL.Tests/Outbox/When_Removing_Messages_From_The_Outbox.cs
@@ -72,7 +72,7 @@ namespace Paramore.Brighter.PostgresSQL.Tests.Outbox
             _sqlOutbox.Delete([_firstMessage.Id], context);
 
             //assert
-            var remainingMessages = _sqlOutbox.OutstandingMessages(0, context);
+            var remainingMessages = _sqlOutbox.OutstandingMessages(TimeSpan.Zero, context);
 
             var msgs = remainingMessages as Message[] ?? remainingMessages.ToArray();
             msgs.Should().HaveCount(2);
@@ -81,7 +81,7 @@ namespace Paramore.Brighter.PostgresSQL.Tests.Outbox
             
             _sqlOutbox.Delete(new []{_secondMessage.Id, _thirdMessage.Id}, context);
 
-            var messages = _sqlOutbox.OutstandingMessages(0, context);
+            var messages = _sqlOutbox.OutstandingMessages(TimeSpan.Zero, context);
 
             messages.Should().HaveCount(0);
         }

--- a/tests/Paramore.Brighter.Sqlite.Tests/Outbox/When_there_are_multiple_messages_and_some_are_received_and_Dispatched_bulk_Async.cs
+++ b/tests/Paramore.Brighter.Sqlite.Tests/Outbox/When_there_are_multiple_messages_and_some_are_received_and_Dispatched_bulk_Async.cs
@@ -51,7 +51,7 @@ namespace Paramore.Brighter.Sqlite.Tests.Outbox
             
             await Task.Delay(200);
 
-            var undispatchedMessages = await _sqlOutbox.OutstandingMessagesAsync(0, context);
+            var undispatchedMessages = await _sqlOutbox.OutstandingMessagesAsync(TimeSpan.Zero, context);
 
             undispatchedMessages.Count().Should().Be(2);
         }


### PR DESCRIPTION
Move to using a `TimeSpan` for any age parameters  instead of an int with an arcane granularity


Feature #3220
