### PR TITLE
Add OTel to the InMemoryInbox

### DIFF
--- a/src/Paramore.Brighter.Inbox.DynamoDB/DynamoDbInbox.cs
+++ b/src/Paramore.Brighter.Inbox.DynamoDB/DynamoDbInbox.cs
@@ -23,7 +23,6 @@ THE SOFTWARE. */
 #endregion
 
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -32,16 +31,21 @@ using Amazon.DynamoDBv2;
 using Amazon.DynamoDBv2.DataModel;
 using Amazon.DynamoDBv2.DocumentModel;
 using Paramore.Brighter.Inbox.Exceptions;
+using Paramore.Brighter.Observability;
 
 namespace Paramore.Brighter.Inbox.DynamoDB
 {
     public class DynamoDbInbox : IAmAnInboxSync, IAmAnInboxAsync
     {
-       private readonly DynamoDBContext _context;
-       private readonly DynamoDBOperationConfig _dynamoOverwriteTableConfig;
+        private readonly DynamoDBContext _context;
+        private readonly DynamoDBOperationConfig _dynamoOverwriteTableConfig;
 
-       public bool ContinueOnCapturedContext { get; set; }
-       
+        /// <inheritdoc/>
+        public bool ContinueOnCapturedContext { get; set; }
+
+        /// <inheritdoc/>
+        public IAmABrighterTracer Tracer { private get; set; }
+
         /// <summary>
         ///     Initialises a new instance of the <see cref="DynamoDbInbox"/> class.
         /// </summary>
@@ -56,64 +60,69 @@ namespace Paramore.Brighter.Inbox.DynamoDB
         }
 
         /// <summary>
-        ///  Adds a command to the store
-        ///  Will block, and consume another thread for callback on threadpool; use within sync pipeline only 
+        ///   Adds a command to the store.
+        ///   Will block, and consume another thread for callback on threadpool; use within sync pipeline only.
         /// </summary>
         /// <typeparam name="T"></typeparam>
-        /// <param name="command">The command to be stored</param>
+        /// <param name="command">The command.</param>
         /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
-        /// <param name="timeoutInMilliseconds">Timeout in milliseconds; -1 for default timeout</param>
-        public void Add<T>(T command, string contextKey, int timeoutInMilliseconds = -1) where T : class, IRequest
+        /// <param name="requestContext">What is the context for this request; used to access the Span</param>
+        /// <param name="timeoutInMilliseconds">Timeout is ignored as DynamoDB handles timeout and retries</param>
+        public void Add<T>(T command, string contextKey, RequestContext requestContext, int timeoutInMilliseconds = -1) where T : class, IRequest
         {            
-            AddAsync(command, contextKey)
-                .ConfigureAwait(false)
+            AddAsync(command, contextKey, requestContext)
+                .ConfigureAwait(ContinueOnCapturedContext)
                 .GetAwaiter()
                 .GetResult();
         }
 
         /// <summary>
-        ///  Finds a command with the specified identifier.
+        ///   Finds a command with the specified identifier.
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="id">The identifier.</param>
         /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
-        /// <param name="timeoutInMilliseconds">Timeout in milliseconds; -1 for default timeout</param>
+        /// <param name="requestContext">What is the context for this request; used to access the Span</param>
+        /// <param name="timeoutInMilliseconds">Timeout is ignored as DynamoDB handles timeout and retries</param>
         /// <returns><see cref="T"/></returns>
-        public T Get<T>(string id, string contextKey, int timeoutInMilliseconds = -1) where T : class, IRequest
+        public T Get<T>(string id, string contextKey, RequestContext requestContext, int timeoutInMilliseconds = -1) where T : class, IRequest
         {
             return GetCommandAsync<T>(id, contextKey)
-                .ConfigureAwait(false)
+                .ConfigureAwait(ContinueOnCapturedContext)
                 .GetAwaiter()
                 .GetResult();
         }
 
         /// <summary>
-        /// Adds a command to the store
+        ///   Awaitably adds a command to the store.
         /// </summary>
         /// <typeparam name="T"></typeparam>
-        /// <param name="command">The command to be stored</param>
+        /// <param name="command">The command.</param>
         /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
-        /// <param name="timeoutInMilliseconds">Timeout in milliseconds; -1 for default timeout</param>
-        /// <param name="cancellationToken">Allows the sender to cancel the request pipeline. Optional</param>D
-        public async Task AddAsync<T>(T command, string contextKey, int timeoutInMilliseconds = -1, CancellationToken cancellationToken = default) where T : class, IRequest
+        /// <param name="requestContext">What is the context for this request; used to access the Span</param>
+        /// <param name="timeoutInMilliseconds">Timeout is ignored as DynamoDB handles timeout and retries</param>
+        /// <param name="cancellationToken">Allow the sender to cancel the operation, if the parameter is supplied</param>
+        /// <returns><see cref="Task"/>.</returns>
+        public async Task AddAsync<T>(T command, string contextKey, RequestContext requestContext, int timeoutInMilliseconds = -1, CancellationToken cancellationToken = default) where T : class, IRequest
         {
             await _context
                 .SaveAsync(new CommandItem<T>(command, contextKey), _dynamoOverwriteTableConfig, cancellationToken)
-                .ConfigureAwait(false);
+                .ConfigureAwait(ContinueOnCapturedContext);
         }
 
         /// <summary>
-        /// Finds the command based on the specified identifier.
+        ///   Awaitably finds a command with the specified identifier.
         /// </summary>
         /// <typeparam name="T"></typeparam>
-        /// <param name="id">The identifier</param>
+        /// <param name="id">The identifier.</param>
         /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
-        /// <param name="timeoutInMilliseconds">Timeout in milliseconds; -1 for default timeout</param>
-        /// <param name="cancellationToken">Allow the sender to cancel the request, optional</param>
-        /// <returns><see cref="Task{T}"/></returns>
-        public async Task<T> GetAsync<T>(string id, string contextKey, int timeoutInMilliseconds = -1, CancellationToken cancellationToken = default) where T : class, IRequest
+        /// <param name="requestContext">What is the context for this request; used to access the Span</param>
+        /// <param name="timeoutInMilliseconds">Timeout is ignored as DynamoDB handles timeout and retries</param>
+        /// <param name="cancellationToken">Allow the sender to cancel the operation, if the parameter is supplied</param>
+        /// <returns><see cref="Task{T}"/>.</returns>
+        public async Task<T> GetAsync<T>(string id, string contextKey, RequestContext requestContext, int timeoutInMilliseconds = -1, CancellationToken cancellationToken = default) where T : class, IRequest
         {                
-            return await GetCommandAsync<T>(id, contextKey, cancellationToken).ConfigureAwait(false);
+            return await GetCommandAsync<T>(id, contextKey, cancellationToken).ConfigureAwait(ContinueOnCapturedContext);
         }
 
         /// <summary>
@@ -121,35 +130,39 @@ namespace Paramore.Brighter.Inbox.DynamoDB
         /// </summary>
         /// <param name="id">The identifier</param>
         /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
+        /// <param name="requestContext">What is the context for this request; used to access the Span</param>
         /// <param name="timeoutInMilliseconds">Timeout is ignored as DynamoDB handles timeout and retries</param>
         /// <param name="cancellationToken">Allow the sender to cancel the request, optional</param>
         /// <typeparam name="T">Type of command being checked</typeparam>
-        /// <returns><see langword="true"/> if Command exists, otherwise <see langword="false"/></returns>
-        public async Task<bool> ExistsAsync<T>(string id, string contextKey, int timeoutInMilliseconds = -1, CancellationToken cancellationToken = default) where T : class, IRequest
-       {
-           try
-           {
-               var command = await GetCommandAsync<T>(id, contextKey, cancellationToken).ConfigureAwait(false);
-               return command != null;
-           }
-           catch (RequestNotFoundException<T>)
-           {
-               return false;
-           }
-       }
-
-
-       /// <summary>
-       ///     Checks if the command exists based on the id
-       /// </summary>
-       /// <param name="id">The identifier</param>
-       /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
-       /// <param name="timeoutInMilliseconds">Timeout is ignored as DynamoDB handles timeout and retries</param>
-       /// <typeparam name="T">Type of command being checked</typeparam>
-       /// <returns><see langword="true"/> if Command exists, otherwise <see langword="false"/></returns>
-       public bool Exists<T>(string id, string contextKey, int timeoutInMilliseconds = -1) where T : class, IRequest
+        /// <returns><see cref="Task{true}"/> if it exists, otherwise <see cref="Task{false}"/>.</returns>
+        public async Task<bool> ExistsAsync<T>(string id, string contextKey, RequestContext requestContext, int timeoutInMilliseconds = -1, CancellationToken cancellationToken = default) where T : class, IRequest
         {
-            return ExistsAsync<T>(id, contextKey).Result;
+            try
+            {
+                var command = await GetCommandAsync<T>(id, contextKey, cancellationToken).ConfigureAwait(ContinueOnCapturedContext);
+                return command != null;
+            }
+            catch (RequestNotFoundException<T>)
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        ///   Checks whether a command with the specified identifier exists in the store.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="id">The identifier.</param>
+        /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
+        /// <param name="requestContext">What is the context for this request; used to access the Span</param>
+        /// <param name="timeoutInMilliseconds">Timeout is ignored as DynamoDB handles timeout and retries</param>
+        /// <returns><see langword="true"/> if it exists, otherwise <see langword="false"/>.</returns>
+        public bool Exists<T>(string id, string contextKey, RequestContext requestContext, int timeoutInMilliseconds = -1) where T : class, IRequest
+        {
+            return ExistsAsync<T>(id, contextKey, requestContext)
+                .ConfigureAwait(ContinueOnCapturedContext)
+                .GetAwaiter()
+                .GetResult();
         }
 
         private async Task<T> GetCommandAsync<T>(string id, string contextKey, CancellationToken cancellationToken = default) where T : class, IRequest
@@ -161,7 +174,7 @@ namespace Paramore.Brighter.Inbox.DynamoDB
             };
            
             //block async to make this sync
-            var messages = await PageAllMessagesAsync<T>(queryConfig).ConfigureAwait(false);
+            var messages = await PageAllMessagesAsync<T>(queryConfig).ConfigureAwait(ContinueOnCapturedContext);
 
             var result = messages.Select(msg => msg.ConvertToCommand()).FirstOrDefault();
             if (result == null)
@@ -178,12 +191,10 @@ namespace Paramore.Brighter.Inbox.DynamoDB
             var messages = new List<CommandItem<T>>();
             do
             { 
-                messages.AddRange(await asyncSearch.GetNextSetAsync().ConfigureAwait(false));
+                messages.AddRange(await asyncSearch.GetNextSetAsync().ConfigureAwait(ContinueOnCapturedContext));
             } while (!asyncSearch.IsDone);
 
             return messages;
         }
- 
-        
-   }
+    }
 }

--- a/src/Paramore.Brighter.Inbox.MongoDb/MongoDbInbox.cs
+++ b/src/Paramore.Brighter.Inbox.MongoDb/MongoDbInbox.cs
@@ -1,6 +1,7 @@
 ﻿using MongoDB.Driver;
 using Paramore.Brighter.Inbox.Exceptions;
 using Paramore.Brighter.MongoDb;
+using Paramore.Brighter.Observability;
 
 namespace Paramore.Brighter.Inbox.MongoDb;
 
@@ -22,7 +23,19 @@ public class MongoDbInbox : BaseMongoDb<InboxMessage>, IAmAnInboxAsync, IAmAnInb
     public bool ContinueOnCapturedContext { get; set; }
 
     /// <inheritdoc />
