### PR TITLE
[Bug] Fix usage of transaction provider when calling sync Add on Dynamo DB outbox

### DIFF
--- a/src/Paramore.Brighter.DynamoDb/DynamoDbUnitOfWork.cs
+++ b/src/Paramore.Brighter.DynamoDb/DynamoDbUnitOfWork.cs
@@ -55,7 +55,7 @@ namespace Paramore.Brighter.DynamoDb
         /// Commit a transaction, performing all associated write actions
         /// Will block thread and use second thread for callback
         /// </summary>
-        public void Commit() => BrighterAsyncContext.Run(async () => await DynamoDb.TransactWriteItemsAsync(_tx));
+        public void Commit() => BrighterAsyncContext.Run(async () => await CommitAsync());
         
         /// <summary>
         /// Commit a transaction, performing all associated write actions

--- a/src/Paramore.Brighter.Outbox.DynamoDB/DynamoDbOutbox.cs
+++ b/src/Paramore.Brighter.Outbox.DynamoDB/DynamoDbOutbox.cs
@@ -130,7 +130,7 @@ namespace Paramore.Brighter.Outbox.DynamoDB
             IAmABoxTransactionProvider<TransactWriteItemsRequest> transactionProvider = null
             )
         {
-            AddAsync(message, requestContext, outBoxTimeout).ConfigureAwait(ContinueOnCapturedContext).GetAwaiter().GetResult();
+            AddAsync(message, requestContext, outBoxTimeout, transactionProvider).ConfigureAwait(ContinueOnCapturedContext).GetAwaiter().GetResult();
         }
 
         /// <summary>

--- a/tests/Paramore.Brighter.DynamoDB.Tests/Outbox/When_there_is_a_transaction_between_outbox_and_entity.cs
+++ b/tests/Paramore.Brighter.DynamoDB.Tests/Outbox/When_there_is_a_transaction_between_outbox_and_entity.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Net;
+using System.Threading.Tasks;
 using Amazon.DynamoDBv2;
 using Amazon.DynamoDBv2.DataModel;
 using Amazon.DynamoDBv2.Model;
+using FluentAssertions;
 using Microsoft.Extensions.Time.Testing;
 using Paramore.Brighter.DynamoDb;
 using Paramore.Brighter.DynamoDB.Tests.TestDoubles;
@@ -18,6 +20,8 @@ public class DynamoDbOutboxTransactionTests : DynamoDBOutboxBaseTest
     private readonly ITestOutputHelper _testOutputHelper;
     private readonly DynamoDbOutbox _dynamoDbOutbox;
     private readonly string _entityTableName;
+    private readonly Dictionary<string, AttributeValue?> _entityAttributes;
+    private readonly Message _message;
 
     public DynamoDbOutboxTransactionTests(ITestOutputHelper testOutputHelper)
     {
@@ -46,14 +50,11 @@ public class DynamoDbOutboxTransactionTests : DynamoDBOutboxBaseTest
         }
 
         _dynamoDbOutbox = new DynamoDbOutbox(Client, new DynamoDbConfiguration(OutboxTableName), fakeTimeProvider);
-    }
 
-    [Fact]
-    public async void When_There_Is_A_Transaction_Between_Outbox_And_Entity()
-    {
         var context = new DynamoDBContext(Client);
         var myItem = new MyEntity { Id = Guid.NewGuid().ToString(), Value = "Test Value for Transaction Checking" };
-        var attributes = context.ToDocument(myItem).ToAttributeMap();
+        _entityAttributes = context.ToDocument(myItem).ToAttributeMap();
+
         var myMessageHeader = new MessageHeader(
             messageId: Guid.NewGuid().ToString(),
             topic: new RoutingKey("test_topic"),
@@ -64,18 +65,51 @@ public class DynamoDbOutboxTransactionTests : DynamoDBOutboxBaseTest
             correlationId: Guid.NewGuid().ToString(),
             replyTo: new RoutingKey("ReplyAddress"),
             contentType: "text/plain");
-
         var body = new MessageBody(myItem.Value);
-        var myMessage = new MessageItem(new Message(myMessageHeader, body));
-        var messageAttributes = context.ToDocument(myMessage).ToAttributeMap();
+        _message = new Message(myMessageHeader, body);
+    }
 
+    [Fact]
+    public void When_There_Is_A_Transaction_Between_Outbox_And_Entity()
+    {
         var uow = new DynamoDbUnitOfWork(Client);
-        TransactWriteItemsResponse response = null;
+        TransactWriteItemsResponse response;
         try
         {
+            _dynamoDbOutbox.Add(_message, new RequestContext(), transactionProvider: uow);
+
+            var transaction = uow.GetTransaction();
+            transaction.TransactItems.Add(new TransactWriteItem { Put = new Put { TableName = _entityTableName, Item = _entityAttributes, } });
+
+            transaction.TransactItems.Count.Should().Be(2);
+
+            uow.Commit();
+            response = uow.LastResponse;
+        }
+        catch (Exception e)
+        {
+            _testOutputHelper.WriteLine(e.ToString());
+            throw;
+        }
+
+        response.Should().NotBeNull();
+        response.HttpStatusCode.Should().Be(HttpStatusCode.OK);
+        response.ContentLength.Should().Be(2); //number of tables in the transaction 
+    }
+
+    [Fact]
+    public async Task When_There_Is_A_Transaction_Between_Outbox_And_Entity_Async()
+    {
+        var uow = new DynamoDbUnitOfWork(Client);
+        TransactWriteItemsResponse response;
+        try
+        {
+            await _dynamoDbOutbox.AddAsync(_message, new RequestContext(), transactionProvider: uow);
+
             var transaction = await uow.GetTransactionAsync();
-            transaction.TransactItems.Add(new TransactWriteItem { Put = new Put { TableName = _entityTableName, Item = attributes, } });
-            transaction.TransactItems.Add(new TransactWriteItem { Put = new Put { TableName = OutboxTableName, Item = messageAttributes}});
+            transaction.TransactItems.Add(new TransactWriteItem { Put = new Put { TableName = _entityTableName, Item = _entityAttributes, } });
+
+            transaction.TransactItems.Count.Should().Be(2);
 
             await uow.CommitAsync();
             response = uow.LastResponse;
@@ -86,8 +120,8 @@ public class DynamoDbOutboxTransactionTests : DynamoDBOutboxBaseTest
             throw;
         }
 
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.HttpStatusCode);
-        Assert.Equal(2, response.ContentLength);    //number of tables in the transaction
+        response.Should().NotBeNull();
+        response.HttpStatusCode.Should().Be(HttpStatusCode.OK);
+        response.ContentLength.Should().Be(2); //number of tables in the transaction 
     }
 }


### PR DESCRIPTION
Currently, when the synchronous `Add` method is called on the DynamoDb outbox, it fails to pass on any transaction provider, if supplied. That means that when one _is_ supplied, the transaction isn't used and the item is added straight to the outbox table.

This PR fixes this by passing on the transaction provider. It also updates the DynamoDb transaction provider to correctly set the `LastResponse` property, as this isn't being set currently when calling the synchronous `Commit` method.