### PR TITLE
Improve support to .NET Standard and .NET Framework

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -121,6 +121,12 @@
     <PackageVersion Include="Pomelo.EntityFrameworkCore.MySql" Version="9.0.0-preview.1" />
     <PackageVersion Include="Npgsql" Version="9.0.2" />
   </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
   <ItemGroup>
     <GlobalPackageReference Include="MinVer" Version="6.0.0" />
     <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -27,6 +27,11 @@
     <FileVersion>10.0.0.0</FileVersion>
     <InformationalVersion>10.0.0</InformationalVersion>
     <Version>10.0.0</Version>
+    
+    <!--  The .NET Version used in all projects -->
+    <BrigtherTargetFrameworks>netstandard2.0;net8.0;net9.0</BrigtherTargetFrameworks>
+    <BrigtherFrameworkAndCoreTargetFrameworks>net462;net8.0;net9.0</BrigtherFrameworkAndCoreTargetFrameworks>
+    <BrigtherCoreTargetFrameworks>net8.0;net9.0</BrigtherCoreTargetFrameworks>
   </PropertyGroup>
 
   <!-- Deterministic builds ensure that the same binary is produced regardless of the machine building it -->

--- a/src/Paramore.Brighter.Archive.Azure/Paramore.Brighter.Archive.Azure.csproj
+++ b/src/Paramore.Brighter.Archive.Azure/Paramore.Brighter.Archive.Azure.csproj
@@ -1,18 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
-        <RootNamespace>Paramore.Brighter.Storage.Azure</RootNamespace>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFrameworks>$(BrigtherTargetFrameworks)</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Paramore.Brighter.Storage.Azure</RootNamespace>
+  </PropertyGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\Paramore.Brighter\Paramore.Brighter.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Paramore.Brighter\Paramore.Brighter.csproj"/>
+  </ItemGroup>
 
-    <ItemGroup>
-      <PackageReference Include="Azure.Storage.Blobs" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Azure.Storage.Blobs"/>
+  </ItemGroup>
 
 </Project>

--- a/src/Paramore.Brighter.Dapper/Paramore.Brighter.Dapper.csproj
+++ b/src/Paramore.Brighter.Dapper/Paramore.Brighter.Dapper.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFrameworks>$(BrigtherTargetFrameworks)</TargetFrameworks>
+  </PropertyGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\Paramore.Brighter\Paramore.Brighter.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Paramore.Brighter\Paramore.Brighter.csproj"/>
+  </ItemGroup>
 
 </Project>

--- a/src/Paramore.Brighter.DynamoDb/Paramore.Brighter.DynamoDb.csproj
+++ b/src/Paramore.Brighter.DynamoDb/Paramore.Brighter.DynamoDb.csproj
@@ -1,16 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFrameworks>$(BrigtherTargetFrameworks)</TargetFrameworks>
+  </PropertyGroup>
 
-    <ItemGroup>
-      <PackageReference Include="AWSSDK.DynamoDBv2" />
-      <PackageReference Include="NJsonSchema" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="AWSSDK.DynamoDBv2"/>
+    <PackageReference Include="NJsonSchema"/>
+  </ItemGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\Paramore.Brighter\Paramore.Brighter.csproj" />
-    </ItemGroup>
-   
+  <ItemGroup>
+    <ProjectReference Include="..\Paramore.Brighter\Paramore.Brighter.csproj"/>
+  </ItemGroup>
+
 </Project>

--- a/src/Paramore.Brighter.Extensions.DependencyInjection/Paramore.Brighter.Extensions.DependencyInjection.csproj
+++ b/src/Paramore.Brighter.Extensions.DependencyInjection/Paramore.Brighter.Extensions.DependencyInjection.csproj
@@ -1,17 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>$(BrigtherTargetFrameworks)</TargetFrameworks>
     <Authors>Daniel Stockhammer, Toby Henderson</Authors>
     <Description>Brighter Microsoft.Extensions.DependencyInjection support</Description>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
-    <PackageReference Include="System.Text.Json" />
- 
 
-  </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Paramore.Brighter.DynamoDb\Paramore.Brighter.DynamoDb.csproj" />
-    <ProjectReference Include="..\Paramore.Brighter\Paramore.Brighter.csproj" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions"/>
+    <PackageReference Include="System.Text.Json"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Paramore.Brighter.DynamoDb\Paramore.Brighter.DynamoDb.csproj"/>
+    <ProjectReference Include="..\Paramore.Brighter\Paramore.Brighter.csproj"/>
   </ItemGroup>
 </Project>

