### PR TITLE
Making internal & private classes sealed to avoid virtual dispatch, plus some Dictionary capacity tweaks

### DIFF
--- a/src/Paramore.Brighter.DynamoDb/DynamoDbTableBuilder.cs
+++ b/src/Paramore.Brighter.DynamoDb/DynamoDbTableBuilder.cs
@@ -114,7 +114,7 @@ namespace Paramore.Brighter.DynamoDb
 
             return tableCheck.Any(kv => kv.Value) ? 
                 (true, tableCheck.Where(tbl => tbl.Value).Select(tbl => tbl.Key)) : 
-                (false, Enumerable.Empty<string>());
+                (false, []);
 
         }
         
@@ -197,12 +197,10 @@ namespace Paramore.Brighter.DynamoDb
             return false;
         }
 
-        private class DynamoDbTableStatus
+        private sealed class DynamoDbTableStatus
         { 
-            public string TableName { get; set; }
+            public string TableName { get; init; }
             public bool IsReady { get; set; }
         }
-
    }
 }
-

--- a/src/Paramore.Brighter.DynamoDb/DynamoDbTableFactory.cs
+++ b/src/Paramore.Brighter.DynamoDb/DynamoDbTableFactory.cs
@@ -25,8 +25,6 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Reflection;
-using System.Threading;
-using System.Threading.Tasks;
 using Amazon.DynamoDBv2;
 using Amazon.DynamoDBv2.DataModel;
 using Amazon.DynamoDBv2.Model;
@@ -401,7 +399,7 @@ namespace Paramore.Brighter.Outbox.DynamoDB
             throw new NotSupportedException($"We can't convert {propertyType.Name} to a DynamoDb type. Avoid marking as an attribute and see if the lib can figure it out");
         }
 
-        private class GlobalSecondaryIndexDetails
+        private sealed class GlobalSecondaryIndexDetails
         {
             public PropertyInfo Prop { get; set; }
             public CustomAttributeData Attribute { get; set; }

--- a/src/Paramore.Brighter.Inbox.DynamoDB/KeyIdContextExpression.cs
+++ b/src/Paramore.Brighter.Inbox.DynamoDB/KeyIdContextExpression.cs
@@ -1,30 +1,24 @@
-using System;
 using System.Collections.Generic;
 using Amazon.DynamoDBv2.DocumentModel;
 
 namespace Paramore.Brighter.Inbox.DynamoDB
 {
-    internal class KeyIdContextExpression
+    internal sealed class KeyIdContextExpression
     {
-        private Expression _expression;
-
-        public KeyIdContextExpression()
+        private readonly Expression _expression = new()
         {
-            _expression = new Expression();
-            _expression.ExpressionStatement = "CommandId = :v_CommandId and ContextKey = :v_ContextKey";
-        }
+            ExpressionStatement = "CommandId = :v_CommandId and ContextKey = :v_ContextKey"
+        };
 
         public Expression Generate(string id, string contextKey)
         {
-            var values = new Dictionary<string, DynamoDBEntry>();
-            values.Add(":v_CommandId", id);
-            values.Add(":v_ContextKey", contextKey);
-
-            _expression.ExpressionAttributeValues = values;
+            _expression.ExpressionAttributeValues = new Dictionary<string, DynamoDBEntry>(capacity: 2)
+            {
+                { ":v_CommandId", id },
+                { ":v_ContextKey", contextKey }
+            };
 
             return _expression;
-  
         }
-
     }
 }

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS/HeaderResult.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS/HeaderResult.cs
@@ -57,7 +57,7 @@ namespace Paramore.Brighter.MessagingGateway.AWSSQS
     /// Class HeaderResult.
     /// </summary>
     /// <typeparam name="TResult">The type of the t result.</typeparam>
-    internal class HeaderResult<TResult>
+    internal sealed class HeaderResult<TResult>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="HeaderResult{TResult}"/> class.

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS/SqsInlineMessageCreator.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS/SqsInlineMessageCreator.cs
@@ -33,7 +33,7 @@ using Paramore.Brighter.Logging;
 
 namespace Paramore.Brighter.MessagingGateway.AWSSQS;
 