-    public async Task AddAsync<T>(T command, string contextKey, int timeoutInMilliseconds = -1,
+    public IAmABrighterTracer? Tracer { private get; set; }
+
+    /// <summary>
+    ///   Awaitably adds a command to the store.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="command">The command.</param>
+    /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
+    /// <param name="requestContext">What is the context for this request; used to access the Span</param>
+    /// <param name="timeoutInMilliseconds">Timeout is ignored as the timeout is handled by the MongoDb SDK</param>
+    /// <param name="cancellationToken">Allow the sender to cancel the operation, if the parameter is supplied</param>
+    /// <returns><see cref="Task"/>.</returns>
+    public async Task AddAsync<T>(T command, string contextKey, RequestContext? requestContext, int timeoutInMilliseconds = -1,
         CancellationToken cancellationToken = default) where T : class, IRequest
     {
         var message = new InboxMessage(command, command.Id, contextKey, Configuration.TimeProvider.GetUtcNow(),
@@ -44,9 +57,17 @@ public class MongoDbInbox : BaseMongoDb<InboxMessage>, IAmAnInboxAsync, IAmAnInb
         }
     }
 
-
-    /// <inheritdoc />
-    public async Task<T> GetAsync<T>(string id, string contextKey, int timeoutInMilliseconds = -1,
+    /// <summary>
+    ///   Awaitably finds a command with the specified identifier.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="id">The identifier.</param>
+    /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
+    /// <param name="requestContext">What is the context for this request; used to access the Span</param>
+    /// <param name="timeoutInMilliseconds">Timeout is ignored as the timeout is handled by the MongoDb SDK</param>
+    /// <param name="cancellationToken">Allow the sender to cancel the operation, if the parameter is supplied</param>
+    /// <returns><see cref="Task{T}"/>.</returns>
+    public async Task<T> GetAsync<T>(string id, string contextKey, RequestContext? requestContext, int timeoutInMilliseconds = -1,
         CancellationToken cancellationToken = default) where T : class, IRequest
     {
         var commandId = new InboxMessage.InboxMessageId { Id = id, ContextKey = contextKey };
@@ -64,8 +85,17 @@ public class MongoDbInbox : BaseMongoDb<InboxMessage>, IAmAnInboxAsync, IAmAnInb
         return command.ToCommand<T>();
     }
 
-    /// <inheritdoc />
-    public async Task<bool> ExistsAsync<T>(string id, string contextKey, int timeoutInMilliseconds = -1,
+    /// <summary>
+    ///   Awaitable checks whether a command with the specified identifier exists in the store.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="id">The identifier.</param>
+    /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
+    /// <param name="requestContext">What is the context for this request; used to access the Span</param>
+    /// <param name="timeoutInMilliseconds">Timeout is ignored as the timeout is handled by the MongoDb SDK</param>
+    /// <param name="cancellationToken">Allow the sender to cancel the operation, if the parameter is supplied</param>
+    /// <returns><see cref="Task{true}"/> if it exists, otherwise <see cref="Task{false}"/>.</returns>
+    public async Task<bool> ExistsAsync<T>(string id, string contextKey, RequestContext? requestContext, int timeoutInMilliseconds = -1,
         CancellationToken cancellationToken = default) where T : class, IRequest
     {
         var commandId = new InboxMessage.InboxMessageId { Id = id, ContextKey = contextKey };
@@ -75,8 +105,16 @@ public class MongoDbInbox : BaseMongoDb<InboxMessage>, IAmAnInboxAsync, IAmAnInb
             .ConfigureAwait(ContinueOnCapturedContext);
     }
 
-    /// <inheritdoc />
-    public void Add<T>(T command, string contextKey, int timeoutInMilliseconds = -1) where T : class, IRequest
+    /// <summary>
+    ///   Adds a command to the store.
+    ///   Will block, and consume another thread for callback on threadpool; use within sync pipeline only.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="command">The command.</param>
+    /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
+    /// <param name="requestContext">What is the context for this request; used to access the Span</param>
+    /// <param name="timeoutInMilliseconds">Timeout is ignored as the timeout is handled by the MongoDb SDK</param>
+    public void Add<T>(T command, string contextKey, RequestContext? requestContext, int timeoutInMilliseconds = -1) where T : class, IRequest
     {
         var message = new InboxMessage(command, command.Id, contextKey, Configuration.TimeProvider.GetUtcNow(),
             ExpireAfterSeconds);
@@ -96,8 +134,16 @@ public class MongoDbInbox : BaseMongoDb<InboxMessage>, IAmAnInboxAsync, IAmAnInb
         }
     }
 
-    /// <inheritdoc />
-    public T Get<T>(string id, string contextKey, int timeoutInMilliseconds = -1) where T : class, IRequest
+    /// <summary>
+    ///   Finds a command with the specified identifier.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="id">The identifier.</param>
+    /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
+    /// <param name="requestContext">What is the context for this request; used to access the Span</param>
+    /// <param name="timeoutInMilliseconds">Timeout is ignored as the timeout is handled by the MongoDb SDK</param>
+    /// <returns><see cref="T"/></returns>
+    public T Get<T>(string id, string contextKey, RequestContext? requestContext, int timeoutInMilliseconds = -1) where T : class, IRequest
     {
         var commandId = new InboxMessage.InboxMessageId { Id = id, ContextKey = contextKey };
         var filter = Builders<InboxMessage>.Filter.Eq(x => x.Id, commandId);
@@ -111,8 +157,16 @@ public class MongoDbInbox : BaseMongoDb<InboxMessage>, IAmAnInboxAsync, IAmAnInb
         return command.ToCommand<T>();
     }
 
-    /// <inheritdoc />
-    public bool Exists<T>(string id, string contextKey, int timeoutInMilliseconds = -1) where T : class, IRequest
+    /// <summary>
+    ///   Checks whether a command with the specified identifier exists in the store.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="id">The identifier.</param>
+    /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
+    /// <param name="requestContext">What is the context for this request; used to access the Span</param>
+    /// <param name="timeoutInMilliseconds">Timeout is ignored as the timeout is handled by the MongoDb SDK</param>
+    /// <returns><see langword="true"/> if it exists, otherwise <see langword="false"/>.</returns>
+    public bool Exists<T>(string id, string contextKey, RequestContext? requestContext, int timeoutInMilliseconds = -1) where T : class, IRequest
     {
         var commandId = new InboxMessage.InboxMessageId { Id = id, ContextKey = contextKey };
         var filter = Builders<InboxMessage>.Filter.Eq("Id", commandId);

--- a/src/Paramore.Brighter.Outbox.MongoDb/MongoDbOutbox.cs
+++ b/src/Paramore.Brighter.Outbox.MongoDb/MongoDbOutbox.cs
@@ -40,9 +40,9 @@ public class MongoDbOutbox : BaseMongoDb<OutboxMessage>, IAmAnOutboxAsync<Messag
         CancellationToken cancellationToken = default)
     {
         var span = Tracer?.CreateDbSpan(
-            new OutboxSpanInfo(DbSystem.Mongodb,
+            new BoxSpanInfo(DbSystem.Mongodb,
                 Configuration.DatabaseName,
-                OutboxDbOperation.Get,
+                BoxDbOperation.Get,
                 Configuration.CollectionName),
             null,
             options: Configuration.InstrumentationOptions);
@@ -90,9 +90,9 @@ public class MongoDbOutbox : BaseMongoDb<OutboxMessage>, IAmAnOutboxAsync<Messag
     )
     {
         var span = Tracer?.CreateDbSpan(
-            new OutboxSpanInfo(DbSystem.Mongodb,
+            new BoxSpanInfo(DbSystem.Mongodb,
                 Configuration.DatabaseName,
-                OutboxDbOperation.Get,
+                BoxDbOperation.Get,
                 Configuration.CollectionName),
             null,
             options: Configuration.InstrumentationOptions);
@@ -127,9 +127,9 @@ public class MongoDbOutbox : BaseMongoDb<OutboxMessage>, IAmAnOutboxAsync<Messag
     public async Task<long> GetNumberOfOutstandingMessagesAsync(CancellationToken cancellationToken = default)
     {
         var span = Tracer?.CreateDbSpan(
-            new OutboxSpanInfo(DbSystem.Mongodb,
+            new BoxSpanInfo(DbSystem.Mongodb,
                 Configuration.DatabaseName,
-                OutboxDbOperation.Get,
+                BoxDbOperation.Get,
                 Configuration.CollectionName),
             null,
             options: Configuration.InstrumentationOptions);
@@ -155,9 +155,9 @@ public class MongoDbOutbox : BaseMongoDb<OutboxMessage>, IAmAnOutboxAsync<Messag
         CancellationToken cancellationToken = default)
     {
         var span = Tracer?.CreateDbSpan(
-            new OutboxSpanInfo(DbSystem.Mongodb,
+            new BoxSpanInfo(DbSystem.Mongodb,
                 Configuration.DatabaseName,
-                OutboxDbOperation.Add,
+                BoxDbOperation.Add,
                 Configuration.CollectionName),
             requestContext?.Span,
             options: Configuration.InstrumentationOptions);
@@ -203,9 +203,9 @@ public class MongoDbOutbox : BaseMongoDb<OutboxMessage>, IAmAnOutboxAsync<Messag
         CancellationToken cancellationToken = default)
     {
         var span = Tracer?.CreateDbSpan(
-            new OutboxSpanInfo(DbSystem.Mongodb,
+            new BoxSpanInfo(DbSystem.Mongodb,
                 Configuration.DatabaseName,
-                OutboxDbOperation.Add,
+                BoxDbOperation.Add,
                 Configuration.CollectionName),
             requestContext?.Span,
             options: Configuration.InstrumentationOptions);
@@ -240,9 +240,9 @@ public class MongoDbOutbox : BaseMongoDb<OutboxMessage>, IAmAnOutboxAsync<Messag
         CancellationToken cancellationToken = default)
     {
         var span = Tracer?.CreateDbSpan(
-            new OutboxSpanInfo(DbSystem.Mongodb,
+            new BoxSpanInfo(DbSystem.Mongodb,
                 Configuration.DatabaseName,
-                OutboxDbOperation.Delete,
+                BoxDbOperation.Delete,
                 Configuration.CollectionName),
             requestContext?.Span,
             options: Configuration.InstrumentationOptions);
@@ -266,9 +266,9 @@ public class MongoDbOutbox : BaseMongoDb<OutboxMessage>, IAmAnOutboxAsync<Messag
         CancellationToken cancellationToken = default)
     {
         var span = Tracer?.CreateDbSpan(
-            new OutboxSpanInfo(DbSystem.Mongodb,
+            new BoxSpanInfo(DbSystem.Mongodb,
                 Configuration.DatabaseName,
-                OutboxDbOperation.DispatchedMessages,
+                BoxDbOperation.DispatchedMessages,
                 Configuration.CollectionName),
             requestContext?.Span,
             options: Configuration.InstrumentationOptions);
@@ -310,9 +310,9 @@ public class MongoDbOutbox : BaseMongoDb<OutboxMessage>, IAmAnOutboxAsync<Messag
         CancellationToken cancellationToken = default)
     {
         var span = Tracer?.CreateDbSpan(
-            new OutboxSpanInfo(DbSystem.Mongodb,
+            new BoxSpanInfo(DbSystem.Mongodb,
                 Configuration.DatabaseName,
-                OutboxDbOperation.Get,
+                BoxDbOperation.Get,
                 Configuration.CollectionName),
             requestContext?.Span,
             options: Configuration.InstrumentationOptions);
@@ -340,9 +340,9 @@ public class MongoDbOutbox : BaseMongoDb<OutboxMessage>, IAmAnOutboxAsync<Messag
         Dictionary<string, object>? args = null, CancellationToken cancellationToken = default)
     {
         var span = Tracer?.CreateDbSpan(
-            new OutboxSpanInfo(DbSystem.Mongodb,
+            new BoxSpanInfo(DbSystem.Mongodb,
                 Configuration.DatabaseName,
-                OutboxDbOperation.MarkDispatched,
+                BoxDbOperation.MarkDispatched,
                 Configuration.CollectionName),
             requestContext?.Span,
             options: Configuration.InstrumentationOptions);
@@ -371,9 +371,9 @@ public class MongoDbOutbox : BaseMongoDb<OutboxMessage>, IAmAnOutboxAsync<Messag
         Dictionary<string, object>? args = null, CancellationToken cancellationToken = default)
     {
         var span = Tracer?.CreateDbSpan(
-            new OutboxSpanInfo(DbSystem.Mongodb,
+            new BoxSpanInfo(DbSystem.Mongodb,
                 Configuration.DatabaseName,
-                OutboxDbOperation.MarkDispatched,
+                BoxDbOperation.MarkDispatched,
                 Configuration.CollectionName),
             requestContext?.Span,
             options: Configuration.InstrumentationOptions);
@@ -402,9 +402,9 @@ public class MongoDbOutbox : BaseMongoDb<OutboxMessage>, IAmAnOutboxAsync<Messag
         CancellationToken cancellationToken = default)
     {
         var span = Tracer?.CreateDbSpan(
-            new OutboxSpanInfo(DbSystem.Mongodb,
+            new BoxSpanInfo(DbSystem.Mongodb,
                 Configuration.DatabaseName,
-                OutboxDbOperation.OutStandingMessages,
+                BoxDbOperation.OutStandingMessages,
                 Configuration.CollectionName),
             requestContext?.Span,
             options: Configuration.InstrumentationOptions);
@@ -451,9 +451,9 @@ public class MongoDbOutbox : BaseMongoDb<OutboxMessage>, IAmAnOutboxAsync<Messag
     public IList<Message> Get(int pageSize = 100, int pageNumber = 1, Dictionary<string, object>? args = null)
     {
         var span = Tracer?.CreateDbSpan(
-            new OutboxSpanInfo(DbSystem.Mongodb,
+            new BoxSpanInfo(DbSystem.Mongodb,
                 Configuration.DatabaseName,
-                OutboxDbOperation.Get,
+                BoxDbOperation.Get,
                 Configuration.CollectionName),
             null,
             options: Configuration.InstrumentationOptions);
@@ -497,9 +497,9 @@ public class MongoDbOutbox : BaseMongoDb<OutboxMessage>, IAmAnOutboxAsync<Messag
     )
     {
         var span = Tracer?.CreateDbSpan(
-            new OutboxSpanInfo(DbSystem.Mongodb,
+            new BoxSpanInfo(DbSystem.Mongodb,
                 Configuration.DatabaseName,
-                OutboxDbOperation.Get,
+                BoxDbOperation.Get,
                 Configuration.CollectionName),
             requestContext?.Span,
             options: Configuration.InstrumentationOptions);
@@ -531,9 +531,9 @@ public class MongoDbOutbox : BaseMongoDb<OutboxMessage>, IAmAnOutboxAsync<Messag
     public long GetNumberOfOutstandingMessages()
     {
         var span = Tracer?.CreateDbSpan(
-            new OutboxSpanInfo(DbSystem.Mongodb,
+            new BoxSpanInfo(DbSystem.Mongodb,
                 Configuration.DatabaseName,
-                OutboxDbOperation.Get,
+                BoxDbOperation.Get,
                 Configuration.CollectionName),
             null,
             options: Configuration.InstrumentationOptions);
@@ -553,9 +553,9 @@ public class MongoDbOutbox : BaseMongoDb<OutboxMessage>, IAmAnOutboxAsync<Messag
         IAmABoxTransactionProvider<IClientSessionHandle>? transactionProvider = null)
     {
         var span = Tracer?.CreateDbSpan(
-            new OutboxSpanInfo(DbSystem.Mongodb,
+            new BoxSpanInfo(DbSystem.Mongodb,
                 Configuration.DatabaseName,
-                OutboxDbOperation.Add,
+                BoxDbOperation.Add,
                 Configuration.CollectionName),
             requestContext?.Span,
             options: Configuration.InstrumentationOptions);
@@ -592,9 +592,9 @@ public class MongoDbOutbox : BaseMongoDb<OutboxMessage>, IAmAnOutboxAsync<Messag
         IAmABoxTransactionProvider<IClientSessionHandle>? transactionProvider = null)
     {
         var span = Tracer?.CreateDbSpan(
-            new OutboxSpanInfo(DbSystem.Mongodb,
+            new BoxSpanInfo(DbSystem.Mongodb,
                 Configuration.DatabaseName,
-                OutboxDbOperation.Add,
+                BoxDbOperation.Add,
                 Configuration.CollectionName),
             requestContext?.Span,
             options: Configuration.InstrumentationOptions);
@@ -621,9 +621,9 @@ public class MongoDbOutbox : BaseMongoDb<OutboxMessage>, IAmAnOutboxAsync<Messag
     public void Delete(string[] messageIds, RequestContext? requestContext, Dictionary<string, object>? args = null)
     {
         var span = Tracer?.CreateDbSpan(
-            new OutboxSpanInfo(DbSystem.Mongodb,
+            new BoxSpanInfo(DbSystem.Mongodb,
                 Configuration.DatabaseName,
-                OutboxDbOperation.Delete,
+                BoxDbOperation.Delete,
                 Configuration.CollectionName),
             requestContext?.Span,
             options: Configuration.InstrumentationOptions);
@@ -644,9 +644,9 @@ public class MongoDbOutbox : BaseMongoDb<OutboxMessage>, IAmAnOutboxAsync<Messag
         int pageNumber = 1, int outBoxTimeout = -1, Dictionary<string, object>? args = null)
     {
         var span = Tracer?.CreateDbSpan(
-            new OutboxSpanInfo(DbSystem.Mongodb,
+            new BoxSpanInfo(DbSystem.Mongodb,
                 Configuration.DatabaseName,
-                OutboxDbOperation.DispatchedMessages,
+                BoxDbOperation.DispatchedMessages,
                 Configuration.CollectionName),
             requestContext?.Span,
             options: Configuration.InstrumentationOptions);
@@ -687,9 +687,9 @@ public class MongoDbOutbox : BaseMongoDb<OutboxMessage>, IAmAnOutboxAsync<Messag
         Dictionary<string, object>? args = null)
     {
         var span = Tracer?.CreateDbSpan(
-            new OutboxSpanInfo(DbSystem.Mongodb,
+            new BoxSpanInfo(DbSystem.Mongodb,
                 Configuration.DatabaseName,
-                OutboxDbOperation.Get,
+                BoxDbOperation.Get,
                 Configuration.CollectionName),
             requestContext?.Span,
             options: Configuration.InstrumentationOptions);
@@ -711,9 +711,9 @@ public class MongoDbOutbox : BaseMongoDb<OutboxMessage>, IAmAnOutboxAsync<Messag
         Dictionary<string, object>? args = null)
     {
         var span = Tracer?.CreateDbSpan(
-            new OutboxSpanInfo(DbSystem.Mongodb,
+            new BoxSpanInfo(DbSystem.Mongodb,
                 Configuration.DatabaseName,
-                OutboxDbOperation.MarkDispatched,
+                BoxDbOperation.MarkDispatched,
                 Configuration.CollectionName),
             requestContext?.Span,
             options: Configuration.InstrumentationOptions);
@@ -740,9 +740,9 @@ public class MongoDbOutbox : BaseMongoDb<OutboxMessage>, IAmAnOutboxAsync<Messag
         int pageNumber = 1, Dictionary<string, object>? args = null)
     {
         var span = Tracer?.CreateDbSpan(
-            new OutboxSpanInfo(DbSystem.Mongodb,
+            new BoxSpanInfo(DbSystem.Mongodb,
                 Configuration.DatabaseName,
-                OutboxDbOperation.OutStandingMessages,
+                BoxDbOperation.OutStandingMessages,
                 Configuration.CollectionName),
             requestContext?.Span,
             options: Configuration.InstrumentationOptions);

--- a/src/Paramore.Brighter.ServiceActivator.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Paramore.Brighter.ServiceActivator.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -13,55 +13,65 @@ namespace Paramore.Brighter.ServiceActivator.Extensions.DependencyInjection
     /// </summary>
     public static class  ServiceActivatorServiceCollectionExtensions 
     {
-       /// <summary>
-       /// Adds a service activator to the .NET IoC Container, used to register one or more message pump for a subscription to messages on an external bus
-       /// Registers as a singleton :-
-       /// - Brighter Options - how we are configuring the command processor used for dispatch of message to handler
-       /// - Dispatcher - the supervisor for the subscription workers
-       /// </summary>
-       /// <param name="services">The .NET IoC container to register with</param>
-       /// <param name="configure">The configuration of the subscriptions</param>
-       /// <returns>A brighter handler builder, used for chaining</returns>
-       /// <exception cref="ArgumentNullException">Throws if no .NET IoC container provided</exception>
+        /// <summary>
+        /// Adds a service activator to the .NET IoC Container, used to register one or more message pump for a subscription to messages on an external bus
+        /// Registers as a singleton :-
+        /// - Brighter Options - how we are configuring the command processor used for dispatch of message to handler
+        /// - Dispatcher - the supervisor for the subscription workers
+        /// </summary>
+        /// <param name="services">The .NET IoC container to register with</param>
+        /// <param name="configure">The configuration of the subscriptions</param>
+        /// <returns>A brighter handler builder, used for chaining</returns>
+        /// <exception cref="ArgumentNullException">Throws if no .NET IoC container provided</exception>
         public static IBrighterBuilder AddServiceActivator(
             this IServiceCollection services,
             Action<ServiceActivatorOptions> configure = null)
-       {
-           if (services == null)
-               throw new ArgumentNullException(nameof(services));
+        {
+            if (services == null)
+                throw new ArgumentNullException(nameof(services));
+            
+            var options = new ServiceActivatorOptions();
+            configure?.Invoke(options);
+            services.TryAddSingleton<IBrighterOptions>(options);
+            services.TryAddSingleton<IServiceActivatorOptions>(options);
+            
+            services.TryAdd(new ServiceDescriptor(typeof(IDispatcher),
+                BuildDispatcher,
+                ServiceLifetime.Singleton));
+            
+            services.TryAddSingleton(options.InboxConfiguration);
+            var inbox = options.InboxConfiguration.Inbox;
+            if (inbox is IAmAnInboxSync)
+            {
+                services.TryAdd(
+                    new ServiceDescriptor(
+                        typeof(IAmAnInboxSync), BuildInbox<IAmAnInboxSync>, ServiceLifetime.Singleton));
+            }
+            if (inbox is IAmAnInboxAsync)
+            {
+                services.TryAdd(
+                    new ServiceDescriptor(
+                        typeof(IAmAnInboxAsync), BuildInbox<IAmAnInboxAsync>, ServiceLifetime.Singleton));
+            }
+            
+            return ServiceCollectionExtensions.BrighterHandlerBuilder(services, options);
+        }
 
-           var options = new ServiceActivatorOptions();
-           configure?.Invoke(options);
-           services.TryAddSingleton<IBrighterOptions>(options);
-           services.TryAddSingleton<IServiceActivatorOptions>(options);
-           
-           services.TryAdd(new ServiceDescriptor(typeof(IDispatcher),
-               (serviceProvider) => (IDispatcher)BuildDispatcher(serviceProvider),
-              ServiceLifetime.Singleton));
-           
-           services.TryAddSingleton(options.InboxConfiguration);
-           var inbox = options.InboxConfiguration.Inbox;
-           if (inbox is IAmAnInboxSync inboxSync) services.TryAddSingleton(inboxSync);
-           if (inbox is IAmAnInboxAsync inboxAsync) services.TryAddSingleton(inboxAsync);
-
-           return ServiceCollectionExtensions.BrighterHandlerBuilder(services, options);
-       }
-
-       private static Dispatcher BuildDispatcher(IServiceProvider serviceProvider)
+        private static Dispatcher BuildDispatcher(IServiceProvider serviceProvider)
         {
             var loggerFactory = serviceProvider.GetService<ILoggerFactory>();
             ApplicationLogging.LoggerFactory = loggerFactory;
-
+        
             var options = serviceProvider.GetService<IServiceActivatorOptions>();
-
+        
             var commandProcessor = serviceProvider.GetService<IAmACommandProcessor>();
-
+        
             var requestContextFactory = serviceProvider.GetService<IAmARequestContextFactory>();
             
             var dispatcherBuilder = DispatchBuilder
                 .StartNew()
                 .CommandProcessor(commandProcessor, requestContextFactory);
-
+        
             var messageMapperRegistry = ServiceCollectionExtensions.MessageMapperRegistry(serviceProvider);
             var messageTransformFactory = ServiceCollectionExtensions.TransformFactory(serviceProvider);
             var messageTransformFactoryAsync = ServiceCollectionExtensions.TransformFactoryAsync(serviceProvider);
@@ -75,6 +85,18 @@ namespace Paramore.Brighter.ServiceActivator.Extensions.DependencyInjection
                 .ConfigureInstrumentation(tracer, options.InstrumentationOptions)
                 .Build();
         }
+
+        private static T BuildInbox<T>(IServiceProvider serviceProvider) where T : class, IAmAnInbox
+        {
+            var inboxConfig = serviceProvider.GetRequiredService<InboxConfiguration>();
+            var tracer = serviceProvider.GetService<IAmABrighterTracer>();
+
+            if (tracer != null)
+            {
+                inboxConfig.Inbox.Tracer = tracer;
+            }
+
+            return inboxConfig.Inbox as T;
+        }
     }
-   
 }

--- a/src/Paramore.Brighter/IAmAnInbox.cs
+++ b/src/Paramore.Brighter/IAmAnInbox.cs
@@ -1,7 +1,14 @@
-﻿namespace Paramore.Brighter
+﻿using Paramore.Brighter.Observability;
+
+namespace Paramore.Brighter
 {
     public interface IAmAnInbox
     {
-        
+        /// <summary>
+        /// The Tracer that we want to use to capture telemetry
+        /// We inject this so that we can use the same tracer as the calling application
+        /// You do not need to set this property as we will set it when setting up the Service Activator
+        /// </summary>
+        IAmABrighterTracer Tracer { set; }
     }
 }

--- a/src/Paramore.Brighter/IAmAnInboxAsync.cs
+++ b/src/Paramore.Brighter/IAmAnInboxAsync.cs
@@ -22,7 +22,6 @@ THE SOFTWARE. */
 
 #endregion
 
-using System;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -40,10 +39,11 @@ namespace Paramore.Brighter
         /// <typeparam name="T"></typeparam>
         /// <param name="command">The command.</param>
         /// <param name="contextKey"></param>
+        /// <param name="requestContext">What is the context for this request; used to access the Span</param>
         /// <param name="timeoutInMilliseconds"></param>
         /// <param name="cancellationToken">Allow the sender to cancel the operation, if the parameter is supplied</param>
         /// <returns><see cref="Task"/>.</returns>
-        Task AddAsync<T>(T command, string contextKey, int timeoutInMilliseconds = -1, CancellationToken cancellationToken = default) where T : class, IRequest;
+        Task AddAsync<T>(T command, string contextKey, RequestContext? requestContext, int timeoutInMilliseconds = -1, CancellationToken cancellationToken = default) where T : class, IRequest;
 
         /// <summary>
         /// Awaitably finds the specified identifier.
@@ -51,10 +51,11 @@ namespace Paramore.Brighter
         /// <typeparam name="T"></typeparam>
         /// <param name="id">The identifier.</param>
         /// <param name="contextKey"></param>
+        /// <param name="requestContext">What is the context for this request; used to access the Span</param>
         /// <param name="timeoutInMilliseconds"></param>
         /// <param name="cancellationToken">Allow the sender to cancel the operation, if the parameter is supplied</param>
         /// <returns><see cref="Task{T}"/>.</returns>
-        Task<T> GetAsync<T>(string id, string contextKey, int timeoutInMilliseconds = -1,
+        Task<T> GetAsync<T>(string id, string contextKey, RequestContext? requestContext, int timeoutInMilliseconds = -1,
             CancellationToken cancellationToken = default) where T : class, IRequest;
 
         /// <summary>
@@ -63,10 +64,11 @@ namespace Paramore.Brighter
         /// <typeparam name="T"></typeparam>
         /// <param name="id">The identifier.</param>
         /// <param name="contextKey"></param>
+        /// <param name="requestContext">What is the context for this request; used to access the Span</param>
         /// <param name="timeoutInMilliseconds"></param>
         /// <param name="cancellationToken">Allow the sender to cancel the operation, if the parameter is supplied</param>
         /// <returns>True if it exists, False otherwise</returns>
-        Task<bool> ExistsAsync<T>(string id, string contextKey, int timeoutInMilliseconds = -1,
+        Task<bool> ExistsAsync<T>(string id, string contextKey, RequestContext? requestContext, int timeoutInMilliseconds = -1,
             CancellationToken cancellationToken = default) where T : class, IRequest;
 
         /// <summary>

--- a/src/Paramore.Brighter/IAmAnInboxAsync.cs
+++ b/src/Paramore.Brighter/IAmAnInboxAsync.cs
@@ -34,49 +34,50 @@ namespace Paramore.Brighter
     public interface IAmAnInboxAsync : IAmAnInbox
     {
         /// <summary>
-        /// Awaitably adds the specified identifier.
+        ///   Awaitably adds a command to the store.
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="command">The command.</param>
-        /// <param name="contextKey"></param>
+        /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
         /// <param name="requestContext">What is the context for this request; used to access the Span</param>
-        /// <param name="timeoutInMilliseconds"></param>
+        /// <param name="timeoutInMilliseconds">Timeout in milliseconds; -1 for default timeout</param>
         /// <param name="cancellationToken">Allow the sender to cancel the operation, if the parameter is supplied</param>
         /// <returns><see cref="Task"/>.</returns>
         Task AddAsync<T>(T command, string contextKey, RequestContext? requestContext, int timeoutInMilliseconds = -1, CancellationToken cancellationToken = default) where T : class, IRequest;
 
         /// <summary>
-        /// Awaitably finds the specified identifier.
+        ///   Awaitably finds a command with the specified identifier.
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="id">The identifier.</param>
-        /// <param name="contextKey"></param>
+        /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
         /// <param name="requestContext">What is the context for this request; used to access the Span</param>
-        /// <param name="timeoutInMilliseconds"></param>
+        /// <param name="timeoutInMilliseconds">Timeout in milliseconds; -1 for default timeout</param>
         /// <param name="cancellationToken">Allow the sender to cancel the operation, if the parameter is supplied</param>
         /// <returns><see cref="Task{T}"/>.</returns>
         Task<T> GetAsync<T>(string id, string contextKey, RequestContext? requestContext, int timeoutInMilliseconds = -1,
             CancellationToken cancellationToken = default) where T : class, IRequest;
 
         /// <summary>
-        /// Checks whether a command with the specified identifier exists in the store
+        ///   Awaitable checks whether a command with the specified identifier exists in the store.
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="id">The identifier.</param>
-        /// <param name="contextKey"></param>
+        /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
         /// <param name="requestContext">What is the context for this request; used to access the Span</param>
-        /// <param name="timeoutInMilliseconds"></param>
+        /// <param name="timeoutInMilliseconds">Timeout in milliseconds; -1 for default timeout</param>
         /// <param name="cancellationToken">Allow the sender to cancel the operation, if the parameter is supplied</param>
-        /// <returns>True if it exists, False otherwise</returns>
+        /// <returns><see cref="Task{true}"/> if it exists, otherwise <see cref="Task{false}"/>.</returns>
         Task<bool> ExistsAsync<T>(string id, string contextKey, RequestContext? requestContext, int timeoutInMilliseconds = -1,
             CancellationToken cancellationToken = default) where T : class, IRequest;
 
         /// <summary>
-        /// If false we the default thread synchronization context to run any continuation, if true we re-use the original synchronization context.
-        /// Default to false unless you know that you need true, as you risk deadlocks with the originating thread if you Wait 
-        /// or access the Result or otherwise block. You may need the originating synchronization context if you need to access thread specific storage
-        /// such as HTTPContext 
+        ///   If false we the default thread synchronization context to run any continuation, if true we re-use the original synchronization context.
+        ///   Default to false unless you know that you need true, as you risk deadlocks with the originating thread if you Wait
+        ///   or access the Result or otherwise block. You may need the originating synchronization context if you need to access thread specific storage
+        ///   such as HTTPContext.
         /// </summary>
+        /// <value><see langword="true"/> if [continue on captured context]; otherwise, <see langword="false"/>.</value>
         bool ContinueOnCapturedContext { get; set; }
     }
 }

--- a/src/Paramore.Brighter/IAmAnInboxSync.cs
+++ b/src/Paramore.Brighter/IAmAnInboxSync.cs
@@ -22,8 +22,6 @@ THE SOFTWARE. */
 
 #endregion
 
-using System;
-
 namespace Paramore.Brighter
 {
     /// <summary>
@@ -38,8 +36,9 @@ namespace Paramore.Brighter
         /// <typeparam name="T"></typeparam>
         /// <param name="command">The command.</param>
         /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
+        /// <param name="requestContext">What is the context for this request; used to access the Span</param>
         /// <param name="timeoutInMilliseconds"></param>
-        void Add<T>(T command, string contextKey, int timeoutInMilliseconds = -1) where T : class, IRequest;
+        void Add<T>(T command, string contextKey, RequestContext? requestContext, int timeoutInMilliseconds = -1) where T : class, IRequest;
 
         /// <summary>
         /// Finds the specified identifier.
@@ -47,9 +46,10 @@ namespace Paramore.Brighter
         /// <typeparam name="T"></typeparam>
         /// <param name="id">The identifier.</param>
         /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
+        /// <param name="requestContext">What is the context for this request; used to access the Span</param>
         /// <param name="timeoutInMilliseconds"></param>
         /// <returns>T.</returns>
-        T Get<T>(string id, string contextKey, int timeoutInMilliseconds = -1) where T : class, IRequest;
+        T Get<T>(string id, string contextKey, RequestContext? requestContext, int timeoutInMilliseconds = -1) where T : class, IRequest;
 
         /// <summary>
         /// Checks whether a command with the specified identifier exists in the store
@@ -57,8 +57,9 @@ namespace Paramore.Brighter
         /// <typeparam name="T"></typeparam>
         /// <param name="id">The identifier.</param>
         /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
+        /// <param name="requestContext">What is the context for this request; used to access the Span</param>
         /// <param name="timeoutInMilliseconds"></param>
         /// <returns>True if it exists, False otherwise</returns>
-        bool Exists<T>(string id, string contextKey, int timeoutInMilliseconds = -1) where T : class, IRequest;
+        bool Exists<T>(string id, string contextKey, RequestContext? requestContextint, int timeoutInMilliseconds = -1) where T : class, IRequest;
     }
 }

--- a/src/Paramore.Brighter/IAmAnInboxSync.cs
+++ b/src/Paramore.Brighter/IAmAnInboxSync.cs
@@ -31,35 +31,36 @@ namespace Paramore.Brighter
     public interface IAmAnInboxSync : IAmAnInbox
     {
         /// <summary>
-        /// Adds the specified identifier.
+        ///   Adds a command to the store.
+        ///   Will block, and consume another thread for callback on threadpool; use within sync pipeline only.
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="command">The command.</param>
         /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
         /// <param name="requestContext">What is the context for this request; used to access the Span</param>
-        /// <param name="timeoutInMilliseconds"></param>
+        /// <param name="timeoutInMilliseconds">Timeout in milliseconds; -1 for default timeout</param>
         void Add<T>(T command, string contextKey, RequestContext? requestContext, int timeoutInMilliseconds = -1) where T : class, IRequest;
 
         /// <summary>
-        /// Finds the specified identifier.
+        ///   Finds a command with the specified identifier.
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="id">The identifier.</param>
         /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
         /// <param name="requestContext">What is the context for this request; used to access the Span</param>
-        /// <param name="timeoutInMilliseconds"></param>
-        /// <returns>T.</returns>
+        /// <param name="timeoutInMilliseconds">Timeout in milliseconds; -1 for default timeout</param>
+        /// <returns><see cref="T"/></returns>
         T Get<T>(string id, string contextKey, RequestContext? requestContext, int timeoutInMilliseconds = -1) where T : class, IRequest;
 
         /// <summary>
-        /// Checks whether a command with the specified identifier exists in the store
+        ///   Checks whether a command with the specified identifier exists in the store.
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="id">The identifier.</param>
         /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
         /// <param name="requestContext">What is the context for this request; used to access the Span</param>
-        /// <param name="timeoutInMilliseconds"></param>
-        /// <returns>True if it exists, False otherwise</returns>
+        /// <param name="timeoutInMilliseconds">Timeout in milliseconds; -1 for default timeout</param>
+        /// <returns><see langword="true"/> if it exists, otherwise <see langword="false"/>.</returns>
         bool Exists<T>(string id, string contextKey, RequestContext? requestContextint, int timeoutInMilliseconds = -1) where T : class, IRequest;
     }
 }

--- a/src/Paramore.Brighter/InMemoryInbox.cs
+++ b/src/Paramore.Brighter/InMemoryInbox.cs
@@ -108,30 +108,20 @@ namespace Paramore.Brighter
         private readonly TimeProvider _timeProvider = timeProvider;
         private readonly InstrumentationOptions _instrumentationOptions = instrumentationOptions;
 
-        /// <summary>
-        /// If false we the default thread synchronization context to run any continuation, if true we re-use the original synchronization context.
-        /// Default to false unless you know that you need true, as you risk deadlocks with the originating thread if you Wait
-        /// or access the Result or otherwise block. You may need the originating synchronization context if you need to access thread specific storage
-        /// such as HTTPContext
-        /// </summary>
-        /// <value><c>true</c> if [continue on captured context]; otherwise, <c>false</c>.</value>
+        /// <inheritdoc />
         public bool ContinueOnCapturedContext { get; set; }
 
-        /// <summary>
-        /// The Tracer that we want to use to capture telemetry
-        /// We inject this so that we can use the same tracer as the calling application
-        /// You do not need to set this property as we will set it when setting up the Service Activator
-        /// </summary>
+        /// <inheritdoc />
         public IAmABrighterTracer? Tracer { private get; set; }
 
         /// <summary>
-        /// Adds the specified identifier.
+        ///   Adds a command to the in-memory store.
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="command">The command.</param>
-        /// <param name="contextKey"></param>
+        /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
         /// <param name="requestContext">What is the context for this request; used to access the Span</param>
-        /// <param name="timeoutInMilliseconds">The timeout in milliseconds.</param>
+        /// <param name="timeoutInMilliseconds">Ignored as commands are stored in-memory</param>
         public void Add<T>(T command, string contextKey, RequestContext? requestContext, int timeoutInMilliseconds = -1) 
             where T : class, IRequest
         {
@@ -162,16 +152,15 @@ namespace Paramore.Brighter
         }
 
         /// <summary>
-        /// Awaitably adds the specified identifier.
+        ///   Awaitably adds a command to the store.
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="command">The command.</param>
-        /// <param name="contextKey"></param>
+        /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
         /// <param name="requestContext">What is the context for this request; used to access the Span</param>
-        /// <param name="timeoutInMilliseconds">The timeout in milliseconds.</param>
-        /// <param name="cancellationToken"></param>
-        /// <returns><see cref="Task" />Allows the sender to cancel the call, optional</returns>
-        /// <exception cref="System.NotImplementedException"></exception>
+        /// <param name="timeoutInMilliseconds">Ignored as commands are stored in-memory</param>
+        /// <param name="cancellationToken">Allow the sender to cancel the operation, if the parameter is supplied</param>
+        /// <returns><see cref="Task"/>.</returns>
         public Task AddAsync<T>(T command, string contextKey, RequestContext? requestContext, 
             int timeoutInMilliseconds = -1, CancellationToken cancellationToken = default) 
             where T : class, IRequest
@@ -192,15 +181,14 @@ namespace Paramore.Brighter
         }
 
         /// <summary>
-        /// Finds the command with the specified identifier.
+        ///   Finds a command with the specified identifier.
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="id">The identifier.</param>
-        /// <param name="contextKey"></param>
+        /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
         /// <param name="requestContext">What is the context for this request; used to access the Span</param>
-        /// <param name="timeoutInMilliseconds">The timeout in milliseconds.</param>
-        /// <returns>ICommand.</returns>
-        /// <exception cref="System.TypeLoadException"></exception>
+        /// <param name="timeoutInMilliseconds">Ignored as commands are stored in-memory</param>
+        /// <returns><see cref="T"/></returns>
         public T Get<T>(string id, string contextKey, RequestContext? requestContext, int timeoutInMilliseconds = -1) 
             where T : class, IRequest
         {
@@ -230,14 +218,14 @@ namespace Paramore.Brighter
         }
 
         /// <summary>
-        /// Checks whether a command with the specified identifier exists in the store
+        ///   Checks whether a command with the specified identifier exists in the store.
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="id">The identifier.</param>
         /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
         /// <param name="requestContext">What is the context for this request; used to access the Span</param>
-        /// <param name="timeoutInMilliseconds"></param>
-        /// <returns>True if it exists, False otherwise</returns>
+        /// <param name="timeoutInMilliseconds">Ignored as commands are stored in-memory</param>
+        /// <returns><see langword="true"/> if it exists, otherwise <see langword="false"/>.</returns>
         public bool Exists<T>(string id, string contextKey, RequestContext? requestContext, int timeoutInMilliseconds = -1) where T : class, IRequest
         {
             var span = Tracer?.CreateDbSpan(
@@ -257,15 +245,15 @@ namespace Paramore.Brighter
         }
 
         /// <summary>
-        /// Checks whether a command with the specified identifier exists in the store
+        ///   Awaitable checks whether a command with the specified identifier exists in the store.
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="id">The identifier.</param>
-        /// <param name="contextKey"></param>
+        /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
         /// <param name="requestContext">What is the context for this request; used to access the Span</param>
-        /// <param name="timeoutInMilliseconds"></param>
-        /// <param name="cancellationToken"></param>
-        /// <returns>True if it exists, False otherwise</returns>
+        /// <param name="timeoutInMilliseconds">Ignored as commands are stored in-memory</param>
+        /// <param name="cancellationToken">Allow the sender to cancel the operation, if the parameter is supplied</param>
+        /// <returns><see cref="Task{true}"/> if it exists, otherwise <see cref="Task{false}"/>.</returns>
         public Task<bool> ExistsAsync<T>(string id, string contextKey, RequestContext? requestContext, int timeoutInMilliseconds = -1,
             CancellationToken cancellationToken = default) where T : class, IRequest
         {
@@ -285,17 +273,15 @@ namespace Paramore.Brighter
         }
 
         /// <summary>
-        /// Awaitably finds the specified identifier.
+        ///   Awaitably finds a command with the specified identifier.
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="id">The identifier.</param>
-        /// <param name="contextKey"></param>
+        /// <param name="contextKey">An identifier for the context in which the command has been processed (for example, the name of the handler)</param>
         /// <param name="requestContext">What is the context for this request; used to access the Span</param>
-        /// <param name="timeoutInMilliseconds">The timeout in milliseconds.</param>
-        /// <param name="cancellationToken"></param>
-        /// <returns><see cref="Task{T}" />.</returns>
-        /// <returns><see cref="Task" />Allows the sender to cancel the call, optional</returns>
-        /// <exception cref="System.NotImplementedException"></exception>
+        /// <param name="timeoutInMilliseconds">Ignored as commands are stored in-memory</param>
+        /// <param name="cancellationToken">Allow the sender to cancel the operation, if the parameter is supplied</param>
+        /// <returns><see cref="Task{T}"/>.</returns>
         public Task<T> GetAsync<T>(string id, string contextKey, RequestContext? requestContext, int timeoutInMilliseconds = -1,
             CancellationToken cancellationToken = default) where T : class, IRequest
         {

--- a/src/Paramore.Brighter/InMemoryOutbox.cs
+++ b/src/Paramore.Brighter/InMemoryOutbox.cs
@@ -120,7 +120,7 @@ namespace Paramore.Brighter
         )
         {
             var span = Tracer?.CreateDbSpan(
-                new OutboxSpanInfo(DbSystem.Brighter, InMemoryAttributes.DbName, OutboxDbOperation.Add, InMemoryAttributes.DbTable),
+                new BoxSpanInfo(DbSystem.Brighter, InMemoryAttributes.OutboxDbName, BoxDbOperation.Add, InMemoryAttributes.DbTable),
                 requestContext?.Span,
                 options: _instrumentationOptions
             );
@@ -286,7 +286,7 @@ namespace Paramore.Brighter
             ClearExpiredMessages();
             
             var span = Tracer?.CreateDbSpan(
-                new OutboxSpanInfo(DbSystem.Brighter, InMemoryAttributes.DbName, OutboxDbOperation.DispatchedMessages, InMemoryAttributes.DbTable),
+                new BoxSpanInfo(DbSystem.Brighter, InMemoryAttributes.OutboxDbName, BoxDbOperation.DispatchedMessages, InMemoryAttributes.DbTable),
                 requestContext?.Span,
                 options: _instrumentationOptions
             );
@@ -345,7 +345,7 @@ namespace Paramore.Brighter
             ClearExpiredMessages();
             
             var span = Tracer?.CreateDbSpan(
-                new OutboxSpanInfo(DbSystem.Brighter, InMemoryAttributes.DbName, OutboxDbOperation.Get, InMemoryAttributes.DbTable),
+                new BoxSpanInfo(DbSystem.Brighter, InMemoryAttributes.OutboxDbName, BoxDbOperation.Get, InMemoryAttributes.DbTable),
                 requestContext?.Span,
                 options: _instrumentationOptions
             );
@@ -459,7 +459,7 @@ namespace Paramore.Brighter
             ClearExpiredMessages();
             
             var span = Tracer?.CreateDbSpan(
-                new OutboxSpanInfo(DbSystem.Brighter, InMemoryAttributes.DbName, OutboxDbOperation.MarkDispatched, InMemoryAttributes.DbTable),
+                new BoxSpanInfo(DbSystem.Brighter, InMemoryAttributes.OutboxDbName, BoxDbOperation.MarkDispatched, InMemoryAttributes.DbTable),
                 requestContext?.Span,
                 options: _instrumentationOptions
             );
@@ -497,7 +497,7 @@ namespace Paramore.Brighter
             ClearExpiredMessages();
 
             var span = Tracer?.CreateDbSpan(
-                new OutboxSpanInfo(DbSystem.Brighter, InMemoryAttributes.DbName, OutboxDbOperation.OutStandingMessages,
+                new BoxSpanInfo(DbSystem.Brighter, InMemoryAttributes.OutboxDbName, BoxDbOperation.OutStandingMessages,
                     InMemoryAttributes.DbTable),
                 requestContext?.Span,
                 options: _instrumentationOptions);
@@ -548,7 +548,7 @@ namespace Paramore.Brighter
         private void Delete(string messageId, RequestContext? requestContext = null)
         {
             var span = Tracer?.CreateDbSpan(
-                new OutboxSpanInfo(DbSystem.Brighter, InMemoryAttributes.DbName, OutboxDbOperation.Delete, InMemoryAttributes.DbTable),
+                new BoxSpanInfo(DbSystem.Brighter, InMemoryAttributes.OutboxDbName, BoxDbOperation.Delete, InMemoryAttributes.DbTable),
                 requestContext?.Span,
                 options: _instrumentationOptions
             );

--- a/src/Paramore.Brighter/Inbox/Handlers/UseInboxHandler.cs
+++ b/src/Paramore.Brighter/Inbox/Handlers/UseInboxHandler.cs
@@ -23,6 +23,7 @@ THE SOFTWARE. */
 #endregion
 
 using System;
+using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Paramore.Brighter.Inbox.Exceptions;
 using Paramore.Brighter.Logging;
@@ -76,12 +77,14 @@ namespace Paramore.Brighter.Inbox.Handlers
         {
             if (_contextKey is null)
                 throw new ArgumentException("ContextKey must be set before Handling");
+
+            var requestContext = InitRequestContext();
             
             if (_onceOnly)
             {
                  s_logger.LogDebug("Checking if command {Id} has already been seen", command.Id);
 
-                 var exists = _inbox.Exists<T>(command.Id, _contextKey); 
+                 var exists = _inbox.Exists<T>(command.Id, _contextKey, requestContext); 
                  
                 if (exists && _onceOnlyAction is OnceOnlyAction.Throw)
                 {                    
@@ -100,10 +103,17 @@ namespace Paramore.Brighter.Inbox.Handlers
 
             s_logger.LogDebug("Writing command {Id} to the Inbox", command.Id);
 
-            _inbox.Add(command, _contextKey);
+            _inbox.Add(command, _contextKey, requestContext);
 
             return handledCommand;
         }
 
+        private RequestContext InitRequestContext()
+        {
+            return new RequestContext()
+            {
+                Span = Activity.Current
+            };
+        }
     }
 }

--- a/src/Paramore.Brighter/Observability/BoxDbOperation.cs
+++ b/src/Paramore.Brighter/Observability/BoxDbOperation.cs
@@ -25,14 +25,15 @@ THE SOFTWARE. */
 namespace Paramore.Brighter.Observability;
 
 /// <summary>
-/// The operation being performed on the outbox
+/// The operation being performed on the inbox/outbox
 /// </summary>
-public enum OutboxDbOperation
+public enum BoxDbOperation
 {
-    Add = 0,                //Add a message to the outbox
+    Add = 0,                //Add a message to the inbox/outbox
     Delete,                 //Delete a message from the outbox
-    DispatchedMessages,     //Retrieve a set of messages marked as dispatched 
-    Get,                    //Get a message from the outbox by id
+    DispatchedMessages,     //Retrieve a set of messages marked as dispatched
+    Get,                    //Get a message from the inbox/outbox by id
     MarkDispatched,         //Mark one or more messages as dispatched
-    OutStandingMessages     //Retrieve a set of messages that are still outstanding 
+    OutStandingMessages,    //Retrieve a set of messages that are still outstanding
+    Exists                  //Check whether a message exists in the inbox
 }

--- a/src/Paramore.Brighter/Observability/BoxSpanInfo.cs
+++ b/src/Paramore.Brighter/Observability/BoxSpanInfo.cs
@@ -42,10 +42,10 @@ namespace Paramore.Brighter.Observability;
 /// <param name="networkPeerPort">Peer port number of the network connection</param>
 /// <param name="serverAddress">Name of the database host</param>
 /// <param name="dbAttributes">Other attributes (key-value pairs) not covered by the standard attributes</param>
-public record OutboxSpanInfo(
+public record BoxSpanInfo(
     DbSystem dbSystem,                    
     string dbName,
-    OutboxDbOperation dbOperation, 
+    BoxDbOperation dbOperation, 
     string dbTable,
     int serverPort = 0, 
     string? dbInstanceId = null, 

--- a/src/Paramore.Brighter/Observability/BrighterSpanExtensions.cs
+++ b/src/Paramore.Brighter/Observability/BrighterSpanExtensions.cs
@@ -47,16 +47,17 @@ public static class BrighterSpanExtensions
    };
 
    ///<summary>
-   /// Provide a string representation of the outbox operation
+   /// Provide a string representation of the inbox/outbox operation
    /// </summary>   
-   public static string ToSpanName(this OutboxDbOperation span) => span switch
+   public static string ToSpanName(this BoxDbOperation span) => span switch
    {
-       OutboxDbOperation.Add => "add.message",
-       OutboxDbOperation.Delete => "delete.message",
-       OutboxDbOperation.DispatchedMessages => "retrieve.dispatched_messages",
-       OutboxDbOperation.Get => "retrieve.message",
-       OutboxDbOperation.MarkDispatched => "mark_as_dispatched.outstanding_messages",
-       OutboxDbOperation.OutStandingMessages => "retrieve.outstanding_messages",
+       BoxDbOperation.Add => "add.message",
+       BoxDbOperation.Delete => "delete.message",
+       BoxDbOperation.DispatchedMessages => "retrieve.dispatched_messages",
+       BoxDbOperation.Get => "retrieve.message",
+       BoxDbOperation.MarkDispatched => "mark_as_dispatched.outstanding_messages",
+       BoxDbOperation.OutStandingMessages => "retrieve.outstanding_messages",
+       BoxDbOperation.Exists => "message.exists",
        _ => throw new ArgumentOutOfRangeException(nameof(span), span, null)
    };
    

--- a/src/Paramore.Brighter/Observability/BrighterTracer.cs
+++ b/src/Paramore.Brighter/Observability/BrighterTracer.cs
@@ -319,7 +319,7 @@ public class BrighterTracer : IAmABrighterTracer
     }
 
     /// <summary>
-    /// Creates a span for an archive operation. Because a sweeper may not create an externa bus, but just use the archiver directly, we
+    /// Creates a span for an archive operation. Because a sweeper may not create an external bus, but just use the archiver directly, we
     /// check for this existing and then recreate directly in the archive provider if it does not exist
     /// </summary>
     /// <param name="parentActivity">A parent activity that called this one</param>
@@ -399,13 +399,13 @@ public class BrighterTracer : IAmABrighterTracer
     } 
 
     /// <summary>
-    /// Create a span for an outbox operation
+    /// Create a span for an inbox or outbox operation
     /// </summary>
-    /// <param name="info">An <see cref="OutboxSpanInfo"/> with the attributes of the db operation</param>
+    /// <param name="info">An <see cref="BoxSpanInfo"/> with the attributes of the db operation</param>
     /// <param name="parentActivity">The parent <see cref="Activity"/>, if any, that we should assign to this span</param>
     /// <param name="options">The <see cref="InstrumentationOptions"/> that explain how deep should the instrumentation go?</param>
     /// /// <returns>A new span named either db.operation db.name db.sql.table or db.operation db.name if db.sql.table not available </returns>
-    public Activity? CreateDbSpan(OutboxSpanInfo info, Activity? parentActivity, InstrumentationOptions options)
+    public Activity? CreateDbSpan(BoxSpanInfo info, Activity? parentActivity, InstrumentationOptions options)
     {
         var spanName = !string.IsNullOrEmpty(info.dbTable) 
             ? $"{info.dbOperation.ToSpanName()} {info.dbName} {info.dbTable}" : $"{info.dbOperation} {info.dbName}";
@@ -576,14 +576,14 @@ public class BrighterTracer : IAmABrighterTracer
     /// This is generic and not specific details from a particular outbox and is thus mostly message properties
     /// NOTE: Events are static, as we only need the instance state to create an activity
     /// </summary>
-    /// <param name="operation">What <see cref="OutboxDbOperation"/> are we performing on the Outbox</param>
+    /// <param name="operation">What <see cref="BoxDbOperation"/> are we performing on the Outbox</param>
     /// <param name="message">What is the <see cref="Message"/> we want to write to the Outbox or have read from the Outbox</param>
     /// <param name="span">What is the parent <see cref="Activity"/> for this event</param>
     /// <param name="isSharedTransaction">Does this from part of a shared transaction with handler code?</param>
     /// <param name="isAsync">Is the handler writing async?</param>
     /// <param name="instrumentationOptions"> <see cref="InstrumentationOptions"/> for how verbose should our instrumentation be</param>
     public static void WriteOutboxEvent(
-        OutboxDbOperation operation, 
+        BoxDbOperation operation, 
         Message message, 
         Activity? span,
         bool isSharedTransaction, 
@@ -617,14 +617,14 @@ public class BrighterTracer : IAmABrighterTracer
     /// This is generic and not specific details from a particular outbox and is thus mostly message properties
     /// NOTE: Events are static, as we only need the instance state to create an activity
     /// </summary>
-    /// <param name="operation">What <see cref="OutboxDbOperation"/> are we performing on the group of messages</param>
+    /// <param name="operation">What <see cref="BoxDbOperation"/> are we performing on the group of messages</param>
     /// <param name="messages">The set of <see cref="Message"/>s we want to record the event for</param>
     /// <param name="span">The <see cref="Activity"/> we are adding the <see cref="ActivityEvent"/> to</param>
     /// <param name="isSharedTransaction">Are we using a shared transaction with the application to write to the Outbox</param>
     /// <param name="isAsync">Is this an async operation</param>
     /// <param name="instrumentationOptions">What <see cref="InstrumentationOptions"/> have we set to control verbosity</param>
     public static void WriteOutboxEvent(
-        OutboxDbOperation operation, 
+        BoxDbOperation operation, 
         IEnumerable<Message> messages, 
         Activity? span, 
         bool isSharedTransaction, 

--- a/src/Paramore.Brighter/Observability/IAmABrighterTracer.cs
+++ b/src/Paramore.Brighter/Observability/IAmABrighterTracer.cs
@@ -140,14 +140,14 @@ public interface IAmABrighterTracer : IDisposable
     );
 
     /// <summary>
-    /// Create a span for an outbox operation
+    /// Create a span for an inbox or outbox operation
     /// </summary>
     /// <param name="info">The attributes of the db operation</param>
     /// <param name="parentActivity">The parent activity, if any, that we should assign to this span</param>
     /// <param name="options">How deep should the instrumentation go?</param>
     /// /// <returns>A new span named either db.operation db.name db.sql.table or db.operation db.name if db.sql.table not available </returns>
     Activity? CreateDbSpan(
-        OutboxSpanInfo info, 
+        BoxSpanInfo info, 
         Activity? parentActivity, 
         InstrumentationOptions options = InstrumentationOptions.All
     );

--- a/src/Paramore.Brighter/Observability/InMemoryAttributes.cs
+++ b/src/Paramore.Brighter/Observability/InMemoryAttributes.cs
@@ -30,6 +30,7 @@ namespace Paramore.Brighter.Observability;
 /// </summary>
 public class InMemoryAttributes
 {
-    public const string DbName = "outbox";
+    public const string OutboxDbName = "outbox";
+    public const string InboxDbName = "inbox";
     public const string DbTable = "requests";
 }

--- a/src/Paramore.Brighter/OutboxProducerMediator.cs
+++ b/src/Paramore.Brighter/OutboxProducerMediator.cs
@@ -204,7 +204,7 @@ namespace Paramore.Brighter
 
             CheckOutboxOutstandingLimit();
 
-            BrighterTracer.WriteOutboxEvent(OutboxDbOperation.Add, message, requestContext.Span,
+            BrighterTracer.WriteOutboxEvent(BoxDbOperation.Add, message, requestContext.Span,
                 overridingTransactionProvider != null, true, _instrumentationOptions);
 
             var written = await RetryAsync(
@@ -247,7 +247,7 @@ namespace Paramore.Brighter
 
             CheckOutboxOutstandingLimit();
 
-            BrighterTracer.WriteOutboxEvent(OutboxDbOperation.Add, message, requestContext.Span,
+            BrighterTracer.WriteOutboxEvent(BoxDbOperation.Add, message, requestContext.Span,
                 overridingTransactionProvider != null, false, _instrumentationOptions);
 
             var written = Retry(() =>
@@ -318,7 +318,7 @@ namespace Paramore.Brighter
                     if (message is null || message.Header.MessageType == MessageType.MT_NONE)
                         throw new NullReferenceException($"Message with Id {messageId} not found in the Outbox");
 
-                    BrighterTracer.WriteOutboxEvent(OutboxDbOperation.Get, message, span, false, false,
+                    BrighterTracer.WriteOutboxEvent(BoxDbOperation.Get, message, span, false, false,
                         _instrumentationOptions);
 
                     Dispatch(new[] { message }, requestContext, args);
@@ -374,7 +374,7 @@ namespace Paramore.Brighter
                     if (message is null || message.Header.MessageType == MessageType.MT_NONE)
                         throw new NullReferenceException($"Message with Id {messageId} not found in the Outbox");
 
-                    BrighterTracer.WriteOutboxEvent(OutboxDbOperation.Get, message, requestContext.Span, false, true,
+                    BrighterTracer.WriteOutboxEvent(BoxDbOperation.Get, message, requestContext.Span, false, true,
                         _instrumentationOptions);
 
                     await DispatchAsync(new[] { message }, requestContext, continueOnCapturedContext,
@@ -511,7 +511,7 @@ namespace Paramore.Brighter
         {
             CheckOutboxOutstandingLimit();
 
-            BrighterTracer.WriteOutboxEvent(OutboxDbOperation.Add, _outboxBatches[batchId], requestContext.Span,
+            BrighterTracer.WriteOutboxEvent(BoxDbOperation.Add, _outboxBatches[batchId], requestContext.Span,
                 transactionProvider != null, false, _instrumentationOptions);
 
             if (_outBox is null) throw new ArgumentException(NoSyncOutboxError);
@@ -540,7 +540,7 @@ namespace Paramore.Brighter
         {
             CheckOutboxOutstandingLimit();
 
-            BrighterTracer.WriteOutboxEvent(OutboxDbOperation.Add, _outboxBatches[batchId], requestContext.Span,
+            BrighterTracer.WriteOutboxEvent(BoxDbOperation.Add, _outboxBatches[batchId], requestContext.Span,
                 transactionProvider != null, true, _instrumentationOptions);
 
             if (_asyncOutbox is null) throw new ArgumentException(NoAsyncOutboxError);
@@ -610,7 +610,7 @@ namespace Paramore.Brighter
                         (await _asyncOutbox.OutstandingMessagesAsync(timeSinceSent, requestContext,
                             pageSize: amountToClear, args: args, cancellationToken: cancellationToken)).ToArray();
 
-                    BrighterTracer.WriteOutboxEvent(OutboxDbOperation.OutStandingMessages, messages, span, false, true,
+                    BrighterTracer.WriteOutboxEvent(BoxDbOperation.OutStandingMessages, messages, span, false, true,
                         _instrumentationOptions);
 
                     requestContext.Span = parentSpan;

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Pipeline/When_Building_A_Pipeline_With_Global_Inbox_Override_Context.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Pipeline/When_Building_A_Pipeline_With_Global_Inbox_Override_Context.cs
@@ -56,7 +56,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.Pipeline
             firstHandler.Handle(myCommmand);
 
             //assert
-            var exists = _inbox.Exists<MyCommand>(myCommmand.Id, CONTEXT_KEY, 500);
+            var exists = _inbox.Exists<MyCommand>(myCommmand.Id, CONTEXT_KEY, null, 500);
             Assert.True(exists);
         }
 

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Pipeline/When_Inserting_A_Default_Inbox_Into_The_Publish_Pipeline.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Pipeline/When_Inserting_A_Default_Inbox_Into_The_Publish_Pipeline.cs
@@ -70,7 +70,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.Pipeline
             _commandProcessor.Publish(@event);
 
             //assert we are in, and auto-context added us under our name
-            var boxed = _inbox.Exists<MyEvent>(@event.Id, typeof(MyGlobalInboxEventHandler).FullName, 100);
+            var boxed = _inbox.Exists<MyEvent>(@event.Id, typeof(MyGlobalInboxEventHandler).FullName, null, 100);
             Assert.True(boxed);
         }
 

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Pipeline/When_Inserting_A_Default_Inbox_Into_The_Publish_Pipeline_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Pipeline/When_Inserting_A_Default_Inbox_Into_The_Publish_Pipeline_Async.cs
@@ -69,7 +69,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.Pipeline
             await _commandProcessor.SendAsync(@event);
 
             //assert we are in, and auto-context added us under our name
-            var boxed = await _inbox.ExistsAsync<MyCommand>(@event.Id, typeof(MyEventHandlerAsync).FullName, 100);
+            var boxed = await _inbox.ExistsAsync<MyCommand>(@event.Id, typeof(MyEventHandlerAsync).FullName, null, 100);
             Assert.True(boxed);
         }
 

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Pipeline/When_Inserting_A_Default_Inbox_Into_The_Send_Pipeline.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Pipeline/When_Inserting_A_Default_Inbox_Into_The_Send_Pipeline.cs
@@ -70,7 +70,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.Pipeline
             //assert we are in, and auto-context added us under our name
             var inbox = _provider.GetService<IAmAnInboxSync>();
             Assert.NotNull(inbox);
-            var boxed = inbox.Exists<MyCommand>(command.Id, typeof(MyCommandHandler).FullName, 100);
+            var boxed = inbox.Exists<MyCommand>(command.Id, typeof(MyCommandHandler).FullName, null, 100);
             Assert.True(boxed);
         }
 

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Pipeline/When_Inserting_A_Default_Inbox_Into_The_Send_Pipeline_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Pipeline/When_Inserting_A_Default_Inbox_Into_The_Send_Pipeline_Async.cs
@@ -68,7 +68,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.Pipeline
             await _commandProcessor.SendAsync(command);
             
             //assert we are in, and auto-context added us under our name
-            var boxed = await _inbox.ExistsAsync<MyCommand>(command.Id, typeof(MyCommandHandlerAsync).FullName, 100);
+            var boxed = await _inbox.ExistsAsync<MyCommand>(command.Id, typeof(MyCommandHandlerAsync).FullName, null, 100);
             Assert.True(boxed);
         }
         

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Publish/When_Inserting_A_Default_Inbox_Into_The_Publish_Pipeline.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Publish/When_Inserting_A_Default_Inbox_Into_The_Publish_Pipeline.cs
@@ -70,7 +70,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.Publish
             _commandProcessor.Publish(@event);
 
             //assert we are in, and auto-context added us under our name
-            var boxed = _inbox.Exists<MyEvent>(@event.Id, typeof(MyGlobalInboxEventHandler).FullName, 100);
+            var boxed = _inbox.Exists<MyEvent>(@event.Id, typeof(MyGlobalInboxEventHandler).FullName, null, 100);
             Assert.True(boxed);
         }
 

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Publish/When_Inserting_A_Default_Inbox_Into_The_Publish_Pipeline_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Publish/When_Inserting_A_Default_Inbox_Into_The_Publish_Pipeline_Async.cs
@@ -73,7 +73,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.Publish
             await _commandProcessor.SendAsync(@event);
 
             //assert we are in, and auto-context added us under our name
-            var boxed = await _inbox.ExistsAsync<MyCommand>(@event.Id, typeof(MyEventHandlerAsync).FullName, 100);
+            var boxed = await _inbox.ExistsAsync<MyCommand>(@event.Id, typeof(MyEventHandlerAsync).FullName, null, 100);
             Assert.True(boxed);
         }
 

--- a/tests/Paramore.Brighter.Core.Tests/Observability/Archive/When_archiving_from_the_outbox.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Observability/Archive/When_archiving_from_the_outbox.cs
@@ -129,13 +129,13 @@ public class ExternalServiceBusArchiveObservabilityTests
 
         //check for outstanding messages span
         var osCheckActivity = _exportedActivities.SingleOrDefault(a =>
-            a.DisplayName == $"{OutboxDbOperation.DispatchedMessages.ToSpanName()} {InMemoryAttributes.DbName} {InMemoryAttributes.DbTable}");
+            a.DisplayName == $"{BoxDbOperation.DispatchedMessages.ToSpanName()} {InMemoryAttributes.OutboxDbName} {InMemoryAttributes.DbTable}");
         Assert.NotNull(osCheckActivity);
         Assert.Equal(createActivity.Id, osCheckActivity?.ParentId);
 
         //check for delete messages span
         var deleteActivity = _exportedActivities.SingleOrDefault(a =>
-            a.DisplayName == $"{OutboxDbOperation.Delete.ToSpanName()} {InMemoryAttributes.DbName} {InMemoryAttributes.DbTable}");
+            a.DisplayName == $"{BoxDbOperation.Delete.ToSpanName()} {InMemoryAttributes.OutboxDbName} {InMemoryAttributes.DbTable}");
         Assert.NotNull(deleteActivity);
         Assert.Equal(createActivity.Id, deleteActivity?.ParentId);
 
@@ -143,16 +143,16 @@ public class ExternalServiceBusArchiveObservabilityTests
         Assert.Contains(createActivity.TagObjects, t => t.Key == BrighterSemanticConventions.ArchiveAge && Math.Abs(Convert.ToDouble(t.Value) - dispatchedSince.TotalMilliseconds) < TOLERANCE);
 
         //check the tags for the outstanding messages span
-        Assert.True(osCheckActivity?.Tags.Any(t => t.Key == BrighterSemanticConventions.DbOperation && t.Value == OutboxDbOperation.DispatchedMessages.ToSpanName()));
+        Assert.True(osCheckActivity?.Tags.Any(t => t.Key == BrighterSemanticConventions.DbOperation && t.Value == BoxDbOperation.DispatchedMessages.ToSpanName()));
         Assert.True(osCheckActivity?.Tags.Any(t => t.Key == BrighterSemanticConventions.DbTable && t.Value == InMemoryAttributes.DbTable));
         Assert.True(osCheckActivity?.Tags.Any(t => t.Key == BrighterSemanticConventions.DbSystem && t.Value == DbSystem.Brighter.ToDbName()));
-        Assert.True(osCheckActivity?.Tags.Any(t => t.Key == BrighterSemanticConventions.DbName && t.Value == InMemoryAttributes.DbName));
+        Assert.True(osCheckActivity?.Tags.Any(t => t.Key == BrighterSemanticConventions.DbName && t.Value == InMemoryAttributes.OutboxDbName));
 
         //check the tags for the delete messages span
-        Assert.True(deleteActivity?.Tags.Any(t => t.Key == BrighterSemanticConventions.DbOperation && t.Value == OutboxDbOperation.Delete.ToSpanName()));
+        Assert.True(deleteActivity?.Tags.Any(t => t.Key == BrighterSemanticConventions.DbOperation && t.Value == BoxDbOperation.Delete.ToSpanName()));
         Assert.True(deleteActivity?.Tags.Any(t => t.Key == BrighterSemanticConventions.DbTable && t.Value == InMemoryAttributes.DbTable));
         Assert.True(deleteActivity?.Tags.Any(t => t.Key == BrighterSemanticConventions.DbSystem && t.Value == DbSystem.Brighter.ToDbName()));
-        Assert.True(deleteActivity?.Tags.Any(t => t.Key == BrighterSemanticConventions.DbName && t.Value == InMemoryAttributes.DbName));
+        Assert.True(deleteActivity?.Tags.Any(t => t.Key == BrighterSemanticConventions.DbName && t.Value == InMemoryAttributes.OutboxDbName));
         
     }
 }

--- a/tests/Paramore.Brighter.Core.Tests/Observability/Archive/When_archiving_from_the_outbox_async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Observability/Archive/When_archiving_from_the_outbox_async.cs
@@ -131,13 +131,13 @@ public class AsyncExternalServiceBusArchiveObservabilityTests
 
         //check for outstanding messages span
         var osCheckActivity = _exportedActivities.SingleOrDefault(a =>
-            a.DisplayName == $"{OutboxDbOperation.DispatchedMessages.ToSpanName()} {InMemoryAttributes.DbName} {InMemoryAttributes.DbTable}");
+            a.DisplayName == $"{BoxDbOperation.DispatchedMessages.ToSpanName()} {InMemoryAttributes.OutboxDbName} {InMemoryAttributes.DbTable}");
         Assert.NotNull(osCheckActivity);
         Assert.Equal(createActivity.Id, osCheckActivity?.ParentId);
 
         //check for delete messages span
         var deleteActivity = _exportedActivities.SingleOrDefault(a =>
-            a.DisplayName == $"{OutboxDbOperation.Delete.ToSpanName()} {InMemoryAttributes.DbName} {InMemoryAttributes.DbTable}");
+            a.DisplayName == $"{BoxDbOperation.Delete.ToSpanName()} {InMemoryAttributes.OutboxDbName} {InMemoryAttributes.DbTable}");
         Assert.NotNull(deleteActivity);
         Assert.Equal(createActivity.Id, deleteActivity?.ParentId);
 
@@ -145,16 +145,16 @@ public class AsyncExternalServiceBusArchiveObservabilityTests
         Assert.Contains(createActivity.TagObjects, t => t.Key == BrighterSemanticConventions.ArchiveAge && Math.Abs(Convert.ToDouble(t.Value) - dispatchedSince.TotalMilliseconds) < TOLERANCE);
 
         //check the tags for the outstanding messages span
-        Assert.True(osCheckActivity?.Tags.Any(t => t.Key == BrighterSemanticConventions.DbOperation && t.Value == OutboxDbOperation.DispatchedMessages.ToSpanName()));
+        Assert.True(osCheckActivity?.Tags.Any(t => t.Key == BrighterSemanticConventions.DbOperation && t.Value == BoxDbOperation.DispatchedMessages.ToSpanName()));
         Assert.True(osCheckActivity?.Tags.Any(t => t.Key == BrighterSemanticConventions.DbTable && t.Value == InMemoryAttributes.DbTable));
         Assert.True(osCheckActivity?.Tags.Any(t => t.Key == BrighterSemanticConventions.DbSystem && t.Value == DbSystem.Brighter.ToDbName()));
-        Assert.True(osCheckActivity?.Tags.Any(t => t.Key == BrighterSemanticConventions.DbName && t.Value == InMemoryAttributes.DbName));
+        Assert.True(osCheckActivity?.Tags.Any(t => t.Key == BrighterSemanticConventions.DbName && t.Value == InMemoryAttributes.OutboxDbName));
 
         //check the tags for the delete messages span
-        Assert.True(deleteActivity?.Tags.Any(t => t.Key == BrighterSemanticConventions.DbOperation && t.Value == OutboxDbOperation.Delete.ToSpanName()));
+        Assert.True(deleteActivity?.Tags.Any(t => t.Key == BrighterSemanticConventions.DbOperation && t.Value == BoxDbOperation.Delete.ToSpanName()));
         Assert.True(deleteActivity?.Tags.Any(t => t.Key == BrighterSemanticConventions.DbTable && t.Value == InMemoryAttributes.DbTable));
         Assert.True(deleteActivity?.Tags.Any(t => t.Key == BrighterSemanticConventions.DbSystem && t.Value == DbSystem.Brighter.ToDbName()));
-        Assert.True(deleteActivity?.Tags.Any(t => t.Key == BrighterSemanticConventions.DbName && t.Value == InMemoryAttributes.DbName));
+        Assert.True(deleteActivity?.Tags.Any(t => t.Key == BrighterSemanticConventions.DbName && t.Value == InMemoryAttributes.OutboxDbName));
         
     }
 }

--- a/tests/Paramore.Brighter.Core.Tests/Observability/CommandProcessor/Clear/When_Clearing_A_Message_A_Span_Is_Exported.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Observability/CommandProcessor/Clear/When_Clearing_A_Message_A_Span_Is_Exported.cs
@@ -140,7 +140,7 @@ public class CommandProcessorClearObservabilityTests
         
         //retrieving the message should be an event
         var message = _internalBus.Stream(new RoutingKey("MyEvent")).Single();
-        var depositEvent = events.Single(e => e.Name == OutboxDbOperation.Get.ToSpanName());
+        var depositEvent = events.Single(e => e.Name == BoxDbOperation.Get.ToSpanName());
         Assert.True(depositEvent.Tags.Any(a => a.Value != null && a.Key == BrighterSemanticConventions.OutboxSharedTransaction && (bool)a.Value == false));
         Assert.True(depositEvent.Tags.Any(a => a.Key == BrighterSemanticConventions.OutboxType && a.Value as string == "sync" ));
         Assert.True(depositEvent.Tags.Any(a => a.Key == BrighterSemanticConventions.MessageId && a.Value as string == message.Id ));
@@ -152,11 +152,11 @@ public class CommandProcessorClearObservabilityTests
         Assert.True(depositEvent.Tags.Any(a => a.Key == BrighterSemanticConventions.MessageHeaders && a.Value as string == JsonSerializer.Serialize(message.Header)));
         
         //there should be a span in the Db for retrieving the message
-        var outBoxActivity = _exportedActivities.Single(a => a.DisplayName == $"{OutboxDbOperation.Get.ToSpanName()} {InMemoryAttributes.DbName} {InMemoryAttributes.DbTable}");
-        Assert.True(outBoxActivity.Tags.Any(t => t.Key == BrighterSemanticConventions.DbOperation && t.Value == OutboxDbOperation.Get.ToSpanName()));
+        var outBoxActivity = _exportedActivities.Single(a => a.DisplayName == $"{BoxDbOperation.Get.ToSpanName()} {InMemoryAttributes.OutboxDbName} {InMemoryAttributes.DbTable}");
+        Assert.True(outBoxActivity.Tags.Any(t => t.Key == BrighterSemanticConventions.DbOperation && t.Value == BoxDbOperation.Get.ToSpanName()));
         Assert.True(outBoxActivity.Tags.Any(t => t.Key == BrighterSemanticConventions.DbTable && t.Value == InMemoryAttributes.DbTable));
         Assert.True(outBoxActivity.Tags.Any(t => t.Key == BrighterSemanticConventions.DbSystem && t.Value == DbSystem.Brighter.ToDbName()));
-        Assert.True(outBoxActivity.Tags.Any(t => t.Key == BrighterSemanticConventions.DbName && t.Value == InMemoryAttributes.DbName));
+        Assert.True(outBoxActivity.Tags.Any(t => t.Key == BrighterSemanticConventions.DbName && t.Value == InMemoryAttributes.OutboxDbName));
 
         //there should be a span for publishing the message via the producer
         var producerActivity = _exportedActivities.Single(a => a.DisplayName == $"{"MyEvent"} {CommandProcessorSpanOperation.Publish.ToSpanName()}");
@@ -199,10 +199,10 @@ public class CommandProcessorClearObservabilityTests
         Assert.True(produceEvent.Tags.Any(t => t.Key == BrighterSemanticConventions.CeType && (string)t.Value == _producer.Publication.Type));
         
         //There should be  a span event to mark as dispatched
-        var markAsDispatchedActivity = _exportedActivities.Single(a => a.DisplayName == $"{OutboxDbOperation.MarkDispatched.ToSpanName()} {InMemoryAttributes.DbName} {InMemoryAttributes.DbTable}");
-        Assert.True(markAsDispatchedActivity.Tags.Any(t => t.Key == BrighterSemanticConventions.DbOperation && t.Value == OutboxDbOperation.MarkDispatched.ToSpanName()));
+        var markAsDispatchedActivity = _exportedActivities.Single(a => a.DisplayName == $"{BoxDbOperation.MarkDispatched.ToSpanName()} {InMemoryAttributes.OutboxDbName} {InMemoryAttributes.DbTable}");
+        Assert.True(markAsDispatchedActivity.Tags.Any(t => t.Key == BrighterSemanticConventions.DbOperation && t.Value == BoxDbOperation.MarkDispatched.ToSpanName()));
         Assert.True(markAsDispatchedActivity.Tags.Any(t => t.Key == BrighterSemanticConventions.DbTable && t.Value == InMemoryAttributes.DbTable));
         Assert.True(markAsDispatchedActivity.Tags.Any(t => t.Key == BrighterSemanticConventions.DbSystem && t.Value == DbSystem.Brighter.ToDbName()));
-        Assert.True(markAsDispatchedActivity.Tags.Any(t => t.Key == BrighterSemanticConventions.DbName && t.Value == InMemoryAttributes.DbName));
+        Assert.True(markAsDispatchedActivity.Tags.Any(t => t.Key == BrighterSemanticConventions.DbName && t.Value == InMemoryAttributes.OutboxDbName));
     }
 }

--- a/tests/Paramore.Brighter.Core.Tests/Observability/CommandProcessor/Clear/When_Clearing_A_Message_A_Span_Is_Exported_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Observability/CommandProcessor/Clear/When_Clearing_A_Message_A_Span_Is_Exported_Async.cs
@@ -141,7 +141,7 @@ public class AsyncCommandProcessorClearObservabilityTests
         
         //retrieving the message should be an event
         var message = _internalBus.Stream(new RoutingKey(_topic)).Single();
-        var depositEvent = events.Single(e => e.Name == OutboxDbOperation.Get.ToSpanName());
+        var depositEvent = events.Single(e => e.Name == BoxDbOperation.Get.ToSpanName());
         Assert.True(depositEvent.Tags.Any(a => a.Value != null && a.Key == BrighterSemanticConventions.OutboxSharedTransaction && (bool)a.Value == false));
         Assert.True(depositEvent.Tags.Any(a => a.Key == BrighterSemanticConventions.OutboxType && a.Value as string == "async" ));
         Assert.True(depositEvent.Tags.Any(a => a.Key == BrighterSemanticConventions.MessageId && a.Value as string == message.Id ));
@@ -153,11 +153,11 @@ public class AsyncCommandProcessorClearObservabilityTests
         Assert.True(depositEvent.Tags.Any(a => a.Key == BrighterSemanticConventions.MessageHeaders && a.Value as string == JsonSerializer.Serialize(message.Header)));
         
         //there should be a span in the Db for retrieving the message
-        var outBoxActivity = _exportedActivities.Single(a => a.DisplayName == $"{OutboxDbOperation.Get.ToSpanName()} {InMemoryAttributes.DbName} {InMemoryAttributes.DbTable}");
-        Assert.True(outBoxActivity.Tags.Any(t => t.Key == BrighterSemanticConventions.DbOperation && t.Value == OutboxDbOperation.Get.ToSpanName()));
+        var outBoxActivity = _exportedActivities.Single(a => a.DisplayName == $"{BoxDbOperation.Get.ToSpanName()} {InMemoryAttributes.OutboxDbName} {InMemoryAttributes.DbTable}");
+        Assert.True(outBoxActivity.Tags.Any(t => t.Key == BrighterSemanticConventions.DbOperation && t.Value == BoxDbOperation.Get.ToSpanName()));
         Assert.True(outBoxActivity.Tags.Any(t => t.Key == BrighterSemanticConventions.DbTable && t.Value == InMemoryAttributes.DbTable));
         Assert.True(outBoxActivity.Tags.Any(t => t.Key == BrighterSemanticConventions.DbSystem && t.Value == DbSystem.Brighter.ToDbName()));
-        Assert.True(outBoxActivity.Tags.Any(t => t.Key == BrighterSemanticConventions.DbName && t.Value == InMemoryAttributes.DbName));
+        Assert.True(outBoxActivity.Tags.Any(t => t.Key == BrighterSemanticConventions.DbName && t.Value == InMemoryAttributes.OutboxDbName));
 
         //there should be a span for publishing the message via the producer
         var producerActivity = _exportedActivities.Single(a => a.DisplayName == $"{_topic} {CommandProcessorSpanOperation.Publish.ToSpanName()}");
@@ -200,11 +200,11 @@ public class AsyncCommandProcessorClearObservabilityTests
         Assert.True(produceEvent.Tags.Any(t => t.Key == BrighterSemanticConventions.CeType && t.Value as string == _producer.Publication.Type));
         
         //There should be  a span event to mark as dispatched
-        var markAsDispatchedActivity = _exportedActivities.Single(a => a.DisplayName == $"{OutboxDbOperation.MarkDispatched.ToSpanName()} {InMemoryAttributes.DbName} {InMemoryAttributes.DbTable}");
-        Assert.True(markAsDispatchedActivity.Tags.Any(t => t.Key == BrighterSemanticConventions.DbOperation && t.Value == OutboxDbOperation.MarkDispatched.ToSpanName()));
+        var markAsDispatchedActivity = _exportedActivities.Single(a => a.DisplayName == $"{BoxDbOperation.MarkDispatched.ToSpanName()} {InMemoryAttributes.OutboxDbName} {InMemoryAttributes.DbTable}");
+        Assert.True(markAsDispatchedActivity.Tags.Any(t => t.Key == BrighterSemanticConventions.DbOperation && t.Value == BoxDbOperation.MarkDispatched.ToSpanName()));
         Assert.True(markAsDispatchedActivity.Tags.Any(t => t.Key == BrighterSemanticConventions.DbTable && t.Value == InMemoryAttributes.DbTable));
         Assert.True(markAsDispatchedActivity.Tags.Any(t => t.Key == BrighterSemanticConventions.DbSystem && t.Value == DbSystem.Brighter.ToDbName()));
-        Assert.True(markAsDispatchedActivity.Tags.Any(t => t.Key == BrighterSemanticConventions.DbName && t.Value == InMemoryAttributes.DbName));
+        Assert.True(markAsDispatchedActivity.Tags.Any(t => t.Key == BrighterSemanticConventions.DbName && t.Value == InMemoryAttributes.OutboxDbName));
 
     }
 }

--- a/tests/Paramore.Brighter.Core.Tests/Observability/CommandProcessor/Clear/When_Clearing_Multipile_Messages_Spans_Are_Exported_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Observability/CommandProcessor/Clear/When_Clearing_Multipile_Messages_Spans_Are_Exported_Async.cs
@@ -138,7 +138,7 @@ public class AsyncCommandProcessorMultipleClearObservabilityTests
         Assert.Equal(3, clearActivity.Count());
 
         //there should be a span in the Db for retrieving the message
-        var outBoxActivity = _exportedActivities.Where(a => a.DisplayName == $"{OutboxDbOperation.Get.ToSpanName()} {InMemoryAttributes.DbName} {InMemoryAttributes.DbTable}");
+        var outBoxActivity = _exportedActivities.Where(a => a.DisplayName == $"{BoxDbOperation.Get.ToSpanName()} {InMemoryAttributes.OutboxDbName} {InMemoryAttributes.DbTable}");
         Assert.Equal(3, outBoxActivity.Count());
 
         //there should be a span for publishing the message via the producer

--- a/tests/Paramore.Brighter.Core.Tests/Observability/CommandProcessor/Clear/When_Clearing_Multiple_Messages_Spans_Are_Exported.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Observability/CommandProcessor/Clear/When_Clearing_Multiple_Messages_Spans_Are_Exported.cs
@@ -137,7 +137,7 @@ public class CommandProcessorMultipleClearObservabilityTests
         Assert.Equal(3, clearActivity.Count());
 
         //there should be a span in the Db for retrieving the message
-        var outBoxActivity = _exportedActivities.Where(a => a.DisplayName == $"{OutboxDbOperation.Get.ToSpanName()} {InMemoryAttributes.DbName} {InMemoryAttributes.DbTable}");
+        var outBoxActivity = _exportedActivities.Where(a => a.DisplayName == $"{BoxDbOperation.Get.ToSpanName()} {InMemoryAttributes.OutboxDbName} {InMemoryAttributes.DbTable}");
         Assert.Equal(3, outBoxActivity.Count());
 
         //there should be a span for publishing the message via the producer

--- a/tests/Paramore.Brighter.Core.Tests/Observability/CommandProcessor/Clear/When_Clearing_Outstanding_Messages_Spans_Are_Exported.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Observability/CommandProcessor/Clear/When_Clearing_Outstanding_Messages_Spans_Are_Exported.cs
@@ -145,7 +145,7 @@ public class CommandProcessorClearOutstandingObservabilityTests
         var events = clearActivity.Events.ToList();
         var messages = _internalBus.Stream(new RoutingKey(_topic)).ToArray();
         
-        var depositEvents = events.Where(e => e.Name == OutboxDbOperation.OutStandingMessages.ToSpanName()).ToArray();
+        var depositEvents = events.Where(e => e.Name == BoxDbOperation.OutStandingMessages.ToSpanName()).ToArray();
         Assert.Equal(messages.Length, depositEvents.Length);
         
         foreach (var message in messages)
@@ -165,12 +165,12 @@ public class CommandProcessorClearOutstandingObservabilityTests
         //there should be a span in the Db for retrieving the message
         var outBoxActivity = _exportedActivities
             .Single(a =>
-                a.DisplayName == $"{OutboxDbOperation.OutStandingMessages.ToSpanName()} {InMemoryAttributes.DbName} {InMemoryAttributes.DbTable}"
+                a.DisplayName == $"{BoxDbOperation.OutStandingMessages.ToSpanName()} {InMemoryAttributes.OutboxDbName} {InMemoryAttributes.DbTable}"
             );
-        Assert.True(outBoxActivity.Tags.Any(t => t.Key == BrighterSemanticConventions.DbOperation && t.Value == OutboxDbOperation.OutStandingMessages.ToSpanName()));
+        Assert.True(outBoxActivity.Tags.Any(t => t.Key == BrighterSemanticConventions.DbOperation && t.Value == BoxDbOperation.OutStandingMessages.ToSpanName()));
         Assert.True(outBoxActivity.Tags.Any(t => t.Key == BrighterSemanticConventions.DbTable && t.Value == InMemoryAttributes.DbTable));
         Assert.True(outBoxActivity.Tags.Any(t => t.Key == BrighterSemanticConventions.DbSystem && t.Value == DbSystem.Brighter.ToDbName()));
-        Assert.True(outBoxActivity.Tags.Any(t => t.Key == BrighterSemanticConventions.DbName && t.Value == InMemoryAttributes.DbName));
+        Assert.True(outBoxActivity.Tags.Any(t => t.Key == BrighterSemanticConventions.DbName && t.Value == InMemoryAttributes.OutboxDbName));
 
         //there should be a span for publishing the message via the producer
         var producerActivity = _exportedActivities

--- a/tests/Paramore.Brighter.Core.Tests/Observability/CommandProcessor/Clear/When_Clearing_Outstanding_Messages_Spans_Are_Exported_Bulk.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Observability/CommandProcessor/Clear/When_Clearing_Outstanding_Messages_Spans_Are_Exported_Bulk.cs
@@ -144,7 +144,7 @@ public class AsyncCommandProcessorBulkClearOutstandingObservabilityTests
         var events = clearActivity.Events.ToList();
         var messages = _internalBus.Stream(new RoutingKey(_topic)).ToArray();
         
-        var depositEvents = events.Where(e => e.Name == OutboxDbOperation.OutStandingMessages.ToSpanName()).ToArray();
+        var depositEvents = events.Where(e => e.Name == BoxDbOperation.OutStandingMessages.ToSpanName()).ToArray();
         Assert.Equal(messages.Length, depositEvents.Length);
         
         foreach (var message in messages)
@@ -163,12 +163,12 @@ public class AsyncCommandProcessorBulkClearOutstandingObservabilityTests
         //there should be a span in the Db for retrieving the message
         var outBoxActivity = _exportedActivities
             .Single(a =>
-                a.DisplayName == $"{OutboxDbOperation.OutStandingMessages.ToSpanName()} {InMemoryAttributes.DbName} {InMemoryAttributes.DbTable}"
+                a.DisplayName == $"{BoxDbOperation.OutStandingMessages.ToSpanName()} {InMemoryAttributes.OutboxDbName} {InMemoryAttributes.DbTable}"
             );
-        Assert.True(outBoxActivity.Tags.Any(t => t.Key == BrighterSemanticConventions.DbOperation && t.Value == OutboxDbOperation.OutStandingMessages.ToSpanName()));
+        Assert.True(outBoxActivity.Tags.Any(t => t.Key == BrighterSemanticConventions.DbOperation && t.Value == BoxDbOperation.OutStandingMessages.ToSpanName()));
         Assert.True(outBoxActivity.Tags.Any(t => t.Key == BrighterSemanticConventions.DbTable && t.Value == InMemoryAttributes.DbTable));
         Assert.True(outBoxActivity.Tags.Any(t => t.Key == BrighterSemanticConventions.DbSystem && t.Value == DbSystem.Brighter.ToDbName()));
-        Assert.True(outBoxActivity.Tags.Any(t => t.Key == BrighterSemanticConventions.DbName && t.Value == InMemoryAttributes.DbName));
+        Assert.True(outBoxActivity.Tags.Any(t => t.Key == BrighterSemanticConventions.DbName && t.Value == InMemoryAttributes.OutboxDbName));
 
         //there should be a span for publishing the message via the producer
         var producerActivity = _exportedActivities

--- a/tests/Paramore.Brighter.Core.Tests/Observability/CommandProcessor/Deposit/When_Depositing_A_Request_A_Span_Is_Exported.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Observability/CommandProcessor/Deposit/When_Depositing_A_Request_A_Span_Is_Exported.cs
@@ -130,7 +130,7 @@ public class CommandProcessorDepositObservabilityTests
         
         //depositing a message should be an event
         var message = _outbox.OutstandingMessages(TimeSpan.Zero, context).Single();
-        var depositEvent = events.Single(e => e.Name == OutboxDbOperation.Add.ToSpanName());
+        var depositEvent = events.Single(e => e.Name == BoxDbOperation.Add.ToSpanName());
         Assert.True(depositEvent.Tags.Any(a => a is { Value: not null, Key: BrighterSemanticConventions.OutboxSharedTransaction } && (bool)a.Value == false));
         Assert.True(depositEvent.Tags.Any(a => a.Key == BrighterSemanticConventions.OutboxType && (string)a.Value == "sync" ));
         Assert.True(depositEvent.Tags.Any(a => a.Key == BrighterSemanticConventions.MessageId && (string)a.Value == message.Id ));
@@ -142,11 +142,11 @@ public class CommandProcessorDepositObservabilityTests
         Assert.True(depositEvent.Tags.Any(a => a.Key == BrighterSemanticConventions.MessageHeaders && (string)a.Value == JsonSerializer.Serialize(message.Header)));
 
         //-- there should be a span for the outbox itself to use for its call; even in-memory here; should use <db.operation> <db.name> for the span name
-        var outBoxActivity = _exportedActivities.Single(a => a.DisplayName == $"{OutboxDbOperation.Add.ToSpanName()} {InMemoryAttributes.DbName} {InMemoryAttributes.DbTable}");
-        Assert.True(outBoxActivity.Tags.Any(t => t.Key == BrighterSemanticConventions.DbOperation && t.Value == OutboxDbOperation.Add.ToSpanName()));
+        var outBoxActivity = _exportedActivities.Single(a => a.DisplayName == $"{BoxDbOperation.Add.ToSpanName()} {InMemoryAttributes.OutboxDbName} {InMemoryAttributes.DbTable}");
+        Assert.True(outBoxActivity.Tags.Any(t => t.Key == BrighterSemanticConventions.DbOperation && t.Value == BoxDbOperation.Add.ToSpanName()));
         Assert.True(outBoxActivity.Tags.Any(t => t.Key == BrighterSemanticConventions.DbTable && t.Value == InMemoryAttributes.DbTable));
         Assert.True(outBoxActivity.Tags.Any(t => t.Key == BrighterSemanticConventions.DbSystem && t.Value == DbSystem.Brighter.ToDbName()));
-        Assert.True(outBoxActivity.Tags.Any(t => t.Key == BrighterSemanticConventions.DbName && t.Value == InMemoryAttributes.DbName));
+        Assert.True(outBoxActivity.Tags.Any(t => t.Key == BrighterSemanticConventions.DbName && t.Value == InMemoryAttributes.OutboxDbName));
 
     }
 }

--- a/tests/Paramore.Brighter.Core.Tests/Observability/CommandProcessor/Deposit/When_Depositing_A_Request_A_Span_Is_Exported_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Observability/CommandProcessor/Deposit/When_Depositing_A_Request_A_Span_Is_Exported_Async.cs
@@ -132,7 +132,7 @@ public class AsyncCommandProcessorDepositObservabilityTests
         
         //depositing a message should be an event
         var message = _outbox.OutstandingMessages(TimeSpan.Zero, context).Single();
-        var depositEvent = events.Single(e => e.Name == OutboxDbOperation.Add.ToSpanName());
+        var depositEvent = events.Single(e => e.Name == BoxDbOperation.Add.ToSpanName());
         Assert.True(depositEvent.Tags.Any(a => a is { Value: not null, Key: BrighterSemanticConventions.OutboxSharedTransaction } && (bool)a.Value == false));
         Assert.True(depositEvent.Tags.Any(a => a.Key == BrighterSemanticConventions.OutboxType && (string)a.Value == "async" ));
         Assert.True(depositEvent.Tags.Any(a => a.Key == BrighterSemanticConventions.MessageId && (string)a.Value == message.Id ));
@@ -144,11 +144,11 @@ public class AsyncCommandProcessorDepositObservabilityTests
         Assert.True(depositEvent.Tags.Any(a => a.Key == BrighterSemanticConventions.MessageHeaders && (string)a.Value == JsonSerializer.Serialize(message.Header)));
 
         //-- there should be a span for the outbox itself to use for its call; even in-memory here; should use <db.operation> <db.name> for the span name
-        var outBoxActivity = _exportedActivities.Single(a => a.DisplayName == $"{OutboxDbOperation.Add.ToSpanName()} {InMemoryAttributes.DbName} {InMemoryAttributes.DbTable}");
-        Assert.True(outBoxActivity.Tags.Any(t => t.Key == BrighterSemanticConventions.DbOperation && t.Value == OutboxDbOperation.Add.ToSpanName()));
+        var outBoxActivity = _exportedActivities.Single(a => a.DisplayName == $"{BoxDbOperation.Add.ToSpanName()} {InMemoryAttributes.OutboxDbName} {InMemoryAttributes.DbTable}");
+        Assert.True(outBoxActivity.Tags.Any(t => t.Key == BrighterSemanticConventions.DbOperation && t.Value == BoxDbOperation.Add.ToSpanName()));
         Assert.True(outBoxActivity.Tags.Any(t => t.Key == BrighterSemanticConventions.DbTable && t.Value == InMemoryAttributes.DbTable));
         Assert.True(outBoxActivity.Tags.Any(t => t.Key == BrighterSemanticConventions.DbSystem && t.Value == DbSystem.Brighter.ToDbName()));
-        Assert.True(outBoxActivity.Tags.Any(t => t.Key == BrighterSemanticConventions.DbName && t.Value == InMemoryAttributes.DbName));
+        Assert.True(outBoxActivity.Tags.Any(t => t.Key == BrighterSemanticConventions.DbName && t.Value == InMemoryAttributes.OutboxDbName));
 
     }
 }

--- a/tests/Paramore.Brighter.Core.Tests/Observability/Common/When_Creating_A_Db_Span_Add_Brighter_Semantic_Conventions.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Observability/Common/When_Creating_A_Db_Span_Add_Brighter_Semantic_Conventions.cs
@@ -45,10 +45,10 @@ public class BrighterSemanticConventionsDbSpanTests
         //act
         var dbInstanceId = Guid.NewGuid().ToString();
         var childActivity = _tracer.CreateDbSpan(
-            new OutboxSpanInfo(
+            new BoxSpanInfo(
                 dbSystem: DbSystem.MySql, 
-                dbName: InMemoryAttributes.DbName, 
-                dbOperation: OutboxDbOperation.Add, 
+                dbName: InMemoryAttributes.OutboxDbName, 
+                dbOperation: BoxDbOperation.Add, 
                 dbTable: InMemoryAttributes.DbTable, 
                 serverPort:3306,
                 dbInstanceId: dbInstanceId,
@@ -73,10 +73,10 @@ public class BrighterSemanticConventionsDbSpanTests
 
         //check the created activity
         Assert.Equal(_parentActivity.Id, childActivity.ParentId);
-        Assert.Equal($"{OutboxDbOperation.Add.ToSpanName()} {InMemoryAttributes.DbName} {InMemoryAttributes.DbTable}", childActivity.DisplayName);
+        Assert.Equal($"{BoxDbOperation.Add.ToSpanName()} {InMemoryAttributes.OutboxDbName} {InMemoryAttributes.DbTable}", childActivity.DisplayName);
         Assert.Contains(childActivity.Tags, t => t.Key == BrighterSemanticConventions.DbInstanceId && t.Value == dbInstanceId);
-        Assert.Contains(childActivity.Tags, t => t.Key == BrighterSemanticConventions.DbName && t.Value == InMemoryAttributes.DbName);
-        Assert.Contains(childActivity.Tags, t => t.Key == BrighterSemanticConventions.DbOperation && t.Value == OutboxDbOperation.Add.ToSpanName());
+        Assert.Contains(childActivity.Tags, t => t.Key == BrighterSemanticConventions.DbName && t.Value == InMemoryAttributes.OutboxDbName);
+        Assert.Contains(childActivity.Tags, t => t.Key == BrighterSemanticConventions.DbOperation && t.Value == BoxDbOperation.Add.ToSpanName());
         Assert.Contains(childActivity.Tags, t => t.Key == BrighterSemanticConventions.DbTable && t.Value == InMemoryAttributes.DbTable);
         Assert.Contains(childActivity.Tags, t => t.Key == BrighterSemanticConventions.DbSystem && t.Value == DbSystem.MySql.ToDbName());
         Assert.Contains(childActivity.Tags, t => t.Key == BrighterSemanticConventions.DbStatement && t.Value == DbStatement);
@@ -89,10 +89,10 @@ public class BrighterSemanticConventionsDbSpanTests
         //check via the exporter as well
         Assert.Equal(2, _exportedActivities.Count);
         Assert.Contains(_exportedActivities, a => a.Source.Name == BrighterSemanticConventions.SourceName);
-        var childSpan = _exportedActivities.First(a => a.DisplayName == $"{OutboxDbOperation.Add.ToSpanName()} {InMemoryAttributes.DbName} {InMemoryAttributes.DbTable}");
+        var childSpan = _exportedActivities.First(a => a.DisplayName == $"{BoxDbOperation.Add.ToSpanName()} {InMemoryAttributes.OutboxDbName} {InMemoryAttributes.DbTable}");
         Assert.NotNull(childSpan);
         Assert.Contains(childSpan.Tags, t => t.Key == BrighterSemanticConventions.DbInstanceId && t.Value == dbInstanceId);
-        Assert.Contains(childSpan.Tags, t => t.Key == BrighterSemanticConventions.DbOperation && t.Value == OutboxDbOperation.Add.ToSpanName());
+        Assert.Contains(childSpan.Tags, t => t.Key == BrighterSemanticConventions.DbOperation && t.Value == BoxDbOperation.Add.ToSpanName());
         Assert.Contains(childSpan.Tags, t => t.Key == BrighterSemanticConventions.DbTable && t.Value == InMemoryAttributes.DbTable);
         Assert.Contains(childSpan.Tags, t => t.Key == BrighterSemanticConventions.DbSystem && t.Value == DbSystem.MySql.ToDbName());
         Assert.Contains(childSpan.Tags, t => t.Key == BrighterSemanticConventions.DbStatement && t.Value == DbStatement);

--- a/tests/Paramore.Brighter.Core.Tests/OnceOnly/When_Handling_A_Command_With_A_Inbox_Enabled.cs
+++ b/tests/Paramore.Brighter.Core.Tests/OnceOnly/When_Handling_A_Command_With_A_Inbox_Enabled.cs
@@ -73,7 +73,7 @@ namespace Paramore.Brighter.Core.Tests.OnceOnly
             _commandProcessor.Send(_command);
 
             //should_store_the_command_to_the_inbox
-            Assert.Equal(_command.Value, _inbox.Get<MyCommand>(_command.Id, _contextKey).Value);
+            Assert.Equal(_command.Value, _inbox.Get<MyCommand>(_command.Id, _contextKey, null).Value);
         }
 
         [Fact]
@@ -83,7 +83,7 @@ namespace Paramore.Brighter.Core.Tests.OnceOnly
 
             Assert.Throws<NotImplementedException>(() => _commandProcessor.Send(new MyCommandToFail { Id = id}));
 
-            Assert.False(_inbox.Exists<MyCommandToFail>(id, typeof(MyStoredCommandToFailHandler).FullName));
+            Assert.False(_inbox.Exists<MyCommandToFail>(id, typeof(MyStoredCommandToFailHandler).FullName, null));
         }
 
         public void Dispose()

--- a/tests/Paramore.Brighter.Core.Tests/OnceOnly/When_Handling_A_Command_With_A_Inbox_Enabled_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/OnceOnly/When_Handling_A_Command_With_A_Inbox_Enabled_Async.cs
@@ -50,7 +50,7 @@ namespace Paramore.Brighter.Core.Tests.OnceOnly
             await _commandProcessor.SendAsync(_command);
 
            // should_store_the_command_to_the_inbox
-            Assert.Equal(_command.Value, (await _inbox.GetAsync<MyCommand>(_command.Id, _contextKey)).Value);
+            Assert.Equal(_command.Value, (await _inbox.GetAsync<MyCommand>(_command.Id, _contextKey, null)).Value);
         }
 
         [Fact]
@@ -59,7 +59,7 @@ namespace Paramore.Brighter.Core.Tests.OnceOnly
             string id = Guid.NewGuid().ToString();
             await Catch.ExceptionAsync(async () =>await _commandProcessor.SendAsync(new MyCommandToFail { Id = id }));
 
-            var exists = await _inbox.ExistsAsync<MyCommandToFail>(id, typeof(MyStoredCommandToFailHandlerAsync).FullName);
+            var exists = await _inbox.ExistsAsync<MyCommandToFail>(id, typeof(MyStoredCommandToFailHandlerAsync).FullName, null);
             Assert.False(exists);
         }
 

--- a/tests/Paramore.Brighter.DynamoDB.Tests/Inbox/DynamoDbInboxDuplicateMessageTests.cs
+++ b/tests/Paramore.Brighter.DynamoDB.Tests/Inbox/DynamoDbInboxDuplicateMessageTests.cs
@@ -44,13 +44,13 @@ namespace Paramore.Brighter.DynamoDB.Tests.Inbox
             _dynamoDbInbox = new DynamoDbInbox(Client, new DynamoDbInboxConfiguration());
             _raisedCommand = new MyCommand { Value = "Test" };
             _contextKey = "context-key";
-            _dynamoDbInbox.Add(_raisedCommand, _contextKey);
+            _dynamoDbInbox.Add(_raisedCommand, _contextKey, null);
         }
 
         [Fact]
         public void When_The_Message_Is_Already_In_The_Inbox()
         {
-            _exception = Catch.Exception(() => _dynamoDbInbox.Add(_raisedCommand, _contextKey));
+            _exception = Catch.Exception(() => _dynamoDbInbox.Add(_raisedCommand, _contextKey, null));
 
             //_should_succeed_even_if_the_message_is_a_duplicate
             Assert.Null(_exception);
@@ -59,9 +59,9 @@ namespace Paramore.Brighter.DynamoDB.Tests.Inbox
         [Fact]
         public void When_The_Message_Is_Already_In_The_Inbox_Different_Context()
         {
-            _dynamoDbInbox.Add(_raisedCommand, "some other key");
+            _dynamoDbInbox.Add(_raisedCommand, "some other key", null);
 
-            var storedCommand = _dynamoDbInbox.Get<MyCommand>(_raisedCommand.Id, "some other key");
+            var storedCommand = _dynamoDbInbox.Get<MyCommand>(_raisedCommand.Id, "some other key", null);
 
             //_should_read_the_command_from_the__dynamo_db_inbox
             Assert.NotNull(storedCommand);

--- a/tests/Paramore.Brighter.DynamoDB.Tests/Inbox/When_checking_for_existing_command.cs
+++ b/tests/Paramore.Brighter.DynamoDB.Tests/Inbox/When_checking_for_existing_command.cs
@@ -20,13 +20,13 @@ namespace Paramore.Brighter.DynamoDB.Tests.Inbox
 
             _dynamoDbInbox = new DynamoDbInbox(Client, new DynamoDbInboxConfiguration());
 
-            _dynamoDbInbox.Add(_command, _contextKey);
+            _dynamoDbInbox.Add(_command, _contextKey, null);
         }
 
         [Fact]
         public void When_checking_a_command_exist()
         {
-            var commandExists = _dynamoDbInbox.Exists<MyCommand>(_command.Id, _contextKey);
+            var commandExists = _dynamoDbInbox.Exists<MyCommand>(_command.Id, _contextKey, null);
 
             Assert.True(commandExists);
         }
@@ -34,7 +34,7 @@ namespace Paramore.Brighter.DynamoDB.Tests.Inbox
         [Fact]
         public void When_checking_a_command_exist_different_context_key()
         {
-            var commandExists = _dynamoDbInbox.Exists<MyCommand>(_command.Id, "some-other-context-key");
+            var commandExists = _dynamoDbInbox.Exists<MyCommand>(_command.Id, "some-other-context-key", null);
 
             Assert.False(commandExists);
         }
@@ -42,7 +42,7 @@ namespace Paramore.Brighter.DynamoDB.Tests.Inbox
         [Fact]
         public void When_checking_a_command_does_not_exist()
         {
-            var commandExists = _dynamoDbInbox.Exists<MyCommand>(Guid.NewGuid().ToString(), _contextKey);
+            var commandExists = _dynamoDbInbox.Exists<MyCommand>(Guid.NewGuid().ToString(), _contextKey, null);
 
             Assert.False(commandExists);
         }

--- a/tests/Paramore.Brighter.DynamoDB.Tests/Inbox/When_checking_for_existing_command_async.cs
+++ b/tests/Paramore.Brighter.DynamoDB.Tests/Inbox/When_checking_for_existing_command_async.cs
@@ -20,13 +20,13 @@ namespace Paramore.Brighter.DynamoDB.Tests.Inbox
 
             _dynamoDbInbox = new DynamoDbInbox(Client, new DynamoDbInboxConfiguration());
 
-            _dynamoDbInbox.Add(_command, _contextKey);
+            _dynamoDbInbox.Add(_command, _contextKey, null);
         }
 
         [Fact]
         public async Task When_checking_a_command_exist()
         {
-            var commandExists = await _dynamoDbInbox.ExistsAsync<MyCommand>(_command.Id, _contextKey);
+            var commandExists = await _dynamoDbInbox.ExistsAsync<MyCommand>(_command.Id, _contextKey, null);
 
             Assert.True(commandExists);
         }
@@ -34,7 +34,7 @@ namespace Paramore.Brighter.DynamoDB.Tests.Inbox
         [Fact]
         public async Task When_checking_a_command_exist_for_a_different_context()
         {
-            var commandExists = await _dynamoDbInbox.ExistsAsync<MyCommand>(_command.Id, "some other context");
+            var commandExists = await _dynamoDbInbox.ExistsAsync<MyCommand>(_command.Id, "some other context", null);
 
             Assert.False(commandExists);
         }
@@ -42,7 +42,7 @@ namespace Paramore.Brighter.DynamoDB.Tests.Inbox
         [Fact]
         public async Task When_checking_a_command_does_not_exist()
         {
-            var commandExists = await _dynamoDbInbox.ExistsAsync<MyCommand>(Guid.NewGuid().ToString(), _contextKey);
+            var commandExists = await _dynamoDbInbox.ExistsAsync<MyCommand>(Guid.NewGuid().ToString(), _contextKey, null);
 
             Assert.False(commandExists);
         }

--- a/tests/Paramore.Brighter.DynamoDB.Tests/Inbox/When_the_message_is_already_in_the_inbox_async.cs
+++ b/tests/Paramore.Brighter.DynamoDB.Tests/Inbox/When_the_message_is_already_in_the_inbox_async.cs
@@ -49,9 +49,9 @@ namespace Paramore.Brighter.DynamoDB.Tests.Inbox
         [Fact]
         public async Task When_the_message_is_already_in_the_Inbox_async()
         {
-            _dynamoDbInbox.Add(_raisedCommand, _contextKey);
+            _dynamoDbInbox.Add(_raisedCommand, _contextKey, null);
 
-            _exception = await Catch.ExceptionAsync(() => _dynamoDbInbox.AddAsync(_raisedCommand, _contextKey));
+            _exception = await Catch.ExceptionAsync(() => _dynamoDbInbox.AddAsync(_raisedCommand, _contextKey, null));
 
             //_should_succeed_even_if_the_message_is_a_duplicate
             Assert.Null(_exception);

--- a/tests/Paramore.Brighter.DynamoDB.Tests/Inbox/When_there_is_no_message_in_the_dynamo_inbox.cs
+++ b/tests/Paramore.Brighter.DynamoDB.Tests/Inbox/When_there_is_no_message_in_the_dynamo_inbox.cs
@@ -43,7 +43,7 @@ namespace Paramore.Brighter.DynamoDB.Tests.Inbox
         [Fact]
         public void When_There_Is_No_Message_In_The_Inbox()
         {
-            var exception = Catch.Exception(() => _dynamoDbInbox.Get<MyCommand>(Guid.NewGuid().ToString(), "some key"));
+            var exception = Catch.Exception(() => _dynamoDbInbox.Get<MyCommand>(Guid.NewGuid().ToString(), "some key", null));
             Assert.IsType<RequestNotFoundException<MyCommand>>(exception);
         }
     }

--- a/tests/Paramore.Brighter.DynamoDB.Tests/Inbox/When_there_is_no_message_in_the_dynamo_inbox_async.cs
+++ b/tests/Paramore.Brighter.DynamoDB.Tests/Inbox/When_there_is_no_message_in_the_dynamo_inbox_async.cs
@@ -46,7 +46,7 @@ namespace Paramore.Brighter.DynamoDB.Tests.Inbox
         public async Task When_There_Is_No_Message_In_The_Sql_Inbox()
         {
             var exception = await Catch.ExceptionAsync(() => 
-                _dynamoDbInbox.GetAsync<MyCommand>(Guid.NewGuid().ToString(), "some key")
+                _dynamoDbInbox.GetAsync<MyCommand>(Guid.NewGuid().ToString(), "some key", null)
             );
             Assert.IsType<RequestNotFoundException<MyCommand>>(exception);
         }

--- a/tests/Paramore.Brighter.DynamoDB.Tests/Inbox/When_writing_a_message_to_the_inbox.cs
+++ b/tests/Paramore.Brighter.DynamoDB.Tests/Inbox/When_writing_a_message_to_the_inbox.cs
@@ -43,13 +43,13 @@ namespace Paramore.Brighter.DynamoDB.Tests.Inbox
 
             _raisedCommand = new MyCommand {Value = "Test"};
             _contextKey = "context-key";
-            _dynamoDbInbox.Add(_raisedCommand, _contextKey);
+            _dynamoDbInbox.Add(_raisedCommand, _contextKey, null);
         }
 
         [Fact]
         public void When_writing_a_message_to_the_inbox()
         {
-            _storedCommand = _dynamoDbInbox.Get<MyCommand>(_raisedCommand.Id, _contextKey);
+            _storedCommand = _dynamoDbInbox.Get<MyCommand>(_raisedCommand.Id, _contextKey, null);
 
             //_should_read_the_command_from_the__dynamo_db_inbox
             Assert.NotNull(_storedCommand);

--- a/tests/Paramore.Brighter.DynamoDB.Tests/Inbox/When_writing_a_message_to_the_inbox_async.cs
+++ b/tests/Paramore.Brighter.DynamoDB.Tests/Inbox/When_writing_a_message_to_the_inbox_async.cs
@@ -19,13 +19,13 @@ namespace Paramore.Brighter.DynamoDB.Tests.Inbox
 
             _raisedCommand = new MyCommand { Value = "Test" };
             _contextKey = "context-key";
-            _dynamoDbInbox.Add(_raisedCommand, _contextKey);
+            _dynamoDbInbox.Add(_raisedCommand, _contextKey, null);
         }
 
         [Fact]
         public async Task When_writing_a_message_to_the_inbox()
         {
-            _storedCommand = await _dynamoDbInbox.GetAsync<MyCommand>(_raisedCommand.Id, _contextKey);
+            _storedCommand = await _dynamoDbInbox.GetAsync<MyCommand>(_raisedCommand.Id, _contextKey, null);
 
             //Should read the command from the dynamo_db inbox
             Assert.NotNull(_storedCommand);

--- a/tests/Paramore.Brighter.InMemory.Tests/Inbox/When_expiring_messages_in_inbox.cs
+++ b/tests/Paramore.Brighter.InMemory.Tests/Inbox/When_expiring_messages_in_inbox.cs
@@ -28,7 +28,7 @@ namespace Paramore.Brighter.InMemory.Tests.Inbox
             var command = new SimpleCommand();            
             
             //Act
-            await inbox.AddAsync(command, contextKey);
+            await inbox.AddAsync(command, contextKey, null);
             
             timeProvider.Advance(TimeSpan.FromMilliseconds(500));
             
@@ -36,7 +36,7 @@ namespace Paramore.Brighter.InMemory.Tests.Inbox
             SimpleCommand foundCommand = null;
             try
             {
-                foundCommand = inbox.Get<SimpleCommand>(command.Id, contextKey);
+                foundCommand = inbox.Get<SimpleCommand>(command.Id, contextKey, null);
             }
             catch (Exception e) when (e is RequestNotFoundException<SimpleCommand> || e is TypeLoadException)
             {
@@ -45,7 +45,7 @@ namespace Paramore.Brighter.InMemory.Tests.Inbox
 
             await Task.Delay(500); //Give the sweep time to run
             
-            var afterExpiryExists = await inbox.ExistsAsync<SimpleCommand>(command.Id, contextKey);
+            var afterExpiryExists = await inbox.ExistsAsync<SimpleCommand>(command.Id, contextKey, null);
             
             //Assert
             Assert.NotNull(foundCommand);
@@ -70,7 +70,7 @@ namespace Paramore.Brighter.InMemory.Tests.Inbox
             var earlyCommands = new[] {new SimpleCommand(), new SimpleCommand(), new SimpleCommand()};            
             foreach (var command in earlyCommands)
             {
-                await inbox.AddAsync(command, contextKey);
+                await inbox.AddAsync(command, contextKey, null);
             }
             
             //allow any sweeper to expire
@@ -83,7 +83,7 @@ namespace Paramore.Brighter.InMemory.Tests.Inbox
             var lateCommands = new[] { new SimpleCommand(), new SimpleCommand(), new SimpleCommand()};
             foreach (var command in lateCommands) //This will trigger cleanup
             {
-                await inbox.AddAsync(command, contextKey);
+                await inbox.AddAsync(command, contextKey, null);
             }
             
             await Task.Delay(500); //Give the sweep time to run and clear the old entries

--- a/tests/Paramore.Brighter.InMemory.Tests/Inbox/When_storing_items_in_inbox.cs
+++ b/tests/Paramore.Brighter.InMemory.Tests/Inbox/When_storing_items_in_inbox.cs
@@ -44,9 +44,9 @@ namespace Paramore.Brighter.InMemory.Tests.Inbox
             var command = new SimpleCommand();
             
             //Act
-            inbox.Add(command, contextKey);
+            inbox.Add(command, contextKey, null);
 
-            var storedCommand = inbox.Get<SimpleCommand>(command.Id, contextKey);
+            var storedCommand = inbox.Get<SimpleCommand>(command.Id, contextKey, null);
 
             //Assert
             Assert.NotNull(storedCommand);
@@ -64,9 +64,9 @@ namespace Paramore.Brighter.InMemory.Tests.Inbox
             var command = new SimpleCommand();
             
             //Act
-            inbox.Add(command, contextKey);
+            inbox.Add(command, contextKey, null);
 
-            var exists = inbox.Exists<SimpleCommand>(command.Id, contextKey);
+            var exists = inbox.Exists<SimpleCommand>(command.Id, contextKey, null);
 
             //Assert
             Assert.True(exists);
@@ -82,7 +82,7 @@ namespace Paramore.Brighter.InMemory.Tests.Inbox
             var command = new SimpleCommand();
             
             //Act
-            var exists = inbox.Exists<SimpleCommand>(command.Id, contextKey);
+            var exists = inbox.Exists<SimpleCommand>(command.Id, contextKey, null);
 
             //Assert
             Assert.False(exists);
@@ -99,12 +99,12 @@ namespace Paramore.Brighter.InMemory.Tests.Inbox
            var commands = new SimpleCommand[] {new SimpleCommand(), new SimpleCommand(), new SimpleCommand(), new SimpleCommand(), new SimpleCommand()};
            foreach (var command in commands)
            {
-               inbox.Add(command, contextKey);
+               inbox.Add(command, contextKey, null);
            }
             
            //Act
-           var firstCommand = inbox.Get<SimpleCommand>(commands[0].Id, contextKey);
-           var lastCommand = inbox.Get<SimpleCommand>(commands[4].Id, contextKey);
+           var firstCommand = inbox.Get<SimpleCommand>(commands[0].Id, contextKey, null);
+           var lastCommand = inbox.Get<SimpleCommand>(commands[4].Id, contextKey, null);
 
            //Assert
            Assert.NotNull(firstCommand);
@@ -125,12 +125,12 @@ namespace Paramore.Brighter.InMemory.Tests.Inbox
             var commands = new SimpleCommand[] {new SimpleCommand(), new SimpleCommand(), new SimpleCommand(), new SimpleCommand(), new SimpleCommand()};
             foreach (var command in commands)
             {
-                inbox.Add(command, contextKey);
+                inbox.Add(command, contextKey, null);
             }
              
             //Act
-            var firstCommandExists = inbox.Exists<SimpleCommand>(commands[0].Id, contextKey);
-            var lastCommandExists = inbox.Exists<SimpleCommand>(commands[4].Id, contextKey);
+            var firstCommandExists = inbox.Exists<SimpleCommand>(commands[0].Id, contextKey, null);
+            var lastCommandExists = inbox.Exists<SimpleCommand>(commands[4].Id, contextKey, null);
  
             //Assert
             Assert.True(firstCommandExists);
@@ -148,11 +148,11 @@ namespace Paramore.Brighter.InMemory.Tests.Inbox
             var commands = new SimpleCommand[] {new SimpleCommand(), new SimpleCommand(), new SimpleCommand(), new SimpleCommand(), new SimpleCommand()};
             foreach (var command in commands)
             {
-                inbox.Add(command, contextKey);
+                inbox.Add(command, contextKey, null);
             }
              
             //Act
-            var firstCommandExists = inbox.Exists<SimpleCommand>(Guid.NewGuid().ToString(), contextKey);
+            var firstCommandExists = inbox.Exists<SimpleCommand>(Guid.NewGuid().ToString(), contextKey, null);
  
             //Assert
             Assert.False(firstCommandExists);

--- a/tests/Paramore.Brighter.MSSQL.Tests/Inbox/When_the_message_Is_already_in_the_Inbox_async.cs
+++ b/tests/Paramore.Brighter.MSSQL.Tests/Inbox/When_the_message_Is_already_in_the_Inbox_async.cs
@@ -52,22 +52,22 @@ namespace Paramore.Brighter.MSSQL.Tests.Inbox
         [Fact]
         public async Task When_The_Message_Is_Already_In_The_Inbox_Async()
         {
-            await _sqlInbox.AddAsync(_raisedCommand, _contextKey);
+            await _sqlInbox.AddAsync(_raisedCommand, _contextKey, null);
 
-            _exception = await Catch.ExceptionAsync(() => _sqlInbox.AddAsync(_raisedCommand, _contextKey));
+            _exception = await Catch.ExceptionAsync(() => _sqlInbox.AddAsync(_raisedCommand, _contextKey, null));
 
            //_should_succeed_even_if_the_message_is_a_duplicate
             Assert.Null(_exception);
-            var exists = await _sqlInbox.ExistsAsync<MyCommand>(_raisedCommand.Id, _contextKey);
+            var exists = await _sqlInbox.ExistsAsync<MyCommand>(_raisedCommand.Id, _contextKey, null);
             Assert.True(exists);
         }
 
         [Fact]
         public async Task When_The_Message_Is_Already_In_The_Inbox_Different_Context()
         {
-            await _sqlInbox.AddAsync(_raisedCommand, "some other key");
+            await _sqlInbox.AddAsync(_raisedCommand, "some other key", null);
 
-            var storedCommand = _sqlInbox.Get<MyCommand>(_raisedCommand.Id, "some other key");
+            var storedCommand = _sqlInbox.Get<MyCommand>(_raisedCommand.Id, "some other key", null);
 
             //should read the command from the dynamo db inbox
             Assert.NotNull(storedCommand);

--- a/tests/Paramore.Brighter.MSSQL.Tests/Inbox/When_the_message_is_already_in_the_inbox.cs
+++ b/tests/Paramore.Brighter.MSSQL.Tests/Inbox/When_the_message_is_already_in_the_inbox.cs
@@ -46,25 +46,25 @@ namespace Paramore.Brighter.MSSQL.Tests.Inbox
             _sqlInbox = new MsSqlInbox(_msSqlTestHelper.InboxConfiguration);
             _raisedCommand = new MyCommand { Value = "Test" };
             _contextKey = "context-key";
-            _sqlInbox.Add(_raisedCommand, _contextKey);
+            _sqlInbox.Add(_raisedCommand, _contextKey, null);
         }
 
         [Fact]
         public void When_The_Message_Is_Already_In_The_Inbox()
         {
-            _exception = Catch.Exception(() => _sqlInbox.Add(_raisedCommand, _contextKey));
+            _exception = Catch.Exception(() => _sqlInbox.Add(_raisedCommand, _contextKey, null));
 
             //_should_succeed_even_if_the_message_is_a_duplicate
             Assert.Null(_exception);
-            Assert.True(_sqlInbox.Exists<MyCommand>(_raisedCommand.Id, _contextKey));
+            Assert.True(_sqlInbox.Exists<MyCommand>(_raisedCommand.Id, _contextKey, null));
         }
 
         [Fact]
         public void When_The_Message_Is_Already_In_The_Inbox_Different_Context()
         {
-            _sqlInbox.Add(_raisedCommand, "some other key");
+            _sqlInbox.Add(_raisedCommand, "some other key", null);
 
-            var storedCommand = _sqlInbox.Get<MyCommand>(_raisedCommand.Id, "some other key");
+            var storedCommand = _sqlInbox.Get<MyCommand>(_raisedCommand.Id, "some other key", null);
 
             //should read the command from the dynamo db inbox
             Assert.NotNull(storedCommand);

--- a/tests/Paramore.Brighter.MSSQL.Tests/Inbox/When_there_Is_no_message_in_the_sql_inbox_async.cs
+++ b/tests/Paramore.Brighter.MSSQL.Tests/Inbox/When_there_Is_no_message_in_the_sql_inbox_async.cs
@@ -49,7 +49,7 @@ namespace Paramore.Brighter.MSSQL.Tests.Inbox
         public async Task When_There_Is_No_Message_In_The_Sql_Inbox_And_I_Get_Async()
         {
             string commandId = Guid.NewGuid().ToString();
-            var exception = await Catch.ExceptionAsync(() => _sqlInbox.GetAsync<MyCommand>(commandId, "some-key"));
+            var exception = await Catch.ExceptionAsync(() => _sqlInbox.GetAsync<MyCommand>(commandId, "some-key", null));
             Assert.IsType<RequestNotFoundException<MyCommand>>(exception);
         }
 
@@ -57,7 +57,7 @@ namespace Paramore.Brighter.MSSQL.Tests.Inbox
         public async Task When_There_Is_No_Message_In_The_Sql_Inbox_And_I_Check_Exists_Async()
         {
             string commandId = Guid.NewGuid().ToString();
-            bool exists = await _sqlInbox.ExistsAsync<MyCommand>(commandId, "some-key");
+            bool exists = await _sqlInbox.ExistsAsync<MyCommand>(commandId, "some-key", null);
             Assert.False(exists);
         }
 

--- a/tests/Paramore.Brighter.MSSQL.Tests/Inbox/When_there_is_no_message_in_the_sql_inbox.cs
+++ b/tests/Paramore.Brighter.MSSQL.Tests/Inbox/When_there_is_no_message_in_the_sql_inbox.cs
@@ -50,7 +50,7 @@ namespace Paramore.Brighter.MSSQL.Tests.Inbox
         public void When_There_Is_No_Message_In_The_Sql_Inbox_And_Call_Get()
         {
             string commandId = Guid.NewGuid().ToString();
-            var exception = Catch.Exception(() => _sqlInbox.Get<MyCommand>(commandId, _contextKey));
+            var exception = Catch.Exception(() => _sqlInbox.Get<MyCommand>(commandId, _contextKey, null));
 
             Assert.IsType<RequestNotFoundException<MyCommand>>(exception);
         }
@@ -59,7 +59,7 @@ namespace Paramore.Brighter.MSSQL.Tests.Inbox
         public void When_There_Is_No_Message_In_The_Sql_Inbox_And_Call_Exists()
         {
             string commandId = Guid.NewGuid().ToString();
-            Assert.False(_sqlInbox.Exists<MyCommand>(commandId, _contextKey));
+            Assert.False(_sqlInbox.Exists<MyCommand>(commandId, _contextKey, null));
         }
 
         public void Dispose()

--- a/tests/Paramore.Brighter.MSSQL.Tests/Inbox/When_writing_a_message_to_the_inbox.cs
+++ b/tests/Paramore.Brighter.MSSQL.Tests/Inbox/When_writing_a_message_to_the_inbox.cs
@@ -47,13 +47,13 @@ namespace Paramore.Brighter.MSSQL.Tests.Inbox
             _sqlInbox = new MsSqlInbox(_msSqlTestHelper.InboxConfiguration);
             _raisedCommand = new MyCommand { Value = "Test" };
             _contextKey = "context-key";
-            _sqlInbox.Add(_raisedCommand, _contextKey);
+            _sqlInbox.Add(_raisedCommand, _contextKey, null);
         }
 
         [Fact]
         public void When_Writing_A_Message_To_The_Inbox()
         {
-            _storedCommand = _sqlInbox.Get<MyCommand>(_raisedCommand.Id, _contextKey);
+            _storedCommand = _sqlInbox.Get<MyCommand>(_raisedCommand.Id, _contextKey, null);
 
             Assert.NotNull(_storedCommand);
             Assert.Equal(_raisedCommand.Value, _storedCommand.Value);
@@ -63,7 +63,7 @@ namespace Paramore.Brighter.MSSQL.Tests.Inbox
         [Fact]
         public void When_Reading_A_Message_From_The_Inbox_And_ContextKey_IsNull()
         {
-            var exception = Catch.Exception(() => _storedCommand = _sqlInbox.Get<MyCommand>(_raisedCommand.Id, null));
+            var exception = Catch.Exception(() => _storedCommand = _sqlInbox.Get<MyCommand>(_raisedCommand.Id, null, null));
             //should_not_read_message
             Assert.IsType<RequestNotFoundException<MyCommand>>(exception);
         }

--- a/tests/Paramore.Brighter.MSSQL.Tests/Inbox/When_writing_a_message_to_the_inbox_async.cs
+++ b/tests/Paramore.Brighter.MSSQL.Tests/Inbox/When_writing_a_message_to_the_inbox_async.cs
@@ -52,9 +52,9 @@ namespace Paramore.Brighter.MSSQL.Tests.Inbox
         [Fact]
         public async Task When_Writing_A_Message_To_The_Inbox_Async()
         {
-            await _sqlInbox.AddAsync(_raisedCommand, _contextKey);
+            await _sqlInbox.AddAsync(_raisedCommand, _contextKey, null);
 
-            _storedCommand = await _sqlInbox.GetAsync<MyCommand>(_raisedCommand.Id, _contextKey);
+            _storedCommand = await _sqlInbox.GetAsync<MyCommand>(_raisedCommand.Id, _contextKey, null);
 
             Assert.NotNull(_storedCommand);
             Assert.Equal(_raisedCommand.Value, _storedCommand.Value);

--- a/tests/Paramore.Brighter.MongoDb.Tests/Inbox/When_the_message_Is_already_in_the_Inbox_async.cs
+++ b/tests/Paramore.Brighter.MongoDb.Tests/Inbox/When_the_message_Is_already_in_the_Inbox_async.cs
@@ -51,22 +51,22 @@ public class MongoDbInboxDuplicateMessageAsyncTests : IDisposable
     [Fact]
     public async Task When_The_Message_Is_Already_In_The_Inbox_Async()
     {
-        await _inbox.AddAsync(_raisedCommand, _contextKey);
+        await _inbox.AddAsync(_raisedCommand, _contextKey, null);
 
-        var exception = await Catch.ExceptionAsync(() => _inbox.AddAsync(_raisedCommand, _contextKey));
+        var exception = await Catch.ExceptionAsync(() => _inbox.AddAsync(_raisedCommand, _contextKey, null));
 
         //_should_succeed_even_if_the_message_is_a_duplicate
         Assert.Null(exception);
-        var exists = await _inbox.ExistsAsync<MyCommand>(_raisedCommand.Id, _contextKey);
+        var exists = await _inbox.ExistsAsync<MyCommand>(_raisedCommand.Id, _contextKey, null);
         Assert.True(exists);
     }
 
     [Fact]
     public async Task When_The_Message_Is_Already_In_The_Inbox_Different_Context()
     {
-        await _inbox.AddAsync(_raisedCommand, "some other key");
+        await _inbox.AddAsync(_raisedCommand, "some other key", null);
 
-        var storedCommand = _inbox.Get<MyCommand>(_raisedCommand.Id, "some other key");
+        var storedCommand = _inbox.Get<MyCommand>(_raisedCommand.Id, "some other key", null);
 
         //_should_read_the_command_from_the__dynamo_db_inbox
         Assert.NotNull(storedCommand);

--- a/tests/Paramore.Brighter.MongoDb.Tests/Inbox/When_the_message_is_already_in_the_inbox.cs
+++ b/tests/Paramore.Brighter.MongoDb.Tests/Inbox/When_the_message_is_already_in_the_inbox.cs
@@ -50,24 +50,24 @@ public class MongoDbInboxDuplicateMessageTests : IDisposable
     [Fact]
     public void When_The_Message_Is_Already_In_The_Inbox()
     {
-        _inbox.Add(_raisedCommand, _contextKey);
+        _inbox.Add(_raisedCommand, _contextKey, null);
 
-        var exception = Catch.Exception(() => _inbox.Add(_raisedCommand, _contextKey));
+        var exception = Catch.Exception(() => _inbox.Add(_raisedCommand, _contextKey, null));
 
         //_should_succeed_even_if_the_message_is_a_duplicate
         Assert.Null(exception);
-        Assert.True(_inbox.Exists<MyCommand>(_raisedCommand.Id, _contextKey));
+        Assert.True(_inbox.Exists<MyCommand>(_raisedCommand.Id, _contextKey, null));
     }
 
     [Fact]
     public void When_The_Message_Is_Already_In_The_Inbox_Different_Context()
     {
-        _inbox.Add(_raisedCommand, _contextKey);
+        _inbox.Add(_raisedCommand, _contextKey, null);
 
         var newcontext = Guid.NewGuid().ToString();
-        _inbox.Add(_raisedCommand, newcontext);
+        _inbox.Add(_raisedCommand, newcontext, null);
 
-        var storedCommand = _inbox.Get<MyCommand>(_raisedCommand.Id, newcontext);
+        var storedCommand = _inbox.Get<MyCommand>(_raisedCommand.Id, newcontext, null);
 
         //_should_read_the_command_from_the__dynamo_db_inbox
         Assert.NotNull(storedCommand);

--- a/tests/Paramore.Brighter.MongoDb.Tests/Inbox/When_there_Is_no_message_in_the_sql_inbox_async.cs
+++ b/tests/Paramore.Brighter.MongoDb.Tests/Inbox/When_there_Is_no_message_in_the_sql_inbox_async.cs
@@ -49,7 +49,7 @@ public class MongoDbInboxEmptyWhenSearchedAsyncTests : IDisposable
     public async Task When_There_Is_No_Message_In_The_Sql_Inbox_And_I_Get_Async()
     {
         string commandId = Guid.NewGuid().ToString();
-        var exception = await Catch.ExceptionAsync(() => _inbox.GetAsync<MyCommand>(commandId, "some-key"));
+        var exception = await Catch.ExceptionAsync(() => _inbox.GetAsync<MyCommand>(commandId, "some-key", null));
         Assert.IsType<RequestNotFoundException<MyCommand>>(exception);
     }
 
@@ -57,7 +57,7 @@ public class MongoDbInboxEmptyWhenSearchedAsyncTests : IDisposable
     public async Task When_There_Is_No_Message_In_The_Sql_Inbox_And_I_Check_Exists_Async()
     {
         string commandId = Guid.NewGuid().ToString();
-        bool exists = await _inbox.ExistsAsync<MyCommand>(commandId, "some-key");
+        bool exists = await _inbox.ExistsAsync<MyCommand>(commandId, "some-key", null);
         Assert.False(exists);
     }
 

--- a/tests/Paramore.Brighter.MongoDb.Tests/Inbox/When_there_is_no_message_in_the_sql_inbox.cs
+++ b/tests/Paramore.Brighter.MongoDb.Tests/Inbox/When_there_is_no_message_in_the_sql_inbox.cs
@@ -50,7 +50,7 @@ public class MongoDbInboxEmptyWhenSearchedTests : IDisposable
     public void When_There_Is_No_Message_In_The_Sql_Inbox_And_Call_Get()
     {
         string commandId = Guid.NewGuid().ToString();
-        var exception = Catch.Exception(() => _ = _inbox.Get<MyCommand>(commandId, _contextKey));
+        var exception = Catch.Exception(() => _ = _inbox.Get<MyCommand>(commandId, _contextKey, null));
 
         Assert.IsType<RequestNotFoundException<MyCommand>>(exception);
     }
@@ -59,7 +59,7 @@ public class MongoDbInboxEmptyWhenSearchedTests : IDisposable
     public void When_There_Is_No_Message_In_The_Sql_Inbox_And_Call_Exists()
     {
         string commandId = Guid.NewGuid().ToString();
-        Assert.False(_inbox.Exists<MyCommand>(commandId, _contextKey));
+        Assert.False(_inbox.Exists<MyCommand>(commandId, _contextKey, null));
     }
     
     public void Dispose()

--- a/tests/Paramore.Brighter.MongoDb.Tests/Inbox/When_writing_a_message_to_the_inbox.cs
+++ b/tests/Paramore.Brighter.MongoDb.Tests/Inbox/When_writing_a_message_to_the_inbox.cs
@@ -47,13 +47,13 @@ public class MongoDbInboxAddMessageTests : IDisposable
 
         _raisedCommand = new MyCommand { Value = "Test" };
         _contextKey = "context-key";
-        _inbox.Add(_raisedCommand, _contextKey);
+        _inbox.Add(_raisedCommand, _contextKey, null);
     }
 
     [Fact]
     public void When_Writing_A_Message_To_The_Inbox()
     {
-        var storedCommand = _inbox.Get<MyCommand>(_raisedCommand.Id, _contextKey);
+        var storedCommand = _inbox.Get<MyCommand>(_raisedCommand.Id, _contextKey, null);
 
         //_should_read_the_command_from_the__sql_inbox
         Assert.NotNull(storedCommand);
@@ -66,7 +66,7 @@ public class MongoDbInboxAddMessageTests : IDisposable
     [Fact]
     public void When_Reading_A_Message_From_The_Inbox_And_ContextKey_IsNull()
     {
-        var exception = Catch.Exception(() => _ = _inbox.Get<MyCommand>(_raisedCommand.Id, null));
+        var exception = Catch.Exception(() => _ = _inbox.Get<MyCommand>(_raisedCommand.Id, null, null));
         //should_not_read_message
         Assert.IsType<RequestNotFoundException<MyCommand>>(exception);
     }

--- a/tests/Paramore.Brighter.MongoDb.Tests/Inbox/When_writing_a_message_to_the_inbox_async.cs
+++ b/tests/Paramore.Brighter.MongoDb.Tests/Inbox/When_writing_a_message_to_the_inbox_async.cs
@@ -52,9 +52,9 @@ public class MongoDbInboxAddMessageAsyncTests : IDisposable
     [Fact]
     public async Task When_Writing_A_Message_To_The_Inbox_Async()
     {
-        await _inbox.AddAsync(_raisedCommand, _contextKey);
+        await _inbox.AddAsync(_raisedCommand, _contextKey, null);
 
-        var storedCommand = await _inbox.GetAsync<MyCommand>(_raisedCommand.Id, _contextKey);
+        var storedCommand = await _inbox.GetAsync<MyCommand>(_raisedCommand.Id, _contextKey, null);
 
         //_should_read_the_command_from_the__sql_inbox
         Assert.NotNull(storedCommand);

--- a/tests/Paramore.Brighter.MySQL.Tests/Inbox/When_the_message_is_already_in_the_inbox.cs
+++ b/tests/Paramore.Brighter.MySQL.Tests/Inbox/When_the_message_is_already_in_the_inbox.cs
@@ -23,25 +23,25 @@ namespace Paramore.Brighter.MySQL.Tests.Inbox
             _mysqlInbox = new MySqlInbox(_mysqlTestHelper.InboxConfiguration);
             _raisedCommand = new MyCommand { Value = "Test" };
             _contextKey = "test-context";
-            _mysqlInbox.Add(_raisedCommand, _contextKey);
+            _mysqlInbox.Add(_raisedCommand, _contextKey, null);
         }
 
         [Fact]
         public void When_The_Message_Is_Already_In_The_Inbox()
         {
-            _exception = Catch.Exception(() => _mysqlInbox.Add(_raisedCommand, _contextKey));
+            _exception = Catch.Exception(() => _mysqlInbox.Add(_raisedCommand, _contextKey, null));
 
             //_should_succeed_even_if_the_message_is_a_duplicate
             Assert.Null(_exception);
-            Assert.True(_mysqlInbox.Exists<MyCommand>(_raisedCommand.Id, _contextKey));
+            Assert.True(_mysqlInbox.Exists<MyCommand>(_raisedCommand.Id, _contextKey, null));
         }
 
         [Fact]
         public void When_The_Message_Is_Already_In_The_Inbox_Different_Context()
         {
-            _mysqlInbox.Add(_raisedCommand, "some other key");
+            _mysqlInbox.Add(_raisedCommand, "some other key", null);
 
-            _exception = Catch.Exception(() => _mysqlInbox.Get<MyCommand>(_raisedCommand.Id, "some other key"));
+            _exception = Catch.Exception(() => _mysqlInbox.Get<MyCommand>(_raisedCommand.Id, "some other key", null));
 
             Assert.IsType<RequestNotFoundException<MyCommand>>(_exception);
         }

--- a/tests/Paramore.Brighter.MySQL.Tests/Inbox/When_the_message_is_already_in_the_inbox_async.cs
+++ b/tests/Paramore.Brighter.MySQL.Tests/Inbox/When_the_message_is_already_in_the_inbox_async.cs
@@ -52,22 +52,22 @@ namespace Paramore.Brighter.MySQL.Tests.Inbox
         [Fact]
         public async Task When_The_Message_Is_Already_In_The_Inbox_Async()
         {
-            await _mysqlInbox.AddAsync(_raisedCommand, _contextKey);
+            await _mysqlInbox.AddAsync(_raisedCommand, _contextKey, null);
 
-            _exception = await Catch.ExceptionAsync(() => _mysqlInbox.AddAsync(_raisedCommand, _contextKey));
+            _exception = await Catch.ExceptionAsync(() => _mysqlInbox.AddAsync(_raisedCommand, _contextKey, null));
 
            //_should_succeed_even_if_the_message_is_a_duplicate
             Assert.Null(_exception);
-            var exists = await _mysqlInbox.ExistsAsync<MyCommand>(_raisedCommand.Id, _contextKey);
+            var exists = await _mysqlInbox.ExistsAsync<MyCommand>(_raisedCommand.Id, _contextKey, null);
             Assert.True(exists);
         }
 
         [Fact]
         public async Task When_The_Message_Is_Already_In_The_Inbox_Different_Context()
         {
-            await _mysqlInbox.AddAsync(_raisedCommand, "some other key");
+            await _mysqlInbox.AddAsync(_raisedCommand, "some other key", null);
 
-            var storedCommand = _mysqlInbox.Get<MyCommand>(_raisedCommand.Id, "some other key");
+            var storedCommand = _mysqlInbox.Get<MyCommand>(_raisedCommand.Id, "some other key", null);
 
             //_should_read_the_command_from_the__dynamo_db_inbox
             Assert.NotNull(storedCommand);

--- a/tests/Paramore.Brighter.MySQL.Tests/Inbox/When_there_Is_no_message_in_the_sql_inbox_async.cs
+++ b/tests/Paramore.Brighter.MySQL.Tests/Inbox/When_there_Is_no_message_in_the_sql_inbox_async.cs
@@ -27,7 +27,7 @@ namespace Paramore.Brighter.MySQL.Tests.Inbox
         public async Task When_There_Is_No_Message_In_The_Sql_Inbox_Get_Async()
         {
             string commandId = Guid.NewGuid().ToString();
-            var exception = await Catch.ExceptionAsync(() => _mysqlInbox.GetAsync<MyCommand>(commandId, _contextKey));
+            var exception = await Catch.ExceptionAsync(() => _mysqlInbox.GetAsync<MyCommand>(commandId, _contextKey, null));
             Assert.IsType<RequestNotFoundException<MyCommand>>(exception);
         }
 
@@ -35,7 +35,7 @@ namespace Paramore.Brighter.MySQL.Tests.Inbox
         public async Task When_There_Is_No_Message_In_The_Sql_Inbox_Exists_Async()
         {
             string commandId = Guid.NewGuid().ToString();
-            bool exists = await _mysqlInbox.ExistsAsync<MyCommand>(commandId, _contextKey);
+            bool exists = await _mysqlInbox.ExistsAsync<MyCommand>(commandId, _contextKey, null);
             Assert.False(exists);
         }
 

--- a/tests/Paramore.Brighter.MySQL.Tests/Inbox/When_there_is_no_message_in_the_sql_inbox.cs
+++ b/tests/Paramore.Brighter.MySQL.Tests/Inbox/When_there_is_no_message_in_the_sql_inbox.cs
@@ -26,7 +26,7 @@ namespace Paramore.Brighter.MySQL.Tests.Inbox
         public void When_There_Is_No_Message_In_The_Sql_Inbox_Get()
         {
             string commandId = Guid.NewGuid().ToString();
-            var exception = Catch.Exception(() => _mysqlInBox.Get<MyCommand>(commandId, _contextKey));
+            var exception = Catch.Exception(() => _mysqlInBox.Get<MyCommand>(commandId, _contextKey, null));
             Assert.IsType<RequestNotFoundException<MyCommand>>(exception);
         }
 
@@ -34,7 +34,7 @@ namespace Paramore.Brighter.MySQL.Tests.Inbox
         public void When_There_Is_No_Message_In_The_Sql_Inbox_Exists()
         {
             string commandId = Guid.NewGuid().ToString();
-            Assert.False(_mysqlInBox.Exists<MyCommand>(commandId, _contextKey));
+            Assert.False(_mysqlInBox.Exists<MyCommand>(commandId, _contextKey, null));
         }
 
         public void Dispose()

--- a/tests/Paramore.Brighter.MySQL.Tests/Inbox/When_writing_a_message_to_the_command_store.cs
+++ b/tests/Paramore.Brighter.MySQL.Tests/Inbox/When_writing_a_message_to_the_command_store.cs
@@ -46,13 +46,13 @@ namespace Paramore.Brighter.MySQL.Tests.Inbox
             _mysqlInbox = new MySqlInbox(_mysqlTestHelper.InboxConfiguration);
             _raisedCommand = new MyCommand { Value = "Test" };
             _contextKey = "test-context";
-            _mysqlInbox.Add(_raisedCommand, _contextKey);
+            _mysqlInbox.Add(_raisedCommand, _contextKey, null);
         }
 
         [Fact]
         public void When_Writing_A_Message_To_The_Inbox()
         {
-            _storedCommand = _mysqlInbox.Get<MyCommand>(_raisedCommand.Id, _contextKey);
+            _storedCommand = _mysqlInbox.Get<MyCommand>(_raisedCommand.Id, _contextKey, null);
 
             //_should_read_the_command_from_the__sql_inbox
             Assert.NotNull(_storedCommand);

--- a/tests/Paramore.Brighter.MySQL.Tests/Inbox/When_writing_a_message_to_the_inbox_async.cs
+++ b/tests/Paramore.Brighter.MySQL.Tests/Inbox/When_writing_a_message_to_the_inbox_async.cs
@@ -52,9 +52,9 @@ namespace Paramore.Brighter.MySQL.Tests.Inbox
         [Fact]
         public async Task When_Writing_A_Message_To_The_Inbox_Async()
         {
-            await _mysqlInbox.AddAsync(_raisedCommand, _contextKey);
+            await _mysqlInbox.AddAsync(_raisedCommand, _contextKey, null);
 
-            _storedCommand = await _mysqlInbox.GetAsync<MyCommand>(_raisedCommand.Id, _contextKey);
+            _storedCommand = await _mysqlInbox.GetAsync<MyCommand>(_raisedCommand.Id, _contextKey, null);
 
             //_should_read_the_command_from_the__sql_inbox
             Assert.NotNull(_storedCommand);

--- a/tests/Paramore.Brighter.PostgresSQL.Tests/Inbox/When_the_message_Is_already_in_the_Inbox_async.cs
+++ b/tests/Paramore.Brighter.PostgresSQL.Tests/Inbox/When_the_message_Is_already_in_the_Inbox_async.cs
@@ -54,22 +54,22 @@ namespace Paramore.Brighter.PostgresSQL.Tests.Inbox
         [Fact]
         public async Task When_The_Message_Is_Already_In_The_Inbox_Async()
         {
-            await _pgSqlInbox.AddAsync(_raisedCommand, _contextKey);
+            await _pgSqlInbox.AddAsync(_raisedCommand, _contextKey, null);
 
-            _exception = await Catch.ExceptionAsync(() => _pgSqlInbox.AddAsync(_raisedCommand, _contextKey));
+            _exception = await Catch.ExceptionAsync(() => _pgSqlInbox.AddAsync(_raisedCommand, _contextKey, null));
 
            //_should_succeed_even_if_the_message_is_a_duplicate
             Assert.Null(_exception);
-            var exists = await _pgSqlInbox.ExistsAsync<MyCommand>(_raisedCommand.Id, _contextKey);
+            var exists = await _pgSqlInbox.ExistsAsync<MyCommand>(_raisedCommand.Id, _contextKey, null);
             Assert.True(exists);
         }
 
         [Fact]
         public async Task When_The_Message_Is_Already_In_The_Inbox_Different_Context()
         {
-            await _pgSqlInbox.AddAsync(_raisedCommand, "some other key");
+            await _pgSqlInbox.AddAsync(_raisedCommand, "some other key", null);
 
-            var storedCommand = _pgSqlInbox.Get<MyCommand>(_raisedCommand.Id, "some other key");
+            var storedCommand = _pgSqlInbox.Get<MyCommand>(_raisedCommand.Id, "some other key", null);
 
             //Should read the command from the dynamo db inbox
             Assert.NotNull(storedCommand);

--- a/tests/Paramore.Brighter.PostgresSQL.Tests/Inbox/When_the_message_is_already_in_the_inbox.cs
+++ b/tests/Paramore.Brighter.PostgresSQL.Tests/Inbox/When_the_message_is_already_in_the_inbox.cs
@@ -53,24 +53,24 @@ namespace Paramore.Brighter.PostgresSQL.Tests.Inbox
         [Fact]
         public void When_The_Message_Is_Already_In_The_Inbox()
         {
-            _pgSqlInbox.Add(_raisedCommand, _contextKey);
+            _pgSqlInbox.Add(_raisedCommand, _contextKey, null);
             
-            _exception = Catch.Exception(() => _pgSqlInbox.Add(_raisedCommand, _contextKey));
+            _exception = Catch.Exception(() => _pgSqlInbox.Add(_raisedCommand, _contextKey, null));
 
             //_should_succeed_even_if_the_message_is_a_duplicate
             Assert.Null(_exception);
-            Assert.True(_pgSqlInbox.Exists<MyCommand>(_raisedCommand.Id, _contextKey));
+            Assert.True(_pgSqlInbox.Exists<MyCommand>(_raisedCommand.Id, _contextKey, null));
         }
 
         [Fact]
         public void When_The_Message_Is_Already_In_The_Inbox_Different_Context()
         {
-            _pgSqlInbox.Add(_raisedCommand, _contextKey);
+            _pgSqlInbox.Add(_raisedCommand, _contextKey, null);
 
             var newcontext = Guid.NewGuid().ToString();
-            _pgSqlInbox.Add(_raisedCommand, newcontext);
+            _pgSqlInbox.Add(_raisedCommand, newcontext, null);
 
-            var storedCommand = _pgSqlInbox.Get<MyCommand>(_raisedCommand.Id, newcontext);
+            var storedCommand = _pgSqlInbox.Get<MyCommand>(_raisedCommand.Id, newcontext, null);
 
             //Should read the command from the dynamo db inbox
             Assert.NotNull(storedCommand);

--- a/tests/Paramore.Brighter.PostgresSQL.Tests/Inbox/When_there_Is_no_message_in_the_sql_inbox_async.cs
+++ b/tests/Paramore.Brighter.PostgresSQL.Tests/Inbox/When_there_Is_no_message_in_the_sql_inbox_async.cs
@@ -51,7 +51,7 @@ namespace Paramore.Brighter.PostgresSQL.Tests.Inbox
         public async Task When_There_Is_No_Message_In_The_Sql_Inbox_And_I_Get_Async()
         {
             string commandId = Guid.NewGuid().ToString();
-            var exception = await Catch.ExceptionAsync(() => _sqlSqlInbox.GetAsync<MyCommand>(commandId, "some-key"));
+            var exception = await Catch.ExceptionAsync(() => _sqlSqlInbox.GetAsync<MyCommand>(commandId, "some-key", null));
             Assert.IsType<RequestNotFoundException<MyCommand>>(exception);
             
         }
@@ -60,7 +60,7 @@ namespace Paramore.Brighter.PostgresSQL.Tests.Inbox
         public async Task When_There_Is_No_Message_In_The_Sql_Inbox_And_I_Check_Exists_Async()
         {
             string commandId = Guid.NewGuid().ToString();
-            bool exists = await _sqlSqlInbox.ExistsAsync<MyCommand>(commandId, "some-key");
+            bool exists = await _sqlSqlInbox.ExistsAsync<MyCommand>(commandId, "some-key", null);
             Assert.False(exists);
         }
 

--- a/tests/Paramore.Brighter.PostgresSQL.Tests/Inbox/When_there_is_no_message_in_the_sql_inbox.cs
+++ b/tests/Paramore.Brighter.PostgresSQL.Tests/Inbox/When_there_is_no_message_in_the_sql_inbox.cs
@@ -53,7 +53,7 @@ namespace Paramore.Brighter.PostgresSQL.Tests.Inbox
         public void When_There_Is_No_Message_In_The_Sql_Inbox_And_Call_Get()
         {
             string commandId = Guid.NewGuid().ToString();
-            var exception = Catch.Exception(() => _storedCommand = _pgSqlInbox.Get<MyCommand>(commandId, _contextKey));
+            var exception = Catch.Exception(() => _storedCommand = _pgSqlInbox.Get<MyCommand>(commandId, _contextKey, null));
 
             Assert.IsType<RequestNotFoundException<MyCommand>>(exception);
         }
@@ -62,7 +62,7 @@ namespace Paramore.Brighter.PostgresSQL.Tests.Inbox
         public void When_There_Is_No_Message_In_The_Sql_Inbox_And_Call_Exists()
         {
             string commandId = Guid.NewGuid().ToString();
-            Assert.False(_pgSqlInbox.Exists<MyCommand>(commandId, _contextKey));
+            Assert.False(_pgSqlInbox.Exists<MyCommand>(commandId, _contextKey, null));
         }
 
         public void Dispose()

--- a/tests/Paramore.Brighter.PostgresSQL.Tests/Inbox/When_writing_a_message_to_the_inbox.cs
+++ b/tests/Paramore.Brighter.PostgresSQL.Tests/Inbox/When_writing_a_message_to_the_inbox.cs
@@ -49,13 +49,13 @@ namespace Paramore.Brighter.PostgresSQL.Tests.Inbox
             _pgSqlInbox = new PostgreSqlInbox(_pgTestHelper.InboxConfiguration);
             _raisedCommand = new MyCommand { Value = "Test" };
             _contextKey = "context-key";
-            _pgSqlInbox.Add(_raisedCommand, _contextKey);
+            _pgSqlInbox.Add(_raisedCommand, _contextKey, null);
         }
 
         [Fact]
         public void When_Writing_A_Message_To_The_Inbox()
         {
-            _storedCommand = _pgSqlInbox.Get<MyCommand>(_raisedCommand.Id, _contextKey);
+            _storedCommand = _pgSqlInbox.Get<MyCommand>(_raisedCommand.Id, _contextKey, null);
 
             //Should read the command from the sql inbox
             Assert.NotNull(_storedCommand);
@@ -68,7 +68,7 @@ namespace Paramore.Brighter.PostgresSQL.Tests.Inbox
         [Fact]
         public void When_Reading_A_Message_From_The_Inbox_And_ContextKey_IsNull()
         {
-            var exception = Catch.Exception(() => _storedCommand = _pgSqlInbox.Get<MyCommand>(_raisedCommand.Id, null));
+            var exception = Catch.Exception(() => _storedCommand = _pgSqlInbox.Get<MyCommand>(_raisedCommand.Id, null, null));
             //should_not_read_message
             Assert.IsType<RequestNotFoundException<MyCommand>>(exception);
         }

--- a/tests/Paramore.Brighter.PostgresSQL.Tests/Inbox/When_writing_a_message_to_the_inbox_async.cs
+++ b/tests/Paramore.Brighter.PostgresSQL.Tests/Inbox/When_writing_a_message_to_the_inbox_async.cs
@@ -54,9 +54,9 @@ namespace Paramore.Brighter.PostgresSQL.Tests.Inbox
         [Fact]
         public async Task When_Writing_A_Message_To_The_Inbox_Async()
         {
-            await _pgSqlInbox.AddAsync(_raisedCommand, _contextKey);
+            await _pgSqlInbox.AddAsync(_raisedCommand, _contextKey, null);
 
-            _storedCommand = await _pgSqlInbox.GetAsync<MyCommand>(_raisedCommand.Id, _contextKey);
+            _storedCommand = await _pgSqlInbox.GetAsync<MyCommand>(_raisedCommand.Id, _contextKey, null);
 
             //Should read the command from the sql inbox
             Assert.NotNull(_storedCommand);

--- a/tests/Paramore.Brighter.Sqlite.Tests/Inbox/When_the_message_is_already_in_The_inbox_async.cs
+++ b/tests/Paramore.Brighter.Sqlite.Tests/Inbox/When_the_message_is_already_in_The_inbox_async.cs
@@ -28,13 +28,13 @@ namespace Paramore.Brighter.Sqlite.Tests.Inbox
         [Fact]
         public async Task When_The_Message_Is_Already_In_The_Inbox_Async()
         {
-            await _sqlInbox.AddAsync(_raisedCommand, _contextKey);
+            await _sqlInbox.AddAsync(_raisedCommand, _contextKey, null);
 
-            _exception = await Catch.ExceptionAsync(() => _sqlInbox.AddAsync(_raisedCommand, _contextKey));
+            _exception = await Catch.ExceptionAsync(() => _sqlInbox.AddAsync(_raisedCommand, _contextKey, null));
 
             //_should_succeed_even_if_the_message_is_a_duplicate
             Assert.Null(_exception);
-            var exists = await _sqlInbox.ExistsAsync<MyCommand>(_raisedCommand.Id, _contextKey);
+            var exists = await _sqlInbox.ExistsAsync<MyCommand>(_raisedCommand.Id, _contextKey, null);
             Assert.True(exists);
         }
 

--- a/tests/Paramore.Brighter.Sqlite.Tests/Inbox/When_the_message_is_already_in_the_inbox.cs
+++ b/tests/Paramore.Brighter.Sqlite.Tests/Inbox/When_the_message_is_already_in_the_inbox.cs
@@ -22,17 +22,17 @@ namespace Paramore.Brighter.Sqlite.Tests.Inbox
             _sqlInbox = new SqliteInbox(_sqliteTestHelper.InboxConfiguration);
             _raisedCommand = new MyCommand { Value = "Test" };
             _contextKey = "context-key";
-            _sqlInbox.Add(_raisedCommand, _contextKey);
+            _sqlInbox.Add(_raisedCommand, _contextKey, null);
         }
 
         [Fact]
         public void When_The_Message_Is_Already_In_The_Inbox()
         {
-            _exception = Catch.Exception(() => _sqlInbox.Add(_raisedCommand, _contextKey));
+            _exception = Catch.Exception(() => _sqlInbox.Add(_raisedCommand, _contextKey, null));
 
             //_should_succeed_even_if_the_message_is_a_duplicate
             Assert.Null(_exception);
-            Assert.True(_sqlInbox.Exists<MyCommand>(_raisedCommand.Id, _contextKey));
+            Assert.True(_sqlInbox.Exists<MyCommand>(_raisedCommand.Id, _contextKey, null));
         }
 
         public async ValueTask DisposeAsync()

--- a/tests/Paramore.Brighter.Sqlite.Tests/Inbox/When_there_is_no_message_in_the_sql_inbox.cs
+++ b/tests/Paramore.Brighter.Sqlite.Tests/Inbox/When_there_is_no_message_in_the_sql_inbox.cs
@@ -26,7 +26,7 @@ namespace Paramore.Brighter.Sqlite.Tests.Inbox
         public void When_There_Is_No_Message_In_The_Sql_Inbox_Get()
         {
             string commandId = Guid.NewGuid().ToString();
-            var exception = Catch.Exception(() => _sqlInbox.Get<MyCommand>(commandId, _contextKey));
+            var exception = Catch.Exception(() => _sqlInbox.Get<MyCommand>(commandId, _contextKey, null));
             Assert.IsType<RequestNotFoundException<MyCommand>>(exception);
         }
 
@@ -34,7 +34,7 @@ namespace Paramore.Brighter.Sqlite.Tests.Inbox
         public void When_There_Is_No_Message_In_The_Sql_Inbox_Exists()
         {
             string commandId = Guid.NewGuid().ToString();
-            Assert.False(_sqlInbox.Exists<MyCommand>(commandId, _contextKey));
+            Assert.False(_sqlInbox.Exists<MyCommand>(commandId, _contextKey, null));
         }
 
         public async ValueTask DisposeAsync()

--- a/tests/Paramore.Brighter.Sqlite.Tests/Inbox/When_there_is_no_message_in_the_sql_inbox_async.cs
+++ b/tests/Paramore.Brighter.Sqlite.Tests/Inbox/When_there_is_no_message_in_the_sql_inbox_async.cs
@@ -27,7 +27,7 @@ namespace Paramore.Brighter.Sqlite.Tests.Inbox
         public async Task When_There_Is_No_Message_In_The_Sql_Inbox_Get_Async()
         {
             string commandId = Guid.NewGuid().ToString();
-            var exception = await Catch.ExceptionAsync(() => _sqlInbox.GetAsync<MyCommand>(commandId, _contextKey));
+            var exception = await Catch.ExceptionAsync(() => _sqlInbox.GetAsync<MyCommand>(commandId, _contextKey, null));
             Assert.IsType<RequestNotFoundException<MyCommand>>(exception);
         }
 
@@ -35,7 +35,7 @@ namespace Paramore.Brighter.Sqlite.Tests.Inbox
         public async Task When_There_Is_No_Message_In_The_Sql_Inbox_Exists_Async()
         {
             string commandId = Guid.NewGuid().ToString();
-            bool exists = await _sqlInbox.ExistsAsync<MyCommand>(commandId, _contextKey);
+            bool exists = await _sqlInbox.ExistsAsync<MyCommand>(commandId, _contextKey, null);
             Assert.False(exists);
         }
 

--- a/tests/Paramore.Brighter.Sqlite.Tests/Inbox/When_writing_a_message_to_the_inbox.cs
+++ b/tests/Paramore.Brighter.Sqlite.Tests/Inbox/When_writing_a_message_to_the_inbox.cs
@@ -23,13 +23,13 @@ namespace Paramore.Brighter.Sqlite.Tests.Inbox
             _sqlInbox = new SqliteInbox(_sqliteTestHelper.InboxConfiguration);
             _raisedCommand = new MyCommand {Value = "Test"};
             _contextKey = "context-key";
-            _sqlInbox.Add(_raisedCommand, _contextKey);
+            _sqlInbox.Add(_raisedCommand, _contextKey, null);
         }
 
         [Fact]
         public void When_Writing_A_Message_To_The_Inbox()
         {
-            _storedCommand = _sqlInbox.Get<MyCommand>(_raisedCommand.Id, _contextKey);
+            _storedCommand = _sqlInbox.Get<MyCommand>(_raisedCommand.Id, _contextKey, null);
 
             //_should_read_the_command_from_the__sql_inbox
             Assert.NotNull(_storedCommand);

--- a/tests/Paramore.Brighter.Sqlite.Tests/Inbox/When_writing_a_message_to_the_inbox_async.cs
+++ b/tests/Paramore.Brighter.Sqlite.Tests/Inbox/When_writing_a_message_to_the_inbox_async.cs
@@ -52,9 +52,9 @@ namespace Paramore.Brighter.Sqlite.Tests.Inbox
         [Fact]
         public async Task When_Writing_A_Message_To_The_Inbox_Async()
         {
-            await _sqlInbox.AddAsync(_raisedCommand, _contextKey);
+            await _sqlInbox.AddAsync(_raisedCommand, _contextKey, null);
 
-            _storedCommand = await _sqlInbox.GetAsync<MyCommand>(_raisedCommand.Id, _contextKey);
+            _storedCommand = await _sqlInbox.GetAsync<MyCommand>(_raisedCommand.Id, _contextKey, null);
 
             //Should read the command from the sql inbox
             Assert.NotNull(_storedCommand);

--- a/tests/Paramore.Brighter.Sqlite.Tests/Outbox/SQlOutboxMigrationTests.cs
+++ b/tests/Paramore.Brighter.Sqlite.Tests/Outbox/SQlOutboxMigrationTests.cs
@@ -19,7 +19,7 @@ namespace Paramore.Brighter.Sqlite.Tests.Outbox
         {
             _sqliteTestHelper = new SqliteTestHelper();
             _sqliteTestHelper.SetupMessageDb();
-            _sqlOutbox  = new SqliteOutbox(new RelationalDatabaseConfiguration(_sqliteTestHelper.ConnectionString, _sqliteTestHelper.OutboxTableName));
+            _sqlOutbox  = new SqliteOutbox(new RelationalDatabaseConfiguration(_sqliteTestHelper.ConnectionString, outBoxTableName: _sqliteTestHelper.OutboxTableName));
 
             _message = new Message(new MessageHeader(
                 Guid.NewGuid().ToString(), 


### PR DESCRIPTION
This PR adds Open Telemetry tracing to the `InMemoryInbox`, by reusing the `OutboxSpanInfo` and `OutboxDbOperation` class and enum, with appropriate renaming and updates to support the `Exists` operation. It also tidies up XML comments across all Inbox implementations.