--- a/src/Paramore.Brighter.Extensions.Diagnostics/Paramore.Brighter.Extensions.Diagnostics.csproj
+++ b/src/Paramore.Brighter.Extensions.Diagnostics/Paramore.Brighter.Extensions.Diagnostics.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>$(BrigtherTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Paramore.Brighter.Inbox.DynamoDB/Paramore.Brighter.Inbox.DynamoDB.csproj
+++ b/src/Paramore.Brighter.Inbox.DynamoDB/Paramore.Brighter.Inbox.DynamoDB.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>$(BrigtherTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="AWSSDK.DynamoDBv2" />
-    
 
-  </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Paramore.Brighter\Paramore.Brighter.csproj" />
+    <PackageReference Include="AWSSDK.DynamoDBv2"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Paramore.Brighter\Paramore.Brighter.csproj"/>
   </ItemGroup>
 </Project>

--- a/src/Paramore.Brighter.Inbox.MsSql/Paramore.Brighter.Inbox.MsSql.csproj
+++ b/src/Paramore.Brighter.Inbox.MsSql/Paramore.Brighter.Inbox.MsSql.csproj
@@ -2,15 +2,16 @@
   <PropertyGroup>
     <Description>This is an implementation of the outbox used for decoupled invocation of commands by Paramore.Brighter, using MS Sql Server</Description>
     <Authors>Francesco Pighi</Authors>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>$(BrigtherFrameworkAndCoreTargetFrameworks)</TargetFrameworks>
     <PackageTags>RabbitMQ;AMQP;Command;Event;Service Activator;Decoupled;Invocation;Messaging;Remote;Command Dispatcher;Command Processor;Request;Service;Task Queue;Work Queue;Retry;Circuit Breaker;Availability</PackageTags>
   </PropertyGroup>
-  <ItemGroup>
-    <None Remove="DDL Scripts\MSSQL\Inbox.sql" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\Paramore.Brighter.MsSql\Paramore.Brighter.MsSql.csproj" />
-    <ProjectReference Include="..\Paramore.Brighter\Paramore.Brighter.csproj" />
-  </ItemGroup>  
 
+  <ItemGroup>
+    <None Remove="DDL Scripts\MSSQL\Inbox.sql"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Paramore.Brighter.MsSql\Paramore.Brighter.MsSql.csproj"/>
+    <ProjectReference Include="..\Paramore.Brighter\Paramore.Brighter.csproj"/>
+  </ItemGroup>
 </Project>

--- a/src/Paramore.Brighter.Inbox.MySql/Paramore.Brighter.Inbox.MySql.csproj
+++ b/src/Paramore.Brighter.Inbox.MySql/Paramore.Brighter.Inbox.MySql.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>This is an implementation of the outbox used for decoupled invocation of commands by Paramore.Brighter, using MySql</Description>
     <Authors>Derek Comartin</Authors>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>$(BrigtherTargetFrameworks)</TargetFrameworks>
     <PackageTags>MySql;Command;Event;Service Activator;Decoupled;Invocation;Messaging;Remote;Command Dispatcher;Command Processor;Request;Service;Task Queue;Work Queue;Retry;Circuit Breaker;Availability</PackageTags>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Paramore.Brighter.Inbox.Postgres/Paramore.Brighter.Inbox.Postgres.csproj
+++ b/src/Paramore.Brighter.Inbox.Postgres/Paramore.Brighter.Inbox.Postgres.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>This is an implementation of the inbox used for decoupled invocation of commands by Paramore.Brighter, using PostgreSql</Description>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>$(BrigtherCoreTargetFrameworks)</TargetFrameworks>
     <PackageTags>MySql;Command;Event;Service Activator;Decoupled;Invocation;Messaging;Remote;Command Dispatcher;Command Processor;Request;Service;Task Queue;Work Queue;Retry;Circuit Breaker;Availability</PackageTags>
   </PropertyGroup>
 

--- a/src/Paramore.Brighter.Inbox.Sqlite/Paramore.Brighter.Inbox.Sqlite.csproj
+++ b/src/Paramore.Brighter.Inbox.Sqlite/Paramore.Brighter.Inbox.Sqlite.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>This is an implementation of the inbox used for decoupled invocation of commands by Paramore.Brighter, using Sqlite</Description>
     <Authors>Ian Cooper</Authors>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>$(BrigtherTargetFrameworks)</TargetFrameworks>
     <PackageTags>RabbitMQ;AMQP;Command;Event;Service Activator;Decoupled;Invocation;Messaging;Remote;Command Dispatcher;Command Processor;Request;Service;Task Queue;Work Queue;Retry;Circuit Breaker;Availability</PackageTags>
   </PropertyGroup>
 

--- a/src/Paramore.Brighter.Locking.Azure/Paramore.Brighter.Locking.Azure.csproj
+++ b/src/Paramore.Brighter.Locking.Azure/Paramore.Brighter.Locking.Azure.csproj
@@ -1,20 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
-        <Title>This is the Azure Distributed Locking Provider.</Title>
-        <Authors>Paul Reardon</Authors>
-        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFrameworks>$(BrigtherTargetFrameworks)</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <Title>This is the Azure Distributed Locking Provider.</Title>
+    <Authors>Paul Reardon</Authors>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+  </PropertyGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\Paramore.Brighter\Paramore.Brighter.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Paramore.Brighter\Paramore.Brighter.csproj"/>
+  </ItemGroup>
 
-    <ItemGroup>
-      <PackageReference Include="Azure.Storage.Blobs" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Azure.Storage.Blobs"/>
+  </ItemGroup>
 
 </Project>

--- a/src/Paramore.Brighter.Locking.DynamoDB/Paramore.Brighter.Locking.DynamoDB.csproj
+++ b/src/Paramore.Brighter.Locking.DynamoDB/Paramore.Brighter.Locking.DynamoDB.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>$(BrigtherTargetFrameworks)</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Title>This is the Dynamo DB Distributed Locking Provider.</Title>

--- a/src/Paramore.Brighter.Locking.MsSql/Paramore.Brighter.Locking.MsSql.csproj
+++ b/src/Paramore.Brighter.Locking.MsSql/Paramore.Brighter.Locking.MsSql.csproj
@@ -1,21 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
-        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-        <Authors>Paul Reardon</Authors>
-        <Description>A Locking Provider for Microsoft SQL Server</Description>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFrameworks>$(BrigtherFrameworkAndCoreTargetFrameworks)</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <Authors>Paul Reardon</Authors>
+    <Description>A Locking Provider for Microsoft SQL Server</Description>
+  </PropertyGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\Paramore.Brighter.MsSql\Paramore.Brighter.MsSql.csproj" />
-      <ProjectReference Include="..\Paramore.Brighter\Paramore.Brighter.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Paramore.Brighter.MsSql\Paramore.Brighter.MsSql.csproj"/>
+    <ProjectReference Include="..\Paramore.Brighter\Paramore.Brighter.csproj"/>
+  </ItemGroup>
 
-    <ItemGroup>
-      <PackageReference Include="Microsoft.Data.SqlClient" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Data.SqlClient"/>
+  </ItemGroup>
 
 </Project>

--- a/src/Paramore.Brighter.Locking.PostgresSql/Paramore.Brighter.Locking.PostgresSql.csproj
+++ b/src/Paramore.Brighter.Locking.PostgresSql/Paramore.Brighter.Locking.PostgresSql.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>This is an implementation of the locking using PostgreSql</Description>
     <Authors>Rafael Lillo</Authors>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>$(BrigtherCoreTargetFrameworks)</TargetFrameworks>
     <PackageTags>Postgres;Brighter;</PackageTags>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS/Paramore.Brighter.MessagingGateway.AWSSQS.csproj
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS/Paramore.Brighter.MessagingGateway.AWSSQS.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>Provides an implementation of the messaging gateway for decoupled invocation in the Paramore.Brighter pipeline, using awssqs</Description>
     <Authors>Deniz Kocak</Authors>
-    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>$(BrigtherTargetFrameworks)</TargetFrameworks>
     <Nullable>enable</Nullable>
     <PackageTags>awssqs;AMQP;Command;Event;Service Activator;Decoupled;Invocation;Messaging;Remote;Command Dispatcher;Command Processor;Request;Service;Task Queue;Work Queue;Retry;Circuit Breaker;Availability</PackageTags>
   </PropertyGroup>

--- a/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/Paramore.Brighter.MessagingGateway.AzureServiceBus.csproj
+++ b/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/Paramore.Brighter.MessagingGateway.AzureServiceBus.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>Provides an implementation of the messaging gateway for decoupled invocation in the Paramore.Brighter pipeline, using azureservicebus</Description>
     <Authors>Yiannis Triantafyllopoulos</Authors>
-    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>$(BrigtherTargetFrameworks)</TargetFrameworks>
     <PackageTags>awssqs;AMQP;Command;Event;Service Activator;Decoupled;Invocation;Messaging;Remote;Command Dispatcher;Command Processor;Request;Service;Task Queue;Work Queue;Retry;Circuit Breaker;Availability</PackageTags>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Nullable>enable</Nullable>

--- a/src/Paramore.Brighter.MessagingGateway.Kafka/Paramore.Brighter.MessagingGateway.Kafka.csproj
+++ b/src/Paramore.Brighter.MessagingGateway.Kafka/Paramore.Brighter.MessagingGateway.Kafka.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>Provides an implementation of the messaging gateway for decoupled invocation in the Paramore.Brighter pipeline, using Kafka.</Description>
     <Authors>Wayne Hunsley</Authors>
-    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>$(BrigtherTargetFrameworks)</TargetFrameworks>
     <PackageTags>Kafka;Command;Event;Service Activator;Decoupled;Invocation;Messaging;Remote;Command Dispatcher;Command Processor;Request;Service;Task Queue;Work Queue;Retry;Circuit Breaker;Availability</PackageTags>
     <SignAssembly>false</SignAssembly>
   </PropertyGroup>

--- a/src/Paramore.Brighter.MessagingGateway.MQTT/Paramore.Brighter.MessagingGateway.MQTT.csproj
+++ b/src/Paramore.Brighter.MessagingGateway.MQTT/Paramore.Brighter.MessagingGateway.MQTT.csproj
@@ -2,14 +2,14 @@
   <PropertyGroup>
     <Description>Provides an implementation of the messaging gateway for decoupled invocation in the Paramore.Brighter pipeline, using MQTT&lt;</Description>
     <Authors>Tim van Wijk</Authors>
-    <TargetFrameworks>netstandard2.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>$(BrigtherTargetFrameworks)</TargetFrameworks>
     <PackageTags>MQTT;Command;Event;Service Activator;Decoupled;Invocation;Messaging;Remote;Command Dispatcher;Command Processor;Request;Service;Task Queue;Work Queue;Retry;Circuit Breaker;Availability</PackageTags>
     <SignAssembly>false</SignAssembly>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Paramore.Brighter\Paramore.Brighter.csproj" />
+    <ProjectReference Include="..\Paramore.Brighter\Paramore.Brighter.csproj"/>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="MQTTnet" />
+    <PackageReference Include="MQTTnet"/>
   </ItemGroup>
 </Project>

--- a/src/Paramore.Brighter.MessagingGateway.MsSql/Paramore.Brighter.MessagingGateway.MsSql.csproj
+++ b/src/Paramore.Brighter.MessagingGateway.MsSql/Paramore.Brighter.MessagingGateway.MsSql.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>Provides an implementation of the messaging gateway for decoupled invocation in the Paramore.Brighter pipeline, using MS Sql Server</Description>
     <Authors>Fred Hoogduin</Authors>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>$(BrigtherFrameworkAndCoreTargetFrameworks)</TargetFrameworks>
     <Nullable>enable</Nullable>
     <PackageTags>RabbitMQ;AMQP;Command;Event;Service Activator;Decoupled;Invocation;Messaging;Remote;Command Dispatcher;Command Processor;Request;Service;Task Queue;Work Queue;Retry;Circuit Breaker;Availability</PackageTags>
   </PropertyGroup>

--- a/src/Paramore.Brighter.MessagingGateway.RMQ/Paramore.Brighter.MessagingGateway.RMQ.csproj
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ/Paramore.Brighter.MessagingGateway.RMQ.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>Provides an implementation of the messaging gateway for decoupled invocation in the Paramore.Brighter pipeline, using RabbitMQ</Description>
     <Authors>Ian Cooper</Authors>
-    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>$(BrigtherTargetFrameworks)</TargetFrameworks>
     <Nullable>enable</Nullable>
     <PackageTags>RabbitMQ;AMQP;Command;Event;Service Activator;Decoupled;Invocation;Messaging;Remote;Command Dispatcher;Command Processor;Request;Service;Task Queue;Work Queue;Retry;Circuit Breaker;Availability</PackageTags>
   </PropertyGroup>

--- a/src/Paramore.Brighter.MessagingGateway.Redis/Paramore.Brighter.MessagingGateway.Redis.csproj
+++ b/src/Paramore.Brighter.MessagingGateway.Redis/Paramore.Brighter.MessagingGateway.Redis.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>Provides an implementation of the messaging gateway for decoupled invocation in the Paramore.Brighter pipeline, using Redis&lt;</Description>
     <Authors>Ian Cooper</Authors>
-    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>$(BrigtherTargetFrameworks)</TargetFrameworks>
     <Nullable>enable</Nullable>
     <PackageTags>Redis;Command;Event;Service Activator;Decoupled;Invocation;Messaging;Remote;Command Dispatcher;Command Processor;Request;Service;Task Queue;Work Queue;Retry;Circuit Breaker;Availability</PackageTags>
     <SignAssembly>false</SignAssembly>

--- a/src/Paramore.Brighter.MsSql.Azure/Paramore.Brighter.MsSql.Azure.csproj
+++ b/src/Paramore.Brighter.MsSql.Azure/Paramore.Brighter.MsSql.Azure.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
       <Description>This is the MsSql Connection providers for Access Token authentication using Azure.Idenity</Description>
       <Authors>Paul Reardon</Authors>
-      <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+      <TargetFrameworks>$(BrigtherFrameworkAndCoreTargetFrameworks)</TargetFrameworks>
       <PackageTags>RabbitMQ;AMQP;Command;Event;Service Activator;Decoupled;Invocation;Messaging;Remote;Command Dispatcher;Command Processor;Request;Service;Task Queue;Work Queue;Retry;Circuit Breaker;Availability</PackageTags>
     </PropertyGroup>
 

--- a/src/Paramore.Brighter.MsSql.EntityFrameworkCore/Paramore.Brighter.MsSql.EntityFrameworkCore.csproj
+++ b/src/Paramore.Brighter.MsSql.EntityFrameworkCore/Paramore.Brighter.MsSql.EntityFrameworkCore.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>This is the MsSql Connection provider to obtain the connection from Entity Framework Core.</Description>
     <Authors>Paul Reardon</Authors>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>$(BrigtherCoreTargetFrameworks)</TargetFrameworks>
     <PackageTags>RabbitMQ;AMQP;Command;Event;Service Activator;Decoupled;Invocation;Messaging;Remote;Command Dispatcher;Command Processor;Request;Service;Task Queue;Work Queue;Retry;Circuit Breaker;Availability</PackageTags>
   </PropertyGroup>
 

--- a/src/Paramore.Brighter.MsSql/Paramore.Brighter.MsSql.csproj
+++ b/src/Paramore.Brighter.MsSql/Paramore.Brighter.MsSql.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
       <Description>This is the common components required to connect to MsSql for Inbox, Outbox, and Messaging Gateway.</Description>
       <Authors>Paul Reardon</Authors>
-      <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+      <TargetFrameworks>$(BrigtherFrameworkAndCoreTargetFrameworks)</TargetFrameworks>
       <PackageTags>RabbitMQ;AMQP;Command;Event;Service Activator;Decoupled;Invocation;Messaging;Remote;Command Dispatcher;Command Processor;Request;Service;Task Queue;Work Queue;Retry;Circuit Breaker;Availability</PackageTags>
     </PropertyGroup>
 

--- a/src/Paramore.Brighter.MySql/Paramore.Brighter.MySql.csproj
+++ b/src/Paramore.Brighter.MySql/Paramore.Brighter.MySql.csproj
@@ -1,15 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFrameworks>$(BrigtherTargetFrameworks)</TargetFrameworks>
+  </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MySqlConnector" />
+    <PackageReference Include="MySqlConnector"/>
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Paramore.Brighter\Paramore.Brighter.csproj" />
+    <ProjectReference Include="..\Paramore.Brighter\Paramore.Brighter.csproj"/>
   </ItemGroup>
 
 </Project>

--- a/src/Paramore.Brighter.Outbox.DynamoDB/Paramore.Brighter.Outbox.DynamoDB.csproj
+++ b/src/Paramore.Brighter.Outbox.DynamoDB/Paramore.Brighter.Outbox.DynamoDB.csproj
@@ -1,15 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>$(BrigtherTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="AWSSDK.DynamoDBv2" />
-    
 
-  </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Paramore.Brighter.DynamoDb\Paramore.Brighter.DynamoDb.csproj" />
-    <ProjectReference Include="..\Paramore.Brighter.Extensions.DependencyInjection\Paramore.Brighter.Extensions.DependencyInjection.csproj" />
-    <ProjectReference Include="..\Paramore.Brighter\Paramore.Brighter.csproj" />
+    <PackageReference Include="AWSSDK.DynamoDBv2"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Paramore.Brighter.DynamoDb\Paramore.Brighter.DynamoDb.csproj"/>
+    <ProjectReference Include="..\Paramore.Brighter.Extensions.DependencyInjection\Paramore.Brighter.Extensions.DependencyInjection.csproj"/>
+    <ProjectReference Include="..\Paramore.Brighter\Paramore.Brighter.csproj"/>
   </ItemGroup>
 </Project>

--- a/src/Paramore.Brighter.Outbox.Hosting/Paramore.Brighter.Outbox.Hosting.csproj
+++ b/src/Paramore.Brighter.Outbox.Hosting/Paramore.Brighter.Outbox.Hosting.csproj
@@ -1,19 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFrameworks>$(BrigtherTargetFrameworks)</TargetFrameworks>
+  </PropertyGroup>
 
-    <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
-      <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
-      <PackageReference Include="Microsoft.Extensions.Hosting" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder"/>
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables"/>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection"/>
+    <PackageReference Include="Microsoft.Extensions.Hosting"/>
+  </ItemGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\Paramore.Brighter.Extensions.DependencyInjection\Paramore.Brighter.Extensions.DependencyInjection.csproj" />
-      <ProjectReference Include="..\Paramore.Brighter\Paramore.Brighter.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Paramore.Brighter.Extensions.DependencyInjection\Paramore.Brighter.Extensions.DependencyInjection.csproj"/>
+    <ProjectReference Include="..\Paramore.Brighter\Paramore.Brighter.csproj"/>
+  </ItemGroup>
 
 </Project>

--- a/src/Paramore.Brighter.Outbox.MsSql/MsSqlOutbox.cs
+++ b/src/Paramore.Brighter.Outbox.MsSql/MsSqlOutbox.cs
@@ -391,7 +391,6 @@ namespace Paramore.Brighter.Outbox.MsSql
             }
 
             dr.Close();
-
             return message ?? new Message();
         }
 
@@ -403,8 +402,11 @@ namespace Paramore.Brighter.Outbox.MsSql
                 message = MapAMessage(dr);
             }
 