-internal class SqsInlineMessageCreator : SqsMessageCreatorBase, ISqsMessageCreator
+internal sealed class SqsInlineMessageCreator : SqsMessageCreatorBase, ISqsMessageCreator
 {
     private static readonly ILogger s_logger = ApplicationLogging.CreateLogger<SqsInlineMessageCreator>();
 

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS/SqsMessageCreator.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS/SqsMessageCreator.cs
@@ -48,7 +48,7 @@ internal enum ARNAmazonSNS
     SubscriptionId = 6
 }
 
-internal class SqsMessageCreator : SqsMessageCreatorBase, ISqsMessageCreator
+internal sealed class SqsMessageCreator : SqsMessageCreatorBase, ISqsMessageCreator
 {
     private static readonly ILogger s_logger = ApplicationLogging.CreateLogger<SqsMessageCreator>();
 

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS/SqsMessageCreatorFactory.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS/SqsMessageCreatorFactory.cs
@@ -23,7 +23,7 @@ THE SOFTWARE. */
 
 namespace Paramore.Brighter.MessagingGateway.AWSSQS
 {
-    internal class SqsMessageCreatorFactory
+    internal sealed class SqsMessageCreatorFactory
     {
         public static ISqsMessageCreator Create(bool rawMessageDelivery)
         {

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS/ValidateTopicByName.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS/ValidateTopicByName.cs
@@ -33,7 +33,7 @@ namespace Paramore.Brighter.MessagingGateway.AWSSQS
     /// <summary>
     /// The <see cref="ValidateTopicByName"/> class is responsible for validating an AWS SNS topic by its name.
     /// </summary>
-    internal class ValidateTopicByName : IValidateTopic
+    internal sealed class ValidateTopicByName : IValidateTopic
     {
         private readonly AmazonSimpleNotificationServiceClient _snsClient;
         private readonly SnsSqsType _type;

--- a/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusWrappers/BrokeredMessageWrapper.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusWrappers/BrokeredMessageWrapper.cs
@@ -4,7 +4,7 @@ using Azure.Messaging.ServiceBus;
 
 namespace Paramore.Brighter.MessagingGateway.AzureServiceBus.AzureServiceBusWrappers
 {
-    internal class BrokeredMessageWrapper : IBrokeredMessageWrapper
+    internal sealed class BrokeredMessageWrapper : IBrokeredMessageWrapper
     {
         private readonly ServiceBusReceivedMessage _brokeredMessage;
 

--- a/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusWrappers/ServiceBusReceiverProvider.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusWrappers/ServiceBusReceiverProvider.cs
@@ -27,7 +27,7 @@ using Paramore.Brighter.MessagingGateway.AzureServiceBus.ClientProvider;
 
 namespace Paramore.Brighter.MessagingGateway.AzureServiceBus.AzureServiceBusWrappers
 {
-    internal class ServiceBusReceiverProvider(IServiceBusClientProvider clientProvider) : IServiceBusReceiverProvider
+    internal sealed class ServiceBusReceiverProvider(IServiceBusClientProvider clientProvider) : IServiceBusReceiverProvider
     {
         private readonly ServiceBusClient _client = clientProvider.GetServiceBusClient();
 

--- a/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusWrappers/ServiceBusReceiverWrapper.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusWrappers/ServiceBusReceiverWrapper.cs
@@ -34,7 +34,7 @@ namespace Paramore.Brighter.MessagingGateway.AzureServiceBus.AzureServiceBusWrap
     /// <summary>
     /// Wraps the <see cref="ServiceBusReceiver"/> to provide additional functionality.
     /// </summary>
-    internal class ServiceBusReceiverWrapper : IServiceBusReceiverWrapper
+    internal sealed class ServiceBusReceiverWrapper : IServiceBusReceiverWrapper
     {
         private readonly ServiceBusReceiver _messageReceiver;
         private static readonly ILogger s_logger = ApplicationLogging.CreateLogger<ServiceBusReceiverWrapper>();

--- a/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusWrappers/ServiceBusSenderProvider.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusWrappers/ServiceBusSenderProvider.cs
@@ -3,7 +3,7 @@ using Paramore.Brighter.MessagingGateway.AzureServiceBus.ClientProvider;
 
 namespace Paramore.Brighter.MessagingGateway.AzureServiceBus.AzureServiceBusWrappers
 {
-    internal class ServiceBusSenderProvider : IServiceBusSenderProvider
+    internal sealed class ServiceBusSenderProvider : IServiceBusSenderProvider
     {
         private readonly ServiceBusClient _client;
 

--- a/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusWrappers/ServiceBusSenderWrapper.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusWrappers/ServiceBusSenderWrapper.cs
@@ -6,7 +6,7 @@ using Azure.Messaging.ServiceBus;
 
 namespace Paramore.Brighter.MessagingGateway.AzureServiceBus.AzureServiceBusWrappers
 {
-    internal class ServiceBusSenderWrapper : IServiceBusSenderWrapper
+    internal sealed class ServiceBusSenderWrapper : IServiceBusSenderWrapper
     {
         private readonly ServiceBusSender _serviceBusSender;
 

--- a/src/Paramore.Brighter.MessagingGateway.Kafka/HeaderResult.cs
+++ b/src/Paramore.Brighter.MessagingGateway.Kafka/HeaderResult.cs
@@ -31,7 +31,7 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
     /// what do we need to know to process a message
     /// </summary>
     /// <typeparam name="TResult">The type of the t result.</typeparam>
-    internal class HeaderResult<TResult>
+    internal sealed class HeaderResult<TResult>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="HeaderResult{TResult}"/> class.

--- a/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaMessagePublisher.cs
+++ b/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaMessagePublisher.cs
@@ -29,7 +29,7 @@ using Confluent.Kafka;
 
 namespace Paramore.Brighter.MessagingGateway.Kafka
 {
-    internal class KafkaMessagePublisher
+    internal sealed class KafkaMessagePublisher
     {
         private readonly IProducer<string, byte[]> _producer;
 

--- a/src/Paramore.Brighter.MessagingGateway.RMQ.Async/HeaderResult.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ.Async/HeaderResult.cs
@@ -30,7 +30,7 @@ namespace Paramore.Brighter.MessagingGateway.RMQ.Async
     /// Class HeaderResult.
     /// </summary>
     /// <typeparam name="TResult">The type of the t result.</typeparam>
-    internal class HeaderResult<TResult>
+    internal sealed class HeaderResult<TResult>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="HeaderResult{TResult}"/> class.

--- a/src/Paramore.Brighter.MessagingGateway.RMQ.Async/RmqMessageCreator.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ.Async/RmqMessageCreator.cs
@@ -35,7 +35,7 @@ using RabbitMQ.Client.Events;
 
 namespace Paramore.Brighter.MessagingGateway.RMQ.Async;
 
-internal class RmqMessageCreator
+internal sealed class RmqMessageCreator
 {
     private static readonly ILogger s_logger = ApplicationLogging.CreateLogger<RmqMessageCreator>();
 

--- a/src/Paramore.Brighter.MessagingGateway.RMQ.Async/RmqMessageGatewayConnectionPool.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ.Async/RmqMessageGatewayConnectionPool.cs
@@ -201,5 +201,5 @@ public class RmqMessageGatewayConnectionPool(string connectionName, ushort conne
             $"{connectionFactory.UserName}.{connectionFactory.Password}.{connectionFactory.HostName}.{connectionFactory.Port}.{connectionFactory.VirtualHost}"
                 .ToLowerInvariant();
 
-    private record PooledConnection(IConnection Connection, AsyncEventHandler<ShutdownEventArgs> ShutdownHandler);
+    private sealed record PooledConnection(IConnection Connection, AsyncEventHandler<ShutdownEventArgs> ShutdownHandler);
 }

--- a/src/Paramore.Brighter.MessagingGateway.RMQ.Async/RmqMessagePublisher.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ.Async/RmqMessagePublisher.cs
@@ -39,7 +39,7 @@ namespace Paramore.Brighter.MessagingGateway.RMQ.Async;
 /// <summary>
 /// Class RmqMessagePublisher.
 /// </summary>
-internal class RmqMessagePublisher
+internal sealed class RmqMessagePublisher
 {
     private static readonly ILogger s_logger = ApplicationLogging.CreateLogger<RmqMessagePublisher>();
 

--- a/src/Paramore.Brighter.MessagingGateway.RMQ.Sync/HeaderResult.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ.Sync/HeaderResult.cs
@@ -30,7 +30,7 @@ namespace Paramore.Brighter.MessagingGateway.RMQ.Sync
     /// Class HeaderResult.
     /// </summary>
     /// <typeparam name="TResult">The type of the t result.</typeparam>
-    internal class HeaderResult<TResult>
+    internal sealed class HeaderResult<TResult>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="HeaderResult{TResult}"/> class.

--- a/src/Paramore.Brighter.MessagingGateway.RMQ.Sync/RmqMessageCreator.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ.Sync/RmqMessageCreator.cs
@@ -35,7 +35,7 @@ using RabbitMQ.Client.Events;
 
 namespace Paramore.Brighter.MessagingGateway.RMQ.Sync
 {
-    internal class RmqMessageCreator
+    internal sealed class RmqMessageCreator
     {
         private static readonly ILogger s_logger = ApplicationLogging.CreateLogger<RmqMessageCreator>();
 

--- a/src/Paramore.Brighter.MessagingGateway.RMQ.Sync/RmqMessageGatewayConnectionPool.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ.Sync/RmqMessageGatewayConnectionPool.cs
@@ -157,7 +157,7 @@ namespace Paramore.Brighter.MessagingGateway.RMQ.Sync
         }
 
 
-        class PooledConnection
+        sealed class PooledConnection
         {
             public IConnection? Connection { get; set; }
             public EventHandler<ShutdownEventArgs>? ShutdownHandler { get; set; }

--- a/src/Paramore.Brighter.MessagingGateway.RMQ.Sync/RmqMessagePublisher.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ.Sync/RmqMessagePublisher.cs
@@ -36,7 +36,7 @@ namespace Paramore.Brighter.MessagingGateway.RMQ.Sync
     /// <summary>
     /// Class RmqMessagePublisher.
     /// </summary>
-internal class RmqMessagePublisher
+internal sealed class RmqMessagePublisher
     {
         private static readonly ILogger s_logger = ApplicationLogging.CreateLogger<RmqMessagePublisher>();
         private static readonly string[] _headersToReset =

--- a/src/Paramore.Brighter.MessagingGateway.Redis/HeaderNames.cs
+++ b/src/Paramore.Brighter.MessagingGateway.Redis/HeaderNames.cs
@@ -24,7 +24,7 @@ THE SOFTWARE. */
 
 namespace Paramore.Brighter.MessagingGateway.Redis
 {
-    internal class HeaderNames
+    internal static class HeaderNames
     {
         /// <summary>
         /// The bag for user defined contents

--- a/src/Paramore.Brighter.Outbox.DynamoDB/BrighterDynamoDBFilter.cs
+++ b/src/Paramore.Brighter.Outbox.DynamoDB/BrighterDynamoDBFilter.cs
@@ -3,7 +3,7 @@ using Amazon.DynamoDBv2.DocumentModel;
 
 namespace Paramore.Brighter.Outbox.DynamoDB
 {
-    internal class BrighterDynamoDBFilter
+    internal sealed class BrighterDynamoDBFilter
     {
         public QueryOperator Operator { get; }
         public IEnumerable<string> Values { get; }

--- a/src/Paramore.Brighter.Outbox.DynamoDB/DispatchedAllTopicsQueryContext.cs
+++ b/src/Paramore.Brighter.Outbox.DynamoDB/DispatchedAllTopicsQueryContext.cs
@@ -27,7 +27,7 @@ using System.Collections.Generic;
 
 namespace Paramore.Brighter.Outbox.DynamoDB;
 
-internal class DispatchedAllTopicsQueryContext
+internal sealed class DispatchedAllTopicsQueryContext
 {
     public int NextPage { get; private set; }
     public string LastEvaluatedKey { get; private set; }

--- a/src/Paramore.Brighter.Outbox.DynamoDB/DispatchedMessagesQueryResult.cs
+++ b/src/Paramore.Brighter.Outbox.DynamoDB/DispatchedMessagesQueryResult.cs
@@ -27,7 +27,7 @@ using System.Collections.Generic;
 
 namespace Paramore.Brighter.Outbox.DynamoDB;
 
-internal class DispatchedMessagesQueryResult
+internal sealed class DispatchedMessagesQueryResult
 {
     public IEnumerable<MessageItem> Messages { get; private set; }
     public string PaginationToken { get; private set; }

--- a/src/Paramore.Brighter.Outbox.DynamoDB/DispatchedTopicQueryContext.cs
+++ b/src/Paramore.Brighter.Outbox.DynamoDB/DispatchedTopicQueryContext.cs
@@ -25,7 +25,7 @@ THE SOFTWARE. */
 
 namespace Paramore.Brighter.Outbox.DynamoDB;
 
-internal class DispatchedTopicQueryContext
+internal sealed class DispatchedTopicQueryContext
 {
     public int NextPage { get; private set; }
     public string LastEvaluatedKey { get; private set; }

--- a/src/Paramore.Brighter.Outbox.DynamoDB/KeyTopicDeliveredTimeExpression.cs
+++ b/src/Paramore.Brighter.Outbox.DynamoDB/KeyTopicDeliveredTimeExpression.cs
@@ -4,14 +4,12 @@ using Amazon.DynamoDBv2.DocumentModel;
 
 namespace Paramore.Brighter.Outbox.DynamoDB
 {
-    internal class KeyTopicDeliveredTimeExpression
+    internal sealed class KeyTopicDeliveredTimeExpression
     {
-        private readonly Expression _expression;
-
-        public KeyTopicDeliveredTimeExpression()
+        private readonly Expression _expression = new()
         {
-            _expression = new Expression { ExpressionStatement = "Topic = :v_Topic and DeliveryTime < :v_SinceTime" };
-        }
+            ExpressionStatement = "Topic = :v_Topic and DeliveryTime < :v_SinceTime"
+        };
 
         public override string ToString()
         {
@@ -20,11 +18,11 @@ namespace Paramore.Brighter.Outbox.DynamoDB
 
         public Expression Generate(string topicName, DateTimeOffset sinceTime)
         {
-            var values = new Dictionary<string, DynamoDBEntry>();
-            values.Add(":v_Topic", topicName);
-            values.Add(":v_SinceTime", sinceTime.Ticks);
-
-            _expression.ExpressionAttributeValues = values;
+            _expression.ExpressionAttributeValues = new Dictionary<string, DynamoDBEntry>(capacity: 2)
+            {
+                { ":v_Topic", topicName },
+                { ":v_SinceTime", sinceTime.Ticks }
+            };
 
             return _expression;
         }

--- a/src/Paramore.Brighter.Outbox.DynamoDB/KeyTopicOutstandingCreatedTimeExpression.cs
+++ b/src/Paramore.Brighter.Outbox.DynamoDB/KeyTopicOutstandingCreatedTimeExpression.cs
@@ -4,14 +4,12 @@ using Amazon.DynamoDBv2.DocumentModel;
 
 namespace Paramore.Brighter.Outbox.DynamoDB
 {
-    internal class KeyTopicOutstandingCreatedTimeExpression
+    internal sealed class KeyTopicOutstandingCreatedTimeExpression
     {
-        private readonly Expression _expression;
-
-        public KeyTopicOutstandingCreatedTimeExpression()
+        private readonly Expression _expression = new()
         {
-            _expression = new Expression { ExpressionStatement = "TopicShard = :v_TopicShard and OutstandingCreatedTime < :v_OutstandingCreatedTime" };
-        }
+            ExpressionStatement = "TopicShard = :v_TopicShard and OutstandingCreatedTime < :v_OutstandingCreatedTime"
+        };
 
         public override string ToString()
         {
@@ -20,11 +18,11 @@ namespace Paramore.Brighter.Outbox.DynamoDB
 
         public Expression Generate(string topicName, DateTimeOffset createdTime, int shard)
         {
-            var values = new Dictionary<string, DynamoDBEntry>();
-            values.Add(":v_TopicShard", $"{topicName}_{shard}");
-            values.Add(":v_OutstandingCreatedTime", createdTime.Ticks);
-
-            _expression.ExpressionAttributeValues = values;
+            _expression.ExpressionAttributeValues = new Dictionary<string, DynamoDBEntry>(capacity: 2)
+            {
+                { ":v_TopicShard", $"{topicName}_{shard}" },
+                { ":v_OutstandingCreatedTime", createdTime.Ticks }
+            };
 
             return _expression;
         }

--- a/src/Paramore.Brighter.Outbox.DynamoDB/OutstandingAllTopicsQueryContext.cs
+++ b/src/Paramore.Brighter.Outbox.DynamoDB/OutstandingAllTopicsQueryContext.cs
@@ -27,7 +27,7 @@ using System.Collections.Generic;
 
 namespace Paramore.Brighter.Outbox.DynamoDB;
 
-internal class OutstandingAllTopicsQueryContext
+internal sealed class OutstandingAllTopicsQueryContext
 {
     public int NextPage { get; private set; }
     public string LastEvaluatedKey { get; private set; }

--- a/src/Paramore.Brighter.Outbox.DynamoDB/OutstandingMessagesQueryResult.cs
+++ b/src/Paramore.Brighter.Outbox.DynamoDB/OutstandingMessagesQueryResult.cs
@@ -27,7 +27,7 @@ using System.Collections.Generic;
 
 namespace Paramore.Brighter.Outbox.DynamoDB;
 
-internal class OutstandingMessagesQueryResult
+internal sealed class OutstandingMessagesQueryResult
 {
     public IEnumerable<MessageItem> Messages { get; private set; }
     public int ShardNumber { get; private set; }

--- a/src/Paramore.Brighter.Outbox.DynamoDB/OutstandingTopicQueryContext.cs
+++ b/src/Paramore.Brighter.Outbox.DynamoDB/OutstandingTopicQueryContext.cs
@@ -25,7 +25,7 @@ THE SOFTWARE. */
 
 namespace Paramore.Brighter.Outbox.DynamoDB;
 
-internal class OutstandingTopicQueryContext
+internal sealed class OutstandingTopicQueryContext
 {
     public int NextPage { get; private set; }
     public int ShardNumber { get; private set; }

--- a/src/Paramore.Brighter.Outbox.DynamoDB/TimeSinceExpression.cs
+++ b/src/Paramore.Brighter.Outbox.DynamoDB/TimeSinceExpression.cs
@@ -4,22 +4,19 @@ using Amazon.DynamoDBv2.DocumentModel;
 
 namespace Paramore.Brighter.Outbox.DynamoDB
 {
-    internal class TimeSinceExpression
+    internal sealed class TimeSinceExpression
     {
-        private Expression _expression;
-
-        public TimeSinceExpression()
+        private readonly Expression _expression = new()
         {
-            _expression = new Expression();
-            _expression.ExpressionStatement = "DeliveryTime >= :v_SinceTime";
-        }
+            ExpressionStatement = "DeliveryTime >= :v_SinceTime"
+        };
 
         public Expression Generate(DateTime sinceTime)
         {
-            var values = new Dictionary<string, DynamoDBEntry>();
-            values.Add(":v_SinceTime", sinceTime.Ticks);
-
-            _expression.ExpressionAttributeValues = values;
+            _expression.ExpressionAttributeValues = new Dictionary<string, DynamoDBEntry>(capacity: 1)
+            {
+                { ":v_SinceTime", sinceTime.Ticks }
+            };
 
             return _expression;
         }

--- a/src/Paramore.Brighter.ServiceActivator/ConsumerFactory.cs
+++ b/src/Paramore.Brighter.ServiceActivator/ConsumerFactory.cs
@@ -27,7 +27,7 @@ using Paramore.Brighter.Observability;
 
 namespace Paramore.Brighter.ServiceActivator
 {
-    internal class ConsumerFactory<TRequest> : IConsumerFactory where TRequest : class, IRequest
+    internal sealed class ConsumerFactory<TRequest> : IConsumerFactory where TRequest : class, IRequest
     {
         private readonly IAmACommandProcessor _commandProcessor;
         private readonly IAmAMessageMapperRegistry? _messageMapperRegistry;

--- a/src/Paramore.Brighter.ServiceActivator/ControlBus/ControlBusReceiverBuilder.cs
+++ b/src/Paramore.Brighter.ServiceActivator/ControlBus/ControlBusReceiverBuilder.cs
@@ -211,7 +211,7 @@ namespace Paramore.Brighter.ServiceActivator.ControlBus
         /// <summary>
         /// We do not track outgoing control bus messages - so this acts as a sink for such messages
         /// </summary>
-        private class SinkOutboxSync : IAmAnOutboxSync<Message, CommittableTransaction>
+        private sealed class SinkOutboxSync : IAmAnOutboxSync<Message, CommittableTransaction>
         {
             public IAmABrighterTracer? Tracer { private get; set; } 
             

--- a/src/Paramore.Brighter.ServiceActivator/MessageMappingException.cs
+++ b/src/Paramore.Brighter.ServiceActivator/MessageMappingException.cs
@@ -26,7 +26,7 @@ using System;
 
 namespace Paramore.Brighter.ServiceActivator
 {
-    internal class MessageMappingException : Exception
+    internal sealed class MessageMappingException : Exception
     {
         public MessageMappingException(string message, Exception exception) : base(message, exception) { }
     }

--- a/src/Paramore.Brighter.ServiceActivator/Ports/ControlBusHandlerFactory.cs
+++ b/src/Paramore.Brighter.ServiceActivator/Ports/ControlBusHandlerFactory.cs
@@ -3,7 +3,7 @@ using Paramore.Brighter.ServiceActivator.Ports.Handlers;
 
 namespace Paramore.Brighter.ServiceActivator.Ports
 {
-    internal class ControlBusHandlerFactorySync : IAmAHandlerFactorySync
+    internal sealed class ControlBusHandlerFactorySync : IAmAHandlerFactorySync
     {
         private readonly Func<IAmACommandProcessor?> _commandProcessorFactory;
         private readonly IDispatcher _worker;

--- a/src/Paramore.Brighter.Tranformers.AWS/S3LuggageStore.cs
+++ b/src/Paramore.Brighter.Tranformers.AWS/S3LuggageStore.cs
@@ -71,7 +71,6 @@ namespace Paramore.Brighter.Tranformers.AWS
         private string _accountId;
         private string _bucketName;
         private IAmazonS3 _client;
-        private AsyncRetryPolicy _policy;
 
         private static readonly ILogger s_logger = ApplicationLogging.CreateLogger<S3LuggageStore>();
         private string _luggagePrefix;
@@ -157,7 +156,6 @@ namespace Paramore.Brighter.Tranformers.AWS
             luggageStore._luggagePrefix = luggagePrefix;
 
             if (policy == null) policy = GetDefaultS3Policy();
-            luggageStore._policy = policy;
 
             if (storeCreation == S3LuggageStoreCreation.CreateIfMissing || storeCreation == S3LuggageStoreCreation.ValidateExists)
             {
@@ -294,7 +292,7 @@ namespace Paramore.Brighter.Tranformers.AWS
             httpClient.BaseAddress = new Uri($"https://{bucketName}.s3.{bucketRegion.Value}.amazonaws.com");
             using var headRequest = new HttpRequestMessage(HttpMethod.Head, @"/");
             headRequest.Headers.Add("x-amz-expected-bucket-owner", accountId);
-            var response = await httpClient.SendAsync(headRequest);
+            using var response = await httpClient.SendAsync(headRequest);
             //If we deny public access to the bucket, but it exists we get access denied; we get not-found if it does not exist 
             return (response.IsSuccessStatusCode || response.StatusCode == HttpStatusCode.Forbidden);
         }

--- a/src/Paramore.Brighter/AsyncRequestHandlers.cs
+++ b/src/Paramore.Brighter/AsyncRequestHandlers.cs
@@ -28,7 +28,7 @@ using System.Linq;
 
 namespace Paramore.Brighter
 {
-    internal class AsyncRequestHandlers<TRequest> : IEnumerable<RequestHandlerAsync<TRequest>>
+    internal sealed class AsyncRequestHandlers<TRequest> : IEnumerable<RequestHandlerAsync<TRequest>>
         where TRequest : class, IRequest
     {
         private readonly IEnumerable<object> _handlers;

--- a/src/Paramore.Brighter/HandlerFactory.cs
+++ b/src/Paramore.Brighter/HandlerFactory.cs
@@ -26,7 +26,7 @@ using System;
 
 namespace Paramore.Brighter
 {
-    internal class HandlerFactory<TRequest> where TRequest : class, IRequest
+    internal sealed class HandlerFactory<TRequest> where TRequest : class, IRequest
     {
         private readonly RequestHandlerAttribute _attribute;
         private readonly IAmAHandlerFactorySync _factorySync;

--- a/src/Paramore.Brighter/HandlerLifetimeScope.cs
+++ b/src/Paramore.Brighter/HandlerLifetimeScope.cs
@@ -30,7 +30,7 @@ using Paramore.Brighter.Logging;
 
 namespace Paramore.Brighter
 {
-    internal class HandlerLifetimeScope : IAmALifetime
+    internal sealed class HandlerLifetimeScope : IAmALifetime
     {
         private static readonly ILogger s_logger= ApplicationLogging.CreateLogger<HandlerLifetimeScope>();
 

--- a/src/Paramore.Brighter/InMemoryMessageConsumer.cs
+++ b/src/Paramore.Brighter/InMemoryMessageConsumer.cs
@@ -271,7 +271,5 @@ public class InMemoryMessageConsumer : IAmAMessageConsumerSync, IAmAMessageConsu
         }
     }
 
-    private record LockedMessage(Message Message, DateTimeOffset LockedAt);
-
-
+    private sealed record LockedMessage(Message Message, DateTimeOffset LockedAt);
 }

--- a/src/Paramore.Brighter/RequestHandlers.cs
+++ b/src/Paramore.Brighter/RequestHandlers.cs
@@ -28,7 +28,7 @@ using System.Linq;
 
 namespace Paramore.Brighter
 {
-    internal class RequestHandlers<TRequest> : IEnumerable<RequestHandler<TRequest>>
+    internal sealed class RequestHandlers<TRequest> : IEnumerable<RequestHandler<TRequest>>
         where TRequest : class, IRequest
     {
         private readonly IEnumerable<object> _handlers;

--- a/src/Paramore.Brighter/Tasks/BrighterTaskQueue.cs
+++ b/src/Paramore.Brighter/Tasks/BrighterTaskQueue.cs
@@ -24,7 +24,7 @@ namespace Paramore.Brighter.Tasks;
 /// <summary>
 /// Represents a task queue that allows tasks to be added and consumed in a thread-safe manner.
 /// </summary>
-internal class BrighterTaskQueue : IDisposable
+internal sealed class BrighterTaskQueue : IDisposable
 {
     private readonly BlockingCollection<Tuple<Task, bool>> _queue = new();
 

--- a/src/Paramore.Brighter/Tasks/BrighterTaskScheduler.cs
+++ b/src/Paramore.Brighter/Tasks/BrighterTaskScheduler.cs
@@ -16,7 +16,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace Paramore.Brighter.Tasks;
@@ -25,7 +24,7 @@ namespace Paramore.Brighter.Tasks;
 /// This class provides a task scheduler that causes all tasks to be executed synchronously on the current thread.
 /// The synchronizationHelper and scheduler are used to run continuations on the same thread as the async operation.
 /// </summary>
-internal class BrighterTaskScheduler : TaskScheduler
+internal sealed class BrighterTaskScheduler : TaskScheduler
 {
     private readonly BrighterAsyncContext _asyncContext;
 

--- a/src/Paramore.Brighter/TransformerFactory.cs
+++ b/src/Paramore.Brighter/TransformerFactory.cs
@@ -25,7 +25,7 @@ using System;
 
 namespace Paramore.Brighter
 {
-    internal class TransformerFactory<TRequest> where TRequest: class, IRequest
+    internal sealed class TransformerFactory<TRequest> where TRequest: class, IRequest
     {
         private readonly TransformAttribute _attribute;
         private readonly IAmAMessageTransformerFactory _factory;

--- a/src/Paramore.Brighter/TransformerFactoryAsync.cs
+++ b/src/Paramore.Brighter/TransformerFactoryAsync.cs
@@ -25,7 +25,7 @@ using System;
 
 namespace Paramore.Brighter
 {
-    internal class TransformerFactoryAsync<TRequest> where TRequest: class, IRequest
+    internal sealed class TransformerFactoryAsync<TRequest> where TRequest: class, IRequest
     {
         private readonly TransformAttribute _attribute;
         private readonly IAmAMessageTransformerFactoryAsync _factory;


### PR DESCRIPTION
As the good Stephen Toub [explains, there is good reasons to make classes sealed.](https://github.com/dotnet/runtime/issues/49944)

I can also make it a warning, if all new code does not obey this, by enabling [CA1852](https://learn.microsoft.com/en-gb/dotnet/fundamentals/code-analysis/quality-rules/ca1852)  
Then I would also have to mark all tests & examples sealed, no problem with me, but a LOT of diff lines.  
Alternatively make a config for tests that explicitly ignore the rule.