### PR TITLE
fix: BrighterTaskScheduler Queue Task When Complete

### DIFF
--- a/src/Paramore.Brighter/Tasks/BrighterSynchronizationContext.cs
+++ b/src/Paramore.Brighter/Tasks/BrighterSynchronizationContext.cs
@@ -145,9 +145,9 @@ namespace Paramore.Brighter.Tasks
                 
             //just execute inline
             // current thread already owns the context, so just execute inline to prevent deadlocks
-            //if (BrighterSynchronizationHelper.Current == SynchronizationHelper)
-                //SynchronizationHelper.ExecuteImmediately(contextCallback, state);
-            //else
+            if (BrighterSynchronizationHelper.Current == SynchronizationHelper)
+                SynchronizationHelper.ExecuteImmediately(contextCallback, state);
+            else
                 base.Post(callback, state);
             
         }

--- a/tests/Paramore.Brighter.Core.Tests/Tasks/BrighterSynchronizationContextsTests.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Tasks/BrighterSynchronizationContextsTests.cs
@@ -6,15 +6,13 @@
 #endregion
 
 using System;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
-using Paramore.Brighter.ServiceActivator;
 using Paramore.Brighter.Tasks;
 using Xunit;
 
-namespace Paramore.Brighter.Core.Tests.SynchronizationContext;
+namespace Paramore.Brighter.Core.Tests.Tasks;
 
 public class BrighterSynchronizationContextsTests
 {
@@ -117,6 +115,20 @@ public class BrighterSynchronizationContextsTests
         var result = BrighterSynchronizationHelper.Run(async () =>
         {
             Task.Delay(50).GetAwaiter().GetResult();
+            resumed = true;
+            return 17;
+        });
+        resumed.Should().BeTrue();
+        result.Should().Be(17);
+    }
+    
+    [Fact]
+    public void Run_AsyncTaskWithResultAndConfigurateAwait_BlockingCode_Still_Ends()
+    {
+        bool resumed = false;
+        var result = BrighterSynchronizationHelper.Run(async () =>
+        {
+            await Task.Delay(50).ConfigureAwait(false);
             resumed = true;
             return 17;
         });


### PR DESCRIPTION
When we complete adding, due to us pumping the pending continuations for a task, we struggle if we are then handed another continuation via the scheduler, as the blockingcollection is complete. (This seems to be a function of ConfigureAwait being called with false on an await in our scope - not sure wy)

In this case, we just use a "Hail Mary" approach (cribbed from RavenDb) of putting the queued task on a new thread.