+#if NET462
+            dr.Close();
+#else
             await dr.CloseAsync();
-
+#endif
             return message ?? new Message();
         }
 
@@ -432,8 +434,11 @@ namespace Paramore.Brighter.Outbox.MsSql
                 messages.Add(MapAMessage(dr));
             }
 
+#if NET462
+            dr.Close();
+#else
             await dr.CloseAsync();
-
+#endif
             return messages;
         }
 
@@ -446,7 +451,11 @@ namespace Paramore.Brighter.Outbox.MsSql
                 outstandingMessages = dr.GetInt32(0);
             }
 
+#if NET462
+            dr.Close();
+#else
             await dr.CloseAsync();
+#endif
             return outstandingMessages;
         }
 

--- a/src/Paramore.Brighter.Outbox.MsSql/Paramore.Brighter.Outbox.MsSql.csproj
+++ b/src/Paramore.Brighter.Outbox.MsSql/Paramore.Brighter.Outbox.MsSql.csproj
@@ -2,16 +2,16 @@
   <PropertyGroup>
     <Description>This is an implementation of the outbox used for decoupled invocation of commands by Paramore.Brighter, using MS Sql Server</Description>
     <Authors>Francesco Pighi</Authors>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>$(BrigtherFrameworkAndCoreTargetFrameworks)</TargetFrameworks>
     <PackageTags>RabbitMQ;AMQP;Command;Event;Service Activator;Decoupled;Invocation;Messaging;Remote;Command Dispatcher;Command Processor;Request;Service;Task Queue;Work Queue;Retry;Circuit Breaker;Availability</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <None Remove="DDL_SCRIPTS\MSSQL\Outbox.sql" />
