### PR TITLE
[Fix] Redis test failing, needs to check value

### DIFF
--- a/tests/Paramore.Brighter.Redis.Tests/MessagingGateway/When_parsing_a_good_redis_message_to_brighter.cs
+++ b/tests/Paramore.Brighter.Redis.Tests/MessagingGateway/When_parsing_a_good_redis_message_to_brighter.cs
@@ -21,7 +21,7 @@ namespace Paramore.Brighter.Redis.Tests.MessagingGateway
 
             message.Id.Should().Be("18669550-2069-48c5-923d-74a2e79c0748");
             message.Header.TimeStamp.Should().Be(DateTime.Parse("2018-02-07T09:38:36Z"));
-            message.Header.Topic.Should().Be("test");
+            message.Header.Topic.Value.Should().Be("test");
             message.Header.MessageType.Should().Be(MessageType.MT_COMMAND);
             message.Header.HandledCount.Should().Be(3);
             message.Header.Delayed.Should().Be(TimeSpan.FromMilliseconds(200));


### PR DESCRIPTION
Following the move to RoutingKey for Topic, we need to check against the RoutingKey Value here, not the RoutingKey