### PR TITLE
Archiver Observability

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -40,7 +40,7 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="8.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -54,7 +54,7 @@
     <PackageVersion Include="MySqlConnector" Version="2.3.7" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="NJsonSchema" Version="11.0.2" />
-    <PackageReference Include="NJsonSchema.NewtonsoftJson" Version="11.0.2" />
+    <PackageVersion Include="NJsonSchema.NewtonsoftJson" Version="11.0.2" />
     <PackageVersion Include="Npgsql" Version="8.0.5" />
     <PackageVersion Include="NUnit" Version="4.2.2" />
     <PackageVersion Include="NUnit.Analyzers" Version="4.3.0">

--- a/docs/adr/0021-move-archive-from-esb.md
+++ b/docs/adr/0021-move-archive-from-esb.md
@@ -1,0 +1,32 @@
+# 20. Move Archive Methods from External Service Bus to Outbox Archiver to Reduce Complexity
+
+Date: 2024-10-28
+
+## Status
+
+Adopted
+
+## Context
+
+The `ExternalServiceBus` class is a mediator between producer and outbox. It suffers from complexity, see ADR 0020.
+
+The `ExternalServiceBus` class has a number of methods that are related to archiving messages. These methods are:
+ - Archive
+ - ArchiveAsync
+
+The OutboxArchiver and the TimedOuboxArchiver are the only callers of these ExternalBus Archive methods. The TimedOutboxArchiver provides both a timer that fires the archiver at a given periodic interval, and uses the global distributed lock to ensure only one archiver runs.
+
+## Decision
+
+Whilst the `Archive` methods were not called out by CodeScene analysis, they do add to the overall set of responsibilities of `ExternalServiceBus`. As they have different reasons to change to `ExternalServiceBus` they should be moved to a separate class.
+
+We will move the implementation from `ExternalServiceBus` into `OutboxArchiver`. We will call `OutboxArchiver` from  `TimedOutboxArchiver`.
+
+## Consequences
+
+One, we have moved these functions, it makes sense to rename the `ExternalServiceBus` class to 'OutboxProducerMediator' as this better describes its role within our codebase.
+
+
+
+
+

--- a/src/Paramore.Brighter.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Paramore.Brighter.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -219,7 +219,7 @@ namespace Paramore.Brighter.Extensions.DependencyInjection
             brighterBuilder.Services.TryAddSingleton<IAmExternalBusConfiguration>(busConfiguration);
            
             brighterBuilder.Services.TryAdd(new ServiceDescriptor(typeof(IAmAnOutboxProducerMediator),
-               (serviceProvider) => BuildExternalBus(
+               (serviceProvider) => BuildOutBoxProducerMediator(
                    serviceProvider, transactionType, busConfiguration, brighterBuilder.PolicyRegistry, outbox
                    ),
                ServiceLifetime.Singleton));
@@ -321,7 +321,7 @@ namespace Paramore.Brighter.Extensions.DependencyInjection
             return commandProcessor;
         }
         
-        private static IAmAnOutboxProducerMediator BuildExternalBus(IServiceProvider serviceProvider,
+        private static IAmAnOutboxProducerMediator BuildOutBoxProducerMediator(IServiceProvider serviceProvider,
             Type transactionType,
             ExternalBusConfiguration busConfiguration,
             IPolicyRegistry<string> policyRegistry,
@@ -340,13 +340,11 @@ namespace Paramore.Brighter.Extensions.DependencyInjection
                 TransformFactoryAsync(serviceProvider),
                 Tracer(serviceProvider),
                 outbox,
-                busConfiguration.ArchiveProvider,
                 RequestContextFactory(serviceProvider),
                 busConfiguration.OutboxTimeout,
                 busConfiguration.MaxOutStandingMessages,
                 busConfiguration.MaxOutStandingCheckInterval,
                 busConfiguration.OutBoxBag,
-                busConfiguration.ArchiveBatchSize,
                 TimeProvider.System,
                 busConfiguration.InstrumentationOptions);
         }

--- a/src/Paramore.Brighter.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Paramore.Brighter.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -30,7 +30,6 @@ using Microsoft.Extensions.Logging;
 using Paramore.Brighter.FeatureSwitch;
 using Paramore.Brighter.Logging;
 using System.Text.Json;
-using System.Transactions;
 using Paramore.Brighter.DynamoDb;
 using Paramore.Brighter.Observability;
 using Polly.Registry;
@@ -94,7 +93,7 @@ namespace Paramore.Brighter.Extensions.DependencyInjection
             var mapperRegistry = new ServiceCollectionMessageMapperRegistry(services, options.MapperLifetime);
             services.TryAddSingleton(mapperRegistry);
             
-            services.TryAddSingleton<IAmARequestContextFactory>(options.RequestContextFactory);
+            services.TryAddSingleton(options.RequestContextFactory);
 
             if (options.FeatureSwitchRegistry != null)
                 services.TryAddSingleton(options.FeatureSwitchRegistry);
@@ -136,9 +135,6 @@ namespace Paramore.Brighter.Extensions.DependencyInjection
         /// </summary>
         /// <param name="brighterBuilder">The Brighter builder to add this option to</param>
         /// <param name="configure">A callback that allows you to configure <see cref="ExternalBusConfiguration"/> options</param>