+    <None Remove="DDL_SCRIPTS\MSSQL\Outbox.sql"/>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Paramore.Brighter.Extensions.DependencyInjection\Paramore.Brighter.Extensions.DependencyInjection.csproj" />
-    <ProjectReference Include="..\Paramore.Brighter.MsSql\Paramore.Brighter.MsSql.csproj" />
-    <ProjectReference Include="..\Paramore.Brighter\Paramore.Brighter.csproj" />
+    <ProjectReference Include="..\Paramore.Brighter.Extensions.DependencyInjection\Paramore.Brighter.Extensions.DependencyInjection.csproj"/>
+    <ProjectReference Include="..\Paramore.Brighter.MsSql\Paramore.Brighter.MsSql.csproj"/>
+    <ProjectReference Include="..\Paramore.Brighter\Paramore.Brighter.csproj"/>
   </ItemGroup>
 
 </Project>

--- a/src/Paramore.Brighter.Outbox.MySql/MySqlOutbox.cs
+++ b/src/Paramore.Brighter.Outbox.MySql/MySqlOutbox.cs
@@ -159,14 +159,14 @@ namespace Paramore.Brighter.Outbox.MySql
 
             if (connection.State != ConnectionState.Open)
                 await connection.OpenAsync(cancellationToken);
-            await using var command = commandFunc.Invoke(connection);
+            using var command = commandFunc.Invoke(connection);
             try
             {
                 return await resultFunc.Invoke(await command.ExecuteReaderAsync(cancellationToken));
             }
             finally
             {
-                await connection.CloseAsync();
+                connection.Close();
             }
         }
 
