### PR TITLE
[Bug] Fixes issue on resolving on DynamoDb Outbox 

### DIFF
--- a/src/Paramore.Brighter.Outbox.DynamoDB/ServiceCollectionExtensions.cs
+++ b/src/Paramore.Brighter.Outbox.DynamoDB/ServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Amazon.DynamoDBv2;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Paramore.Brighter.Extensions.DependencyInjection;
 
 namespace Paramore.Brighter.Outbox.DynamoDB
@@ -23,9 +24,9 @@ namespace Paramore.Brighter.Outbox.DynamoDB
         public static IBrighterBuilder UseDynamoDbOutbox(
             this IBrighterBuilder brighterBuilder, ServiceLifetime serviceLifetime = ServiceLifetime.Singleton)
         {
-            brighterBuilder.Services.Add(new ServiceDescriptor(typeof(IAmAnOutbox<Message>), GetOrBuildDynamoDbOutbox, serviceLifetime));
-            brighterBuilder.Services.Add(new ServiceDescriptor(typeof(IAmAnOutboxSync<Message>), GetOrBuildDynamoDbOutbox, serviceLifetime));
-            brighterBuilder.Services.Add(new ServiceDescriptor(typeof(IAmAnOutboxAsync<Message>), GetOrBuildDynamoDbOutbox, serviceLifetime));
+            brighterBuilder.Services.TryAdd(new ServiceDescriptor(typeof(IAmAnOutbox<Message>), GetOrBuildDynamoDbOutbox, serviceLifetime));
+            brighterBuilder.Services.TryAdd(new ServiceDescriptor(typeof(IAmAnOutboxSync<Message>), GetOrBuildDynamoDbOutbox, serviceLifetime));
+            brighterBuilder.Services.TryAdd(new ServiceDescriptor(typeof(IAmAnOutboxAsync<Message>), GetOrBuildDynamoDbOutbox, serviceLifetime));
 
             return brighterBuilder;
         }
@@ -57,10 +58,6 @@ namespace Paramore.Brighter.Outbox.DynamoDB
             var dynamoDb = provider.GetService<IAmazonDynamoDB>();
             if (dynamoDb == null)
                 throw new InvalidOperationException("No service of type IAmazonDynamoDb was found. Please register before calling this method");
-
-            var existingOutbox = provider.GetService<IAmAnOutbox<Message>>();
-            if (existingOutbox != null)
-                return existingOutbox as DynamoDbOutbox;
 
             return new DynamoDbOutbox(dynamoDb, config);
         }


### PR DESCRIPTION
The current implementation to avoid duplication makes an infinity loop to find another `IAmAnOutbox`

Question: Should we allow only one `IAmAnOutbox`, or should I change the implementation to allow a multi-outbox pattern register but only one DynamoDB?