-        /// <param name="transactionProvider">The transaction provider for the outbox, can be null for in-memory default
-        /// of <see cref="CommittableTransactionProvider"/> which you must set the generic type to <see cref="CommittableTransaction"/> for
-        /// </param>
         /// <param name="serviceLifetime">The lifetime of the transaction provider</param>
         /// <returns>The Brighter builder to allow chaining of requests</returns>
         public static IBrighterBuilder UseExternalBus(

--- a/src/Paramore.Brighter.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Paramore.Brighter.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -222,7 +222,7 @@ namespace Paramore.Brighter.Extensions.DependencyInjection
             
             brighterBuilder.Services.TryAddSingleton<IAmExternalBusConfiguration>(busConfiguration);
            
-            brighterBuilder.Services.TryAdd(new ServiceDescriptor(typeof(IAmAnExternalBusService),
+            brighterBuilder.Services.TryAdd(new ServiceDescriptor(typeof(IAmAnOutboxProducerMediator),
                (serviceProvider) => BuildExternalBus(
                    serviceProvider, transactionType, busConfiguration, brighterBuilder.PolicyRegistry, outbox
                    ),
@@ -237,7 +237,7 @@ namespace Paramore.Brighter.Extensions.DependencyInjection
             INeedMessaging messagingBuilder,
             IUseRpc useRequestResponse)
         {
-            var eventBus = provider.GetService<IAmAnExternalBusService>();
+            var eventBus = provider.GetService<IAmAnOutboxProducerMediator>();
             var eventBusConfiguration = provider.GetService<IAmExternalBusConfiguration>();
             var serviceActivatorOptions = provider.GetService<IServiceActivatorOptions>();
 
@@ -325,7 +325,7 @@ namespace Paramore.Brighter.Extensions.DependencyInjection
             return commandProcessor;
         }
         
-        private static IAmAnExternalBusService BuildExternalBus(IServiceProvider serviceProvider,
+        private static IAmAnOutboxProducerMediator BuildExternalBus(IServiceProvider serviceProvider,
             Type transactionType,
             ExternalBusConfiguration busConfiguration,
             IPolicyRegistry<string> policyRegistry,
@@ -333,9 +333,9 @@ namespace Paramore.Brighter.Extensions.DependencyInjection
         {
             //Because the bus has specialized types as members, we need to create the bus type dynamically
             //again to prevent someone configuring Brighter from having to pass generic types
-            var busType = typeof(ExternalBusService<,>).MakeGenericType(typeof(Message), transactionType);
+            var busType = typeof(OutboxProducerMediator<,>).MakeGenericType(typeof(Message), transactionType);
 
-            return (IAmAnExternalBusService)Activator.CreateInstance(
+            return (IAmAnOutboxProducerMediator)Activator.CreateInstance(
                 busType,
                 busConfiguration.ProducerRegistry,
                 policyRegistry,

--- a/src/Paramore.Brighter.Extensions.Hosting/HostedServiceCollectionExtensions.cs
+++ b/src/Paramore.Brighter.Extensions.Hosting/HostedServiceCollectionExtensions.cs
@@ -57,7 +57,7 @@ namespace Paramore.Brighter.Extensions.Hosting
             brighterBuilder.Services.TryAddSingleton<TimedOutboxArchiverOptions>(options);
             brighterBuilder.Services.AddSingleton<IAmAnArchiveProvider>(archiveProvider);
             
-            brighterBuilder.Services.AddHostedService<TimedOutboxArchiver>();
+            brighterBuilder.Services.AddHostedService<TimedOutboxArchiver<Message, TTransaction>>();
 
             return brighterBuilder;
         }

--- a/src/Paramore.Brighter.ServiceActivator/ControlBus/ControlBusReceiverBuilder.cs
+++ b/src/Paramore.Brighter.ServiceActivator/ControlBus/ControlBusReceiverBuilder.cs
@@ -158,7 +158,7 @@ namespace Paramore.Brighter.ServiceActivator.ControlBus
 
             var outbox = new SinkOutboxSync();
             
-            var externalBus = new ExternalBusService<Message, CommittableTransaction>(
+            var externalBus = new OutboxProducerMediator<Message, CommittableTransaction>(
                 producerRegistry: producerRegistry,
                 policyRegistry: new DefaultPolicy(),
                 mapperRegistry: outgoingMessageMapperRegistry,

--- a/src/Paramore.Brighter.ServiceActivator/ControlBus/ControlBusReceiverBuilder.cs
+++ b/src/Paramore.Brighter.ServiceActivator/ControlBus/ControlBusReceiverBuilder.cs
@@ -158,7 +158,7 @@ namespace Paramore.Brighter.ServiceActivator.ControlBus
 
             var outbox = new SinkOutboxSync();
             
-            var externalBus = new OutboxProducerMediator<Message, CommittableTransaction>(
+            var mediator = new OutboxProducerMediator<Message, CommittableTransaction>(
                 producerRegistry: producerRegistry,
                 policyRegistry: new DefaultPolicy(),
                 mapperRegistry: outgoingMessageMapperRegistry,
@@ -175,7 +175,7 @@ namespace Paramore.Brighter.ServiceActivator.ControlBus
             commandProcessor = CommandProcessorBuilder.StartNew()
                 .Handlers(new HandlerConfiguration(subscriberRegistry, new ControlBusHandlerFactorySync(_dispatcher, () => commandProcessor)))
                 .Policies(policyRegistry)
-                .ExternalBus(ExternalBusType.FireAndForget, externalBus)
+                .ExternalBus(ExternalBusType.FireAndForget, mediator)
                 .ConfigureInstrumentation(null, InstrumentationOptions.None)
                 .RequestContextFactory(new InMemoryRequestContextFactory())
                 .Build();

--- a/src/Paramore.Brighter/CommandProcessor.cs
+++ b/src/Paramore.Brighter/CommandProcessor.cs
@@ -101,9 +101,9 @@ namespace Paramore.Brighter
         /// Bus: We want to hold a reference to the bus; use double lock to let us pass parameters to the constructor from the first instance
         /// MethodCache: Used to reduce the cost of reflection for bulk calls
         /// </summary>
-        private static IAmAnExternalBusService? s_bus;
+        private static IAmAnOutboxProducerMediator? s_outboxProducerMediator;
         private static readonly object s_padlock = new();
-        private static ConcurrentDictionary<string, MethodInfo> s_boundDepositCalls = new(); 
+        private static readonly ConcurrentDictionary<string, MethodInfo> s_boundDepositCalls = new(); 
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CommandProcessor"/> class
@@ -167,7 +167,7 @@ namespace Paramore.Brighter
             IAmAHandlerFactory handlerFactory,
             IAmARequestContextFactory requestContextFactory,
             IPolicyRegistry<string> policyRegistry,
-            IAmAnExternalBusService bus,
+            IAmAnOutboxProducerMediator bus,
             IAmAFeatureSwitchRegistry? featureSwitchRegistry = null,
             InboxConfiguration? inboxConfiguration = null,
             IEnumerable<Subscription>? replySubscriptions = null,
@@ -199,7 +199,7 @@ namespace Paramore.Brighter
         public CommandProcessor(
             IAmARequestContextFactory requestContextFactory,
             IPolicyRegistry<string> policyRegistry,
-            IAmAnExternalBusService bus,
+            IAmAnOutboxProducerMediator bus,
             IAmAFeatureSwitchRegistry? featureSwitchRegistry = null,
             InboxConfiguration? inboxConfiguration = null,
             IEnumerable<Subscription>? replySubscriptions = null,
@@ -562,16 +562,16 @@ namespace Paramore.Brighter
 
             try
             {
-                Message message = s_bus!.CreateMessageFromRequest(request, context);
+                Message message = s_outboxProducerMediator!.CreateMessageFromRequest(request, context);
                 
-                var bus = ((IAmAnExternalBusService<Message, TTransaction>)s_bus);
+                var bus = ((IAmAnOutboxProducerMediator<Message, TTransaction>)s_outboxProducerMediator);
 
                 if (!bus.HasOutbox())
                     throw new InvalidOperationException("No outbox defined.");
 
                 bus.AddToOutbox(message, context, transactionProvider, batchId);
 
-                return message.Id!;
+                return message.Id;
             }
             catch (Exception e)
             {
@@ -632,9 +632,9 @@ namespace Paramore.Brighter
             {
                 var successfullySentMessage = new List<string>();
                 
-                var bus = (IAmAnExternalBusService<Message, TTransaction>)s_bus!;
+                var mediator = (IAmAnOutboxProducerMediator<Message, TTransaction>)s_outboxProducerMediator!;
                 
-                var batchId = bus.StartBatchAddToOutbox();
+                var batchId = mediator.StartBatchAddToOutbox();
 
                 foreach (var request in requests)
                 {
@@ -644,7 +644,7 @@ namespace Paramore.Brighter
                     context.Span = createSpan;
                 }
                 
-                bus.EndBatchAddToOutbox(batchId, transactionProvider, context);
+                mediator.EndBatchAddToOutbox(batchId, transactionProvider, context);
                 
                 return successfullySentMessage.ToArray();
             }
@@ -758,9 +758,9 @@ namespace Paramore.Brighter
 
             try
             {
-                Message message = await s_bus!.CreateMessageFromRequestAsync(request, context, cancellationToken);
+                Message message = await s_outboxProducerMediator!.CreateMessageFromRequestAsync(request, context, cancellationToken);
                 
-                var bus = ((IAmAnExternalBusService<Message, TTransaction>)s_bus);
+                var bus = ((IAmAnOutboxProducerMediator<Message, TTransaction>)s_outboxProducerMediator);
                 
                 if (!bus.HasAsyncOutbox())
                     throw new InvalidOperationException("No async outbox defined.");
@@ -768,7 +768,7 @@ namespace Paramore.Brighter
                 await bus.AddToOutboxAsync(message, context, transactionProvider, continueOnCapturedContext,
                     cancellationToken, batchId);
 
-                return message.Id!;
+                return message.Id;
             }
             catch (Exception e)
             {
@@ -843,7 +843,7 @@ namespace Paramore.Brighter
             {
                 var successfullySentMessage = new List<string>();
 
-                var bus = (IAmAnExternalBusService<Message, TTransaction>)s_bus!;
+                var bus = (IAmAnOutboxProducerMediator<Message, TTransaction>)s_outboxProducerMediator!;
                 
                 var batchId = bus.StartBatchAddToOutbox();
 
@@ -919,7 +919,7 @@ namespace Paramore.Brighter
             
             try
             {
-                s_bus!.ClearOutbox(ids, context, args);
+                s_outboxProducerMediator!.ClearOutbox(ids, context, args);
             }
             catch (Exception e)
             {
@@ -953,7 +953,7 @@ namespace Paramore.Brighter
             
             try
             {
-                await s_bus!.ClearOutboxAsync(posts, context, continueOnCapturedContext, args, cancellationToken);
+                await s_outboxProducerMediator!.ClearOutboxAsync(posts, context, continueOnCapturedContext, args, cancellationToken);
             }
             catch (Exception e)
             {
@@ -990,7 +990,7 @@ namespace Paramore.Brighter
             try
             {
                 var minAge = minimumAge ?? TimeSpan.FromMilliseconds(5000);
-                s_bus!.ClearOutstandingFromOutbox(amountToClear, minAge, useBulk, context, args);
+                s_outboxProducerMediator!.ClearOutstandingFromOutbox(amountToClear, minAge, useBulk, context, args);
             }
             catch (Exception e)
             {
@@ -1028,10 +1028,10 @@ namespace Paramore.Brighter
             var subscription = _replySubscriptions?.FirstOrDefault(s => s.DataType == typeof(TResponse));
 
             if (subscription is null)
-                throw new ArgumentOutOfRangeException($"No Subscription registered fpr replies of type {typeof(T)}");
+                throw new InvalidOperationException($"No Subscription registered fpr replies of type {typeof(T)}");
             
             if (_responseChannelFactory is null)
-                throw new ArgumentOutOfRangeException("No ResponseChannelFactory registered");
+                throw new InvalidOperationException("No ResponseChannelFactory registered");
 
             //create a reply queue via creating a consumer - we use random identifiers as we will destroy
             var channelName = Guid.NewGuid();
@@ -1055,11 +1055,11 @@ namespace Paramore.Brighter
 
             try
             {
-                var outMessage = s_bus!.CreateMessageFromRequest(request, context);
+                var outMessage = s_outboxProducerMediator!.CreateMessageFromRequest(request, context);
 
                 //We don't store the message, if we continue to fail further retry is left to the sender 
                 s_logger.LogDebug("Sending request  with routingkey {ChannelName}", channelName);
-                s_bus.CallViaExternalBus<T, TResponse>(outMessage, requestContext);
+                s_outboxProducerMediator.CallViaExternalBus<T, TResponse>(outMessage, requestContext);
 
                 Message? responseMessage = null;
 
@@ -1071,7 +1071,7 @@ namespace Paramore.Brighter
                 {
                     s_logger.LogDebug("Reply received from {ChannelName}", channelName);
                     //map to request is map to a response, but it is a request from consumer point of view. Confusing, but...
-                    s_bus.CreateRequestFromMessage(responseMessage, context, out TResponse response);
+                    s_outboxProducerMediator.CreateRequestFromMessage(responseMessage, context, out TResponse response);
                     Send(response);
 
                     return response;
@@ -1099,15 +1099,12 @@ namespace Paramore.Brighter
         /// </summary>
         public static void ClearServiceBus()
         {
-            if (s_bus != null)
+            if (s_outboxProducerMediator != null)
             {
                 lock (s_padlock)
                 {
-                    if (s_bus != null)
-                    {
-                        s_bus.Dispose();
-                        s_bus = null;
-                    }
+                    s_outboxProducerMediator.Dispose();
+                    s_outboxProducerMediator = null;
                 }
             }
             s_boundDepositCalls.Clear();
@@ -1130,7 +1127,7 @@ namespace Paramore.Brighter
         {
             // If we do not have a subscriber registry and we do not have a handler factory 
             // then we're creating a control bus sender and we don't need them
-            if (_subscriberRegistry is null && handlerFactory is null)
+            if (_subscriberRegistry is null)
                 return false;
 
             switch (handlerFactory)
@@ -1143,16 +1140,16 @@ namespace Paramore.Brighter
             }
         }
  
-        // Create an instance of the ExternalBusService if one not already set for this app. Note that we do not support reinitialization here, so once you have
+        // Create an instance of the OutboxProducerMediator if one not already set for this app. Note that we do not support reinitialization here, so once you have
         // set a command processor for the app, you can't call init again to set them - although the properties are not read-only so overwriting is possible
         // if needed as a "get out of gaol" card.
-        private static void InitExtServiceBus(IAmAnExternalBusService bus)
+        private static void InitExtServiceBus(IAmAnOutboxProducerMediator bus)
         {
-            if (s_bus == null)
+            if (s_outboxProducerMediator == null)
             {
                 lock (s_padlock)
                 {
-                    s_bus ??= bus;
+                    s_outboxProducerMediator ??= bus;
                 }
             }
         }

--- a/src/Paramore.Brighter/CommandProcessorBuilder.cs
+++ b/src/Paramore.Brighter/CommandProcessorBuilder.cs
@@ -86,7 +86,7 @@ namespace Paramore.Brighter
         private IPolicyRegistry<string>? _policyRegistry;
 
         private IAmAFeatureSwitchRegistry? _featureSwitchRegistry;
-        private IAmAnExternalBusService? _bus;
+        private IAmAnOutboxProducerMediator? _bus;
         private bool _useRequestReplyQueues;
         private IAmAChannelFactory? _responseChannelFactory;
         private IEnumerable<Subscription>? _replySubscriptions;
@@ -174,7 +174,7 @@ namespace Paramore.Brighter
         /// <returns></returns>
         public INeedInstrumentation ExternalBus(
             ExternalBusType busType, 
-            IAmAnExternalBusService bus, 
+            IAmAnOutboxProducerMediator bus, 
             IAmAChannelFactory? responseChannelFactory = null, 
             IEnumerable<Subscription>? subscriptions = null,
             InboxConfiguration? inboxConfiguration = null
@@ -372,7 +372,7 @@ namespace Paramore.Brighter
         /// <returns></returns>
         INeedInstrumentation ExternalBus(
             ExternalBusType busType, 
-            IAmAnExternalBusService bus, 
+            IAmAnOutboxProducerMediator bus, 
             IAmAChannelFactory? responseChannelFactory = null, 
             IEnumerable<Subscription>? subscriptions = null,
             InboxConfiguration? inboxConfiguration = null

--- a/src/Paramore.Brighter/ControlBusSenderFactory.cs
+++ b/src/Paramore.Brighter/ControlBusSenderFactory.cs
@@ -49,7 +49,7 @@ namespace Paramore.Brighter
                 null);
             mapper.Register<MonitorEvent, MonitorEventMessageMapper>();
 
-            var bus = new OutboxProducerMediator<Message, CommittableTransaction>(
+            var mediator = new OutboxProducerMediator<Message, CommittableTransaction>(
                 producerRegistry: producerRegistry,
                 policyRegistry: new DefaultPolicy(),
                 mapperRegistry: mapper,
@@ -62,7 +62,7 @@ namespace Paramore.Brighter
                 CommandProcessorBuilder.StartNew()
                 .Handlers(new HandlerConfiguration())
                 .DefaultPolicy()
-                .ExternalBus(ExternalBusType.FireAndForget, bus)   
+                .ExternalBus(ExternalBusType.FireAndForget, mediator)   
                 .ConfigureInstrumentation(null, InstrumentationOptions.None)
                 .RequestContextFactory(new InMemoryRequestContextFactory())
                 .Build()

--- a/src/Paramore.Brighter/ControlBusSenderFactory.cs
+++ b/src/Paramore.Brighter/ControlBusSenderFactory.cs
@@ -49,7 +49,7 @@ namespace Paramore.Brighter
                 null);
             mapper.Register<MonitorEvent, MonitorEventMessageMapper>();
 
-            var bus = new ExternalBusService<Message, CommittableTransaction>(
+            var bus = new OutboxProducerMediator<Message, CommittableTransaction>(
                 producerRegistry: producerRegistry,
                 policyRegistry: new DefaultPolicy(),
                 mapperRegistry: mapper,

--- a/src/Paramore.Brighter/ExternalBusService.cs
+++ b/src/Paramore.Brighter/ExternalBusService.cs
@@ -250,7 +250,8 @@ namespace Paramore.Brighter
         /// <param name="requestContext">The request context for the pipeline</param>
         public void Archive(TimeSpan dispatchedSince, RequestContext requestContext)
         {
-            var span = _tracer?.(CommandProcessorSpanOperation.Create, requestContext?.Span, options: _instrumentationOptions);
+            //This is a archive span parent; we expect individual archiving operations for messages to have their own spans
+            var span = _tracer?.CreateArchiveSpan(requestContext.Span, options: _instrumentationOptions);
             
             try
             {
@@ -284,6 +285,10 @@ namespace Paramore.Brighter
             {
                 s_logger.LogError(e, "Error while archiving from the outbox");
                 throw;
+            }
+            finally
+            {
+                _tracer?.EndSpan(span);    
             }
         }
 

--- a/src/Paramore.Brighter/ExternalBusService.cs
+++ b/src/Paramore.Brighter/ExternalBusService.cs
@@ -250,6 +250,8 @@ namespace Paramore.Brighter
         /// <param name="requestContext">The request context for the pipeline</param>
         public void Archive(TimeSpan dispatchedSince, RequestContext requestContext)
         {
+            var span = _tracer?.(CommandProcessorSpanOperation.Create, requestContext?.Span, options: _instrumentationOptions);
+            
             try
             {
                 if (_outBox is null) throw new ArgumentException(NoSyncOutboxError);

--- a/src/Paramore.Brighter/ExternalBusService.cs
+++ b/src/Paramore.Brighter/ExternalBusService.cs
@@ -151,7 +151,7 @@ namespace Paramore.Brighter
             if (_disposed)
                 return;
 
-            if (disposing && _producerRegistry != null)
+            if (disposing)
                 _producerRegistry.CloseAll();
             _disposed = true;
         }
@@ -568,7 +568,7 @@ namespace Paramore.Brighter
         {
             CheckOutboxOutstandingLimit();
 
-            BrighterTracer.WriteOutboxEvent(OutboxDbOperation.Add, _outboxBatches[batchId], requestContext?.Span,
+            BrighterTracer.WriteOutboxEvent(OutboxDbOperation.Add, _outboxBatches[batchId], requestContext.Span,
                 transactionProvider != null, false, _instrumentationOptions);
 
             if (_outBox is null) throw new ArgumentException(NoSyncOutboxError);
@@ -597,7 +597,7 @@ namespace Paramore.Brighter
         {
             CheckOutboxOutstandingLimit();
 
-            BrighterTracer.WriteOutboxEvent(OutboxDbOperation.Add, _outboxBatches[batchId], requestContext?.Span,
+            BrighterTracer.WriteOutboxEvent(OutboxDbOperation.Add, _outboxBatches[batchId], requestContext.Span,
                 transactionProvider != null, true, _instrumentationOptions);
 
             if (_asyncOutbox is null) throw new ArgumentException(NoAsyncOutboxError);
@@ -654,7 +654,7 @@ namespace Paramore.Brighter
                 s_clearSemaphoreToken.Wait();
                 
                 var parentSpan = requestContext.Span;
-                var span = _tracer?.CreateClearSpan(CommandProcessorSpanOperation.Clear, requestContext.Span, null,
+                var span = _tracer.CreateClearSpan(CommandProcessorSpanOperation.Clear, requestContext.Span, null,
                     _instrumentationOptions);
 
                 try
@@ -687,7 +687,7 @@ namespace Paramore.Brighter
                 }
                 finally
                 {
-                    _tracer?.EndSpan(span);
+                    _tracer.EndSpan(span);
                     s_clearSemaphoreToken.Release();
                     s_backgroundClearSemaphoreToken.Release();
                 }
@@ -722,7 +722,7 @@ namespace Paramore.Brighter
                 await s_clearSemaphoreToken.WaitAsync();
                 
                 var parentSpan = requestContext.Span;
-                var span = _tracer?.CreateClearSpan(CommandProcessorSpanOperation.Clear, requestContext.Span, null,
+                var span = _tracer.CreateClearSpan(CommandProcessorSpanOperation.Clear, requestContext.Span, null,
                     _instrumentationOptions);
                 try
                 {
@@ -760,7 +760,7 @@ namespace Paramore.Brighter
                 }
                 finally
                 {
-                    _tracer?.EndSpan(span);
+                    _tracer.EndSpan(span);
                     s_clearSemaphoreToken.Release();
                     s_backgroundClearSemaphoreToken.Release();
                 }

--- a/src/Paramore.Brighter/ExternalBusService.cs
+++ b/src/Paramore.Brighter/ExternalBusService.cs
@@ -251,7 +251,9 @@ namespace Paramore.Brighter
         public void Archive(TimeSpan dispatchedSince, RequestContext requestContext)
         {
             //This is a archive span parent; we expect individual archiving operations for messages to have their own spans
-            var span = _tracer?.CreateArchiveSpan(requestContext.Span, options: _instrumentationOptions);
+            var parentSpan = requestContext.Span;
+            var createSpan = _tracer?.CreateArchiveSpan(requestContext.Span, options: _instrumentationOptions);
+            requestContext.Span = createSpan;
             
             try
             {
@@ -288,7 +290,8 @@ namespace Paramore.Brighter
             }
             finally
             {
-                _tracer?.EndSpan(span);    
+                _tracer?.EndSpan(createSpan);
+                requestContext.Span = parentSpan;
             }
         }
 

--- a/src/Paramore.Brighter/ExternalBusService.cs
+++ b/src/Paramore.Brighter/ExternalBusService.cs
@@ -11,6 +11,8 @@ using Paramore.Brighter.Observability;
 using Polly;
 using Polly.Registry;
 
+// ReSharper disable StaticMemberInGenericType
+
 namespace Paramore.Brighter
 {
     /// <summary>
@@ -119,7 +121,7 @@ namespace Paramore.Brighter
             _transformPipelineBuilderAsync =
                 new TransformPipelineBuilderAsync(mapperRegistryAsync, messageTransformerFactoryAsync);
 
-            //default to in-memory; expectation for a in memory box is Message and CommittableTransaction
+            //default to in-memory; expectation for an in memory box is Message and CommittableTransaction
             outbox ??= new InMemoryOutbox(TimeProvider.System);
             outbox.Tracer = tracer;
 
@@ -250,9 +252,9 @@ namespace Paramore.Brighter
         /// <param name="requestContext">The request context for the pipeline</param>
         public void Archive(TimeSpan dispatchedSince, RequestContext requestContext)
         {
-            //This is a archive span parent; we expect individual archiving operations for messages to have their own spans
+            //This is an archive span parent; we expect individual archiving operations for messages to have their own spans
             var parentSpan = requestContext.Span;
-            var createSpan = _tracer?.CreateArchiveSpan(requestContext.Span, options: _instrumentationOptions);
+            var createSpan = _tracer.CreateArchiveSpan(requestContext.Span, dispatchedSince, options: _instrumentationOptions);
             requestContext.Span = createSpan;
             
             try
@@ -290,7 +292,7 @@ namespace Paramore.Brighter
             }
             finally
             {
-                _tracer?.EndSpan(createSpan);
+                _tracer.EndSpan(createSpan);
                 requestContext.Span = parentSpan;
             }
         }
@@ -565,7 +567,7 @@ namespace Paramore.Brighter
         /// <summary>
         /// Commence a batch of outbox messages to add
         /// </summary>
-        /// <returns>The Id of the new batch</returns>
+        /// <returns>The ID of the new batch</returns>
         public string StartBatchAddToOutbox()
         {
             var batchId = Guid.NewGuid().ToString();
@@ -597,7 +599,7 @@ namespace Paramore.Brighter
         /// <summary>
         /// Flush the batch of Messages to the outbox.
         /// </summary>
-        /// <param name="batchId">The Id of the batch to be flushed</param>
+        /// <param name="batchId">The ID of the batch to be flushed</param>
         /// <param name="transactionProvider"></param>
         /// <param name="requestContext">The context of the request; if null we will start one via a <see cref="IAmARequestContextFactory"/> </param>
         /// <param name="cancellationToken"></param>

--- a/src/Paramore.Brighter/IAmAnExternalBusService.cs
+++ b/src/Paramore.Brighter/IAmAnExternalBusService.cs
@@ -11,22 +11,6 @@ namespace Paramore.Brighter
     /// </summary>
     public interface IAmAnExternalBusService : IDisposable
     {
-
-        /// <summary>
-        /// Archive Message from the outbox to the outbox archive provider
-        /// </summary>
-        /// <param name="dispatchedSince">Minimum age</param>
-        /// <param name="requestContext">What is the context for this request; used to access the Span</param>        
-        void Archive(TimeSpan dispatchedSince, RequestContext requestContext);
-
-        /// <summary>
-        /// Archive Message from the outbox to the outbox archive provider
-        /// </summary>
-        /// <param name="dispatchedSince">How stale is the message that we want to archive</param>
-        /// <param name="requestContext">The context for the request pipeline; gives us the OTel span for example</param>
-        /// <param name="cancellationToken">The Cancellation Token</param>
-        Task ArchiveAsync(TimeSpan dispatchedSince, RequestContext requestContext, CancellationToken cancellationToken);
-        
         /// <summary>
         /// Used with RPC to call a remote service via the external bus
         /// </summary>

--- a/src/Paramore.Brighter/IAmAnOutboxProducerMediator.cs
+++ b/src/Paramore.Brighter/IAmAnOutboxProducerMediator.cs
@@ -9,7 +9,7 @@ namespace Paramore.Brighter
     /// An external bus service allows us to send messages to external systems
     /// The interaction with the CommandProcessor is mostly via the Outbox and the Message Mapper
     /// </summary>
-    public interface IAmAnExternalBusService : IDisposable
+    public interface IAmAnOutboxProducerMediator : IDisposable
     {
         /// <summary>
         /// Used with RPC to call a remote service via the external bus
@@ -103,7 +103,7 @@ namespace Paramore.Brighter
     /// An external bus service allows us to send messages to external systems
     /// The interaction with the CommandProcessor is mostly via the Outbox and the Message Mapper
     /// </summary>
-    public interface IAmAnExternalBusService<TMessage, TTransaction> : IDisposable
+    public interface IAmAnOutboxProducerMediator<TMessage, TTransaction> : IDisposable
     {
         /// <summary>
         /// Adds a message to the outbox

--- a/src/Paramore.Brighter/InMemoryOutbox.cs
+++ b/src/Paramore.Brighter/InMemoryOutbox.cs
@@ -283,8 +283,8 @@ namespace Paramore.Brighter
         {
             ClearExpiredMessages();
 
-            var age =
-                _timeProvider.GetUtcNow() - dispatchedSince;
+            var now = _timeProvider.GetUtcNow();
+            var age = now - dispatchedSince;
             return Requests.Values
                 .Where(oe => (oe.TimeFlushed != DateTimeOffset.MinValue) && (oe.TimeFlushed <= age))
                 .Take(pageSize)
@@ -439,7 +439,7 @@ namespace Paramore.Brighter
 
             if (Requests.TryGetValue(id, out OutboxEntry? entry))
             {
-                entry.TimeFlushed = dispatchedAt ?? _timeProvider.GetUtcNow().DateTime;
+                entry.TimeFlushed = dispatchedAt ?? _timeProvider.GetUtcNow();
             }
         }
 

--- a/src/Paramore.Brighter/MessageMapperRegistry.cs
+++ b/src/Paramore.Brighter/MessageMapperRegistry.cs
@@ -23,9 +23,7 @@ THE SOFTWARE. */
 #endregion
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Paramore.Brighter
 {
@@ -38,7 +36,7 @@ namespace Paramore.Brighter
     /// </summary>
     public class MessageMapperRegistry : IAmAMessageMapperRegistry, IAmAMessageMapperRegistryAsync 
     {
-        private readonly IAmAMessageMapperFactory _messageMapperFactory;
+        private readonly IAmAMessageMapperFactory? _messageMapperFactory;
         private readonly IAmAMessageMapperFactoryAsync? _messageMapperFactoryAsync;
         private readonly Dictionary<Type, Type> _messageMappers = new Dictionary<Type, Type>();
         private readonly Dictionary<Type, Type> _asyncMessageMappers = new Dictionary<Type, Type>();
@@ -48,7 +46,7 @@ namespace Paramore.Brighter
         /// </summary>
         /// <param name="messageMapperFactory">The message mapper factory.</param>
         /// <param name="messageMapperFactoryAsync">The async message mapper factory</param>
-        public MessageMapperRegistry(IAmAMessageMapperFactory messageMapperFactory, IAmAMessageMapperFactoryAsync? messageMapperFactoryAsync)
+        public MessageMapperRegistry(IAmAMessageMapperFactory? messageMapperFactory, IAmAMessageMapperFactoryAsync? messageMapperFactoryAsync)
         {
             _messageMapperFactory = messageMapperFactory;
             _messageMapperFactoryAsync = messageMapperFactoryAsync;
@@ -64,7 +62,7 @@ namespace Paramore.Brighter
         /// <returns>IAmAMessageMapper&lt;TRequest&gt;.</returns>
         public IAmAMessageMapper<TRequest>? Get<TRequest>() where TRequest : class, IRequest
         {
-            if (_messageMappers.ContainsKey(typeof(TRequest)))
+            if ( _messageMapperFactory is not null && _messageMappers.ContainsKey(typeof(TRequest)))
             {
                 var messageMapperType = _messageMappers[typeof(TRequest)];
                 return (IAmAMessageMapper<TRequest>)_messageMapperFactory.Create(messageMapperType);

--- a/src/Paramore.Brighter/Observability/BrighterSemanticConventions.cs
+++ b/src/Paramore.Brighter/Observability/BrighterSemanticConventions.cs
@@ -29,6 +29,7 @@ namespace Paramore.Brighter.Observability;
 /// </summary>
 public static class BrighterSemanticConventions
 {
+    public const string ArchiveAge = "paramore.brighter.archive_age_in_milliseconds"; 
     public const string ArchiveMessages = "paramore.brighter.archive_messages";
     public const string CeSource = "cloudevents.event_source";
     public const string CeMessageId = "cloudevents.event_id";

--- a/src/Paramore.Brighter/Observability/BrighterSemanticConventions.cs
+++ b/src/Paramore.Brighter/Observability/BrighterSemanticConventions.cs
@@ -29,6 +29,7 @@ namespace Paramore.Brighter.Observability;
 /// </summary>
 public static class BrighterSemanticConventions
 {
+    public const string ArchiveMessages = "paramore.brighter.archive_messages";
     public const string CeSource = "cloudevents.event_source";
     public const string CeMessageId = "cloudevents.event_id";
     public const string CeVersion = "cloudevents.event_spec_version";

--- a/src/Paramore.Brighter/Observability/BrighterSpanExtensions.cs
+++ b/src/Paramore.Brighter/Observability/BrighterSpanExtensions.cs
@@ -41,6 +41,7 @@ public static class BrighterSpanExtensions
        CommandProcessorSpanOperation.Publish => "publish",
        CommandProcessorSpanOperation.Send => "send",
        CommandProcessorSpanOperation.Clear => "clear",
+       CommandProcessorSpanOperation.Archive => "archive",
        _ => throw new ArgumentOutOfRangeException(nameof(operation), operation, null)
    };
 

--- a/src/Paramore.Brighter/Observability/BrighterTracer.cs
+++ b/src/Paramore.Brighter/Observability/BrighterTracer.cs
@@ -286,9 +286,15 @@ public class BrighterTracer : IAmABrighterTracer
         return activity;
     }
     
+    /// <summary>
+    /// Creates a span for an archive operation. Because a sweeper may not create an externa bus, but just use the archiver directly, we
+    /// check for this existing and then recreate directly in the archive provider if it does not exist
+    /// </summary>
+    /// <param name="parentActivity">A parent activity that called this one</param>
+    /// <param name="options">The <see cref="InstrumentationOptions"/> for how deep should the instrumentation go?</param>
+    /// <returns></returns>
     public Activity? CreateArchiveSpan(
         Activity? parentActivity,
-        string? messageId = null,
         InstrumentationOptions options = InstrumentationOptions.All)
     {
         var spanName = $"{BrighterSemanticConventions.ArchiveMessages} {CommandProcessorSpanOperation.Archive.ToSpanName()}";

--- a/src/Paramore.Brighter/Observability/BrighterTracer.cs
+++ b/src/Paramore.Brighter/Observability/BrighterTracer.cs
@@ -67,6 +67,31 @@ public class BrighterTracer : IAmABrighterTracer
     }
 
     /// <summary>
+    /// If an activity has an exception, then we should record it on the span
+    /// </summary>
+    /// <param name="span"></param>
+    /// <param name="exceptions"></param>
+    public void AddExceptionToSpan(Activity? span, IEnumerable<Exception> exceptions)
+    {
+        if (span == null ) return;
+
+        var exceptionList = exceptions.ToArray();
+        
+        if (exceptionList.Length == 0) return;
+        
+        if (exceptionList .Length == 1)
+        {
+            span.RecordException(exceptionList[0]);
+            span.SetStatus(ActivityStatusCode.Error, exceptionList[0].Message);
+            return;
+        }
+
+        var exception = new  AggregateException("Operation failed, see inner exceptions for details",  exceptionList); 
+        span.RecordException(exception);
+        span.SetStatus(ActivityStatusCode.Error, exception.Message);
+    }
+
+    /// <summary>
     /// Create a span for a request in CommandProcessor
     /// </summary>
     /// <param name="operation">The <see cref="CommandProcessorSpanOperation"/> that tells us what type of span are we creating</param>

--- a/src/Paramore.Brighter/Observability/BrighterTracer.cs
+++ b/src/Paramore.Brighter/Observability/BrighterTracer.cs
@@ -285,6 +285,27 @@ public class BrighterTracer : IAmABrighterTracer
 
         return activity;
     }
+    
+    public Activity? CreateArchiveSpan(
+        Activity? parentActivity,
+        string? messageId = null,
+        InstrumentationOptions options = InstrumentationOptions.All)
+    {
+        var spanName = $"{BrighterSemanticConventions.ArchiveMessages} {CommandProcessorSpanOperation.Archive.ToSpanName()}";
+        var kind = ActivityKind.Producer;
+        var parentId = parentActivity?.Id;
+        var now = _timeProvider.GetUtcNow();  
+        
+        var activity = ActivitySource.StartActivity(
+            name: spanName,
+            kind: kind,
+            parentId: parentId,
+            startTime: now);
+        
+        Activity.Current = activity;
+
+        return activity;
+    }
 
     /// <summary>
     /// Create a span for a batch of messages to be cleared  

--- a/src/Paramore.Brighter/Observability/CommandProcessorSpanOperation.cs
+++ b/src/Paramore.Brighter/Observability/CommandProcessorSpanOperation.cs
@@ -33,5 +33,6 @@ public enum CommandProcessorSpanOperation
     Create = 1,     // A batch operation, such as publishing an event or clearing a message
     Publish = 2,    // Publish an event
     Deposit = 3,    // Deposit a message in the outbox
-    Clear = 4       // Clear a message from the outbox
+    Clear = 4,      // Clear a message from the outbox
+    Archive = 5     //Archive a message from the outbox
 }

--- a/src/Paramore.Brighter/Observability/IAmABrighterTracer.cs
+++ b/src/Paramore.Brighter/Observability/IAmABrighterTracer.cs
@@ -25,6 +25,7 @@ THE SOFTWARE. */
 
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace Paramore.Brighter.Observability;
@@ -184,4 +185,11 @@ public interface IAmABrighterTracer : IDisposable
     /// </summary>
     /// <param name="handlerSpans"></param>
     void LinkSpans(ConcurrentDictionary<string, Activity> handlerSpans);
+
+    /// <summary>
+    /// If an activity has an exception, then we should record it on the span
+    /// </summary>
+    /// <param name="span"></param>
+    /// <param name="exceptions"></param>
+    void AddExceptionToSpan(Activity? span, IEnumerable<Exception> exceptions);
 }

--- a/src/Paramore.Brighter/Observability/IAmABrighterTracer.cs
+++ b/src/Paramore.Brighter/Observability/IAmABrighterTracer.cs
@@ -25,7 +25,6 @@ THE SOFTWARE. */
 
 using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace Paramore.Brighter.Observability;
@@ -74,15 +73,18 @@ public interface IAmABrighterTracer : IDisposable
     /// check for this existing and then recreate directly in the archive provider if it does not exist
     /// </summary>
     /// <param name="parentActivity">A parent activity that called this one</param>
+    /// <param name="dispatchedSince">The minimum age of a row to be archived</param>
     /// <param name="options">The <see cref="InstrumentationOptions"/> for how deep should the instrumentation go?</param>
     /// <returns></returns>
-    Activity? CreateArchiveSpan(Activity? parentActivity, InstrumentationOptions options = InstrumentationOptions.All);
+    Activity? CreateArchiveSpan(
+        Activity? parentActivity, 
+        TimeSpan dispatchedSince, 
+        InstrumentationOptions options = InstrumentationOptions.All
+        );
     
     /// <summary>
     /// Create a span for a request in CommandProcessor
     /// </summary>
-    /// <param name="operation">What type of span are we creating</param>
-    /// <param name="request">What is the request that we are tracking with this span</param>
     /// <param name="parentActivity">The parent activity, if any, that we should assign to this span</param>
     /// <param name="links">Are there links to other spans that we should add to this span</param>
     /// <param name="options">How deep should the instrumentation go?</param>
@@ -96,12 +98,11 @@ public interface IAmABrighterTracer : IDisposable
     /// <summary>
     /// The parent span for the message pump. This is the entry point for the message pump
     /// </summary>
-    /// <param name="operation">The <see cref="MessagePumpSpanOperation"/>. This should be Begin or End</param></param>
+    /// <param name="operation">The <see cref="MessagePumpSpanOperation"/>. This should be Begin or End</param>
     /// <param name="topic">The <see cref="RoutingKey"/> for this span</param>
     /// <param name="messagingSystem">The <see cref="MessagingSystem"/> that we are receiving from</param>
     /// <param name="options">The <see cref="InstrumentationOptions"/> for how deep should the instrumentation go?</param>
     /// <returns>A span (or dotnet Activity) for the current request named request.name operation.name</returns>
-    /// <param name="options">How deep should the instrumentation go?</param>
     Activity? CreateMessagePumpSpan(
         MessagePumpSpanOperation operation,
         RoutingKey topic,

--- a/src/Paramore.Brighter/Observability/IAmABrighterTracer.cs
+++ b/src/Paramore.Brighter/Observability/IAmABrighterTracer.cs
@@ -70,6 +70,15 @@ public interface IAmABrighterTracer : IDisposable
     ) where TRequest : class, IRequest;
     
     /// <summary>
+    /// Creates a span for an archive operation. Because a sweeper may not create an externa bus, but just use the archiver directly, we
+    /// check for this existing and then recreate directly in the archive provider if it does not exist
+    /// </summary>
+    /// <param name="parentActivity">A parent activity that called this one</param>
+    /// <param name="options">The <see cref="InstrumentationOptions"/> for how deep should the instrumentation go?</param>
+    /// <returns></returns>
+    Activity? CreateArchiveSpan(Activity? parentActivity, InstrumentationOptions options = InstrumentationOptions.All);
+    
+    /// <summary>
     /// Create a span for a request in CommandProcessor
     /// </summary>
     /// <param name="operation">What type of span are we creating</param>
@@ -83,6 +92,21 @@ public interface IAmABrighterTracer : IDisposable
         ActivityLink[]? links = null, 
         InstrumentationOptions options = InstrumentationOptions.All
     ) where TRequest : class, IRequest;
+    
+    /// <summary>
+    /// The parent span for the message pump. This is the entry point for the message pump
+    /// </summary>
+    /// <param name="operation">The <see cref="MessagePumpSpanOperation"/>. This should be Begin or End</param></param>
+    /// <param name="topic">The <see cref="RoutingKey"/> for this span</param>
+    /// <param name="messagingSystem">The <see cref="MessagingSystem"/> that we are receiving from</param>
+    /// <param name="options">The <see cref="InstrumentationOptions"/> for how deep should the instrumentation go?</param>
+    /// <returns>A span (or dotnet Activity) for the current request named request.name operation.name</returns>
+    /// <param name="options">How deep should the instrumentation go?</param>
+    Activity? CreateMessagePumpSpan(
+        MessagePumpSpanOperation operation,
+        RoutingKey topic,
+        MessagingSystem messagingSystem,
+        InstrumentationOptions options = InstrumentationOptions.All);
 
     /// <param name="messagePumpException"></param>
     /// <param name="topic">The <see cref="RoutingKey"/> for this span</param>
@@ -159,18 +183,4 @@ public interface IAmABrighterTracer : IDisposable
     /// </summary>
     /// <param name="handlerSpans"></param>
     void LinkSpans(ConcurrentDictionary<string, Activity> handlerSpans);
-
-    /// <summary>
-    /// The parent span for the message pump. This is the entry point for the message pump
-    /// </summary>
-    /// <param name="operation">The <see cref="MessagePumpSpanOperation"/>. This should be Begin or End</param></param>
-    /// <param name="topic">The <see cref="RoutingKey"/> for this span</param>
-    /// <param name="messagingSystem">The <see cref="MessagingSystem"/> that we are receiving from</param>
-    /// <param name="options">The <see cref="InstrumentationOptions"/> for how deep should the instrumentation go?</param>
-    /// <returns>A span (or dotnet Activity) for the current request named request.name operation.name</returns>
-    Activity? CreateMessagePumpSpan(
-        MessagePumpSpanOperation operation,
-        RoutingKey topic,
-        MessagingSystem messagingSystem,
-        InstrumentationOptions instrumentationOptions = InstrumentationOptions.All);
 }

--- a/src/Paramore.Brighter/OutboxArchiver.cs
+++ b/src/Paramore.Brighter/OutboxArchiver.cs
@@ -55,27 +55,11 @@ namespace Paramore.Brighter
         /// that these are transient errors which can be retried
         /// </summary>
         /// <param name="dispatchedSince">How stale is the message that we want archive</param>
-        public void Archive(TimeSpan dispatchedSince)
+        /// <param name="requestContext">The context for the request pipeline; gives us the OTel span for example</param>
+         public void Archive(TimeSpan dispatchedSince, RequestContext? requestContext = null)
         {
-#pragma warning disable CS0618 // Type or member is obsolete
-            var activity = ApplicationTelemetry.ActivitySource.StartActivity(ARCHIVE_OUTBOX, ActivityKind.Server);
-#pragma warning restore CS0618 // Type or member is obsolete
-            var requestContext = _requestContextFactory.Create();
-            requestContext.Span = activity;
-            
-            try
-            {
-                bus.Archive(dispatchedSince, requestContext);  
-            }
-            catch (Exception e)
-            {
-                activity?.SetStatus(ActivityStatusCode.Error, e.Message);
-            }
-            finally
-            {
-                if(activity?.DisplayName == ARCHIVE_OUTBOX)
-                    activity.Dispose();
-            }
+            requestContext = requestContext ?? _requestContextFactory.Create();
+             bus.Archive(dispatchedSince, requestContext);  
         }
 
         /// <summary>
@@ -86,26 +70,10 @@ namespace Paramore.Brighter
         /// <param name="dispatchedSince">How stale is the message that</param>
         /// <param name="requestContext">The context for the request pipeline; gives us the OTel span for example</param>
         /// <param name="cancellationToken">The Cancellation Token</param>
-        public async Task ArchiveAsync(TimeSpan dispatchedSince, RequestContext requestContext, CancellationToken cancellationToken)
+        public async Task ArchiveAsync(TimeSpan dispatchedSince, RequestContext? requestContext = null, CancellationToken cancellationToken = default)
         {
-#pragma warning disable CS0618 // Type or member is obsolete
-            var activity = ApplicationTelemetry.ActivitySource.StartActivity(ARCHIVE_OUTBOX, ActivityKind.Server);
-#pragma warning restore CS0618 // Type or member is obsolete
-            requestContext.Span = activity;
-            
-            try
-            {
-                await bus.ArchiveAsync(dispatchedSince, requestContext, cancellationToken);
-            }
-            catch (Exception e)
-            {
-                activity?.SetStatus(ActivityStatusCode.Error, e.Message);
-            }
-            finally
-            {
-                if(activity?.DisplayName == ARCHIVE_OUTBOX)
-                    activity.Dispose();
-            }
+            requestContext = requestContext ?? _requestContextFactory.Create();
+            await bus.ArchiveAsync(dispatchedSince, requestContext, cancellationToken);
         }
     }
 }

--- a/src/Paramore.Brighter/OutboxArchiver.cs
+++ b/src/Paramore.Brighter/OutboxArchiver.cs
@@ -23,12 +23,8 @@ THE SOFTWARE. */
 #endregion
 
 using System;
-using System.Diagnostics;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Logging;
-using Paramore.Brighter.Logging;
 
 namespace Paramore.Brighter
 {
@@ -42,12 +38,7 @@ namespace Paramore.Brighter
         IAmARequestContextFactory? requestContextFactory = null)
         where TMessage : Message
     {
-        private const string ARCHIVE_OUTBOX = "Archive Outbox";
-        
-        private readonly ILogger _logger = ApplicationLogging.CreateLogger<OutboxArchiver<TMessage, TTransaction>>();
         private readonly IAmARequestContextFactory _requestContextFactory = requestContextFactory ?? new InMemoryRequestContextFactory();
-
-        private const string SUCCESS_MESSAGE = "Successfully archiver {NumberOfMessageArchived} out of {MessagesToArchive}, batch size : {BatchSize}";
 
         /// <summary>
         /// Archive Message from the outbox to the outbox archive provider
@@ -58,7 +49,7 @@ namespace Paramore.Brighter
         /// <param name="requestContext">The context for the request pipeline; gives us the OTel span for example</param>
          public void Archive(TimeSpan dispatchedSince, RequestContext? requestContext = null)
         {
-            requestContext = requestContext ?? _requestContextFactory.Create();
+            requestContext ??= _requestContextFactory.Create();
              bus.Archive(dispatchedSince, requestContext);  
         }
 
@@ -72,7 +63,7 @@ namespace Paramore.Brighter
         /// <param name="cancellationToken">The Cancellation Token</param>
         public async Task ArchiveAsync(TimeSpan dispatchedSince, RequestContext? requestContext = null, CancellationToken cancellationToken = default)
         {
-            requestContext = requestContext ?? _requestContextFactory.Create();
+            requestContext ??= _requestContextFactory.Create();
             await bus.ArchiveAsync(dispatchedSince, requestContext, cancellationToken);
         }
     }

--- a/tests/Paramore.Brighter.Core.Tests/Archiving/When_Archiving_Old_Messages_From_The_Outbox.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Archiving/When_Archiving_Old_Messages_From_The_Outbox.cs
@@ -3,10 +3,7 @@ using System.Collections.Generic;
 using System.Transactions;
 using FluentAssertions;
 using Microsoft.Extensions.Time.Testing;
-using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
 using Paramore.Brighter.Observability;
-using Polly;
-using Polly.Registry;
 using Xunit;
 
 namespace Paramore.Brighter.Core.Tests.Archiving;
@@ -15,52 +12,23 @@ public class ServiceBusMessageStoreArchiverTests
 {
     private readonly InMemoryOutbox _outbox;
     private readonly InMemoryArchiveProvider _archiveProvider;
-    private readonly ExternalBusService<Message,CommittableTransaction> _bus;
     private readonly FakeTimeProvider _timeProvider;
     private readonly RoutingKey _routingKey = new("MyTopic");
+    private readonly OutboxArchiver<Message,CommittableTransaction> _archiver;
 
     public ServiceBusMessageStoreArchiverTests()
     {
         _timeProvider = new FakeTimeProvider();
-        var producer = new InMemoryProducer(new InternalBus(), _timeProvider){Publication = {Topic = _routingKey, RequestType = typeof(MyCommand)}};
 
-        var messageMapperRegistry = new MessageMapperRegistry(
-            new SimpleMessageMapperFactory((_) => new MyCommandMessageMapper()),
-            null);
-
-        var retryPolicy = Policy
-            .Handle<Exception>()
-            .Retry();
-
-        var circuitBreakerPolicy = Policy
-            .Handle<Exception>()
-            .CircuitBreaker(1, TimeSpan.FromMilliseconds(1));
-
-        var producerRegistry = new ProducerRegistry(new Dictionary<RoutingKey, IAmAMessageProducer>
-        {
-            { _routingKey, producer },
-        });
-
-        var policyRegistry = new PolicyRegistry
-        {
-            { CommandProcessor.RETRYPOLICY, retryPolicy },
-            { CommandProcessor.CIRCUITBREAKER, circuitBreakerPolicy }
-        }; 
-        
         var tracer = new BrighterTracer();
         _outbox = new InMemoryOutbox(_timeProvider){Tracer = tracer};
         _archiveProvider = new InMemoryArchiveProvider();
-        
-        _bus = new ExternalBusService<Message, CommittableTransaction>(
-            producerRegistry, 
-            policyRegistry,
-            messageMapperRegistry,
-            new EmptyMessageTransformerFactory(),
-            new EmptyMessageTransformerFactoryAsync(),
-            tracer,
+
+        _archiver = new OutboxArchiver<Message, CommittableTransaction>(
             _outbox,
-            _archiveProvider 
-        ); 
+            _archiveProvider
+        );
+
     }
     
     [Fact]
@@ -86,7 +54,7 @@ public class ServiceBusMessageStoreArchiverTests
         
        _timeProvider.Advance(TimeSpan.FromMinutes(15)); 
        
-        _bus.Archive(TimeSpan.FromMilliseconds(500), context);
+        _archiver.Archive(TimeSpan.FromMilliseconds(500), context);
         
         //assert
         _outbox.EntryCount.Should().Be(0);
@@ -116,7 +84,7 @@ public class ServiceBusMessageStoreArchiverTests
         
         _timeProvider.Advance(TimeSpan.FromSeconds(30));
         
-        _bus.Archive(TimeSpan.FromSeconds(30), context);
+        _archiver.Archive(TimeSpan.FromSeconds(30), context);
         
         //assert
         _outbox.EntryCount.Should().Be(1);
@@ -142,7 +110,7 @@ public class ServiceBusMessageStoreArchiverTests
         //act
         _outbox.EntryCount.Should().Be(3);
         
-        _bus.Archive(TimeSpan.FromMilliseconds(20000), context);
+        _archiver.Archive(TimeSpan.FromMilliseconds(20000), context);
         
         //assert
         _outbox.EntryCount.Should().Be(3);
@@ -155,7 +123,7 @@ public class ServiceBusMessageStoreArchiverTests
     public void When_Archiving_An_Empty_The_Outbox()
     {
         var context = new RequestContext();
-        _bus.Archive(TimeSpan.FromMilliseconds(20000), context);
+        _archiver.Archive(TimeSpan.FromMilliseconds(20000), context);
         
         //assert
         _outbox.EntryCount.Should().Be(0);

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Call/When_Calling_A_Server_Via_The_Command_Processor.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Call/When_Calling_A_Server_Via_The_Command_Processor.cs
@@ -76,7 +76,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.Call
                 });
 
             var tracer = new BrighterTracer();
-            IAmAnExternalBusService bus = new ExternalBusService<Message, CommittableTransaction>(
+            IAmAnOutboxProducerMediator bus = new OutboxProducerMediator<Message, CommittableTransaction>(
                 producerRegistry, 
                 policyRegistry,           
                 _messageMapperRegistry,

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Call/When_Calling_A_Server_Via_The_Command_Processor_With_No_In_Mapper.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Call/When_Calling_A_Server_Via_The_Command_Processor_With_No_In_Mapper.cs
@@ -63,7 +63,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.Call
 
             var tracer = new BrighterTracer();
             
-            IAmAnExternalBusService bus = new ExternalBusService<Message, CommittableTransaction>(
+            IAmAnOutboxProducerMediator bus = new OutboxProducerMediator<Message, CommittableTransaction>(
                 producerRegistry, 
                 policyRegistry, 
                 messageMapperRegistry,

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Call/When_Calling_A_Server_Via_The_Command_Processor_With_No_In_Mapper.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Call/When_Calling_A_Server_Via_The_Command_Processor_With_No_In_Mapper.cs
@@ -93,7 +93,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.Call
             var exception = Catch.Exception(() => _commandProcessor.Call<MyRequest, MyResponse>(_myRequest, new RequestContext(), TimeSpan.FromMilliseconds(500)));
             
             //should throw an exception as we require a mapper for the outgoing request 
-            exception.Should().BeOfType<ArgumentOutOfRangeException>();
+            exception.Should().BeOfType<InvalidOperationException>();
         }
 
         public void Dispose()

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Call/When_Calling_A_Server_Via_The_Command_Processor_With_No_Out_Mapper.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Call/When_Calling_A_Server_Via_The_Command_Processor_With_No_Out_Mapper.cs
@@ -62,7 +62,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.Call
             });
 
             var tracer = new BrighterTracer(timeProvider);
-            IAmAnExternalBusService bus = new ExternalBusService<Message, CommittableTransaction>(
+            IAmAnOutboxProducerMediator bus = new OutboxProducerMediator<Message, CommittableTransaction>(
                 producerRegistry, 
                 policyRegistry,
                 messageMapperRegistry,

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Call/When_Calling_A_Server_Via_The_Command_Processor_With_No_Timeout.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Call/When_Calling_A_Server_Via_The_Command_Processor_With_No_Timeout.cs
@@ -74,7 +74,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.Call
 
             var timeProvider = fakeTimeProvider;
             var tracer = new BrighterTracer(timeProvider);
-            IAmAnExternalBusService bus = new ExternalBusService<Message, CommittableTransaction>(
+            IAmAnOutboxProducerMediator bus = new OutboxProducerMediator<Message, CommittableTransaction>(
                 producerRegistry, 
                 policyRegistry, 
                 messageMapperRegistry,

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Clear/When_Bulk_Clearing_The_PostBox_On_The_Command_Processor_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Clear/When_Bulk_Clearing_The_PostBox_On_The_Command_Processor_Async.cs
@@ -101,7 +101,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.Clear
             var tracer = new BrighterTracer();
             _outbox = new InMemoryOutbox(timeProvider) {Tracer = tracer};
 
-            IAmAnExternalBusService bus = new ExternalBusService<Message, CommittableTransaction>(
+            IAmAnOutboxProducerMediator bus = new OutboxProducerMediator<Message, CommittableTransaction>(
                 producerRegistry, 
                 policyRegistry, 
                 messageMapperRegistry,

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Clear/When_Clearing_The_PostBox_On_The_Command_Processor _Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Clear/When_Clearing_The_PostBox_On_The_Command_Processor _Async.cs
@@ -87,7 +87,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.Clear
             var tracer = new BrighterTracer(timeProvider);
             _outbox = new InMemoryOutbox(timeProvider) {Tracer = tracer};
             
-            IAmAnExternalBusService bus = new ExternalBusService<Message, CommittableTransaction>(
+            IAmAnOutboxProducerMediator bus = new OutboxProducerMediator<Message, CommittableTransaction>(
                 producerRegistry, 
                 policyRegistry,                     
                 messageMapperRegistry,

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Clear/When_Clearing_The_PostBox_On_The_Command_Processor.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Clear/When_Clearing_The_PostBox_On_The_Command_Processor.cs
@@ -86,7 +86,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.Clear
             var tracer = new BrighterTracer(timeProvider);
             _outbox = new InMemoryOutbox(timeProvider) {Tracer = tracer};
             
-            IAmAnExternalBusService bus = new ExternalBusService<Message, CommittableTransaction>(
+            IAmAnOutboxProducerMediator bus = new OutboxProducerMediator<Message, CommittableTransaction>(
                 producerRegistry, 
                 policyRegistry, 
                 messageMapperRegistry,

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Clear/When_Implicit_Clearing_The_PostBox_On_The_Command_Processor.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Clear/When_Implicit_Clearing_The_PostBox_On_The_Command_Processor.cs
@@ -95,7 +95,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.Clear
             var tracer = new BrighterTracer();
             _outbox = new InMemoryOutbox(timeProvider){Tracer = tracer};
             
-            IAmAnExternalBusService bus = new ExternalBusService<Message, CommittableTransaction>(
+            IAmAnOutboxProducerMediator bus = new OutboxProducerMediator<Message, CommittableTransaction>(
                 producerRegistry, 
                 policyRegistry, 
                 messageMapperRegistry,

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Clear/When_Implicit_Clearing_The_PostBox_On_The_Command_Processor_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Clear/When_Implicit_Clearing_The_PostBox_On_The_Command_Processor_Async.cs
@@ -95,7 +95,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.Clear
             
             _outbox = new InMemoryOutbox(timeProvider);
             
-            IAmAnExternalBusService bus = new ExternalBusService<Message, CommittableTransaction>(
+            IAmAnOutboxProducerMediator bus = new OutboxProducerMediator<Message, CommittableTransaction>(
                 producerRegistry, 
                 policyRegistry,
                 messageMapperRegistry,

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Deposit/When_Depositing_A_Message_In_The_Message_Store.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Deposit/When_Depositing_A_Message_In_The_Message_Store.cs
@@ -67,7 +67,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.Deposit
             var tracer = new BrighterTracer();
             _fakeOutbox = new InMemoryOutbox(timeProvider) {Tracer = tracer};
             
-            IAmAnExternalBusService bus = new ExternalBusService<Message, CommittableTransaction>(
+            IAmAnOutboxProducerMediator bus = new OutboxProducerMediator<Message, CommittableTransaction>(
                 producerRegistry, 
                 policyRegistry,
                 messageMapperRegistry,

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Deposit/When_Depositing_A_Message_In_The_Message_StoreAsync.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Deposit/When_Depositing_A_Message_In_The_Message_StoreAsync.cs
@@ -69,7 +69,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.Deposit
             var tracer = new BrighterTracer();
             _outbox = new InMemoryOutbox(timeProvider) { Tracer = tracer };
             
-            IAmAnExternalBusService bus = new ExternalBusService<Message, CommittableTransaction>(
+            IAmAnOutboxProducerMediator bus = new OutboxProducerMediator<Message, CommittableTransaction>(
                 producerRegistry, 
                 policyRegistry, 
                 messageMapperRegistry,

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Deposit/When_Depositing_A_Message_In_The_Message_StoreAsync_Bulk.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Deposit/When_Depositing_A_Message_In_The_Message_StoreAsync_Bulk.cs
@@ -103,7 +103,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.Deposit
             var tracer = new BrighterTracer(new FakeTimeProvider());
             _outbox = new InMemoryOutbox(timeProvider) {Tracer = tracer};
             
-            IAmAnExternalBusService bus = new ExternalBusService<Message, CommittableTransaction>(
+            IAmAnOutboxProducerMediator bus = new OutboxProducerMediator<Message, CommittableTransaction>(
                 producerRegistry, 
                 policyRegistry,
                 messageMapperRegistry,

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Deposit/When_Depositing_A_Message_In_The_Message_Store_Bulk.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Deposit/When_Depositing_A_Message_In_The_Message_Store_Bulk.cs
@@ -99,7 +99,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.Deposit
             var tracer = new BrighterTracer();
             _outbox = new InMemoryOutbox(timeProvider) {Tracer = tracer};
             
-            IAmAnExternalBusService bus = new ExternalBusService<Message, CommittableTransaction>(
+            IAmAnOutboxProducerMediator bus = new OutboxProducerMediator<Message, CommittableTransaction>(
                 producerRegistry, 
                 policyRegistry,
                 messageMapperRegistry,

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Post/When_Posting_A_Message_And_There_Is_No_Message_Mapper_Registry.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Post/When_Posting_A_Message_And_There_Is_No_Message_Mapper_Registry.cs
@@ -80,7 +80,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.Post
             var tracer = new BrighterTracer(timeProvider);
             var outbox = new InMemoryOutbox(timeProvider) {Tracer = tracer};
 
-            IAmAnExternalBusService bus = new ExternalBusService<Message, CommittableTransaction>(
+            IAmAnOutboxProducerMediator bus = new OutboxProducerMediator<Message, CommittableTransaction>(
                 producerRegistry, 
                 policyRegistry,
                 messageMapperRegistry,

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Post/When_Posting_A_Message_And_There_Is_No_Message_Mapper_Registry_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Post/When_Posting_A_Message_And_There_Is_No_Message_Mapper_Registry_Async.cs
@@ -73,7 +73,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.Post
             var tracer = new BrighterTracer(timeProvider);
             var outbox = new InMemoryOutbox(timeProvider) {Tracer = tracer};
             
-            IAmAnExternalBusService bus = new ExternalBusService<Message, CommittableTransaction>(
+            IAmAnOutboxProducerMediator bus = new OutboxProducerMediator<Message, CommittableTransaction>(
                 producerRegistry, 
                 policyRegistry, 
                 messageMapperRegistry,

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Post/When_Posting_A_Message_And_There_Is_No_Message_Producer.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Post/When_Posting_A_Message_And_There_Is_No_Message_Producer.cs
@@ -75,7 +75,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.Post
         {                                             
             var policyRegistry = new PolicyRegistry { { CommandProcessor.RETRYPOLICY, _retryPolicy }, { CommandProcessor.CIRCUITBREAKER, _circuitBreakerPolicy } };
 
-            _exception = Catch.Exception(() => new ExternalBusService<Message, CommittableTransaction>(
+            _exception = Catch.Exception(() => new OutboxProducerMediator<Message, CommittableTransaction>(
                 null, 
                 policyRegistry,
                 _messageMapperRegistry,

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Post/When_Posting_A_Message_And_There_Is_No_Message_Transformer.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Post/When_Posting_A_Message_And_There_Is_No_Message_Transformer.cs
@@ -98,7 +98,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.Post
         [Fact]
         public void When_Creating_A_Command_Processor_Without_Message_Transformer()
         {                                             
-            _exception = Catch.Exception(() => new ExternalBusService<Message, CommittableTransaction>(
+            _exception = Catch.Exception(() => new OutboxProducerMediator<Message, CommittableTransaction>(
                 _producerRegistry, 
                 _policyRegistry,
                 _messageMapperRegistry,

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Post/When_Posting_A_Message_And_There_Is_No_Message_Transformer_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Post/When_Posting_A_Message_And_There_Is_No_Message_Transformer_Async.cs
@@ -89,7 +89,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.Post
         [Fact]
         public void When_Creating_A_Command_Processor_Without_Message_Transformer_Async()
         {                                             
-            _exception = Catch.Exception(() => new ExternalBusService<Message, CommittableTransaction>(
+            _exception = Catch.Exception(() => new OutboxProducerMediator<Message, CommittableTransaction>(
                 _producerRegistry, 
                 _policyRegistry,
                 _messageMapperRegistry,

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Post/When_Posting_A_Message_To_The_Command_Processor.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Post/When_Posting_A_Message_To_The_Command_Processor.cs
@@ -83,7 +83,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.Post
             var tracer = new BrighterTracer(timeProvider);
             _outbox = new InMemoryOutbox(timeProvider) {Tracer = tracer};
             
-            IAmAnExternalBusService bus = new ExternalBusService<Message, CommittableTransaction>(
+            IAmAnOutboxProducerMediator bus = new OutboxProducerMediator<Message, CommittableTransaction>(
                 producerRegistry, 
                 policyRegistry, 
                 messageMapperRegistry,

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Post/When_Posting_A_Message_To_The_Command_Processor_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Post/When_Posting_A_Message_To_The_Command_Processor_Async.cs
@@ -80,7 +80,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.Post
             var tracer = new BrighterTracer(timeProvider); 
             _outbox = new InMemoryOutbox(timeProvider) {Tracer = tracer};
             
-            IAmAnExternalBusService bus = new ExternalBusService<Message, CommittableTransaction>(
+            IAmAnOutboxProducerMediator bus = new OutboxProducerMediator<Message, CommittableTransaction>(
                 producerRegistry, 
                 policyRegistry, 
                 messageMapperRegistry,

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Post/When_Posting_Fails_Limit_Total_Writes_To_OutBox_In_Window.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Post/When_Posting_Fails_Limit_Total_Writes_To_OutBox_In_Window.cs
@@ -61,7 +61,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.Post
             var producerRegistry =
                 new ProducerRegistry(new Dictionary<RoutingKey, IAmAMessageProducer> { { routingKey, producer }, }); 
             
-            var externalBus = new ExternalBusService<Message, CommittableTransaction>(
+            var externalBus = new OutboxProducerMediator<Message, CommittableTransaction>(
                 producerRegistry: producerRegistry,
                 policyRegistry: new DefaultPolicy(),
                 mapperRegistry: messageMapperRegistry,

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Post/When_Posting_Via_A_Control_Bus_Sender.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Post/When_Posting_Via_A_Control_Bus_Sender.cs
@@ -81,7 +81,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.Post
             var tracer = new BrighterTracer(_timeProvider);
             _outbox = new InMemoryOutbox(_timeProvider) {Tracer = tracer};
             
-            IAmAnExternalBusService bus = new ExternalBusService<Message, CommittableTransaction>(
+            IAmAnOutboxProducerMediator bus = new OutboxProducerMediator<Message, CommittableTransaction>(
                 producerRegistry, 
                 policyRegistry, 
                 messageMapperRegistry,

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Post/When_Posting_Via_A_Control_Bus_Sender_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Post/When_Posting_Via_A_Control_Bus_Sender_Async.cs
@@ -78,7 +78,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.Post
 
             var producerRegistry = new ProducerRegistry(new Dictionary<RoutingKey, IAmAMessageProducer> {{_routingKey, producer},});
             var policyRegistry = new PolicyRegistry { { CommandProcessor.RETRYPOLICYASYNC, retryPolicy }, { CommandProcessor.CIRCUITBREAKERASYNC, circuitBreakerPolicy } };
-            IAmAnExternalBusService bus = new ExternalBusService<Message, CommittableTransaction>(
+            IAmAnOutboxProducerMediator bus = new OutboxProducerMediator<Message, CommittableTransaction>(
                 producerRegistry, 
                 policyRegistry, 
                 messageMapperRegistry,

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Post/When_Posting_With_A_Default_Policy.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Post/When_Posting_With_A_Default_Policy.cs
@@ -71,7 +71,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.Post
             var producerRegistry =
                 new ProducerRegistry(new Dictionary<RoutingKey, IAmAMessageProducer> { { _routingKey, producer }, });
 
-            var externalBus = new ExternalBusService<Message, CommittableTransaction>(
+            var externalBus = new OutboxProducerMediator<Message, CommittableTransaction>(
                 producerRegistry: producerRegistry,
                 policyRegistry: new DefaultPolicy(),
                 mapperRegistry: messageMapperRegistry,

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Post/When_Posting_With_An_In_Memory_Message_Store.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Post/When_Posting_With_An_In_Memory_Message_Store.cs
@@ -80,7 +80,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.Post
             var tracer = new BrighterTracer(timeProvider);
             _outbox = new InMemoryOutbox(timeProvider) {Tracer = tracer};
             
-            IAmAnExternalBusService bus = new ExternalBusService<Message, CommittableTransaction>(
+            IAmAnOutboxProducerMediator bus = new OutboxProducerMediator<Message, CommittableTransaction>(
                 producerRegistry, 
                 policyRegistry,
                 messageMapperRegistry,

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Post/When_Posting_With_An_In_Memory_Message_Store_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Post/When_Posting_With_An_In_Memory_Message_Store_Async.cs
@@ -81,7 +81,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.Post
 
             var policyRegistry = new PolicyRegistry { { CommandProcessor.RETRYPOLICYASYNC, retryPolicy }, { CommandProcessor.CIRCUITBREAKERASYNC, circuitBreakerPolicy } };
             var producerRegistry = new ProducerRegistry(new Dictionary<RoutingKey, IAmAMessageProducer> {{_routingKey, producer},});
-            IAmAnExternalBusService bus = new ExternalBusService<Message, CommittableTransaction>(
+            IAmAnOutboxProducerMediator bus = new OutboxProducerMediator<Message, CommittableTransaction>(
                 producerRegistry, 
                 policyRegistry, 
                 messageMapperRegistry,

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_A_Request_Context_Is_Provided.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_A_Request_Context_Is_Provided.cs
@@ -170,7 +170,7 @@ public class RequestContextPresentTests : IDisposable
         var tracer = new BrighterTracer(timeProvider);
         var fakeOutbox = new InMemoryOutbox(timeProvider) {Tracer = tracer};
         
-        var bus = new ExternalBusService<Message, CommittableTransaction>(
+        var bus = new OutboxProducerMediator<Message, CommittableTransaction>(
             producerRegistry, 
             _policyRegistry,
             messageMapperRegistry,
@@ -220,7 +220,7 @@ public class RequestContextPresentTests : IDisposable
         var tracer = new BrighterTracer(timeProvider);
         var fakeOutbox = new InMemoryOutbox(timeProvider) {Tracer = tracer};
         
-        var bus = new ExternalBusService<Message, CommittableTransaction>(
+        var bus = new OutboxProducerMediator<Message, CommittableTransaction>(
             producerRegistry, 
             _policyRegistry,
             messageMapperRegistry,
@@ -270,7 +270,7 @@ public class RequestContextPresentTests : IDisposable
         var tracer = new BrighterTracer(timeProvider);
         var fakeOutbox = new InMemoryOutbox(timeProvider) {Tracer = tracer};
         
-        var bus = new ExternalBusService<Message, CommittableTransaction>(
+        var bus = new OutboxProducerMediator<Message, CommittableTransaction>(
             producerRegistry, 
             _policyRegistry,
             messageMapperRegistry,
@@ -324,7 +324,7 @@ public class RequestContextPresentTests : IDisposable
         var tracer = new BrighterTracer(timeProvider);
         var fakeOutbox = new InMemoryOutbox(timeProvider);
         
-        var bus = new ExternalBusService<Message, CommittableTransaction>(
+        var bus = new OutboxProducerMediator<Message, CommittableTransaction>(
             producerRegistry, 
             _policyRegistry,
             messageMapperRegistry,

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_No_Request_Context_Is_Provided.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/When_No_Request_Context_Is_Provided.cs
@@ -141,7 +141,7 @@ public class RequestContextFromFactoryTests : IDisposable
         var tracer = new BrighterTracer();
         var fakeOutbox = new InMemoryOutbox(timeProvider) {Tracer = tracer};
         
-        var bus = new ExternalBusService<Message, CommittableTransaction>(
+        var bus = new OutboxProducerMediator<Message, CommittableTransaction>(
             producerRegistry, 
             _policyRegistry,
             messageMapperRegistry,
@@ -187,7 +187,7 @@ public class RequestContextFromFactoryTests : IDisposable
         var tracer = new BrighterTracer();
         var fakeOutbox = new InMemoryOutbox(timeProvider) {Tracer = tracer};
         
-        var bus = new ExternalBusService<Message, CommittableTransaction>(
+        var bus = new OutboxProducerMediator<Message, CommittableTransaction>(
             producerRegistry, 
             _policyRegistry,
             messageMapperRegistry,
@@ -234,7 +234,7 @@ public class RequestContextFromFactoryTests : IDisposable
         var tracer = new BrighterTracer();
         var fakeOutbox = new InMemoryOutbox(timeProvider) {Tracer = tracer};
         
-        var bus = new ExternalBusService<Message, CommittableTransaction>(
+        var bus = new OutboxProducerMediator<Message, CommittableTransaction>(
             producerRegistry, 
             _policyRegistry,
             messageMapperRegistry,
@@ -285,7 +285,7 @@ public class RequestContextFromFactoryTests : IDisposable
         var tracer = new BrighterTracer();
         var fakeOutbox = new InMemoryOutbox(timeProvider) {Tracer = tracer};
         
-        var bus = new ExternalBusService<Message, CommittableTransaction>(
+        var bus = new OutboxProducerMediator<Message, CommittableTransaction>(
             producerRegistry, 
             _policyRegistry,
             messageMapperRegistry,

--- a/tests/Paramore.Brighter.Core.Tests/Observability/Archive/When_archiving_from_the_outbox.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Observability/Archive/When_archiving_from_the_outbox.cs
@@ -115,7 +115,7 @@ public class ExternalServiceBusArchiveObservabilityTests
         _traceProvider.ForceFlush();
         
         //We should have exported matching activities
-        _exportedActivities.Count.Should().Be(5);
+        _exportedActivities.Count.Should().Be(6);
         
         _exportedActivities.Any(a => a.Source.Name == "Paramore.Brighter").Should().BeTrue();
         

--- a/tests/Paramore.Brighter.Core.Tests/Observability/Archive/When_archiving_from_the_outbox.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Observability/Archive/When_archiving_from_the_outbox.cs
@@ -19,7 +19,7 @@ namespace Paramore.Brighter.Core.Tests.Observability.Archive;
 public class ExternalServiceBusArchiveObservabilityTests
 {
     private readonly List<Activity> _exportedActivities = new();
-    private readonly ExternalBusService<Message,CommittableTransaction> _bus;
+    private readonly OutboxProducerMediator<Message,CommittableTransaction> _bus;
     private readonly Publication _publication;
     private readonly FakeTimeProvider _timeProvider;
     private RoutingKey _routingKey = new("MyEvent");
@@ -76,7 +76,7 @@ public class ExternalServiceBusArchiveObservabilityTests
 
         _archiver = new OutboxArchiver<Message, CommittableTransaction>(_outbox, archiveProvider, tracer: tracer);
 
-        _bus = new ExternalBusService<Message, CommittableTransaction>(
+        _bus = new OutboxProducerMediator<Message, CommittableTransaction>(
             producerRegistry,
             policyRegistry,
             messageMapperRegistry,

--- a/tests/Paramore.Brighter.Core.Tests/Observability/Archive/When_archiving_from_the_outbox.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Observability/Archive/When_archiving_from_the_outbox.cs
@@ -130,7 +130,7 @@ public class ExternalServiceBusArchiveObservabilityTests
         var osCheckActivity = _exportedActivities.SingleOrDefault(a =>
             a.DisplayName == $"{OutboxDbOperation.DispatchedMessages.ToSpanName()} {InMemoryAttributes.DbName} {InMemoryAttributes.DbTable}");
         osCheckActivity.Should().NotBeNull();
-        osCheckActivity.ParentId.Should().Be(createActivity.Id);
+        osCheckActivity?.ParentId.Should().Be(createActivity.Id);
 
         //check for delete messages span
         var deleteActivity = _exportedActivities.SingleOrDefault(a =>
@@ -140,5 +140,18 @@ public class ExternalServiceBusArchiveObservabilityTests
         
         //check the tags for the create span
         createActivity.TagObjects.Should().Contain(t => t.Key == BrighterSemanticConventions.ArchiveAge && Math.Abs(Convert.ToDouble(t.Value) - dispatchedSince.TotalMilliseconds) < TOLERANCE);
+        
+        //check the tags for the outstanding messages span
+        osCheckActivity?.Tags.Any(t => t.Key == BrighterSemanticConventions.DbOperation && t.Value == OutboxDbOperation.DispatchedMessages.ToSpanName()).Should().BeTrue();
+        osCheckActivity?.Tags.Any(t => t.Key == BrighterSemanticConventions.DbTable && t.Value == InMemoryAttributes.DbTable).Should().BeTrue();
+        osCheckActivity?.Tags.Any(t => t.Key == BrighterSemanticConventions.DbSystem && t.Value == DbSystem.Brighter.ToDbName()).Should().BeTrue();
+        osCheckActivity?.Tags.Any(t => t.Key == BrighterSemanticConventions.DbName && t.Value == InMemoryAttributes.DbName).Should().BeTrue();
+        
+        //check the tages for the delete messages span
+        deleteActivity?.Tags.Any(t => t.Key == BrighterSemanticConventions.DbOperation && t.Value == OutboxDbOperation.Delete.ToSpanName()).Should().BeTrue();
+        deleteActivity?.Tags.Any(t => t.Key == BrighterSemanticConventions.DbTable && t.Value == InMemoryAttributes.DbTable).Should().BeTrue();
+        deleteActivity?.Tags.Any(t => t.Key == BrighterSemanticConventions.DbSystem && t.Value == DbSystem.Brighter.ToDbName()).Should().BeTrue();
+        deleteActivity?.Tags.Any(t => t.Key == BrighterSemanticConventions.DbName && t.Value == InMemoryAttributes.DbName).Should().BeTrue();
+        
     }
 }

--- a/tests/Paramore.Brighter.Core.Tests/Observability/Archive/When_archiving_from_the_outbox.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Observability/Archive/When_archiving_from_the_outbox.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Transactions;
+using FluentAssertions;
+using Microsoft.Extensions.Time.Testing;
+using OpenTelemetry;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
+using Paramore.Brighter.Observability;
+using Polly;
+using Polly.Registry;
+using Xunit;
+
+namespace Paramore.Brighter.Core.Tests.Observability.Archive;
+
+public class ExternalServiceBusArchiveObservabilityTests
+{
+    private readonly List<Activity> _exportedActivities = new();
+    private readonly ExternalBusService<Message,CommittableTransaction> _bus;
+    private readonly Publication _publication;
+    private readonly FakeTimeProvider _timeProvider;
+    private RoutingKey _routingKey = new("MyEvent");
+    private readonly InMemoryOutbox _outbox;
+
+    public ExternalServiceBusArchiveObservabilityTests()
+    {
+        IAmABus internalBus = new InternalBus();
+        _timeProvider = new FakeTimeProvider();
+        var tracer = new BrighterTracer(_timeProvider);
+
+        var builder = Sdk.CreateTracerProviderBuilder();
+
+        var traceProvider = builder
+            .AddSource("Paramore.Brighter.Tests", "Paramore.Brighter")
+            .ConfigureResource(r => r.AddService("in-memory-tracer"))
+            .AddInMemoryExporter(_exportedActivities)
+            .Build();
+
+        Brighter.CommandProcessor.ClearServiceBus();
+
+        _publication = new Publication
+        {
+            Source = new Uri("http://localhost"),
+            RequestType = typeof(MyEvent),
+            Topic = _routingKey,
+            Type = nameof(MyEvent),
+        };
+
+        var producer = new InMemoryProducer(internalBus, _timeProvider)
+        {
+            Publication = _publication
+        };
+
+        var producerRegistry =
+            new ProducerRegistry(new Dictionary<RoutingKey, IAmAMessageProducer> { { _routingKey, producer } });
+
+        var retryPolicy = Policy
+            .Handle<Exception>()
+            .Retry();
+
+        var policyRegistry = new PolicyRegistry { { Brighter.CommandProcessor.RETRYPOLICY, retryPolicy } };
+
+        var messageMapperRegistry = new MessageMapperRegistry(
+            new SimpleMessageMapperFactory((_) => new MyEventMessageMapper()),
+            null);
+        messageMapperRegistry.Register<MyEvent, MyEventMessageMapper>();
+
+        _outbox = new InMemoryOutbox(_timeProvider) { Tracer = tracer };
+        var archiveProvider = new InMemoryArchiveProvider();
+
+        _bus = new ExternalBusService<Message, CommittableTransaction>(
+            producerRegistry,
+            policyRegistry,
+            messageMapperRegistry,
+            new EmptyMessageTransformerFactory(),
+            new EmptyMessageTransformerFactoryAsync(),
+            tracer,
+            _outbox,
+            archiveProvider,
+            timeProvider:_timeProvider);
+    }
+
+    [Fact]
+    public void When_archiving_from_the_outbox()
+    {
+        var context = new RequestContext();
+        
+        //add and clear message
+        var myEvent = new MyEvent();
+        var myMessage = new MyEventMessageMapper().MapToMessage(myEvent, _publication);
+        _bus.AddToOutbox(myMessage, context); 
+        _bus.ClearOutbox([myMessage.Id], context);
+        
+        //se should have an entry in the outbox
+        _outbox.EntryCount.Should().Be(1);
+        
+        //allow time to pass
+        _timeProvider.Advance(TimeSpan.FromSeconds(300)); 
+        
+        //archive
+        _bus.Archive(TimeSpan.FromSeconds(100), context);
+        
+        //should be no messages in the outbox
+        _outbox.EntryCount.Should().Be(0);
+        
+    }
+}

--- a/tests/Paramore.Brighter.Core.Tests/Observability/Archive/When_archiving_from_the_outbox_async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Observability/Archive/When_archiving_from_the_outbox_async.cs
@@ -21,7 +21,7 @@ namespace Paramore.Brighter.Core.Tests.Observability.Archive;
 public class AsyncExternalServiceBusArchiveObservabilityTests
 {
     private readonly List<Activity> _exportedActivities = new();
-    private readonly ExternalBusService<Message,CommittableTransaction> _bus;
+    private readonly OutboxProducerMediator<Message,CommittableTransaction> _bus;
     private readonly Publication _publication;
     private readonly FakeTimeProvider _timeProvider;
     private readonly RoutingKey _routingKey = new("MyEvent");
@@ -78,7 +78,7 @@ public class AsyncExternalServiceBusArchiveObservabilityTests
 
         _archiver = new OutboxArchiver<Message, CommittableTransaction>(_outbox, archiveProvider, tracer: tracer);
 
-        _bus = new ExternalBusService<Message, CommittableTransaction>(
+        _bus = new OutboxProducerMediator<Message, CommittableTransaction>(
             producerRegistry,
             policyRegistry,
             messageMapperRegistry,

--- a/tests/Paramore.Brighter.Core.Tests/Observability/Archive/When_archiving_from_the_outbox_async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Observability/Archive/When_archiving_from_the_outbox_async.cs
@@ -1,0 +1,159 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Transactions;
+using FluentAssertions;
+using Microsoft.Extensions.Time.Testing;
+using OpenTelemetry;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
+using Paramore.Brighter.Observability;
+using Polly;
+using Polly.Registry;
+using Xunit;
+// ReSharper disable ExplicitCallerInfoArgument
+
+namespace Paramore.Brighter.Core.Tests.Observability.Archive;
+
+public class AsyncExternalServiceBusArchiveObservabilityTests
+{
+    private readonly List<Activity> _exportedActivities = new();
+    private readonly ExternalBusService<Message,CommittableTransaction> _bus;
+    private readonly Publication _publication;
+    private readonly FakeTimeProvider _timeProvider;
+    private RoutingKey _routingKey = new("MyEvent");
+    private readonly InMemoryOutbox _outbox;
+    private readonly TracerProvider _traceProvider;
+    private const double TOLERANCE = 0.000000001;
+
+    public AsyncExternalServiceBusArchiveObservabilityTests()
+    {
+        IAmABus internalBus = new InternalBus();
+        _timeProvider = new FakeTimeProvider();
+        var tracer = new BrighterTracer(_timeProvider);
+
+        var builder = Sdk.CreateTracerProviderBuilder();
+
+        _traceProvider = builder
+            .AddSource("Paramore.Brighter.Tests", "Paramore.Brighter")
+            .ConfigureResource(r => r.AddService("in-memory-tracer"))
+            .AddInMemoryExporter(_exportedActivities)
+            .Build();
+
+        Brighter.CommandProcessor.ClearServiceBus();
+
+        _publication = new Publication
+        {
+            Source = new Uri("http://localhost"),
+            RequestType = typeof(MyEvent),
+            Topic = _routingKey,
+            Type = nameof(MyEvent),
+        };
+
+        var producer = new InMemoryProducer(internalBus, _timeProvider)
+        {
+            Publication = _publication
+        };
+
+        var producerRegistry =
+            new ProducerRegistry(new Dictionary<RoutingKey, IAmAMessageProducer> { { _routingKey, producer } });
+
+        var retryPolicy = Policy
+            .Handle<Exception>()
+            .RetryAsync();
+
+        var policyRegistry = new PolicyRegistry { { Brighter.CommandProcessor.RETRYPOLICYASYNC, retryPolicy } };
+
+        var messageMapperRegistry = new MessageMapperRegistry(
+            new SimpleMessageMapperFactory((_) => new MyEventMessageMapper()),
+            null);
+        messageMapperRegistry.Register<MyEvent, MyEventMessageMapper>();
+
+        _outbox = new InMemoryOutbox(_timeProvider) { Tracer = tracer };
+        var archiveProvider = new InMemoryArchiveProvider();
+
+        _bus = new ExternalBusService<Message, CommittableTransaction>(
+            producerRegistry,
+            policyRegistry,
+            messageMapperRegistry,
+            new EmptyMessageTransformerFactory(),
+            new EmptyMessageTransformerFactoryAsync(),
+            tracer,
+            _outbox,
+            archiveProvider,
+            timeProvider:_timeProvider);
+    }
+
+    [Fact]
+    public async Task When_archiving_from_the_outbox()
+    {
+        var parentActivity = new ActivitySource("Paramore.Brighter.Tests").StartActivity("BrighterTracerSpanTests");
+        
+        var context = new RequestContext();
+        context.Span = parentActivity;
+        
+        //add and clear message
+        var myEvent = new MyEvent();
+        var myMessage = new MyEventMessageMapper().MapToMessage(myEvent, _publication);
+        await _bus.AddToOutboxAsync(myMessage, context); 
+        await  _bus.ClearOutboxAsync([myMessage.Id], context);
+        
+        //se should have an entry in the outbox
+        _outbox.EntryCount.Should().Be(1);
+        
+        //allow time to pass
+        _timeProvider.Advance(TimeSpan.FromSeconds(300)); 
+        
+        //archive
+        var dispatchedSince = TimeSpan.FromSeconds(100);
+        await _bus.ArchiveAsync(dispatchedSince, context);
+        
+        //should be no messages in the outbox
+        _outbox.EntryCount.Should().Be(0);
+        
+        parentActivity?.Stop();
+        
+        _traceProvider.ForceFlush();
+        
+        //We should have exported matching activities
+        _exportedActivities.Count.Should().Be(9);
+        
+        _exportedActivities.Any(a => a.Source.Name == "Paramore.Brighter").Should().BeTrue();
+        
+        //there should be a n archive create span for the batch
+        var createActivity = _exportedActivities.Single(a => a.DisplayName == $"{BrighterSemanticConventions.ArchiveMessages} {CommandProcessorSpanOperation.Archive.ToSpanName()}");
+        createActivity.Should().NotBeNull();
+        createActivity.ParentId.Should().Be(parentActivity?.Id);
+        
+        //check for outstanding messages span
+        var osCheckActivity = _exportedActivities.SingleOrDefault(a =>
+            a.DisplayName == $"{OutboxDbOperation.DispatchedMessages.ToSpanName()} {InMemoryAttributes.DbName} {InMemoryAttributes.DbTable}");
+        osCheckActivity.Should().NotBeNull();
+        osCheckActivity?.ParentId.Should().Be(createActivity.Id);
+
+        //check for delete messages span
+        var deleteActivity = _exportedActivities.SingleOrDefault(a =>
+            a.DisplayName == $"{OutboxDbOperation.Delete.ToSpanName()} {InMemoryAttributes.DbName} {InMemoryAttributes.DbTable}");
+        deleteActivity.Should().NotBeNull();
+        deleteActivity?.ParentId.Should().Be(createActivity.Id);
+        
+        //check the tags for the create span
+        createActivity.TagObjects.Should().Contain(t => t.Key == BrighterSemanticConventions.ArchiveAge && Math.Abs(Convert.ToDouble(t.Value) - dispatchedSince.TotalMilliseconds) < TOLERANCE);
+        
+        //check the tags for the outstanding messages span
+        osCheckActivity?.Tags.Any(t => t.Key == BrighterSemanticConventions.DbOperation && t.Value == OutboxDbOperation.DispatchedMessages.ToSpanName()).Should().BeTrue();
+        osCheckActivity?.Tags.Any(t => t.Key == BrighterSemanticConventions.DbTable && t.Value == InMemoryAttributes.DbTable).Should().BeTrue();
+        osCheckActivity?.Tags.Any(t => t.Key == BrighterSemanticConventions.DbSystem && t.Value == DbSystem.Brighter.ToDbName()).Should().BeTrue();
+        osCheckActivity?.Tags.Any(t => t.Key == BrighterSemanticConventions.DbName && t.Value == InMemoryAttributes.DbName).Should().BeTrue();
+        
+        //check the tages for the delete messages span
+        deleteActivity?.Tags.Any(t => t.Key == BrighterSemanticConventions.DbOperation && t.Value == OutboxDbOperation.Delete.ToSpanName()).Should().BeTrue();
+        deleteActivity?.Tags.Any(t => t.Key == BrighterSemanticConventions.DbTable && t.Value == InMemoryAttributes.DbTable).Should().BeTrue();
+        deleteActivity?.Tags.Any(t => t.Key == BrighterSemanticConventions.DbSystem && t.Value == DbSystem.Brighter.ToDbName()).Should().BeTrue();
+        deleteActivity?.Tags.Any(t => t.Key == BrighterSemanticConventions.DbName && t.Value == InMemoryAttributes.DbName).Should().BeTrue();
+        
+    }
+}

--- a/tests/Paramore.Brighter.Core.Tests/Observability/CommandProcessor/Clear/When_Clearing_A_Message_A_Span_Is_Exported.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Observability/CommandProcessor/Clear/When_Clearing_A_Message_A_Span_Is_Exported.cs
@@ -77,7 +77,7 @@ public class CommandProcessorClearObservabilityTests
             {routingKey, _producer}
         });
         
-        IAmAnExternalBusService bus = new ExternalBusService<Message, CommittableTransaction>(
+        IAmAnOutboxProducerMediator bus = new OutboxProducerMediator<Message, CommittableTransaction>(
             producerRegistry, 
             policyRegistry, 
             messageMapperRegistry, 

--- a/tests/Paramore.Brighter.Core.Tests/Observability/CommandProcessor/Clear/When_Clearing_A_Message_A_Span_Is_Exported.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Observability/CommandProcessor/Clear/When_Clearing_A_Message_A_Span_Is_Exported.cs
@@ -143,14 +143,14 @@ public class CommandProcessorClearObservabilityTests
         var message = _internalBus.Stream(new RoutingKey("MyEvent")).Single();
         var depositEvent = events.Single(e => e.Name == OutboxDbOperation.Get.ToSpanName());
         depositEvent.Tags.Any(a => a.Value != null && a.Key == BrighterSemanticConventions.OutboxSharedTransaction && (bool)a.Value == false).Should().BeTrue();
-        depositEvent.Tags.Any(a => a.Key == BrighterSemanticConventions.OutboxType && (string)a.Value == "sync" ).Should().BeTrue();
-        depositEvent.Tags.Any(a => a.Key == BrighterSemanticConventions.MessageId && (string)a.Value == message.Id ).Should().BeTrue();
-        depositEvent.Tags.Any(a => a.Key == BrighterSemanticConventions.MessagingDestination && (RoutingKey)a.Value == message.Header.Topic).Should().BeTrue();
+        depositEvent.Tags.Any(a => a.Key == BrighterSemanticConventions.OutboxType && a.Value as string == "sync" ).Should().BeTrue();
+        depositEvent.Tags.Any(a => a.Key == BrighterSemanticConventions.MessageId && a.Value as string == message.Id ).Should().BeTrue();
+        depositEvent.Tags.Any(a => a.Key == BrighterSemanticConventions.MessagingDestination && a.Value as string == message.Header.Topic.Value).Should().BeTrue();
         depositEvent.Tags.Any(a => a is { Value: not null, Key: BrighterSemanticConventions.MessageBodySize } && (int)a.Value == message.Body.Bytes.Length).Should().BeTrue();
-        depositEvent.Tags.Any(a => a.Key == BrighterSemanticConventions.MessageBody && (string)a.Value == message.Body.Value).Should().BeTrue();
-        depositEvent.Tags.Any(a => a.Key == BrighterSemanticConventions.MessageType && (string)a.Value == message.Header.MessageType.ToString()).Should().BeTrue();
-        depositEvent.Tags.Any(a => a.Key == BrighterSemanticConventions.MessagingDestinationPartitionId && (string)a.Value == message.Header.PartitionKey).Should().BeTrue();
-        depositEvent.Tags.Any(a => a.Key == BrighterSemanticConventions.MessageHeaders && (string)a.Value == JsonSerializer.Serialize(message.Header)).Should().BeTrue();
+        depositEvent.Tags.Any(a => a.Key == BrighterSemanticConventions.MessageBody && a.Value as string == message.Body.Value).Should().BeTrue();
+        depositEvent.Tags.Any(a => a.Key == BrighterSemanticConventions.MessageType && a.Value as string == message.Header.MessageType.ToString()).Should().BeTrue();
+        depositEvent.Tags.Any(a => a.Key == BrighterSemanticConventions.MessagingDestinationPartitionId && a.Value as string == message.Header.PartitionKey).Should().BeTrue();
+        depositEvent.Tags.Any(a => a.Key == BrighterSemanticConventions.MessageHeaders && a.Value as string == JsonSerializer.Serialize(message.Header)).Should().BeTrue();
         
         //there should be a span in the Db for retrieving the message
         var outBoxActivity = _exportedActivities.Single(a => a.DisplayName == $"{OutboxDbOperation.Get.ToSpanName()} {InMemoryAttributes.DbName} {InMemoryAttributes.DbTable}");
@@ -164,15 +164,15 @@ public class CommandProcessorClearObservabilityTests
         producerActivity.ParentId.Should().Be(clearActivity.Id);
         producerActivity.Kind.Should().Be(ActivityKind.Producer);
         
-        producerActivity.TagObjects.Any(t => t.Key == BrighterSemanticConventions.MessagingOperationType && (string)t.Value == CommandProcessorSpanOperation.Publish.ToSpanName()).Should().BeTrue();
-        producerActivity.TagObjects.Any(t => t.Key == BrighterSemanticConventions.MessageId && (string)t.Value == message.Id).Should().BeTrue();
-        producerActivity.TagObjects.Any(t => t.Key == BrighterSemanticConventions.MessageType && (string)t.Value == message.Header.MessageType.ToString()).Should().BeTrue();
+        producerActivity.TagObjects.Any(t => t.Key == BrighterSemanticConventions.MessagingOperationType && t.Value as string == CommandProcessorSpanOperation.Publish.ToSpanName()).Should().BeTrue();
+        producerActivity.TagObjects.Any(t => t.Key == BrighterSemanticConventions.MessageId && t.Value as string == message.Id).Should().BeTrue();
+        producerActivity.TagObjects.Any(t => t.Key == BrighterSemanticConventions.MessageType && t.Value as string == message.Header.MessageType.ToString()).Should().BeTrue();
         producerActivity.TagObjects.Any(t => t is { Value: not null, Key: BrighterSemanticConventions.MessagingDestination } && t.Value.ToString() == "MyEvent").Should().BeTrue(); 
-        producerActivity.TagObjects.Any(t => t.Key == BrighterSemanticConventions.MessagingDestinationPartitionId && (string)t.Value == message.Header.PartitionKey).Should().BeTrue();
+        producerActivity.TagObjects.Any(t => t.Key == BrighterSemanticConventions.MessagingDestinationPartitionId && t.Value as string == message.Header.PartitionKey).Should().BeTrue();
         producerActivity.TagObjects.Any(t => t.Key == BrighterSemanticConventions.MessageHeaders && (string)t.Value == JsonSerializer.Serialize(message.Header)).Should().BeTrue();
         producerActivity.TagObjects.Any(t => t is { Value: not null, Key: BrighterSemanticConventions.MessageBodySize } && (int)t.Value == message.Body.Bytes.Length).Should().BeTrue();
-        producerActivity.TagObjects.Any(t => t.Key == BrighterSemanticConventions.MessageBody && (string)t.Value == message.Body.Value).Should().BeTrue();
-        producerActivity.TagObjects.Any(t => t.Key == BrighterSemanticConventions.ConversationId && (string)t.Value == message.Header.CorrelationId).Should().BeTrue();
+        producerActivity.TagObjects.Any(t => t.Key == BrighterSemanticConventions.MessageBody && t.Value as string == message.Body.Value).Should().BeTrue();
+        producerActivity.TagObjects.Any(t => t.Key == BrighterSemanticConventions.ConversationId && t.Value as string == message.Header.CorrelationId).Should().BeTrue();
         
         producerActivity.TagObjects.Any(t => t.Key == BrighterSemanticConventions.CeMessageId && (string)t.Value == message.Id).Should().BeTrue();
         producerActivity.TagObjects.Any(t => t.Key == BrighterSemanticConventions.CeSource && (Uri)t.Value == _producer.Publication.Source).Should().BeTrue();

--- a/tests/Paramore.Brighter.Core.Tests/Observability/CommandProcessor/Clear/When_Clearing_A_Message_A_Span_Is_Exported_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Observability/CommandProcessor/Clear/When_Clearing_A_Message_A_Span_Is_Exported_Async.cs
@@ -121,7 +121,7 @@ public class AsyncCommandProcessorClearObservabilityTests
         _traceProvider.ForceFlush();
         
         //assert 
-        _exportedActivities.Count.Should().Be(7);
+        _exportedActivities.Count.Should().Be(8);
         _exportedActivities.Any(a => a.Source.Name == "Paramore.Brighter").Should().BeTrue();
         
         //there should be a create span for the batch
@@ -143,14 +143,14 @@ public class AsyncCommandProcessorClearObservabilityTests
         var message = _internalBus.Stream(new RoutingKey(_topic)).Single();
         var depositEvent = events.Single(e => e.Name == OutboxDbOperation.Get.ToSpanName());
         depositEvent.Tags.Any(a => a.Value != null && a.Key == BrighterSemanticConventions.OutboxSharedTransaction && (bool)a.Value == false).Should().BeTrue();
-        depositEvent.Tags.Any(a => a.Key == BrighterSemanticConventions.OutboxType && (string)a.Value == "async" ).Should().BeTrue();
-        depositEvent.Tags.Any(a => a.Key == BrighterSemanticConventions.MessageId && (string)a.Value == message.Id ).Should().BeTrue();
-        depositEvent.Tags.Any(a => a.Key == BrighterSemanticConventions.MessagingDestination && (RoutingKey)a.Value == message.Header.Topic).Should().BeTrue();
+        depositEvent.Tags.Any(a => a.Key == BrighterSemanticConventions.OutboxType && a.Value as string == "async" ).Should().BeTrue();
+        depositEvent.Tags.Any(a => a.Key == BrighterSemanticConventions.MessageId && a.Value as string == message.Id ).Should().BeTrue();
+        depositEvent.Tags.Any(a => a.Key == BrighterSemanticConventions.MessagingDestination && a.Value?.ToString() == message.Header.Topic.ToString()).Should().BeTrue();
         depositEvent.Tags.Any(a => a is { Value: not null, Key: BrighterSemanticConventions.MessageBodySize } && (int)a.Value == message.Body.Bytes.Length).Should().BeTrue();
-        depositEvent.Tags.Any(a => a.Key == BrighterSemanticConventions.MessageBody && (string)a.Value == message.Body.Value).Should().BeTrue();
-        depositEvent.Tags.Any(a => a.Key == BrighterSemanticConventions.MessageType && (string)a.Value == message.Header.MessageType.ToString()).Should().BeTrue();
-        depositEvent.Tags.Any(a => a.Key == BrighterSemanticConventions.MessagingDestinationPartitionId && (string)a.Value == message.Header.PartitionKey).Should().BeTrue();
-        depositEvent.Tags.Any(a => a.Key == BrighterSemanticConventions.MessageHeaders && (string)a.Value == JsonSerializer.Serialize(message.Header)).Should().BeTrue();
+        depositEvent.Tags.Any(a => a.Key == BrighterSemanticConventions.MessageBody && a.Value as string == message.Body.Value).Should().BeTrue();
+        depositEvent.Tags.Any(a => a.Key == BrighterSemanticConventions.MessageType && a.Value as string == message.Header.MessageType.ToString()).Should().BeTrue();
+        depositEvent.Tags.Any(a => a.Key == BrighterSemanticConventions.MessagingDestinationPartitionId && a.Value as string == message.Header.PartitionKey).Should().BeTrue();
+        depositEvent.Tags.Any(a => a.Key == BrighterSemanticConventions.MessageHeaders && a.Value as string == JsonSerializer.Serialize(message.Header)).Should().BeTrue();
         
         //there should be a span in the Db for retrieving the message
         var outBoxActivity = _exportedActivities.Single(a => a.DisplayName == $"{OutboxDbOperation.Get.ToSpanName()} {InMemoryAttributes.DbName} {InMemoryAttributes.DbTable}");
@@ -164,39 +164,47 @@ public class AsyncCommandProcessorClearObservabilityTests
         producerActivity.ParentId.Should().Be(clearActivity.Id);
         producerActivity.Kind.Should().Be(ActivityKind.Producer);
         
-        producerActivity.TagObjects.Any(t => t.Key == BrighterSemanticConventions.MessagingOperationType && (string)t.Value == CommandProcessorSpanOperation.Publish.ToSpanName()).Should().BeTrue();
-        producerActivity.TagObjects.Any(t => t.Key == BrighterSemanticConventions.MessageId && (string)t.Value == message.Id).Should().BeTrue();
-        producerActivity.TagObjects.Any(t => t.Key == BrighterSemanticConventions.MessageType && (string)t.Value == message.Header.MessageType.ToString()).Should().BeTrue();
-        producerActivity.TagObjects.Any(t => t is { Value: not null, Key: BrighterSemanticConventions.MessagingDestination } && t.Value.ToString() == _topic).Should().BeTrue(); 
-        producerActivity.TagObjects.Any(t => t.Key == BrighterSemanticConventions.MessagingDestinationPartitionId && (string)t.Value == message.Header.PartitionKey).Should().BeTrue();
-        producerActivity.TagObjects.Any(t => t.Key == BrighterSemanticConventions.MessageHeaders && (string)t.Value == JsonSerializer.Serialize(message.Header)).Should().BeTrue();
+        producerActivity.TagObjects.Any(t => t.Key == BrighterSemanticConventions.MessagingOperationType && t.Value as string == CommandProcessorSpanOperation.Publish.ToSpanName()).Should().BeTrue();
+        producerActivity.TagObjects.Any(t => t.Key == BrighterSemanticConventions.MessageId && t.Value as string == message.Id).Should().BeTrue();
+        producerActivity.TagObjects.Any(t => t.Key == BrighterSemanticConventions.MessageType && t.Value as string == message.Header.MessageType.ToString()).Should().BeTrue();
+        producerActivity.TagObjects.Any(t => t is { Value: not null, Key: BrighterSemanticConventions.MessagingDestination } && t.Value.ToString() == _topic.Value.ToString()).Should().BeTrue(); 
+        producerActivity.TagObjects.Any(t => t.Key == BrighterSemanticConventions.MessagingDestinationPartitionId && t.Value as string == message.Header.PartitionKey).Should().BeTrue();
+        producerActivity.TagObjects.Any(t => t.Key == BrighterSemanticConventions.MessageHeaders && t.Value as string == JsonSerializer.Serialize(message.Header)).Should().BeTrue();
         producerActivity.TagObjects.Any(t => t is { Value: not null, Key: BrighterSemanticConventions.MessageBodySize } && (int)t.Value == message.Body.Bytes.Length).Should().BeTrue();
-        producerActivity.TagObjects.Any(t => t.Key == BrighterSemanticConventions.MessageBody && (string)t.Value == message.Body.Value).Should().BeTrue();
-        producerActivity.TagObjects.Any(t => t.Key == BrighterSemanticConventions.ConversationId && (string)t.Value == message.Header.CorrelationId).Should().BeTrue();
+        producerActivity.TagObjects.Any(t => t.Key == BrighterSemanticConventions.MessageBody && t.Value as string == message.Body.Value).Should().BeTrue();
+        producerActivity.TagObjects.Any(t => t.Key == BrighterSemanticConventions.ConversationId && t.Value as string == message.Header.CorrelationId).Should().BeTrue();
         
-        producerActivity.TagObjects.Any(t => t.Key == BrighterSemanticConventions.CeMessageId && (string)t.Value == message.Id).Should().BeTrue();
-        producerActivity.TagObjects.Any(t => t.Key == BrighterSemanticConventions.CeSource && (Uri)t.Value == _producer.Publication.Source).Should().BeTrue();
-        producerActivity.TagObjects.Any(t => t.Key == BrighterSemanticConventions.CeVersion && (string)t.Value == "1.0").Should().BeTrue();
-        producerActivity.TagObjects.Any(t => t.Key == BrighterSemanticConventions.CeSubject && (string)t.Value == _producer.Publication.Subject).Should().BeTrue();
-        producerActivity.TagObjects.Any(t => t.Key == BrighterSemanticConventions.CeType && (string)t.Value == _producer.Publication.Type).Should().BeTrue();
+        producerActivity.TagObjects.Any(t => t.Key == BrighterSemanticConventions.CeMessageId && t.Value as string == message.Id).Should().BeTrue();
+        producerActivity.TagObjects.Any(t => t.Key == BrighterSemanticConventions.CeSource && t.Value as Uri == _producer.Publication.Source).Should().BeTrue();
+        producerActivity.TagObjects.Any(t => t.Key == BrighterSemanticConventions.CeVersion && t.Value as string == "1.0").Should().BeTrue();
+        producerActivity.TagObjects.Any(t => t.Key == BrighterSemanticConventions.CeSubject && t.Value as string == _producer.Publication.Subject).Should().BeTrue();
+        producerActivity.TagObjects.Any(t => t.Key == BrighterSemanticConventions.CeType && t.Value as string == _producer.Publication.Type).Should().BeTrue();
         
         //there should be an event in the producer for producing the message
         var produceEvent = producerActivity.Events.Single(e => e.Name ==$"{_topic} {CommandProcessorSpanOperation.Publish.ToSpanName()}");
-        produceEvent.Tags.Any(t => t.Key == BrighterSemanticConventions.MessagingOperationType && (string)t.Value == CommandProcessorSpanOperation.Publish.ToSpanName()).Should().BeTrue();
-        produceEvent.Tags.Any(t => t.Key == BrighterSemanticConventions.MessagingSystem && (string)t.Value == MessagingSystem.InternalBus.ToMessagingSystemName()).Should().BeTrue();          
-        produceEvent.Tags.Any(t => t.Key == BrighterSemanticConventions.MessagingDestination && (RoutingKey)t.Value == _topic).Should().BeTrue();
-        produceEvent.Tags.Any(t => t.Key == BrighterSemanticConventions.MessagingDestinationPartitionId && (string)t.Value == message.Header.PartitionKey).Should().BeTrue();
-        produceEvent.Tags.Any(t => t.Key == BrighterSemanticConventions.MessageId && (string)t.Value == message.Id).Should().BeTrue();
-        produceEvent.Tags.Any(t => t.Key == BrighterSemanticConventions.MessageType && (string)t.Value == message.Header.MessageType.ToString()).Should().BeTrue();
-        produceEvent.Tags.Any(t => t.Key == BrighterSemanticConventions.MessageHeaders && (string)t.Value == JsonSerializer.Serialize(message.Header)).Should().BeTrue();
+        produceEvent.Tags.Any(t => t.Key == BrighterSemanticConventions.MessagingOperationType && t.Value as string == CommandProcessorSpanOperation.Publish.ToSpanName()).Should().BeTrue();
+        produceEvent.Tags.Any(t => t.Key == BrighterSemanticConventions.MessagingSystem && t.Value as string == MessagingSystem.InternalBus.ToMessagingSystemName()).Should().BeTrue();          
+        produceEvent.Tags.Any(t => t.Key == BrighterSemanticConventions.MessagingDestination && t.Value?.ToString() == _topic.Value.ToString()).Should().BeTrue();
+        produceEvent.Tags.Any(t => t.Key == BrighterSemanticConventions.MessagingDestinationPartitionId && t.Value as string == message.Header.PartitionKey).Should().BeTrue();
+        produceEvent.Tags.Any(t => t.Key == BrighterSemanticConventions.MessageId && t.Value as string == message.Id).Should().BeTrue();
+        produceEvent.Tags.Any(t => t.Key == BrighterSemanticConventions.MessageType && t.Value as string == message.Header.MessageType.ToString()).Should().BeTrue();
+        produceEvent.Tags.Any(t => t.Key == BrighterSemanticConventions.MessageHeaders && t.Value as string == JsonSerializer.Serialize(message.Header)).Should().BeTrue();
         produceEvent.Tags.Any(t => t is { Value: not null, Key: BrighterSemanticConventions.MessageBodySize } && (int)t.Value == message.Body.Bytes.Length).Should().BeTrue();
-        produceEvent.Tags.Any(t => t.Key == BrighterSemanticConventions.MessageBody && (string)t.Value == message.Body.Value).Should().BeTrue();
-        produceEvent.Tags.Any(t => t.Key == BrighterSemanticConventions.ConversationId && (string)t.Value == message.Header.CorrelationId).Should().BeTrue();
+        produceEvent.Tags.Any(t => t.Key == BrighterSemanticConventions.MessageBody && t.Value as string == message.Body.Value).Should().BeTrue();
+        produceEvent.Tags.Any(t => t.Key == BrighterSemanticConventions.ConversationId && t.Value as string == message.Header.CorrelationId).Should().BeTrue();
         
-        produceEvent.Tags.Any(t => t.Key == BrighterSemanticConventions.CeMessageId && (string)t.Value == message.Id).Should().BeTrue();
-        produceEvent.Tags.Any(t => t.Key == BrighterSemanticConventions.CeSource && (Uri)t.Value == _producer.Publication.Source).Should().BeTrue();
-        produceEvent.Tags.Any(t => t.Key == BrighterSemanticConventions.CeVersion && (string)t.Value == "1.0").Should().BeTrue();
-        produceEvent.Tags.Any(t => t.Key == BrighterSemanticConventions.CeSubject && (string)t.Value == _producer.Publication.Subject).Should().BeTrue();
-        produceEvent.Tags.Any(t => t.Key == BrighterSemanticConventions.CeType && (string)t.Value == _producer.Publication.Type).Should().BeTrue();
+        produceEvent.Tags.Any(t => t.Key == BrighterSemanticConventions.CeMessageId && t.Value as string == message.Id).Should().BeTrue();
+        produceEvent.Tags.Any(t => t.Key == BrighterSemanticConventions.CeSource && t.Value as Uri == _producer.Publication.Source).Should().BeTrue();
+        produceEvent.Tags.Any(t => t.Key == BrighterSemanticConventions.CeVersion && t.Value as string == "1.0").Should().BeTrue();
+        produceEvent.Tags.Any(t => t.Key == BrighterSemanticConventions.CeSubject && t.Value as string == _producer.Publication.Subject).Should().BeTrue();
+        produceEvent.Tags.Any(t => t.Key == BrighterSemanticConventions.CeType && t.Value as string == _producer.Publication.Type).Should().BeTrue();
+        
+        //There should be  a span event to mark as dispatched
+        var markAsDispatchedActivity = _exportedActivities.Single(a => a.DisplayName == $"{OutboxDbOperation.MarkDispatched.ToSpanName()} {InMemoryAttributes.DbName} {InMemoryAttributes.DbTable}");
+        markAsDispatchedActivity.Tags.Any(t => t.Key == BrighterSemanticConventions.DbOperation && t.Value == OutboxDbOperation.MarkDispatched.ToSpanName()).Should().BeTrue();
+        markAsDispatchedActivity.Tags.Any(t => t.Key == BrighterSemanticConventions.DbTable && t.Value == InMemoryAttributes.DbTable).Should().BeTrue();
+        markAsDispatchedActivity.Tags.Any(t => t.Key == BrighterSemanticConventions.DbSystem && t.Value == DbSystem.Brighter.ToDbName()).Should().BeTrue();
+        markAsDispatchedActivity.Tags.Any(t => t.Key == BrighterSemanticConventions.DbName && t.Value == InMemoryAttributes.DbName).Should().BeTrue();
+
     }
 }

--- a/tests/Paramore.Brighter.Core.Tests/Observability/CommandProcessor/Clear/When_Clearing_A_Message_A_Span_Is_Exported_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Observability/CommandProcessor/Clear/When_Clearing_A_Message_A_Span_Is_Exported_Async.cs
@@ -77,7 +77,7 @@ public class AsyncCommandProcessorClearObservabilityTests
             {_topic, _producer}
         });
         
-        IAmAnExternalBusService bus = new ExternalBusService<Message, CommittableTransaction>(
+        IAmAnOutboxProducerMediator bus = new OutboxProducerMediator<Message, CommittableTransaction>(
             producerRegistry, 
             policyRegistry, 
             messageMapperRegistry, 

--- a/tests/Paramore.Brighter.Core.Tests/Observability/CommandProcessor/Clear/When_Clearing_Multipile_Messages_Spans_Are_Exported_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Observability/CommandProcessor/Clear/When_Clearing_Multipile_Messages_Spans_Are_Exported_Async.cs
@@ -80,7 +80,7 @@ public class AsyncCommandProcessorMultipleClearObservabilityTests
             {routingKey, producer}
         });
         
-        IAmAnExternalBusService bus = new ExternalBusService<Message, CommittableTransaction>(
+        IAmAnOutboxProducerMediator bus = new OutboxProducerMediator<Message, CommittableTransaction>(
             producerRegistry, 
             policyRegistry, 
             messageMapperRegistry, 

--- a/tests/Paramore.Brighter.Core.Tests/Observability/CommandProcessor/Clear/When_Clearing_Multipile_Messages_Spans_Are_Exported_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Observability/CommandProcessor/Clear/When_Clearing_Multipile_Messages_Spans_Are_Exported_Async.cs
@@ -126,7 +126,7 @@ public class AsyncCommandProcessorMultipleClearObservabilityTests
         _traceProvider.ForceFlush();
         
         //assert 
-        _exportedActivities.Count.Should().Be(18);
+        _exportedActivities.Count.Should().Be(21);
         _exportedActivities.Any(a => a.Source.Name == "Paramore.Brighter").Should().BeTrue();
         
         //there should be a create span for the batch

--- a/tests/Paramore.Brighter.Core.Tests/Observability/CommandProcessor/Clear/When_Clearing_Multiple_Messages_Spans_Are_Exported.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Observability/CommandProcessor/Clear/When_Clearing_Multiple_Messages_Spans_Are_Exported.cs
@@ -78,7 +78,7 @@ public class CommandProcessorMultipleClearObservabilityTests
             {routingKey, producer}
         });
         
-        IAmAnExternalBusService bus = new ExternalBusService<Message, CommittableTransaction>(
+        IAmAnOutboxProducerMediator bus = new OutboxProducerMediator<Message, CommittableTransaction>(
             producerRegistry, 
             policyRegistry, 
             messageMapperRegistry, 

--- a/tests/Paramore.Brighter.Core.Tests/Observability/CommandProcessor/Clear/When_Clearing_Multiple_Messages_Spans_Are_Exported.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Observability/CommandProcessor/Clear/When_Clearing_Multiple_Messages_Spans_Are_Exported.cs
@@ -125,7 +125,7 @@ public class CommandProcessorMultipleClearObservabilityTests
         _traceProvider.ForceFlush();
         
         //assert 
-        _exportedActivities.Count.Should().Be(18);
+        _exportedActivities.Count.Should().Be(21);
         _exportedActivities.Any(a => a.Source.Name == "Paramore.Brighter").Should().BeTrue();
         
         //there should be a create span for the batch

--- a/tests/Paramore.Brighter.Core.Tests/Observability/CommandProcessor/Clear/When_Clearing_Outstanding_Messages_Spans_Are_Exported.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Observability/CommandProcessor/Clear/When_Clearing_Outstanding_Messages_Spans_Are_Exported.cs
@@ -80,7 +80,7 @@ public class CommandProcessorClearOutstandingObservabilityTests
             {routingKey, producer}
         });
         
-        IAmAnExternalBusService bus = new ExternalBusService<Message, CommittableTransaction>(
+        IAmAnOutboxProducerMediator bus = new OutboxProducerMediator<Message, CommittableTransaction>(
             producerRegistry, 
             policyRegistry, 
             messageMapperRegistry, 

--- a/tests/Paramore.Brighter.Core.Tests/Observability/CommandProcessor/Clear/When_Clearing_Outstanding_Messages_Spans_Are_Exported_Bulk.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Observability/CommandProcessor/Clear/When_Clearing_Outstanding_Messages_Spans_Are_Exported_Bulk.cs
@@ -79,7 +79,7 @@ public class AsyncCommandProcessorBulkClearOutstandingObservabilityTests
             {routingKey, producer}
         });
         
-        IAmAnExternalBusService bus = new ExternalBusService<Message, CommittableTransaction>(
+        IAmAnOutboxProducerMediator bus = new OutboxProducerMediator<Message, CommittableTransaction>(
             producerRegistry, 
             policyRegistry, 
             messageMapperRegistry, 

--- a/tests/Paramore.Brighter.Core.Tests/Observability/CommandProcessor/Deposit/When_Depositing_A_Request_A_Span_Is_Exported.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Observability/CommandProcessor/Deposit/When_Depositing_A_Request_A_Span_Is_Exported.cs
@@ -71,7 +71,7 @@ public class CommandProcessorDepositObservabilityTests
             }
         });
         
-        IAmAnExternalBusService bus = new ExternalBusService<Message, CommittableTransaction>(
+        IAmAnOutboxProducerMediator bus = new OutboxProducerMediator<Message, CommittableTransaction>(
             producerRegistry, 
             policyRegistry, 
             messageMapperRegistry, 

--- a/tests/Paramore.Brighter.Core.Tests/Observability/CommandProcessor/Deposit/When_Depositing_A_Request_A_Span_Is_Exported_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Observability/CommandProcessor/Deposit/When_Depositing_A_Request_A_Span_Is_Exported_Async.cs
@@ -73,7 +73,7 @@ public class AsyncCommandProcessorDepositObservabilityTests
             }
         });
         
-        IAmAnExternalBusService bus = new ExternalBusService<Message, CommittableTransaction>(
+        IAmAnOutboxProducerMediator bus = new OutboxProducerMediator<Message, CommittableTransaction>(
             producerRegistry, 
             policyRegistry, 
             messageMapperRegistry, 

--- a/tests/Paramore.Brighter.Core.Tests/Observability/CommandProcessor/Deposit/When_Depositing_Multiple_Requests_Spans_Are_Exported.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Observability/CommandProcessor/Deposit/When_Depositing_Multiple_Requests_Spans_Are_Exported.cs
@@ -70,7 +70,7 @@ public class CommandProcessorMultipleDepositObservabilityTests : IDisposable
             }
         });
         
-        IAmAnExternalBusService bus = new ExternalBusService<Message, CommittableTransaction>(
+        IAmAnOutboxProducerMediator bus = new OutboxProducerMediator<Message, CommittableTransaction>(
             producerRegistry, 
             policyRegistry, 
             messageMapperRegistry, 

--- a/tests/Paramore.Brighter.Core.Tests/Observability/CommandProcessor/Deposit/When_Depositing_Multiple_Requests_Spans_Are_Exported_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Observability/CommandProcessor/Deposit/When_Depositing_Multiple_Requests_Spans_Are_Exported_Async.cs
@@ -71,7 +71,7 @@ public class AsyncCommandProcessorMultipleDepositObservabilityTests : IDisposabl
             }
         });
         
-        IAmAnExternalBusService bus = new ExternalBusService<Message, CommittableTransaction>(
+        IAmAnOutboxProducerMediator bus = new OutboxProducerMediator<Message, CommittableTransaction>(
             producerRegistry, 
             policyRegistry, 
             messageMapperRegistry, 

--- a/tests/Paramore.Brighter.InMemory.Tests/Sweeper/When_sweeping_the_outbox.cs
+++ b/tests/Paramore.Brighter.InMemory.Tests/Sweeper/When_sweeping_the_outbox.cs
@@ -52,7 +52,7 @@ namespace Paramore.Brighter.InMemory.Tests.Sweeper
             
             mapperRegistry.Register<MyEvent, MyEventMessageMapper>();
             
-            var bus = new ExternalBusService<Message, CommittableTransaction>(
+            var bus = new OutboxProducerMediator<Message, CommittableTransaction>(
                 producerRegistry,
                 new DefaultPolicy(),
                 mapperRegistry,
@@ -128,7 +128,7 @@ namespace Paramore.Brighter.InMemory.Tests.Sweeper
             
             mapperRegistry.Register<MyEvent, MyEventMessageMapper>();            
             
-            var bus = new ExternalBusService<Message, CommittableTransaction>(
+            var bus = new OutboxProducerMediator<Message, CommittableTransaction>(
                 producerRegistry,
                 new DefaultPolicy(),
                 mapperRegistry,
@@ -203,7 +203,7 @@ namespace Paramore.Brighter.InMemory.Tests.Sweeper
             
             mapperRegistry.Register<MyEvent, MyEventMessageMapper>();
 
-            var bus = new ExternalBusService<Message, CommittableTransaction>(
+            var bus = new OutboxProducerMediator<Message, CommittableTransaction>(
                 producerRegistry,
                 new DefaultPolicy(),
                 mapperRegistry,
@@ -287,7 +287,7 @@ namespace Paramore.Brighter.InMemory.Tests.Sweeper
             
             mapperRegistry.Register<MyEvent, MyEventMessageMapper>();
 
-            var bus = new ExternalBusService<Message, CommittableTransaction>(
+            var bus = new OutboxProducerMediator<Message, CommittableTransaction>(
                 producerRegistry,
                 new DefaultPolicy(),
                 mapperRegistry,


### PR DESCRIPTION
We want to add observability to the archiver. 

* We call ExternalServiceBus.Archive from the OutboxArchiver. An interesting question here is: should we begin the trace in OutboxArchiver or within ExternalServiceBus. in this case we choose ExternalServiceBus, because it is the last possible moment that the span could begin, but is possible that we could argue to place in OutboxArchiver as the initiator.
* There are no OTel semantic conventions for this, but we follow the same pattern as elsewhere: create span for the batch; archive batch for each item; use links when available to link the child spans back to the parent.