@@ -341,7 +341,7 @@ namespace Paramore.Brighter.Outbox.MySql
                 outstandingMessages = dr.GetInt32(0);
             }
 
-            await dr.CloseAsync();
+            dr.Close();
             return outstandingMessages;
         }
 

--- a/src/Paramore.Brighter.Outbox.MySql/Paramore.Brighter.Outbox.MySql.csproj
+++ b/src/Paramore.Brighter.Outbox.MySql/Paramore.Brighter.Outbox.MySql.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>This is an implementation of the outbox used for decoupled invocation of commands by Paramore.Brighter, using MySql</Description>
     <Authors>Derek Comartin</Authors>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>$(BrigtherTargetFrameworks)</TargetFrameworks>
     <PackageTags>RabbitMQ;AMQP;Command;Event;Service Activator;Decoupled;Invocation;Messaging;Remote;Command Dispatcher;Command Processor;Request;Service;Task Queue;Work Queue;Retry;Circuit Breaker;Availability</PackageTags>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Paramore.Brighter.Outbox.PostgreSql/Paramore.Brighter.Outbox.PostgreSql.csproj
+++ b/src/Paramore.Brighter.Outbox.PostgreSql/Paramore.Brighter.Outbox.PostgreSql.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>This is an implementation of the outbox used for decoupled invocation of commands by Paramore.Brighter, using PostgreSql</Description>
     <Authors>Tarun Pothulapati</Authors>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>$(BrigtherCoreTargetFrameworks)</TargetFrameworks>
     <PackageTags>RabbitMQ;AMQP;Command;Event;Service Activator;Decoupled;Invocation;Messaging;Remote;Command Dispatcher;Command Processor;Request;Service;Task Queue;Work Queue;Retry;Circuit Breaker;Availability</PackageTags>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Paramore.Brighter.Outbox.Sqlite/Paramore.Brighter.Outbox.Sqlite.csproj
+++ b/src/Paramore.Brighter.Outbox.Sqlite/Paramore.Brighter.Outbox.Sqlite.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>This is an implementation of the outbox used for decoupled invocation of commands by Paramore.Brighter, using Sqlite</Description>
     <Authors>Francesco Pighi</Authors>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>$(BrigtherTargetFrameworks)</TargetFrameworks>
     <PackageTags>RabbitMQ;AMQP;Command;Event;Service Activator;Decoupled;Invocation;Messaging;Remote;Command Dispatcher;Command Processor;Request;Service;Task Queue;Work Queue;Retry;Circuit Breaker;Availability</PackageTags>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Paramore.Brighter.Outbox.Sqlite/SqliteOutbox.cs
+++ b/src/Paramore.Brighter.Outbox.Sqlite/SqliteOutbox.cs
@@ -102,7 +102,12 @@ namespace Paramore.Brighter.Outbox.Sqlite
             CancellationToken cancellationToken)
         {
             var connection = await GetOpenConnectionAsync(_connectionProvider, transactionProvider, cancellationToken);
+            
+#if NETSTANDARD
+            using var command = commandFunc.Invoke(connection);
+#else
             await using var command = commandFunc.Invoke(connection);
+#endif
             try
             {
                 if (transactionProvider != null && transactionProvider.HasOpenTransaction)
@@ -339,7 +344,11 @@ namespace Paramore.Brighter.Outbox.Sqlite
                 messages.Add(MapAMessage(dr));
             }
 
+#if NETSTANDARD
+            dr.Close();
+#else
             await dr.CloseAsync();
+#endif 
 
             return messages;
         }
@@ -353,7 +362,11 @@ namespace Paramore.Brighter.Outbox.Sqlite
                 outstandingMessages = dr.GetInt32(0);
             }
 
+#if NETSTANDARD
+            dr.Close();
+#else
             await dr.CloseAsync();
+#endif 
             return outstandingMessages;
         }
 
@@ -428,7 +441,12 @@ namespace Paramore.Brighter.Outbox.Sqlite
             var i = dr.GetOrdinal("Body");
             var body = dr.GetStream(i);
             var buffer = new byte[body.Length];
+            
+#if NETSTANDARD
+            body.Read(buffer, 0, (int)body.Length);
+#else
             body.ReadExactly(buffer, 0, (int)body.Length);
+#endif 
             return buffer;
         }
 

--- a/src/Paramore.Brighter.PostgreSql.EntityFrameworkCore/Paramore.Brighter.PostgreSql.EntityFrameworkCore.csproj
+++ b/src/Paramore.Brighter.PostgreSql.EntityFrameworkCore/Paramore.Brighter.PostgreSql.EntityFrameworkCore.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Authors>Sam Rumley</Authors>
     <Description>Common components required to get a PostgreSql connection from Entity Framework Core.</Description>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>$(BrigtherCoreTargetFrameworks)</TargetFrameworks>
     <PackageTags>RabbitMQ;AMQP;Command;Event;Service Activator;Decoupled;Invocation;Messaging;Remote;Command Dispatcher;Command Processor;Request;Service;Task Queue;Work Queue;Retry;Circuit Breaker;Availability</PackageTags>
   </PropertyGroup>
 

--- a/src/Paramore.Brighter.PostgreSql/Paramore.Brighter.PostgreSql.csproj
+++ b/src/Paramore.Brighter.PostgreSql/Paramore.Brighter.PostgreSql.csproj
@@ -4,7 +4,7 @@
     <Authors>Sam Rumley</Authors>
     <Description>Common components required to connect to PostgreSql for inbox and outbox.</Description>
     <PackageTags>RabbitMQ;AMQP;Command;Event;Service Activator;Decoupled;Invocation;Messaging;Remote;Command Dispatcher;Command Processor;Request;Service;Task Queue;Work Queue;Retry;Circuit Breaker;Availability</PackageTags>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>$(BrigtherCoreTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Paramore.Brighter.ServiceActivator.Control.Api/Paramore.Brighter.ServiceActivator.Control.Api.csproj
+++ b/src/Paramore.Brighter.ServiceActivator.Control.Api/Paramore.Brighter.ServiceActivator.Control.Api.csproj
@@ -1,18 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
-    <PropertyGroup>
-        <OutputType>Library</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
-        <Authors>Paul Reardon</Authors>
-        <IsPackable>true</IsPackable>
-        <Description>The API extensions for the Brighter Service Activator Control module</Description>
-        <PackageTags>Command;Event;Service Activator;Decoupled;Invocation;Messaging;Remote;Command Dispatcher;Command Processor;Request;Service;Task Queue;Work Queue;Retry;Circuit Breaker;Availability</PackageTags>
-    </PropertyGroup>
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFrameworks>$(BrigtherCoreTargetFrameworks)</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <Authors>Paul Reardon</Authors>
+    <IsPackable>true</IsPackable>
+    <Description>The API extensions for the Brighter Service Activator Control module</Description>
+    <PackageTags>Command;Event;Service Activator;Decoupled;Invocation;Messaging;Remote;Command Dispatcher;Command Processor;Request;Service;Task Queue;Work Queue;Retry;Circuit Breaker;Availability</PackageTags>
+  </PropertyGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\Paramore.Brighter.ServiceActivator.Control\Paramore.Brighter.ServiceActivator.Control.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Paramore.Brighter.ServiceActivator.Control\Paramore.Brighter.ServiceActivator.Control.csproj"/>
+  </ItemGroup>
 
 </Project>

--- a/src/Paramore.Brighter.ServiceActivator.Control/Hosting/HeartbeatHostedService.cs
+++ b/src/Paramore.Brighter.ServiceActivator.Control/Hosting/HeartbeatHostedService.cs
@@ -26,12 +26,24 @@ public class HeartbeatHostedService : IHostedService
         return Task.CompletedTask;
     }
 
+#if NETSTANDARD2_0
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Stopping heartbeat service");
+        _timer?.Dispose();
+
+        return Task.CompletedTask;
+    }
+#else
     public async Task StopAsync(CancellationToken cancellationToken)
     {
         _logger.LogInformation("Stopping heartbeat service");
         if (_timer != null)
+        {
             await _timer.DisposeAsync();
+        }
     }
+#endif
 
     private void SendHeartbeat(object? state)
     {

--- a/src/Paramore.Brighter.ServiceActivator.Control/Paramore.Brighter.ServiceActivator.Control.csproj
+++ b/src/Paramore.Brighter.ServiceActivator.Control/Paramore.Brighter.ServiceActivator.Control.csproj
@@ -1,24 +1,24 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
-        <Authors>Paul Reardon</Authors>
-        <Description>The Control modules for Brighter Service Activator</Description>
-        <PackageTags>Command;Event;Service Activator;Decoupled;Invocation;Messaging;Remote;Command Dispatcher;Command Processor;Request;Service;Task Queue;Work Queue;Retry;Circuit Breaker;Availability</PackageTags>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFrameworks>$(BrigtherTargetFrameworks)</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <Authors>Paul Reardon</Authors>
+    <Description>The Control modules for Brighter Service Activator</Description>
+    <PackageTags>Command;Event;Service Activator;Decoupled;Invocation;Messaging;Remote;Command Dispatcher;Command Processor;Request;Service;Task Queue;Work Queue;Retry;Circuit Breaker;Availability</PackageTags>
+  </PropertyGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\Paramore.Brighter.Extensions.DependencyInjection\Paramore.Brighter.Extensions.DependencyInjection.csproj" />
-      <ProjectReference Include="..\Paramore.Brighter.ServiceActivator.Extensions.DependencyInjection\Paramore.Brighter.ServiceActivator.Extensions.DependencyInjection.csproj" />
-      <ProjectReference Include="..\Paramore.Brighter.ServiceActivator\Paramore.Brighter.ServiceActivator.csproj" />
-      <ProjectReference Include="..\Paramore.Brighter\Paramore.Brighter.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Paramore.Brighter.Extensions.DependencyInjection\Paramore.Brighter.Extensions.DependencyInjection.csproj"/>
+    <ProjectReference Include="..\Paramore.Brighter.ServiceActivator.Extensions.DependencyInjection\Paramore.Brighter.ServiceActivator.Extensions.DependencyInjection.csproj"/>
+    <ProjectReference Include="..\Paramore.Brighter.ServiceActivator\Paramore.Brighter.ServiceActivator.csproj"/>
+    <ProjectReference Include="..\Paramore.Brighter\Paramore.Brighter.csproj"/>
+  </ItemGroup>
 
-    <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
-      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions"/>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions"/>
+  </ItemGroup>
 
 </Project>

--- a/src/Paramore.Brighter.ServiceActivator.Extensions.DependencyInjection/Paramore.Brighter.ServiceActivator.Extensions.DependencyInjection.csproj
+++ b/src/Paramore.Brighter.ServiceActivator.Extensions.DependencyInjection/Paramore.Brighter.ServiceActivator.Extensions.DependencyInjection.csproj
@@ -1,20 +1,20 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>$(BrigtherTargetFrameworks)</TargetFrameworks>
     <Description>Service Activator Microsoft.Extensions.DependencyInjection support</Description>
     <Authors>Toby Henderson</Authors>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Paramore.Brighter.Extensions.DependencyInjection\Paramore.Brighter.Extensions.DependencyInjection.csproj" />
-    <ProjectReference Include="..\Paramore.Brighter.ServiceActivator\Paramore.Brighter.ServiceActivator.csproj" />
+    <ProjectReference Include="..\Paramore.Brighter.Extensions.DependencyInjection\Paramore.Brighter.Extensions.DependencyInjection.csproj"/>
+    <ProjectReference Include="..\Paramore.Brighter.ServiceActivator\Paramore.Brighter.ServiceActivator.csproj"/>
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
-    
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder"/>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection"/>
+
 
   </ItemGroup>
 

--- a/src/Paramore.Brighter.ServiceActivator.Extensions.Diagnostics/Paramore.Brighter.ServiceActivator.Extensions.Diagnostics.csproj
+++ b/src/Paramore.Brighter.ServiceActivator.Extensions.Diagnostics/Paramore.Brighter.ServiceActivator.Extensions.Diagnostics.csproj
@@ -1,18 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>$(BrigtherTargetFrameworks)</TargetFrameworks>
     <Description>This Microsoft Extensions Diagnostics Health Checks for Service Activator</Description>
     <Authors>Paul Reardon</Authors>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions"/>
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Paramore.Brighter.ServiceActivator\Paramore.Brighter.ServiceActivator.csproj" />
+    <ProjectReference Include="..\Paramore.Brighter.ServiceActivator\Paramore.Brighter.ServiceActivator.csproj"/>
   </ItemGroup>
 
 </Project>

--- a/src/Paramore.Brighter.ServiceActivator.Extensions.Hosting/Paramore.Brighter.ServiceActivator.Extensions.Hosting.csproj
+++ b/src/Paramore.Brighter.ServiceActivator.Extensions.Hosting/Paramore.Brighter.ServiceActivator.Extensions.Hosting.csproj
@@ -1,17 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>$(BrigtherTargetFrameworks)</TargetFrameworks>
     <Description>Service Activator Microsoft.Extensions.Hosting (IHostBuilder) support for background tasks</Description>
     <Authors>Toby Henderson</Authors>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder"/>
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables"/>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection"/>
+    <PackageReference Include="Microsoft.Extensions.Hosting"/>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Paramore.Brighter.Extensions.DependencyInjection\Paramore.Brighter.Extensions.DependencyInjection.csproj" />
-    <ProjectReference Include="..\Paramore.Brighter.ServiceActivator\Paramore.Brighter.ServiceActivator.csproj" />
+    <ProjectReference Include="..\Paramore.Brighter.Extensions.DependencyInjection\Paramore.Brighter.Extensions.DependencyInjection.csproj"/>
+    <ProjectReference Include="..\Paramore.Brighter.ServiceActivator\Paramore.Brighter.ServiceActivator.csproj"/>
   </ItemGroup>
 </Project>

--- a/src/Paramore.Brighter.ServiceActivator/Paramore.Brighter.ServiceActivator.csproj
+++ b/src/Paramore.Brighter.ServiceActivator/Paramore.Brighter.ServiceActivator.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>The Command Dispatcher pattern is an addition to the Command design pattern that decouples the dispatcher for a service from its execution. A Command Dispatcher component maps commands to handlers. A Command Processor pattern provides a  framework for handling orthogonal concerns such as logging, timeouts, or circuit breakers</Description>
     <Authors>Ian Cooper</Authors>
-    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>$(BrigtherTargetFrameworks)</TargetFrameworks>
     <PackageTags>Command;Event;Service Activator;Decoupled;Invocation;Messaging;Remote;Command Dispatcher;Command Processor;Request;Service;Task Queue;Work Queue;Retry;Circuit Breaker;Availability</PackageTags>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/Paramore.Brighter.Sqlite.Dapper/Paramore.Brighter.Sqlite.Dapper.csproj
+++ b/src/Paramore.Brighter.Sqlite.Dapper/Paramore.Brighter.Sqlite.Dapper.csproj
@@ -1,16 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-     <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFrameworks>$(BrigtherTargetFrameworks)</TargetFrameworks>
+  </PropertyGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\Paramore.Brighter.Dapper\Paramore.Brighter.Dapper.csproj" />
-      <ProjectReference Include="..\Paramore.Brighter.Sqlite\Paramore.Brighter.Sqlite.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Paramore.Brighter.Dapper\Paramore.Brighter.Dapper.csproj"/>
+    <ProjectReference Include="..\Paramore.Brighter.Sqlite\Paramore.Brighter.Sqlite.csproj"/>
+  </ItemGroup>
 
-    <ItemGroup>
-      <PackageReference Include="Dapper" />
-      <PackageReference Include="Dapper.Contrib" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Dapper"/>
+    <PackageReference Include="Dapper.Contrib"/>
+  </ItemGroup>
 </Project>

--- a/src/Paramore.Brighter.Sqlite.EntityFrameworkCore/Paramore.Brighter.Sqlite.EntityFrameworkCore.csproj
+++ b/src/Paramore.Brighter.Sqlite.EntityFrameworkCore/Paramore.Brighter.Sqlite.EntityFrameworkCore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Authors>Ian Cooper</Authors>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>$(BrigtherCoreTargetFrameworks)</TargetFrameworks>
     <PackageTags>RabbitMQ;AMQP;Command;Event;Service Activator;Decoupled;Invocation;Messaging;Remote;Command Dispatcher;Command Processor;Request;Service;Task Queue;Work Queue;Retry;Circuit Breaker;Availability</PackageTags>
   </PropertyGroup>
 

--- a/src/Paramore.Brighter.Sqlite/Paramore.Brighter.Sqlite.csproj
+++ b/src/Paramore.Brighter.Sqlite/Paramore.Brighter.Sqlite.csproj
@@ -1,16 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <Authors>Ian Cooper</Authors>
-        <PackageTags>RabbitMQ;AMQP;Command;Event;Service Activator;Decoupled;Invocation;Messaging;Remote;Command Dispatcher;Command Processor;Request;Service;Task Queue;Work Queue;Retry;Circuit Breaker;Availability</PackageTags>
-      <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0;net9.0</TargetFrameworks>
-    </PropertyGroup>
-  
-     <ItemGroup>
-       <PackageReference Include="Microsoft.Data.Sqlite" />
-     </ItemGroup>
+  <PropertyGroup>
+    <Authors>Ian Cooper</Authors>
+    <PackageTags>RabbitMQ;AMQP;Command;Event;Service Activator;Decoupled;Invocation;Messaging;Remote;Command Dispatcher;Command Processor;Request;Service;Task Queue;Work Queue;Retry;Circuit Breaker;Availability</PackageTags>
+    <TargetFrameworks>$(BrigtherTargetFrameworks)</TargetFrameworks>
+  </PropertyGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\Paramore.Brighter\Paramore.Brighter.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Data.Sqlite"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Paramore.Brighter\Paramore.Brighter.csproj"/>
+  </ItemGroup>
 </Project>

--- a/src/Paramore.Brighter.Tranformers.AWS/Paramore.Brighter.Tranformers.AWS.csproj
+++ b/src/Paramore.Brighter.Tranformers.AWS/Paramore.Brighter.Tranformers.AWS.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>$(BrigtherTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Paramore.Brighter.Transformers.Azure/Paramore.Brighter.Transformers.Azure.csproj
+++ b/src/Paramore.Brighter.Transformers.Azure/Paramore.Brighter.Transformers.Azure.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>$(BrigtherTargetFrameworks)</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Authors>Paul Reardon</Authors>
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Paramore.Brighter\Paramore.Brighter.csproj" />
+    <ProjectReference Include="..\Paramore.Brighter\Paramore.Brighter.csproj"/>
   </ItemGroup>
 
 </Project>

--- a/src/Paramore.Brighter/Paramore.Brighter.csproj
+++ b/src/Paramore.Brighter/Paramore.Brighter.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>The Command Dispatcher pattern is an addition to the Command design pattern that decouples the dispatcher for a service from its execution. A Command Dispatcher component maps commands to handlers. A Command Processor pattern provides a  framework for handling orthogonal concerns such as logging, timeouts, or circuit breakers</Description>
     <Authors>Ian Cooper</Authors>
-    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>$(BrigtherTargetFrameworks)</TargetFrameworks>
     <PackageTags>Command;Event;Command Dispatcher;Command Processor;Request;Service;Task Queue;Work Queue;Retry;Circuit Breaker;Availability</PackageTags>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
@@ -17,7 +17,7 @@
     <PackageReference Include="Polly" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Text.Json" />
   </ItemGroup>
   


### PR DESCRIPTION
Many projects can have support for .NET Standard and we haven't added support to it.

I've created 3 variables:
- BrigtherTargetFrameworks -> This should be the default (netstandard2.0;net8.0;net9.0)
- BrigtherCoreTargetFrameworks -> Some libs have drop support to .NET Standard & .NET Framework like postgres (net462;net8.0;net9.0)
- BrigtherFrameworkAndCoreTargetFrameworks -> For projects that have support to target .NET Core & .NET Framework like MsSQL (net462;net8.0;net9.0)