### PR TITLE
Refactor RDBMS Inbox implementations to use a base class

### DIFF
--- a/src/Paramore.Brighter.Inbox.MsSql/MsSqlInbox.cs
+++ b/src/Paramore.Brighter.Inbox.MsSql/MsSqlInbox.cs
@@ -26,41 +26,33 @@ THE SOFTWARE. */
 using System;
 using System.Data;
 using System.Data.Common;
-using Microsoft.Data.SqlClient;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Logging;
+using Microsoft.Data.SqlClient;
 using Paramore.Brighter.Inbox.Exceptions;
-using Paramore.Brighter.MsSql;
 using Paramore.Brighter.Logging;
-using Paramore.Brighter.Observability;
+using Paramore.Brighter.MsSql;
 
 namespace Paramore.Brighter.Inbox.MsSql
 {
     /// <summary>
     ///     Class MsSqlInbox.
     /// </summary>
-    public class MsSqlInbox : IAmAnInboxSync, IAmAnInboxAsync
+    public class MsSqlInbox : RelationalDatabaseInbox
     {
-        private static readonly ILogger s_logger = ApplicationLogging.CreateLogger<MsSqlInbox>();
-
         private const int MsSqlDuplicateKeyError_UniqueIndexViolation = 2601;
         private const int MsSqlDuplicateKeyError_UniqueConstraintViolation = 2627;
-        private readonly IAmARelationalDatabaseConfiguration _configuration;
         private readonly IAmARelationalDbConnectionProvider _connectionProvider;
-
-        /// <inheritdoc />
-        public IAmABrighterTracer Tracer { private get; set; }
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="MsSqlInbox" /> class.
         /// </summary>
         /// <param name="configuration">The configuration.</param>
         /// <param name="connectionProvider">The Connection Provider.</param>
-        public MsSqlInbox(IAmARelationalDatabaseConfiguration configuration, IAmARelationalDbConnectionProvider connectionProvider)
+        public MsSqlInbox(IAmARelationalDatabaseConfiguration configuration, IAmARelationalDbConnectionProvider connectionProvider) 
+            : base(configuration.InBoxTableName, new MsSqlQueries(), ApplicationLogging.CreateLogger<MsSqlInbox>())
         {
-            _configuration = configuration;
             ContinueOnCapturedContext = false;
             _connectionProvider = connectionProvider;
         }
@@ -74,24 +66,31 @@ namespace Paramore.Brighter.Inbox.MsSql
         {
         }
 
-        /// <inheritdoc/>
-        public void Add<T>(T command, string contextKey, RequestContext requestContext, int timeoutInMilliseconds = -1) where T : class, IRequest
+        protected override DbCommand CreateCommand(
+            DbConnection connection, string sqlText, int outBoxTimeout, params IDbDataParameter[] parameters)
         {
-            var parameters = InitAddDbParameters(command, contextKey);
+            var command = connection.CreateCommand();
 
-            using var connection = _connectionProvider.GetConnection();
-            var sqlcmd = InitAddDbCommand(connection, parameters, timeoutInMilliseconds);
+            command.CommandTimeout = outBoxTimeout < 0 ? 0 : outBoxTimeout;
+            command.CommandText = sqlText;
+            command.Parameters.AddRange(parameters);
+
+            return command;
+        }
+
+        protected override void WriteToStore(Func<DbConnection, DbCommand> commandFunc, Action loggingAction)
+        {
+            using var connection = GetOpenConnection(_connectionProvider);
+            using var command = commandFunc.Invoke(connection);
             try
             {
-                sqlcmd.ExecuteNonQuery();
+                command.ExecuteNonQuery();
             }
-            catch (SqlException sqlException)
+            catch (SqlException ex)
             {
-                if (sqlException.Number == MsSqlDuplicateKeyError_UniqueIndexViolation || sqlException.Number == MsSqlDuplicateKeyError_UniqueConstraintViolation)
+                if (ex.Number == MsSqlDuplicateKeyError_UniqueIndexViolation || ex.Number == MsSqlDuplicateKeyError_UniqueConstraintViolation)
                 {
-                    s_logger.LogWarning(
-                        "MsSqlOutbox: A duplicate Command with the CommandId {Id} was inserted into the Outbox, ignoring and continuing",
-                        command.Id);
+                    loggingAction.Invoke();
                     return;
                 }
 
@@ -99,51 +98,20 @@ namespace Paramore.Brighter.Inbox.MsSql
             }
         }
 
-        /// <inheritdoc/>
-        public T Get<T>(string id, string contextKey, RequestContext requestContext, int timeoutInMilliseconds = -1) where T : class, IRequest
+        protected override async Task WriteToStoreAsync(Func<DbConnection, DbCommand> commandFunc, 
+            Action loggingAction, CancellationToken cancellationToken)
         {
-            var sql = $"select * from {_configuration.InBoxTableName} where CommandId = @commandId AND ContextKey = @contextKey";
-            var parameters = new[]
-            {
-                CreateSqlParameter("CommandId", id),
-                CreateSqlParameter("ContextKey", contextKey)
-            };
-
-            return ExecuteCommand(command => ReadCommand<T>(command.ExecuteReader(), id), sql, timeoutInMilliseconds, parameters);
-        }
-
-        /// <inheritdoc/>
-        public bool Exists<T>(string id, string contextKey, RequestContext requestContext, int timeoutInMilliseconds = -1) where T : class, IRequest
-        {
-            var sql = $"SELECT TOP 1 CommandId FROM {_configuration.InBoxTableName} WHERE CommandId = @commandId AND ContextKey = @contextKey";
-            var parameters = new[]
-            {
-                CreateSqlParameter("CommandId", id),
-                CreateSqlParameter("ContextKey", contextKey)
-            };
-
-            return ExecuteCommand(command => command.ExecuteReader().HasRows, sql, timeoutInMilliseconds, parameters);
-        }
-
-        /// <inheritdoc/>
-        public async Task AddAsync<T>(T command, string contextKey, RequestContext requestContext, int timeoutInMilliseconds = -1, CancellationToken cancellationToken = default)
-            where T : class, IRequest
-        {
-            var parameters = InitAddDbParameters(command, contextKey);
-
-            using var connection = await _connectionProvider.GetConnectionAsync(cancellationToken);
-            var sqlcmd = InitAddDbCommand(connection, parameters, timeoutInMilliseconds);
+            using var connection = await GetOpenConnectionAsync(_connectionProvider, cancellationToken);
+            using var command = commandFunc.Invoke(connection);
             try
             {
-                await sqlcmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(ContinueOnCapturedContext);
+                await command.ExecuteNonQueryAsync(cancellationToken);
             }
-            catch (SqlException sqlException)
+            catch (SqlException ex)
             {
-                if (sqlException.Number == MsSqlDuplicateKeyError_UniqueIndexViolation || sqlException.Number == MsSqlDuplicateKeyError_UniqueConstraintViolation)
+                if (ex.Number == MsSqlDuplicateKeyError_UniqueIndexViolation || ex.Number == MsSqlDuplicateKeyError_UniqueConstraintViolation)
                 {
-                    s_logger.LogWarning(
-                        "MsSqlOutbox: A duplicate Command with the CommandId {Id} was inserted into the Outbox, ignoring and continuing",
-                        command.Id);
+                    loggingAction.Invoke();
                     return;
                 }
 
@@ -151,109 +119,28 @@ namespace Paramore.Brighter.Inbox.MsSql
             }
         }
 
-
-        /// <inheritdoc/>
-        public async Task<bool> ExistsAsync<T>(string id, string contextKey, RequestContext requestContext, int timeoutInMilliseconds = -1,
-            CancellationToken cancellationToken = default) where T : class, IRequest
-        {
-            var sql = $"SELECT TOP 1 CommandId FROM {_configuration.InBoxTableName} WHERE CommandId = @commandId AND ContextKey = @contextKey";
-            var parameters = new[]
-            {
-                CreateSqlParameter("CommandId", id),
-                CreateSqlParameter("ContextKey", contextKey)
-            };
-
-            return await ExecuteCommandAsync<bool>(
-                    async command =>
-                    {
-                        var reader = await command.ExecuteReaderAsync(cancellationToken);
-                        return reader.HasRows;
-                    },
-                    sql,
-                    timeoutInMilliseconds,
-                    cancellationToken,
-                    parameters)
-                .ConfigureAwait(ContinueOnCapturedContext);
-        }
-
-        /// <inheritdoc/>
-        public bool ContinueOnCapturedContext { get; set; }
-
-        /// <inheritdoc/>
-        public async Task<T> GetAsync<T>(string id, string contextKey, RequestContext requestContext, int timeoutInMilliseconds = -1,
-            CancellationToken cancellationToken = default)
-            where T : class, IRequest
-        {
-            var sql = $"select * from {_configuration.InBoxTableName} where CommandId = @commandId AND ContextKey = @contextKey";
-
-            var parameters = new[]
-            {
-                CreateSqlParameter("CommandId", id),
-                CreateSqlParameter("ContextKey", contextKey)
-            };
-
-            return await ExecuteCommandAsync(
-                async command => ReadCommand<T>(await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(ContinueOnCapturedContext), id),
-                sql,
-                timeoutInMilliseconds,
-                cancellationToken,
-                parameters)
-                .ConfigureAwait(ContinueOnCapturedContext);
-        }
-
-        private SqlParameter CreateSqlParameter(string parameterName, object value)
-        {
-            return new SqlParameter(parameterName, value ?? DBNull.Value);
-        }
-
-        private T ExecuteCommand<T>(
-            Func<DbCommand, T> execute, 
-            string sql, 
-            int timeoutInMilliseconds,
-            params IDbDataParameter[] parameters
-            )
+        protected override T ReadFromStore<T>(Func<DbConnection, DbCommand> commandFunc, Func<DbDataReader, string, T> resultFunc, string commandId)
         {
             using var connection = _connectionProvider.GetConnection();
-            using var command = connection.CreateCommand();
-            if (timeoutInMilliseconds != -1) command.CommandTimeout = timeoutInMilliseconds;
-            command.CommandText = sql;
-            command.Parameters.AddRange(parameters);
+            using var command = commandFunc.Invoke(connection);
 
-            var item = execute(command);
-            return item;
+            var result = command.ExecuteReader();
+            return resultFunc.Invoke(result, commandId);
         }
 
-        private async Task<T> ExecuteCommandAsync<T>(
-            Func<DbCommand, Task<T>> execute,
-            string sql,
-            int timeoutInMilliseconds,
-            CancellationToken cancellationToken = default,
-            params IDbDataParameter[] parameters)
+        protected override async Task<T> ReadFromStoreAsync<T>(Func<DbConnection, DbCommand> commandFunc, 
+            Func<DbDataReader, string, CancellationToken, Task<T>> resultFunc, 
+            string commandId, 
+            CancellationToken cancellationToken)
         {
             using var connection = await _connectionProvider.GetConnectionAsync(cancellationToken);
-            using var command = connection.CreateCommand();
-            if (timeoutInMilliseconds != -1) command.CommandTimeout = timeoutInMilliseconds;
-            command.CommandText = sql;
-            command.Parameters.AddRange(parameters);
+            using var command = commandFunc.Invoke(connection);
 
-            var item = await execute(command).ConfigureAwait(ContinueOnCapturedContext);
-            return item;
+            var result = await command.ExecuteReaderAsync(cancellationToken);
+            return await resultFunc.Invoke(result, commandId, cancellationToken);
         }
 
-        private DbCommand InitAddDbCommand(DbConnection connection, IDbDataParameter[] parameters, int timeoutInMilliseconds)
-        {
-            var sqlAdd =
-                $"insert into {_configuration.InBoxTableName} (CommandID, CommandType, CommandBody, Timestamp, ContextKey) values (@CommandID, @CommandType, @CommandBody, @Timestamp, @ContextKey)";
-
-            var sqlcmd = connection.CreateCommand();
-            if (timeoutInMilliseconds != -1) sqlcmd.CommandTimeout = timeoutInMilliseconds;
-
-            sqlcmd.CommandText = sqlAdd;
-            sqlcmd.Parameters.AddRange(parameters);
-            return sqlcmd;
-        }
-
-        private IDbDataParameter[] InitAddDbParameters<T>(T command, string contextKey) where T : class, IRequest
+        protected override IDbDataParameter[] CreateAddParameters<T>(T command, string contextKey)
         {
             var commandJson = JsonSerializer.Serialize(command, JsonSerialisationOptions.Options);
             var parameters = new[]
@@ -267,15 +154,95 @@ namespace Paramore.Brighter.Inbox.MsSql
             return parameters;
         }
 
-        private TResult ReadCommand<TResult>(IDataReader dr, string commandId) where TResult : class, IRequest
+        protected override IDbDataParameter[] CreateGetParameters(string commandId, string contextKey)
         {
-            if (dr.Read())
+            var parameters = new[]
             {
-                var body = dr.GetString(dr.GetOrdinal("CommandBody"));
-                return JsonSerializer.Deserialize<TResult>(body, JsonSerialisationOptions.Options);
+                CreateSqlParameter("CommandID", commandId),
+                CreateSqlParameter("ContextKey", contextKey)
+            };
+            return parameters;
+        }
+
+        protected override IDbDataParameter[] CreateExistsParameters(string commandId, string contextKey)
+        {
+            var parameters = new[]
+            {
+                CreateSqlParameter("CommandID", commandId),
+                CreateSqlParameter("ContextKey", contextKey)
+            };
+            return parameters;
+        }
+
+        private SqlParameter CreateSqlParameter(string parameterName, object value)
+        {
+            return new SqlParameter(parameterName, value ?? DBNull.Value);
+        }
+
+        protected override T MapFunction<T>(DbDataReader dr, string commandId)
+        {
+            try
+            {
+                if (dr.Read())
+                {
+                    var body = dr.GetString(dr.GetOrdinal("CommandBody"));
+                    return JsonSerializer.Deserialize<T>(body, JsonSerialisationOptions.Options);
+                }
+            }
+            finally
+            {
+                dr.Close();
             }
 
-            throw new RequestNotFoundException<TResult>(commandId);
+            throw new RequestNotFoundException<T>(commandId);
+        }
+
+        protected override async Task<T> MapFunctionAsync<T>(DbDataReader dr, string commandId, 
+            CancellationToken cancellationToken)
+        {
+            try
+            {
+                if (await dr.ReadAsync())
+                {
+                    var body = dr.GetString(dr.GetOrdinal("CommandBody"));
+                    return JsonSerializer.Deserialize<T>(body, JsonSerialisationOptions.Options);
+                }
+            }
+            finally
+            {
+#if NET462
+                dr.Close();
+#else
+                await dr.CloseAsync();
+#endif
+            }
+
+            throw new RequestNotFoundException<T>(commandId);
+        }
+
+        protected override bool MapBoolFunction(DbDataReader dr, string commandId)
+        {
+            try
+            {
+                return dr.HasRows;
+            }
+            finally
+            {
+                dr.Close();
+            }
+        }
+
+        protected override Task<bool> MapBoolFunctionAsync(DbDataReader dr, string commandId, 
+            CancellationToken cancellationToken)
+        {
+            try
+            {
+                return Task.FromResult(dr.HasRows);
+            }
+            finally
+            {
+                dr.Close();
+            }
         }
     }
 }

--- a/src/Paramore.Brighter.Inbox.MsSql/MsSqlQueries.cs
+++ b/src/Paramore.Brighter.Inbox.MsSql/MsSqlQueries.cs
@@ -1,0 +1,36 @@
+﻿#region Licence
+
+/* The MIT License (MIT)
+Copyright © 2025 Dominic Hickie <dominichickie@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+namespace Paramore.Brighter.Inbox.MsSql
+{
+    public class MsSqlQueries : IRelationalDatabaseInboxQueries
+    {
+        public string AddCommand { get; } = "INSERT INTO {0} ([CommandID], [CommandType], [CommandBody], [Timestamp], [ContextKey]) VALUES (@CommandID, @CommandType, @CommandBody, @Timestamp, @ContextKey)";
+
+        public string ExistsCommand { get; } = "SELECT TOP 1 [CommandID] FROM {0} WHERE [CommandID] = @CommandID AND [ContextKey] = @ContextKey";
+
+        public string GetCommand { get; } = "SELECT * FROM {0} where [CommandID] = @CommandID AND [ContextKey] = @ContextKey";
+    }
+}

--- a/src/Paramore.Brighter.Inbox.MySql/MySqlInbox.cs
+++ b/src/Paramore.Brighter.Inbox.MySql/MySqlInbox.cs
@@ -29,56 +29,67 @@ using System.Data.Common;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Logging;
 using MySqlConnector;
 using Paramore.Brighter.Inbox.Exceptions;
 using Paramore.Brighter.Logging;
-using Paramore.Brighter.Observability;
+using Paramore.Brighter.MySql;
 
 namespace Paramore.Brighter.Inbox.MySql
 {
     /// <summary>
     ///     Class MySqlInbox.
     /// </summary>
-    public class MySqlInbox : IAmAnInboxSync, IAmAnInboxAsync
+    public class MySqlInbox : RelationalDatabaseInbox
     {
-        private static readonly ILogger s_logger = ApplicationLogging.CreateLogger<MySqlInbox>();
-
         private const int MySqlDuplicateKeyError = 1062;
-        private readonly IAmARelationalDatabaseConfiguration _configuration;
-
-        /// <inheritdoc />
-        public IAmABrighterTracer Tracer { private get; set; }
+        private readonly IAmARelationalDbConnectionProvider _connectionProvider;
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="MySqlInbox" /> class.
         /// </summary>
         /// <param name="configuration">The configuration.</param>
-        public MySqlInbox(IAmARelationalDatabaseConfiguration configuration)
+        /// <param name="connectionProvider">The Connection Provider.</param>
+        public MySqlInbox(IAmARelationalDatabaseConfiguration configuration, IAmARelationalDbConnectionProvider connectionProvider)
+            : base(configuration.InBoxTableName, new MySqlQueries(), ApplicationLogging.CreateLogger<MySqlInbox>())
         {
-            _configuration = configuration;
             ContinueOnCapturedContext = false;
+            _connectionProvider = connectionProvider;
         }
 
-        /// <inheritdoc />
-        public void Add<T>(T command, string contextKey, RequestContext requestContext, int timeoutInMilliseconds = -1) where T : class, IRequest
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="MySqlInbox" /> class.
+        /// </summary>
+        /// <param name="configuration">The configuration.</param>
+        public MySqlInbox(IAmARelationalDatabaseConfiguration configuration) : this(configuration,
+            new MySqlConnectionProvider(configuration))
         {
-            var parameters = InitAddDbParameters(command, contextKey);
+        }
 
-            using var connection = GetConnection();
-            connection.Open();
-            var sqlcmd = InitAddDbCommand(connection, parameters, timeoutInMilliseconds);
+        protected override DbCommand CreateCommand(
+            DbConnection connection, string sqlText, int outBoxTimeout, params IDbDataParameter[] parameters)
+        {
+            var command = connection.CreateCommand();
+
+            command.CommandTimeout = outBoxTimeout < 0 ? 0 : outBoxTimeout;
+            command.CommandText = sqlText;
+            command.Parameters.AddRange(parameters);
+
+            return command;
+        }
+
+        protected override void WriteToStore(Func<DbConnection, DbCommand> commandFunc, Action loggingAction)
+        {
+            using var connection = GetOpenConnection(_connectionProvider);
+            using var command = commandFunc.Invoke(connection);
             try
             {
-                sqlcmd.ExecuteNonQuery();
+                command.ExecuteNonQuery();
             }
-            catch (MySqlException sqlException)
+            catch (MySqlException ex)
             {
-                if (sqlException.Number == MySqlDuplicateKeyError)
+                if (ex.Number == MySqlDuplicateKeyError)
                 {
-                    s_logger.LogWarning(
-                        "MySqlOutbox: A duplicate Command with the CommandId {Id} was inserted into the Outbox, ignoring and continuing",
-                        command.Id);
+                    loggingAction.Invoke();
                     return;
                 }
 
@@ -86,78 +97,20 @@ namespace Paramore.Brighter.Inbox.MySql
             }
         }
 
-        /// <inheritdoc />
-        public T Get<T>(string id, string contextKey, RequestContext requestContext, int timeoutInMilliseconds = -1) where T : class, IRequest
+        protected override async Task WriteToStoreAsync(Func<DbConnection, DbCommand> commandFunc,
+            Action loggingAction, CancellationToken cancellationToken)
         {
-            var sql = $"select * from {_configuration.InBoxTableName} where CommandId = @commandId and ContextKey = @contextKey";
-            var parameters = new[]
-            {
-                CreateSqlParameter("CommandId", id),
-                CreateSqlParameter("ContextKey", contextKey)
-            };
-
-            return ExecuteCommand(command => ReadCommand<T>(command.ExecuteReader(), id), sql, timeoutInMilliseconds,
-                parameters);
-        }
-
-        /// <inheritdoc />
-        public bool Exists<T>(string id, string contextKey, RequestContext requestContext, int timeoutInMilliseconds = -1) where T : class, IRequest
-        {
-            var sql = $"SELECT CommandId FROM {_configuration.InBoxTableName} WHERE CommandId = @commandId and ContextKey = @contextKey LIMIT 1";
-            var parameters = new[]
-            {
-                CreateSqlParameter("CommandId", id),
-                CreateSqlParameter("ContextKey", contextKey)
-            };
-
-            return ExecuteCommand(command => command.ExecuteReader().HasRows, sql, timeoutInMilliseconds,
-                parameters);
-        }
-
-        /// <inheritdoc />
-        public async Task<bool> ExistsAsync<T>(string id, string contextKey, RequestContext requestContext, int timeoutInMilliseconds = -1,
-            CancellationToken cancellationToken = default) where T : class, IRequest
-        {
-            var sql = $"SELECT CommandId FROM {_configuration.InBoxTableName} WHERE CommandId = @commandId and ContextKey = @contextKey LIMIT 1";
-            var parameters = new[]
-            {
-                CreateSqlParameter("CommandId", id),
-                CreateSqlParameter("ContextKey", contextKey)
-            };
-
-            return await ExecuteCommandAsync<bool>(
-                    async command =>
-                    {
-                        var reader = await command.ExecuteReaderAsync(cancellationToken);
-                        return reader.HasRows;
-                    },
-                    sql,
-                    timeoutInMilliseconds,
-                    cancellationToken,
-                    parameters)
-                .ConfigureAwait(ContinueOnCapturedContext);
-        }
-
-        /// <inheritdoc />
-        public async Task AddAsync<T>(T command, string contextKey, RequestContext requestContext, int timeoutInMilliseconds = -1, CancellationToken cancellationToken = default)
-            where T : class, IRequest
-        {
-            var parameters = InitAddDbParameters(command, contextKey);
-
-            using var connection = GetConnection();
-            await connection.OpenAsync(cancellationToken).ConfigureAwait(ContinueOnCapturedContext);
-            var sqlcmd = InitAddDbCommand(connection, parameters, timeoutInMilliseconds);
+            using var connection = await GetOpenConnectionAsync(_connectionProvider, cancellationToken);
+            using var command = commandFunc.Invoke(connection);
             try
             {
-                await sqlcmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(ContinueOnCapturedContext);
+                await command.ExecuteNonQueryAsync(cancellationToken);
             }
-            catch (MySqlException sqlException)
+            catch (MySqlException ex)
             {
-                if (sqlException.Number == MySqlDuplicateKeyError)
+                if (ex.Number == MySqlDuplicateKeyError)
                 {
-                    s_logger.LogWarning(
-                        "MySqlOutbox: A duplicate Command with the CommandId {Id} was inserted into the Outbox, ignoring and continuing",
-                        command.Id);
+                    loggingAction.Invoke();
                     return;
                 }
 
@@ -165,29 +118,59 @@ namespace Paramore.Brighter.Inbox.MySql
             }
         }
 
-        /// <inheritdoc />
-        public bool ContinueOnCapturedContext { get; set; }
-
-        /// <inheritdoc />
-        public async Task<T> GetAsync<T>(string id, string contextKey, RequestContext requestContext, int timeoutInMilliseconds = -1,
-            CancellationToken cancellationToken = default)
-            where T : class, IRequest
+        protected override T ReadFromStore<T>(Func<DbConnection, DbCommand> commandFunc, Func<DbDataReader, string, T> resultFunc, string commandId)
         {
-            var sql = $"select * from {_configuration.InBoxTableName} where CommandId = @commandId and ContextKey = @contextKey";
+            using var connection = _connectionProvider.GetConnection();
+            using var command = commandFunc.Invoke(connection);
 
+            var result = command.ExecuteReader();
+            return resultFunc.Invoke(result, commandId);
+        }
+
+        protected override async Task<T> ReadFromStoreAsync<T>(Func<DbConnection, DbCommand> commandFunc,
+            Func<DbDataReader, string, CancellationToken, Task<T>> resultFunc,
+            string commandId,
+            CancellationToken cancellationToken)
+        {
+            using var connection = await _connectionProvider.GetConnectionAsync(cancellationToken);
+            using var command = commandFunc.Invoke(connection);
+
+            var result = await command.ExecuteReaderAsync(cancellationToken);
+            return await resultFunc.Invoke(result, commandId, cancellationToken);
+        }
+
+        protected override IDbDataParameter[] CreateAddParameters<T>(T command, string contextKey)
+        {
+            var commandJson = JsonSerializer.Serialize(command, JsonSerialisationOptions.Options);
             var parameters = new[]
             {
-                CreateSqlParameter("CommandId", id),
+                CreateSqlParameter("CommandID", command.Id),
+                CreateSqlParameter("CommandType", typeof (T).Name),
+                CreateSqlParameter("CommandBody", commandJson),
+                CreateSqlParameter("Timestamp", DateTime.UtcNow),
                 CreateSqlParameter("ContextKey", contextKey)
             };
+            return parameters;
+        }
 
-            return await ExecuteCommandAsync(
-                async command => ReadCommand<T>(await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(ContinueOnCapturedContext), id),
-                sql,
-                timeoutInMilliseconds,
-                cancellationToken,
-                parameters)
-                .ConfigureAwait(ContinueOnCapturedContext);
+        protected override IDbDataParameter[] CreateGetParameters(string commandId, string contextKey)
+        {
+            var parameters = new[]
+            {
+                CreateSqlParameter("CommandID", commandId),
+                CreateSqlParameter("ContextKey", contextKey)
+            };
+            return parameters;
+        }
+
+        protected override IDbDataParameter[] CreateExistsParameters(string commandId, string contextKey)
+        {
+            var parameters = new[]
+            {
+                CreateSqlParameter("CommandID", commandId),
+                CreateSqlParameter("ContextKey", contextKey)
+            };
+            return parameters;
         }
 
         private DbParameter CreateSqlParameter(string parameterName, object value)
@@ -199,79 +182,70 @@ namespace Paramore.Brighter.Inbox.MySql
             };
         }
 
-        private T ExecuteCommand<T>(Func<DbCommand, T> execute, string sql, int timeoutInMilliseconds,
-            params DbParameter[] parameters)
+        protected override T MapFunction<T>(DbDataReader dr, string commandId)
         {
-            using var connection = GetConnection();
-            using var command = connection.CreateCommand();
-            if (timeoutInMilliseconds != -1) command.CommandTimeout = timeoutInMilliseconds;
-            command.CommandText = sql;
-            command.Parameters.AddRange(parameters);
-
-            connection.Open();
-            var item = execute(command);
-            return item;
-        }
-
-        private async Task<T> ExecuteCommandAsync<T>(
-            Func<DbCommand, Task<T>> execute,
-            string sql,
-            int timeoutInMilliseconds,
-            CancellationToken cancellationToken = default,
-            params DbParameter[] parameters)
-        {
-            using var connection = GetConnection();
-            using var command = connection.CreateCommand();
-            if (timeoutInMilliseconds != -1) command.CommandTimeout = timeoutInMilliseconds;
-            command.CommandText = sql;
-            command.Parameters.AddRange(parameters);
-
-            await connection.OpenAsync(cancellationToken).ConfigureAwait(ContinueOnCapturedContext);
-            var item = await execute(command).ConfigureAwait(ContinueOnCapturedContext);
-            return item;
-        }
-
-        private DbConnection GetConnection()
-        {
-            return new MySqlConnection(_configuration.ConnectionString);
-        }
-
-        private DbCommand InitAddDbCommand(DbConnection connection, DbParameter[] parameters, int timeoutInMilliseconds)
-        {
-            var sqlAdd =
-                $"insert into {_configuration.InBoxTableName} (CommandID, CommandType, CommandBody, Timestamp, ContextKey) values (@CommandID, @CommandType, @CommandBody, @Timestamp, @ContextKey)";
-
-            var sqlcmd = connection.CreateCommand();
-            if (timeoutInMilliseconds != -1) sqlcmd.CommandTimeout = timeoutInMilliseconds;
-
-            sqlcmd.CommandText = sqlAdd;
-            sqlcmd.Parameters.AddRange(parameters);
-            return sqlcmd;
-        }
-
-        private DbParameter[] InitAddDbParameters<T>(T command, string contextKey) where T : class, IRequest
-        {
-            var commandJson = JsonSerializer.Serialize(command, JsonSerialisationOptions.Options);
-            var parameters = new[]
+            try
             {
-                CreateSqlParameter("CommandID", command.Id),
-                CreateSqlParameter("CommandType", typeof (T).Name),
-                CreateSqlParameter("CommandBody", commandJson),
-                CreateSqlParameter("Timestamp", DateTime.UtcNow),
-                CreateSqlParameter("ContextKey", contextKey),
-            };
-            return parameters;
-        }
-
-        private TResult ReadCommand<TResult>(IDataReader dr, string id) where TResult : class, IRequest
-        {
-            if (dr.Read())
+                if (dr.Read())
+                {
+                    var body = dr.GetString(dr.GetOrdinal("CommandBody"));
+                    return JsonSerializer.Deserialize<T>(body, JsonSerialisationOptions.Options);
+                }
+            }
+            finally
             {
-                var body = dr.GetString(dr.GetOrdinal("CommandBody"));
-                return JsonSerializer.Deserialize<TResult>(body, JsonSerialisationOptions.Options);
+                dr.Close();
             }
 
-            throw new RequestNotFoundException<TResult>(id);
+            throw new RequestNotFoundException<T>(commandId);
+        }
+
+        protected override async Task<T> MapFunctionAsync<T>(DbDataReader dr, string commandId,
+            CancellationToken cancellationToken)
+        {
+            try
+            {
+                if (await dr.ReadAsync())
+                {
+                    var body = dr.GetString(dr.GetOrdinal("CommandBody"));
+                    return JsonSerializer.Deserialize<T>(body, JsonSerialisationOptions.Options);
+                }
+            }
+            finally
+            {
+#if NETSTANDARD2_0
+                dr.Close();
+#else
+                await dr.CloseAsync();
+#endif
+            }
+
+            throw new RequestNotFoundException<T>(commandId);
+        }
+
+        protected override bool MapBoolFunction(DbDataReader dr, string commandId)
+        {
+            try
+            {
+                return dr.HasRows;
+            }
+            finally
+            {
+                dr.Close();
+            }
+        }
+
+        protected override Task<bool> MapBoolFunctionAsync(DbDataReader dr, string commandId,
+            CancellationToken cancellationToken)
+        {
+            try
+            {
+                return Task.FromResult(dr.HasRows);
+            }
+            finally
+            {
+                dr.Close();
+            }
         }
     }
 }

--- a/src/Paramore.Brighter.Inbox.MySql/MySqlQueries.cs
+++ b/src/Paramore.Brighter.Inbox.MySql/MySqlQueries.cs
@@ -1,0 +1,36 @@
+﻿#region Licence
+
+/* The MIT License (MIT)
+Copyright © 2025 Dominic Hickie <dominichickie@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+namespace Paramore.Brighter.Inbox.MySql
+{
+    public class MySqlQueries : IRelationalDatabaseInboxQueries
+    {
+        public string AddCommand { get; } = "INSERT INTO {0} ([CommandID], [CommandType], [CommandBody], [Timestamp], [ContextKey]) VALUES (@CommandID, @CommandType, @CommandBody, @Timestamp, @ContextKey)";
+
+        public string ExistsCommand { get; } = "SELECT [CommandID] FROM {0} WHERE [CommandID] = @CommandID AND [ContextKey] = @ContextKey LIMIT 1";
+
+        public string GetCommand { get; } = "SELECT * FROM {0} where [CommandID] = @CommandID AND [ContextKey] = @ContextKey";
+    }
+}

--- a/src/Paramore.Brighter.Inbox.MySql/MySqlQueries.cs
+++ b/src/Paramore.Brighter.Inbox.MySql/MySqlQueries.cs
@@ -27,10 +27,10 @@ namespace Paramore.Brighter.Inbox.MySql
 {
     public class MySqlQueries : IRelationalDatabaseInboxQueries
     {
-        public string AddCommand { get; } = "INSERT INTO {0} ([CommandID], [CommandType], [CommandBody], [Timestamp], [ContextKey]) VALUES (@CommandID, @CommandType, @CommandBody, @Timestamp, @ContextKey)";
+        public string AddCommand { get; } = "INSERT INTO {0} (CommandID, CommandType, CommandBody, Timestamp, ContextKey) VALUES (@CommandID, @CommandType, @CommandBody, @Timestamp, @ContextKey)";
 
-        public string ExistsCommand { get; } = "SELECT [CommandID] FROM {0} WHERE [CommandID] = @CommandID AND [ContextKey] = @ContextKey LIMIT 1";
+        public string ExistsCommand { get; } = "SELECT CommandID FROM {0} WHERE CommandID = @CommandID AND ContextKey = @ContextKey LIMIT 1";
 
-        public string GetCommand { get; } = "SELECT * FROM {0} where [CommandID] = @CommandID AND [ContextKey] = @ContextKey";
+        public string GetCommand { get; } = "SELECT * FROM {0} where CommandID = @CommandID AND ContextKey = @ContextKey";
     }
 }

--- a/src/Paramore.Brighter.Inbox.MySql/Paramore.Brighter.Inbox.MySql.csproj
+++ b/src/Paramore.Brighter.Inbox.MySql/Paramore.Brighter.Inbox.MySql.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>This is an implementation of the outbox used for decoupled invocation of commands by Paramore.Brighter, using MySql</Description>
     <Authors>Derek Comartin</Authors>
@@ -6,7 +6,8 @@
     <PackageTags>MySql;Command;Event;Service Activator;Decoupled;Invocation;Messaging;Remote;Command Dispatcher;Command Processor;Request;Service;Task Queue;Work Queue;Retry;Circuit Breaker;Availability</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Paramore.Brighter\Paramore.Brighter.csproj" />
+    <ProjectReference Include="..\Paramore.Brighter.MySql\Paramore.Brighter.MySql.csproj"/>
+    <ProjectReference Include="..\Paramore.Brighter\Paramore.Brighter.csproj"/>
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="MySqlConnector" />

--- a/src/Paramore.Brighter.Inbox.Postgres/PostgreSqlInbox.cs
+++ b/src/Paramore.Brighter.Inbox.Postgres/PostgreSqlInbox.cs
@@ -29,256 +29,215 @@ using System.Data.Common;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Logging;
 using Npgsql;
 using NpgsqlTypes;
 using Paramore.Brighter.Inbox.Exceptions;
 using Paramore.Brighter.Logging;
-using Paramore.Brighter.Observability;
+using Paramore.Brighter.PostgreSql;
 
 namespace Paramore.Brighter.Inbox.Postgres
 {
-    public class PostgreSqlInbox : IAmAnInboxSync, IAmAnInboxAsync
+    public class PostgreSqlInbox : RelationalDatabaseInbox
     {
         private readonly IAmARelationalDatabaseConfiguration _configuration;
-        private static readonly ILogger s_logger = ApplicationLogging.CreateLogger<PostgreSqlInbox>();
+        private readonly IAmARelationalDbConnectionProvider _connectionProvider;
 
-        /// <inheritdoc />
-        public bool ContinueOnCapturedContext { get; set; }
-
-        /// <inheritdoc />
-        public IAmABrighterTracer Tracer { private get; set; }
-
-        public PostgreSqlInbox(IAmARelationalDatabaseConfiguration configuration)
+        public PostgreSqlInbox(IAmARelationalDbConnectionProvider connectionProvider, IAmARelationalDatabaseConfiguration configuration)
+            : base(configuration.InBoxTableName, new PostgreSqlQueries(), ApplicationLogging.CreateLogger<PostgreSqlInbox>())
         {
+            _connectionProvider = connectionProvider;
             _configuration = configuration;
             ContinueOnCapturedContext = false;
         }
 
-        /// <inheritdoc />
-        public void Add<T>(T command, string contextKey, RequestContext requestContext, int timeoutInMilliseconds = -1) where T : class, IRequest
+        public PostgreSqlInbox(IAmARelationalDatabaseConfiguration configuration) 
+            : this(new PostgreSqlConnectionProvider(configuration), configuration)
         {
-            var parameters = InitAddDbParameters(command, contextKey);
-            var connection = GetConnection(); 
+        }
+
+        protected override void WriteToStore(Func<DbConnection, DbCommand> commandFunc, Action loggingAction)
+        {
+            using var connection = GetOpenConnection(_connectionProvider);
+            using var command = commandFunc.Invoke(connection);
             try
             {
-                using var sqlcmd = InitAddDbCommand(connection, parameters, timeoutInMilliseconds);
-                sqlcmd.ExecuteNonQuery();
+                command.ExecuteNonQuery();
             }
-            catch (PostgresException sqlException)
+            catch (PostgresException ex)
             {
-                if (sqlException.SqlState == PostgresErrorCodes.UniqueViolation)
+                if (ex.SqlState == PostgresErrorCodes.UniqueViolation)
                 {
-                    s_logger.LogWarning(
-                        "PostgresSqlOutbox: A duplicate Command with the CommandId {Id} was inserted into the Outbox, ignoring and continuing",
-                        command.Id);
-                    return;
-                }
-                throw;
-            }
-            finally
-            {
-                    connection.Dispose();
-            }
-        }
-
-        /// <inheritdoc />
-        public T Get<T>(string id, string contextKey, RequestContext requestContext, int timeoutInMilliseconds = -1) where T : class, IRequest
-        {
-            var sql = $"SELECT * FROM {_configuration.InBoxTableName} WHERE CommandId = @CommandId AND ContextKey = @ContextKey";
-            var parameters = new[]
-            {
-                InitNpgsqlParameter("CommandId", id),
-                InitNpgsqlParameter("ContextKey", contextKey)
-            };
-
-            return ExecuteCommand(command => ReadCommand<T>(command.ExecuteReader(), id), sql, timeoutInMilliseconds, parameters);
-        }
-
-        /// <inheritdoc />
-        public bool Exists<T>(string id, string contextKey, RequestContext requestContext, int timeoutInMilliseconds = -1) where T : class, IRequest
-        {
-            var sql = $"SELECT DISTINCT CommandId FROM {_configuration.InBoxTableName} WHERE CommandId = @CommandId AND ContextKey = @ContextKey FETCH FIRST 1 ROWS ONLY";
-            var parameters = new[]
-            {
-                InitNpgsqlParameter("CommandId", id),
-                InitNpgsqlParameter("ContextKey", contextKey)
-            };
-
-            return ExecuteCommand(command => command.ExecuteReader().HasRows, sql, timeoutInMilliseconds, parameters);
-        }
-
-        /// <inheritdoc />
-        public async Task AddAsync<T>(T command, string contextKey, RequestContext requestContext, int timeoutInMilliseconds = -1,
-            CancellationToken cancellationToken = default) where T : class, IRequest
-        {
-            var parameters = InitAddDbParameters(command, contextKey);
-            var connection = GetConnection(); 
-
-            try
-            {
-                using var sqlcmd = InitAddDbCommand(connection, parameters, timeoutInMilliseconds);
-                await sqlcmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(ContinueOnCapturedContext);
-            }
-            catch (PostgresException sqlException)
-            {
-                if (sqlException.SqlState == PostgresErrorCodes.UniqueViolation)
-                {
-                    s_logger.LogWarning(
-                        "PostgresSqlOutbox: A duplicate Command with the CommandId {Id} was inserted into the Outbox, ignoring and continuing",
-                        command.Id);
+                    loggingAction.Invoke();
                     return;
                 }
 
                 throw;
             }
-            finally
+        }
+
+        protected override async Task WriteToStoreAsync(Func<DbConnection, DbCommand> commandFunc, Action loggingAction, CancellationToken cancellationToken)
+        {
+            using var connection = await GetOpenConnectionAsync(_connectionProvider, cancellationToken)
+                .ConfigureAwait(ContinueOnCapturedContext);
+            using var command = commandFunc.Invoke(connection);
+            try
             {
-                connection.Dispose();
+                await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(ContinueOnCapturedContext);
+            }
+            catch (PostgresException ex)
+            {
+                if (ex.SqlState == PostgresErrorCodes.UniqueViolation)
+                {
+                    loggingAction.Invoke();
+                    return;
+                }
+
+                throw;
             }
         }
 
-        /// <inheritdoc />
-        public async Task<T> GetAsync<T>(string id, string contextKey, RequestContext requestContext, int timeoutInMilliseconds = -1,
-            CancellationToken cancellationToken = default) where T : class, IRequest
+        protected override T ReadFromStore<T>(Func<DbConnection, DbCommand> commandFunc, Func<DbDataReader, string, T> resultFunc, string commandId)
         {
-            var sql = $"SELECT * FROM {_configuration.InBoxTableName} WHERE CommandId = @CommandId AND ContextKey = @ContextKey";
+            using var connection = _connectionProvider.GetConnection();
+            using var command = commandFunc.Invoke(connection);
 
-            var parameters = new[]
-            {
-                InitNpgsqlParameter("CommandId", id),
-                InitNpgsqlParameter("ContextKey", contextKey)
-            };
+            var result = command.ExecuteReader();
+            return resultFunc.Invoke(result, commandId);
+        }
 
-            return await ExecuteCommandAsync(
-                    async command => ReadCommand<T>(await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(ContinueOnCapturedContext), id),
-                    sql,
-                    timeoutInMilliseconds,
-                    cancellationToken,
-                    parameters)
+        protected override async Task<T> ReadFromStoreAsync<T>(Func<DbConnection, DbCommand> commandFunc, 
+            Func<DbDataReader, string, CancellationToken, Task<T>> resultFunc, 
+            string commandId, 
+            CancellationToken cancellationToken)
+        {
+            using var connection = await _connectionProvider.GetConnectionAsync(cancellationToken)
                 .ConfigureAwait(ContinueOnCapturedContext);
+            using var command = commandFunc.Invoke(connection);
+
+            var result = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(ContinueOnCapturedContext);
+            return await resultFunc.Invoke(result, commandId, cancellationToken);
         }
 
-        /// <inheritdoc />
-        public async Task<bool> ExistsAsync<T>(string id, string contextKey, RequestContext requestContext, int timeoutInMilliseconds = -1,
-            CancellationToken cancellationToken = default) where T : class, IRequest
-        {
-            var sql = $"SELECT DISTINCT CommandId FROM {_configuration.InBoxTableName} WHERE CommandId = @CommandId AND ContextKey = @ContextKey FETCH FIRST 1 ROWS ONLY";
-            var parameters = new[]
-            {
-                InitNpgsqlParameter("CommandId", id),
-                InitNpgsqlParameter("ContextKey", contextKey)
-            };
-
-            return await ExecuteCommandAsync<bool>(
-                    async command =>
-                    {
-                        var reader = await command.ExecuteReaderAsync(cancellationToken);
-                        return reader.HasRows;
-                    },
-                    sql,
-                    timeoutInMilliseconds,
-                    cancellationToken,
-                    parameters)
-                .ConfigureAwait(ContinueOnCapturedContext);
-        }
-        
-        private DbConnection GetConnection()
-        {
-            var connection = new NpgsqlConnection(_configuration.ConnectionString);
-            connection.Open();
-            return connection;
-        }
-
-        private NpgsqlParameter InitNpgsqlParameter(string parametername, object value)
-        {
-            if (value != null)
-                return new NpgsqlParameter(parametername, value);
-            else
-                return new NpgsqlParameter(parametername, DBNull.Value);
-        }
-
-        private DbCommand InitAddDbCommand(DbConnection connection, DbParameter[] parameters, int timeoutInMilliseconds)
+        protected override DbCommand CreateCommand(
+            DbConnection connection, string sqlText, int outBoxTimeout, params IDbDataParameter[] parameters)
         {
             var command = connection.CreateCommand();
-            command.CommandText = string.Format(
-                "INSERT INTO {0} (CommandID, CommandType, CommandBody, Timestamp, ContextKey) VALUES (@CommandID, @CommandType, @CommandBody, @Timestamp, @ContextKey)",
-                _configuration.InBoxTableName);
+
+            command.CommandTimeout = outBoxTimeout < 0 ? 0 : outBoxTimeout;
+            command.CommandText = sqlText;
             command.Parameters.AddRange(parameters);
+
             return command;
         }
 
-        private DbParameter[] InitAddDbParameters<T>(T command, string contextKey) where T : class, IRequest
+        protected override IDbDataParameter[] CreateAddParameters<T>(T command, string contextKey)
         {
             var commandJson = JsonSerializer.Serialize(command, JsonSerialisationOptions.Options);
             var parameters = new[]
             {
-                InitNpgsqlParameter("CommandID", command.Id),
-                InitNpgsqlParameter("CommandType", typeof (T).Name),
-                InitNpgsqlParameter("CommandBody", commandJson),
-                new NpgsqlParameter("Timestamp", NpgsqlDbType.TimestampTz) {Value = DateTimeOffset.UtcNow},
-                InitNpgsqlParameter("ContextKey", contextKey)
+                CreateNpgsqlParameter("CommandID", command.Id),
+                CreateNpgsqlParameter("CommandType", typeof (T).Name),
+                CreateNpgsqlParameter("CommandBody", commandJson),
+                CreateNpgsqlParameter("Timestamp", NpgsqlDbType.TimestampTz, DateTimeOffset.UtcNow),
+                CreateNpgsqlParameter("ContextKey", contextKey)
             };
             return parameters;
         }
 
-        private T ExecuteCommand<T>(Func<DbCommand, T> execute, string sql, int timeoutInMilliseconds,
-            params DbParameter[] parameters)
+        protected override IDbDataParameter[] CreateExistsParameters(string commandId, string contextKey)
         {
-            var connection = GetConnection(); 
+            var parameters = new[]
+            {
+                CreateNpgsqlParameter("CommandId", commandId),
+                CreateNpgsqlParameter("ContextKey", contextKey)
+            };
+            return parameters;
+        }
 
+        protected override IDbDataParameter[] CreateGetParameters(string commandId, string contextKey)
+        {
+            var parameters = new[]
+            {
+                CreateNpgsqlParameter("CommandId", commandId),
+                CreateNpgsqlParameter("ContextKey", contextKey)
+            };
+            return parameters;
+        }
+
+        private NpgsqlParameter CreateNpgsqlParameter(string parameterName, object value)
+        {
+            if (value != null)
+                return new NpgsqlParameter(parameterName, value);
+            else
+                return new NpgsqlParameter(parameterName, DBNull.Value);
+        }
+
+        private NpgsqlParameter CreateNpgsqlParameter(string parameterName, NpgsqlDbType dbType, object value)
+        {
+            if (value != null)
+                return new NpgsqlParameter(parameterName, dbType) { Value = value };
+            else
+                return new NpgsqlParameter(parameterName, dbType) { Value = DBNull.Value };
+        }
+
+        protected override T MapFunction<T>(DbDataReader dr, string commandId)
+        {
             try
             {
-                using var command = connection.CreateCommand();
-                if (timeoutInMilliseconds != -1)
-                    command.CommandTimeout = timeoutInMilliseconds;
-
-                command.CommandText = sql;
-                command.Parameters.AddRange(parameters);
-
-                return execute(command);
+                if (dr.Read())
+                {
+                    var body = dr.GetString(dr.GetOrdinal("CommandBody"));
+                    return JsonSerializer.Deserialize<T>(body, JsonSerialisationOptions.Options);
+                }
             }
             finally
             {
-                connection.Dispose();
+                dr.Close();
             }
+
+            throw new RequestNotFoundException<T>(commandId);
         }
 
-        private async Task<T> ExecuteCommandAsync<T>(
-            Func<DbCommand, Task<T>> execute,
-            string sql,
-            int timeoutInMilliseconds,
-            CancellationToken cancellationToken = default,
-            params DbParameter[] parameters)
+        protected override async Task<T> MapFunctionAsync<T>(DbDataReader dr, string commandId, CancellationToken cancellationToken)
         {
-            var connection = GetConnection(); 
-
             try
             {
-                using var command = connection.CreateCommand();
-                if (timeoutInMilliseconds != -1)
-                    command.CommandTimeout = timeoutInMilliseconds;
-
-                command.CommandText = sql;
-                command.Parameters.AddRange(parameters);
-
-                return await execute(command).ConfigureAwait(ContinueOnCapturedContext);
+                if (await dr.ReadAsync(cancellationToken).ConfigureAwait(ContinueOnCapturedContext))
+                {
+                    var body = dr.GetString(dr.GetOrdinal("CommandBody"));
+                    return JsonSerializer.Deserialize<T>(body, JsonSerialisationOptions.Options);
+                }
             }
             finally
             {
-                connection.Dispose();
+                await dr.CloseAsync().ConfigureAwait(ContinueOnCapturedContext);
+            }
+
+            throw new RequestNotFoundException<T>(commandId);
+        }
+
+        protected override bool MapBoolFunction(DbDataReader dr, string commandId)
+        {
+            try
+            {
+                return dr.HasRows;
+            }
+            finally
+            {
+                dr.Close();
             }
         }
 
-        private TResult ReadCommand<TResult>(IDataReader dr, string commandId) where TResult : class, IRequest
+        protected override Task<bool> MapBoolFunctionAsync(DbDataReader dr, string commandId, CancellationToken cancellationToken)
         {
-            if (dr.Read())
+            try
             {
-                var body = dr.GetString(dr.GetOrdinal("CommandBody"));
-                return JsonSerializer.Deserialize<TResult>(body, JsonSerialisationOptions.Options);
+                return Task.FromResult(dr.HasRows);
             }
-
-            throw new RequestNotFoundException<TResult>(commandId);
+            finally
+            {
+                dr.Close();
+            }
         }
     }
 }

--- a/src/Paramore.Brighter.Inbox.Postgres/PostgreSqlQueries.cs
+++ b/src/Paramore.Brighter.Inbox.Postgres/PostgreSqlQueries.cs
@@ -1,0 +1,36 @@
+﻿#region Licence
+
+/* The MIT License (MIT)
+Copyright © 2025 Dominic Hickie <dominichickie@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+namespace Paramore.Brighter.Inbox.Postgres
+{
+    public class PostgreSqlQueries : IRelationalDatabaseInboxQueries
+    {
+        public string AddCommand { get; } = "INSERT INTO {0} (\"CommandID\", \"CommandType\", \"CommandBody\", \"Timestamp\", \"ContextKey\") VALUES (@CommandID, @CommandType, @CommandBody, @Timestamp, @ContextKey)";
+
+        public string ExistsCommand { get; } = "SELECT DISTINCT \"CommandId\" FROM {0} WHERE \"CommandId\" = @CommandId AND \"ContextKey\" = @ContextKey FETCH FIRST 1 ROWS ONLY";
+
+        public string GetCommand { get; } = "SELECT * FROM {0} WHERE \"CommandId\" = @CommandId AND \"ContextKey\" = @ContextKey";
+    }
+}

--- a/src/Paramore.Brighter.Inbox.Postgres/PostgreSqlQueries.cs
+++ b/src/Paramore.Brighter.Inbox.Postgres/PostgreSqlQueries.cs
@@ -27,10 +27,10 @@ namespace Paramore.Brighter.Inbox.Postgres
 {
     public class PostgreSqlQueries : IRelationalDatabaseInboxQueries
     {
-        public string AddCommand { get; } = "INSERT INTO {0} (\"CommandID\", \"CommandType\", \"CommandBody\", \"Timestamp\", \"ContextKey\") VALUES (@CommandID, @CommandType, @CommandBody, @Timestamp, @ContextKey)";
+        public string AddCommand { get; } = "INSERT INTO {0} (CommandId, CommandType, CommandBody, Timestamp, ContextKey) VALUES (@CommandId, @CommandType, @CommandBody, @Timestamp, @ContextKey)";
 
-        public string ExistsCommand { get; } = "SELECT DISTINCT \"CommandId\" FROM {0} WHERE \"CommandId\" = @CommandId AND \"ContextKey\" = @ContextKey FETCH FIRST 1 ROWS ONLY";
+        public string ExistsCommand { get; } = "SELECT DISTINCT CommandId FROM {0} WHERE CommandId = @CommandId AND ContextKey = @ContextKey FETCH FIRST 1 ROWS ONLY";
 
-        public string GetCommand { get; } = "SELECT * FROM {0} WHERE \"CommandId\" = @CommandId AND \"ContextKey\" = @ContextKey";
+        public string GetCommand { get; } = "SELECT * FROM {0} WHERE CommandId = @CommandId AND ContextKey = @ContextKey";
     }
 }

--- a/src/Paramore.Brighter.Inbox.Sqlite/Paramore.Brighter.Inbox.Sqlite.csproj
+++ b/src/Paramore.Brighter.Inbox.Sqlite/Paramore.Brighter.Inbox.Sqlite.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Microsoft.Data.Sqlite" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\Paramore.Brighter.Sqlite\Paramore.Brighter.Sqlite.csproj" />
     <ProjectReference Include="..\Paramore.Brighter\Paramore.Brighter.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Paramore.Brighter.Inbox.Sqlite/SqliteInbox.cs
+++ b/src/Paramore.Brighter.Inbox.Sqlite/SqliteInbox.cs
@@ -30,259 +30,219 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Data.Sqlite;
-using Microsoft.Extensions.Logging;
 using Paramore.Brighter.Inbox.Exceptions;
 using Paramore.Brighter.Logging;
-using Paramore.Brighter.Observability;
+using Paramore.Brighter.Sqlite;
 
 namespace Paramore.Brighter.Inbox.Sqlite
 {
     /// <summary>
     ///     Class SqliteInbox.
     /// </summary>
-    public class SqliteInbox : IAmAnInboxSync, IAmAnInboxAsync
+    public class SqliteInbox : RelationalDatabaseInbox
     {
-        private static readonly ILogger s_logger = ApplicationLogging.CreateLogger<SqliteInbox>();
-
+        private readonly IAmARelationalDbConnectionProvider _connectionProvider;
         private const int SqliteDuplicateKeyError = 1555;
         private const int SqliteUniqueKeyError = 19;
-
-        /// <inheritdoc/>
-        public IAmABrighterTracer Tracer { private get; set; }
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="SqliteInbox" /> class.
         /// </summary>
-        /// <param name="configuration">The configuration.</param>
-        public SqliteInbox(IAmARelationalDatabaseConfiguration configuration)
+        /// <param name="connectionProvider">The connection provider for the database.</param>
+        /// <param name="configuration">The configuration for the database.</param>
+        public SqliteInbox(IAmARelationalDbConnectionProvider connectionProvider, IAmARelationalDatabaseConfiguration configuration)
+            : base(configuration.InBoxTableName, new SqliteQueries(), ApplicationLogging.CreateLogger<SqliteInbox>())
         {
-            Configuration = configuration;
+            _connectionProvider = connectionProvider;
             ContinueOnCapturedContext = false;
         }
 
-        /// <inheritdoc />
-        public void Add<T>(T command, string contextKey, RequestContext requestContext, int timeoutInMilliseconds = -1) where T : class, IRequest
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="SqliteInbox" /> class.
+        /// </summary>
+        /// <param name="configuration">The configuration for the database.</param>
+        public SqliteInbox(IAmARelationalDatabaseConfiguration configuration) 
+            : this(new SqliteConnectionProvider(configuration), configuration)
         {
-            var parameters = InitAddDbParameters(command, contextKey);
+        }
 
-            using var connection = GetConnection();
-            connection.Open();
-            var sqlAdd = GetAddSql();
-            using var sqlcmd = connection.CreateCommand();
-            FormatAddCommand(parameters, sqlcmd, sqlAdd, timeoutInMilliseconds);
+        protected override void WriteToStore(Func<DbConnection, DbCommand> commandFunc, Action loggingAction)
+        {
+            using var connection = GetOpenConnection(_connectionProvider);
+            using var command = commandFunc.Invoke(connection);
             try
             {
-                sqlcmd.ExecuteNonQuery();
+                command.ExecuteNonQuery();
             }
-            catch (SqliteException sqliteException)
+            catch (SqliteException ex)
             {
-                if (IsExceptionUnqiueOrDuplicateIssue(sqliteException))
+                if (ex.SqliteErrorCode == SqliteDuplicateKeyError ||
+                   ex.SqliteErrorCode == SqliteUniqueKeyError)
                 {
-                    s_logger.LogWarning(
-                        "MsSqlOutbox: A duplicate Command with the CommandId {Id} was inserted into the Outbox, ignoring and continuing",
-                        command.Id);
+                    loggingAction.Invoke();
+                    return;
                 }
+
+                throw;
             }
         }
 
-        private static bool IsExceptionUnqiueOrDuplicateIssue(SqliteException sqlException)
+        protected override async Task WriteToStoreAsync(Func<DbConnection, DbCommand> commandFunc, Action loggingAction, CancellationToken cancellationToken)
         {
-            return sqlException.SqliteErrorCode == SqliteDuplicateKeyError ||
-                   sqlException.SqliteErrorCode == SqliteUniqueKeyError;
-        }
-
-        /// <inheritdoc />
-        public T Get<T>(string id, string contextKey, RequestContext requestContext, int timeoutInMilliseconds = -1) where T : class, IRequest
-        {
-            var sql = $"select * from {this.OutboxTableName} where CommandId = @CommandId and ContextKey = @ContextKey";
-            var parameters = new[]
-            {
-                CreateSqlParameter("CommandId", id),
-                CreateSqlParameter("ContextKey", contextKey)
-            };
-
-            return ExecuteCommand(command => ReadCommand<T>(command.ExecuteReader(), id), sql, timeoutInMilliseconds, parameters);
-        }
-
-        /// <inheritdoc />
-        public bool Exists<T>(string id, string contextKey, RequestContext requestContext, int timeoutInMilliseconds = -1) where T : class, IRequest
-        {
-            var sql = $"SELECT CommandId FROM {OutboxTableName} WHERE CommandId = @CommandId and ContextKey = @ContextKey LIMIT 1";
-            var parameters = new[]
-            {
-                CreateSqlParameter("CommandId", id),
-                CreateSqlParameter("ContextKey", contextKey)
-            };
-
-            return ExecuteCommand(command => command.ExecuteReader().HasRows, sql, timeoutInMilliseconds,
-                parameters);
-        }
-
-        /// <inheritdoc />
-        public async Task<bool> ExistsAsync<T>(string id, string contextKey, RequestContext requestContext, int timeoutInMilliseconds = -1,
-            CancellationToken cancellationToken = default) where T : class, IRequest
-        {
-            var sql = $"SELECT CommandId FROM {OutboxTableName} WHERE CommandId = @CommandId and ContextKey = @ContextKey LIMIT 1";
-            var parameters = new[]
-            {
-                CreateSqlParameter("CommandId", id),
-                CreateSqlParameter("ContextKey", contextKey)
-            };
-
-            return await ExecuteCommandAsync<bool>(
-                    async command =>
-                    {
-                        var reader = await command.ExecuteReaderAsync(cancellationToken);
-                        return reader.HasRows;
-                    },
-                    sql,
-                    timeoutInMilliseconds,
-                    parameters,
-                    cancellationToken)
+            using var connection = await GetOpenConnectionAsync(_connectionProvider, cancellationToken)
                 .ConfigureAwait(ContinueOnCapturedContext);
-        }
-
-        /// <inheritdoc />
-        public async Task AddAsync<T>(T command, string contextKey, RequestContext requestContext, int timeoutInMilliseconds = -1, CancellationToken cancellationToken = default) where T : class, IRequest
-        {
-            var parameters = InitAddDbParameters(command, contextKey);
-
-            using var connection = GetConnection();
-            await connection.OpenAsync(cancellationToken).ConfigureAwait(ContinueOnCapturedContext);
-            var sqlAdd = GetAddSql();
-            using var sqlcmd = connection.CreateCommand();
-            FormatAddCommand(parameters, sqlcmd, sqlAdd, timeoutInMilliseconds);
+            using var command = commandFunc.Invoke(connection);
             try
             {
-                await sqlcmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(ContinueOnCapturedContext);
+                await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(ContinueOnCapturedContext);
             }
-            catch (SqliteException sqliteException)
+            catch (SqliteException ex)
             {
-                if (!IsExceptionUnqiueOrDuplicateIssue(sqliteException)) throw;
-                s_logger.LogWarning(
-                    "MsSqlOutbox: A duplicate Command with the CommandId {Id} was inserted into the Outbox, ignoring and continuing",
-                    command.Id);
-            }
-        }
-
-        /// <inheritdoc />
-        public async Task<T> GetAsync<T>(string id, string contextKey, RequestContext requestContext, int timeoutInMilliseconds = -1,
-            CancellationToken cancellationToken = default) where T : class, IRequest
-        {
-            var sql = $"select * from {OutboxTableName} where CommandId = @CommandId and ContextKey = @ContextKey";
-            var parameters = new[]
-            {
-                CreateSqlParameter("@CommandId", id),
-                CreateSqlParameter("ContextKey", contextKey)
-            };
-
-            return await ExecuteCommandAsync(
-                async command =>
+                if (ex.SqliteErrorCode == SqliteDuplicateKeyError ||
+                   ex.SqliteErrorCode == SqliteUniqueKeyError)
                 {
-                    return ReadCommand<T>(await command.ExecuteReaderAsync(cancellationToken)
-                        .ConfigureAwait(ContinueOnCapturedContext), id);
-                },
-                sql,
-                timeoutInMilliseconds,
-                parameters,
-                cancellationToken)
+                    loggingAction.Invoke();
+                    return;
+                }
+
+                throw;
+            }
+        }
+
+        protected override T ReadFromStore<T>(Func<DbConnection, DbCommand> commandFunc, Func<DbDataReader, string, T> resultFunc, string commandId)
+        {
+            using var connection = _connectionProvider.GetConnection();
+            using var command = commandFunc.Invoke(connection);
+
+            var result = command.ExecuteReader();
+            return resultFunc.Invoke(result, commandId); 
+        }
+
+        protected override async Task<T> ReadFromStoreAsync<T>(Func<DbConnection, DbCommand> commandFunc, 
+            Func<DbDataReader, string, CancellationToken, Task<T>> resultFunc, 
+            string commandId, 
+            CancellationToken cancellationToken)
+        {
+            using var connection = await _connectionProvider.GetConnectionAsync(cancellationToken)
                 .ConfigureAwait(ContinueOnCapturedContext);
+            using var command = commandFunc.Invoke(connection);
+
+            var result = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(ContinueOnCapturedContext);
+            return await resultFunc.Invoke(result, commandId, cancellationToken);
         }
 
-        /// <inheritdoc/>
-        public bool ContinueOnCapturedContext { get; set; }
-
-        public IAmARelationalDatabaseConfiguration Configuration { get; }
-
-        public string OutboxTableName => Configuration.InBoxTableName;
-
-        public DbParameter CreateSqlParameter(string parameterName, object value)
+        protected override DbCommand CreateCommand(DbConnection connection, string sqlText, int outBoxTimeout, params IDbDataParameter[] parameters)
         {
-            return new SqliteParameter(parameterName, value);
+            var command = connection.CreateCommand();
+
+            command.CommandTimeout = outBoxTimeout < 0 ? 0 : outBoxTimeout;
+            command.CommandText = sqlText;
+            command.Parameters.AddRange(parameters);
+
+            return command;
         }
 
-        public DbConnection GetConnection()
-        {
-            return new SqliteConnection(Configuration.ConnectionString);
-        }
-        
-        public T ExecuteCommand<T>(Func<DbCommand, T> execute, string sql, 
-            int timeoutInMilliseconds, params DbParameter[] parameters)
-        {
-            using var connection = GetConnection();
-            using var command = connection.CreateCommand();
-            if (timeoutInMilliseconds != -1) command.CommandTimeout = timeoutInMilliseconds;
-            command.CommandText = sql;
-            AddParamtersParamArrayToCollection(parameters, command);
-
-            connection.Open();
-            var item = execute(command);
-            return item;
-        }
-
-        public async Task<T> ExecuteCommandAsync<T>(Func<DbCommand, Task<T>> execute, 
-            string sql, int timeoutInMilliseconds, DbParameter[] parameters, CancellationToken cancellationToken = default)
-        {
-            using var connection = GetConnection();
-            using var command = connection.CreateCommand();
-            if (timeoutInMilliseconds != -1) command.CommandTimeout = timeoutInMilliseconds;
-            command.CommandText = sql;
-            AddParamtersParamArrayToCollection(parameters, command);
-
-            await connection.OpenAsync(cancellationToken).ConfigureAwait(ContinueOnCapturedContext);
-            return await execute(command).ConfigureAwait(ContinueOnCapturedContext);
-        }
-
-        private void FormatAddCommand(DbParameter[] parameters, DbCommand sqlcmd, string sqlAdd, int timeoutInMilliseconds)
-        {
-            if (timeoutInMilliseconds != -1) sqlcmd.CommandTimeout = timeoutInMilliseconds;
-
-            sqlcmd.CommandText = sqlAdd;
-            AddParamtersParamArrayToCollection(parameters, sqlcmd);
-        }
-
-        private string GetAddSql()
-        {
-            var sqlAdd = $"insert into {OutboxTableName} (CommandID, CommandType, CommandBody, Timestamp, ContextKey) values (@CommandID, @CommandType, @CommandBody, @Timestamp, @ContextKey)";
-            return sqlAdd;
-        }
-
-        private DbParameter[] InitAddDbParameters<T>(T command, string contextKey) where T : class, IRequest
+        protected override IDbDataParameter[] CreateAddParameters<T>(T command, string contextKey)
         {
             var commandJson = JsonSerializer.Serialize(command, JsonSerialisationOptions.Options);
             var parameters = new[]
             {
-                CreateSqlParameter("CommandID", command.Id), //was CommandId
-                CreateSqlParameter("CommandType", typeof (T).Name), 
-                CreateSqlParameter("CommandBody", commandJson), 
+                CreateSqlParameter("CommandId", command.Id), //was CommandId
+                CreateSqlParameter("CommandType", typeof (T).Name),
+                CreateSqlParameter("CommandBody", commandJson),
                 CreateSqlParameter("Timestamp", DateTime.UtcNow),
                 CreateSqlParameter("ContextKey", contextKey)
             };
             return parameters;
         }
 
-        private TResult ReadCommand<TResult>(IDataReader dr, string id) where TResult : class, IRequest
+        protected override IDbDataParameter[] CreateExistsParameters(string commandId, string contextKey)
         {
-            using (dr)
+            var parameters = new[]
+            {
+                CreateSqlParameter("CommandId", commandId),
+                CreateSqlParameter("ContextKey", contextKey)
+            };
+            return parameters;
+        }
+
+        protected override IDbDataParameter[] CreateGetParameters(string commandId, string contextKey)
+        {
+            var parameters = new[]
+            {
+                CreateSqlParameter("CommandId", commandId),
+                CreateSqlParameter("ContextKey", contextKey)
+            };
+            return parameters;
+        }
+
+        private DbParameter CreateSqlParameter(string parameterName, object value)
+        {
+            return new SqliteParameter(parameterName, value);
+        }
+
+        protected override T MapFunction<T>(DbDataReader dr, string commandId)
+        {
+            try
             {
                 if (dr.Read())
                 {
                     var body = dr.GetString(dr.GetOrdinal("CommandBody"));
-
-                    dr.Close();
-                    return JsonSerializer.Deserialize<TResult>(body, JsonSerialisationOptions.Options);
+                    return JsonSerializer.Deserialize<T>(body, JsonSerialisationOptions.Options);
                 }
+            }
+            finally
+            {
+                dr.Close();
+            }
 
-                throw new RequestNotFoundException<TResult>(id);
+            throw new RequestNotFoundException<T>(commandId);
+        }
+
+        protected override async Task<T> MapFunctionAsync<T>(DbDataReader dr, string commandId,
+            CancellationToken cancellationToken)
+        {
+            try
+            {
+                if (await dr.ReadAsync().ConfigureAwait(ContinueOnCapturedContext))
+                {
+                    var body = dr.GetString(dr.GetOrdinal("CommandBody"));
+                    return JsonSerializer.Deserialize<T>(body, JsonSerialisationOptions.Options);
+                }
+            }
+            finally
+            {
+#if NETSTANDARD2_0
+                dr.Close();
+#else
+                await dr.CloseAsync().ConfigureAwait(ContinueOnCapturedContext);
+#endif
+            }
+
+            throw new RequestNotFoundException<T>(commandId);
+        }
+
+        protected override bool MapBoolFunction(DbDataReader dr, string commandId)
+        {
+            try
+            {
+                return dr.HasRows;
+            }
+            finally
+            {
+                dr.Close();
             }
         }
 
-        private void AddParamtersParamArrayToCollection(DbParameter[] parameters, DbCommand command)
+        protected override Task<bool> MapBoolFunctionAsync(DbDataReader dr, string commandId, CancellationToken cancellationToken)
         {
-            //command.Parameters.AddRange(parameters); used to work... but can't with current Sqlite lib. Iterator issue
-            for (var index = 0; index < parameters.Length; index++)
+            try
             {
-                command.Parameters.Add(parameters[index]);
+                return Task.FromResult(dr.HasRows);
+            }
+            finally
+            {
+                dr.Close();
             }
         }
     }

--- a/src/Paramore.Brighter.Inbox.Sqlite/SqliteQueries.cs
+++ b/src/Paramore.Brighter.Inbox.Sqlite/SqliteQueries.cs
@@ -1,0 +1,36 @@
+﻿#region Licence
+
+/* The MIT License (MIT)
+Copyright © 2025 Dominic Hickie <dominichickie@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+namespace Paramore.Brighter.Inbox.Sqlite
+{
+    public class SqliteQueries : IRelationalDatabaseInboxQueries
+    {
+        public string AddCommand { get; } = "INSERT INTO {0} (CommandId, CommandType, CommandBody, Timestamp, ContextKey) values (@CommandId, @CommandType, @CommandBody, @Timestamp, @ContextKey)";
+
+        public string ExistsCommand { get; } = "SELECT CommandId FROM {0} WHERE CommandId = @CommandId and ContextKey = @ContextKey LIMIT 1";
+
+        public string GetCommand { get; } = "SELECT * FROM {0} WHERE CommandId = @CommandId AND ContextKey = @ContextKey";
+    }
+}

--- a/src/Paramore.Brighter/IAmAnInboxSync.cs
+++ b/src/Paramore.Brighter/IAmAnInboxSync.cs
@@ -61,6 +61,6 @@ namespace Paramore.Brighter
         /// <param name="requestContext">What is the context for this request; used to access the Span</param>
         /// <param name="timeoutInMilliseconds">Timeout in milliseconds; -1 for default timeout</param>
         /// <returns><see langword="true"/> if it exists, otherwise <see langword="false"/>.</returns>
-        bool Exists<T>(string id, string contextKey, RequestContext? requestContextint, int timeoutInMilliseconds = -1) where T : class, IRequest;
+        bool Exists<T>(string id, string contextKey, RequestContext? requestContext, int timeoutInMilliseconds = -1) where T : class, IRequest;
     }
 }

--- a/src/Paramore.Brighter/IRelationalDatabaseInboxQueries.cs
+++ b/src/Paramore.Brighter/IRelationalDatabaseInboxQueries.cs
@@ -1,0 +1,9 @@
+﻿namespace Paramore.Brighter
+{
+    public interface IRelationalDatabaseInboxQueries
+    {
+        string AddCommand { get; }
+        string ExistsCommand { get; }
+        string GetCommand { get; }
+    }
+}

--- a/src/Paramore.Brighter/RelationalDatabaseInbox.cs
+++ b/src/Paramore.Brighter/RelationalDatabaseInbox.cs
@@ -1,0 +1,166 @@
+﻿using System;
+using System.Data;
+using System.Data.Common;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Paramore.Brighter.Observability;
+
+namespace Paramore.Brighter
+{
+    public abstract class RelationalDatabaseInbox(
+        string outboxTableName,
+        IRelationalDatabaseInboxQueries queries,
+        ILogger logger)
+        : IAmAnInboxSync, IAmAnInboxAsync
+    {
+        /// <inheritdoc/>
+        public bool ContinueOnCapturedContext { get; set; }
+
+        /// <inheritdoc/>
+        public IAmABrighterTracer? Tracer { private get; set; }
+
+        public void Add<T>(T command, string contextKey, RequestContext? requestContext, int timeoutInMilliseconds)
+            where T : class, IRequest
+        {
+            var parameters = CreateAddParameters(command, contextKey);
+            WriteToStore(
+                connection => CreateAddCommand(connection, parameters),
+                () =>
+                {
+                    logger.LogWarning("Inbox: A duplicate command with the ID {Id} was inserted into the Inbox, ignoring and continuing",
+                        command.Id);
+                });
+        }
+
+        public T Get<T>(string id, string contextKey, RequestContext? requestContext, int timeoutInMilliseconds)
+            where T : class, IRequest
+        {
+            var parameters = CreateGetParameters(id, contextKey);
+            return ReadFromStore(
+                connection => CreateGetCommand(connection, timeoutInMilliseconds, parameters), 
+                MapFunction<T>);
+        }
+
+        public bool Exists<T>(string id, string contextKey, RequestContext? requestContext, int timeoutInMilliseconds)
+            where T : class, IRequest
+        {
+            var parameters = CreateExistsParameters(id, contextKey);
+            return ReadFromStore(
+                connection => CreateExistsCommand(connection, timeoutInMilliseconds, parameters),
+                MapBoolFunction);
+        }
+
+        public async Task AddAsync<T>(T command, string contextKey, RequestContext? requestContext, int timeoutInMilliseconds, CancellationToken cancellationToken)
+            where T : class, IRequest
+        {
+            var parameters = CreateAddParameters(command, contextKey);
+            await WriteToStoreAsync(
+                connection => CreateAddCommand(connection, parameters),
+                () =>
+                {
+                    logger.LogWarning("Inbox: A duplicate command with the ID {Id} was inserted into the Inbox, ignoring and continuing",
+                        command.Id);
+                },
+                cancellationToken);
+        }
+
+        public async Task<T> GetAsync<T>(string id, string contextKey, RequestContext? requestContext, int timeoutInMilliseconds, CancellationToken cancellationToken)
+            where T : class, IRequest
+        {
+            var parameters = CreateGetParameters(id, contextKey);
+            return await ReadFromStoreAsync(
+                connection => CreateGetCommand(connection, timeoutInMilliseconds, parameters),
+                MapFunctionAsync<T>,
+                cancellationToken);
+        }
+
+        public async Task<bool> ExistsAsync<T>(string id, string contextKey, RequestContext? requestContext, int timeoutInMilliseconds, CancellationToken cancellationToken)
+            where T : class, IRequest
+        {
+            var parameters = CreateExistsParameters(id, contextKey);
+            return await ReadFromStoreAsync(
+                connection => CreateExistsCommand(connection, timeoutInMilliseconds, parameters),
+                MapBoolFunctionAsync,
+                cancellationToken);
+        }
+
+        protected abstract void WriteToStore(
+            Func<DbConnection, DbCommand> commandFunc,
+            Action? loggingAction
+        );
+
+        protected abstract Task WriteToStoreAsync(
+            Func<DbConnection, DbCommand> commandFunc,
+            Action? loggingAction,
+            CancellationToken cancellationToken
+        );
+
+        protected abstract T ReadFromStore<T>(
+            Func<DbConnection, DbCommand> commandFunc,
+            Func<DbDataReader, T> resultFunc
+        );
+
+        protected abstract Task<T> ReadFromStoreAsync<T>(
+            Func<DbConnection, DbCommand> commandFunc,
+            Func<DbDataReader, CancellationToken, Task<T>> resultFunc,
+            CancellationToken cancellationToken
+        );
+
+        protected DbConnection GetOpenConnection(IAmARelationalDbConnectionProvider connectionProvider)
+        {
+            var connection = connectionProvider.GetConnection();
+
+            if (connection.State != ConnectionState.Open)
+                connection.Open();
+
+            return connection;
+        }
+
+        protected async Task<DbConnection> GetOpenConnectionAsync(
+            IAmARelationalDbConnectionProvider connectionProvider, CancellationToken cancellationToken)
+        {
+            var connection = await connectionProvider.GetConnectionAsync(cancellationToken);
+
+            if (connection.State != ConnectionState.Open)
+                await connection.OpenAsync(cancellationToken);
+
+            return connection;
+        }
+
+        protected void FinishWrite(DbConnection connection)
+        {
+            connection.Close();
+        }
+
+        private DbCommand CreateAddCommand(DbConnection connection, IDbDataParameter[] parameters)
+            => CreateCommand(connection, GenerateSqlText(queries.AddCommand), 0, parameters);
+
+        private DbCommand CreateExistsCommand(DbConnection connection, int inboxTimeout, IDbDataParameter[] parameters)
+            => CreateCommand(connection, GenerateSqlText(queries.ExistsCommand), inboxTimeout, parameters);
+
+        private DbCommand CreateGetCommand(DbConnection connection, int inboxTimeout, IDbDataParameter[] parameters)
+            => CreateCommand(connection, GenerateSqlText(queries.GetCommand), inboxTimeout, parameters);
+
+        private string GenerateSqlText(string sqlFormat, params string[] orderedParams)
+            => string.Format(sqlFormat, orderedParams.Prepend(outboxTableName).ToArray());
+
+        protected abstract DbCommand CreateCommand(DbConnection connection, string sqlText, int outBoxTimeout,
+            params IDbDataParameter[] parameters);
+
+        protected abstract IDbDataParameter[] CreateAddParameters<T>(T command, string contextKey) where T : class, IRequest;
+
+        protected abstract IDbDataParameter[] CreateExistsParameters(string commandId, string contextKey);
+
+        protected abstract IDbDataParameter[] CreateGetParameters(string commandId, string contextKey);
+
+        protected abstract T MapFunction<T>(DbDataReader dr) where T : class, IRequest;
+
+        protected abstract Task<T> MapFunctionAsync<T>(DbDataReader dr, CancellationToken cancellationToken) where T : class, IRequest;
+
+        protected abstract bool MapBoolFunction(DbDataReader dr);
+
+        protected abstract Task<bool> MapBoolFunctionAsync(DbDataReader dr, CancellationToken cancellationToken);
+    }
+}

--- a/tests/Paramore.Brighter.MSSQL.Tests/Inbox/When_the_message_Is_already_in_the_Inbox_async.cs
+++ b/tests/Paramore.Brighter.MSSQL.Tests/Inbox/When_the_message_Is_already_in_the_Inbox_async.cs
@@ -52,22 +52,22 @@ namespace Paramore.Brighter.MSSQL.Tests.Inbox
         [Fact]
         public async Task When_The_Message_Is_Already_In_The_Inbox_Async()
         {
-            await _sqlInbox.AddAsync(_raisedCommand, _contextKey, null);
+            await _sqlInbox.AddAsync(_raisedCommand, _contextKey, null, -1, default);
 
-            _exception = await Catch.ExceptionAsync(() => _sqlInbox.AddAsync(_raisedCommand, _contextKey, null));
+            _exception = await Catch.ExceptionAsync(() => _sqlInbox.AddAsync(_raisedCommand, _contextKey, null, -1, default));
 
            //_should_succeed_even_if_the_message_is_a_duplicate
             Assert.Null(_exception);
-            var exists = await _sqlInbox.ExistsAsync<MyCommand>(_raisedCommand.Id, _contextKey, null);
+            var exists = await _sqlInbox.ExistsAsync<MyCommand>(_raisedCommand.Id, _contextKey, null, -1, default);
             Assert.True(exists);
         }
 
         [Fact]
         public async Task When_The_Message_Is_Already_In_The_Inbox_Different_Context()
         {
-            await _sqlInbox.AddAsync(_raisedCommand, "some other key", null);
+            await _sqlInbox.AddAsync(_raisedCommand, "some other key", null, -1, default);
 
-            var storedCommand = _sqlInbox.Get<MyCommand>(_raisedCommand.Id, "some other key", null);
+            var storedCommand = _sqlInbox.Get<MyCommand>(_raisedCommand.Id, "some other key", null, -1);
 
             //should read the command from the dynamo db inbox
             Assert.NotNull(storedCommand);

--- a/tests/Paramore.Brighter.MSSQL.Tests/Inbox/When_the_message_is_already_in_the_inbox.cs
+++ b/tests/Paramore.Brighter.MSSQL.Tests/Inbox/When_the_message_is_already_in_the_inbox.cs
@@ -46,25 +46,25 @@ namespace Paramore.Brighter.MSSQL.Tests.Inbox
             _sqlInbox = new MsSqlInbox(_msSqlTestHelper.InboxConfiguration);
             _raisedCommand = new MyCommand { Value = "Test" };
             _contextKey = "context-key";
-            _sqlInbox.Add(_raisedCommand, _contextKey, null);
+            _sqlInbox.Add(_raisedCommand, _contextKey, null, -1);
         }
 
         [Fact]
         public void When_The_Message_Is_Already_In_The_Inbox()
         {
-            _exception = Catch.Exception(() => _sqlInbox.Add(_raisedCommand, _contextKey, null));
+            _exception = Catch.Exception(() => _sqlInbox.Add(_raisedCommand, _contextKey, null, -1));
 
             //_should_succeed_even_if_the_message_is_a_duplicate
             Assert.Null(_exception);
-            Assert.True(_sqlInbox.Exists<MyCommand>(_raisedCommand.Id, _contextKey, null));
+            Assert.True(_sqlInbox.Exists<MyCommand>(_raisedCommand.Id, _contextKey, null, -1));
         }
 
         [Fact]
         public void When_The_Message_Is_Already_In_The_Inbox_Different_Context()
         {
-            _sqlInbox.Add(_raisedCommand, "some other key", null);
+            _sqlInbox.Add(_raisedCommand, "some other key", null, -1);
 
-            var storedCommand = _sqlInbox.Get<MyCommand>(_raisedCommand.Id, "some other key", null);
+            var storedCommand = _sqlInbox.Get<MyCommand>(_raisedCommand.Id, "some other key", null, -1);
 
             //should read the command from the dynamo db inbox
             Assert.NotNull(storedCommand);

--- a/tests/Paramore.Brighter.MSSQL.Tests/Inbox/When_there_Is_no_message_in_the_sql_inbox_async.cs
+++ b/tests/Paramore.Brighter.MSSQL.Tests/Inbox/When_there_Is_no_message_in_the_sql_inbox_async.cs
@@ -49,7 +49,7 @@ namespace Paramore.Brighter.MSSQL.Tests.Inbox
         public async Task When_There_Is_No_Message_In_The_Sql_Inbox_And_I_Get_Async()
         {
             string commandId = Guid.NewGuid().ToString();
-            var exception = await Catch.ExceptionAsync(() => _sqlInbox.GetAsync<MyCommand>(commandId, "some-key", null));
+            var exception = await Catch.ExceptionAsync(() => _sqlInbox.GetAsync<MyCommand>(commandId, "some-key", null, -1, default));
             Assert.IsType<RequestNotFoundException<MyCommand>>(exception);
         }
 
@@ -57,7 +57,7 @@ namespace Paramore.Brighter.MSSQL.Tests.Inbox
         public async Task When_There_Is_No_Message_In_The_Sql_Inbox_And_I_Check_Exists_Async()
         {
             string commandId = Guid.NewGuid().ToString();
-            bool exists = await _sqlInbox.ExistsAsync<MyCommand>(commandId, "some-key", null);
+            bool exists = await _sqlInbox.ExistsAsync<MyCommand>(commandId, "some-key", null, -1, default);
             Assert.False(exists);
         }
 

--- a/tests/Paramore.Brighter.MSSQL.Tests/Inbox/When_there_is_no_message_in_the_sql_inbox.cs
+++ b/tests/Paramore.Brighter.MSSQL.Tests/Inbox/When_there_is_no_message_in_the_sql_inbox.cs
@@ -50,7 +50,7 @@ namespace Paramore.Brighter.MSSQL.Tests.Inbox
         public void When_There_Is_No_Message_In_The_Sql_Inbox_And_Call_Get()
         {
             string commandId = Guid.NewGuid().ToString();
-            var exception = Catch.Exception(() => _sqlInbox.Get<MyCommand>(commandId, _contextKey, null));
+            var exception = Catch.Exception(() => _sqlInbox.Get<MyCommand>(commandId, _contextKey, null, -1));
 
             Assert.IsType<RequestNotFoundException<MyCommand>>(exception);
         }
@@ -59,7 +59,7 @@ namespace Paramore.Brighter.MSSQL.Tests.Inbox
         public void When_There_Is_No_Message_In_The_Sql_Inbox_And_Call_Exists()
         {
             string commandId = Guid.NewGuid().ToString();
-            Assert.False(_sqlInbox.Exists<MyCommand>(commandId, _contextKey, null));
+            Assert.False(_sqlInbox.Exists<MyCommand>(commandId, _contextKey, null, -1));
         }
 
         public void Dispose()

--- a/tests/Paramore.Brighter.MSSQL.Tests/Inbox/When_writing_a_message_to_the_inbox.cs
+++ b/tests/Paramore.Brighter.MSSQL.Tests/Inbox/When_writing_a_message_to_the_inbox.cs
@@ -47,13 +47,13 @@ namespace Paramore.Brighter.MSSQL.Tests.Inbox
             _sqlInbox = new MsSqlInbox(_msSqlTestHelper.InboxConfiguration);
             _raisedCommand = new MyCommand { Value = "Test" };
             _contextKey = "context-key";
-            _sqlInbox.Add(_raisedCommand, _contextKey, null);
+            _sqlInbox.Add(_raisedCommand, _contextKey, null, -1);
         }
 
         [Fact]
         public void When_Writing_A_Message_To_The_Inbox()
         {
-            _storedCommand = _sqlInbox.Get<MyCommand>(_raisedCommand.Id, _contextKey, null);
+            _storedCommand = _sqlInbox.Get<MyCommand>(_raisedCommand.Id, _contextKey, null, -1);
 
             Assert.NotNull(_storedCommand);
             Assert.Equal(_raisedCommand.Value, _storedCommand.Value);
@@ -63,7 +63,7 @@ namespace Paramore.Brighter.MSSQL.Tests.Inbox
         [Fact]
         public void When_Reading_A_Message_From_The_Inbox_And_ContextKey_IsNull()
         {
-            var exception = Catch.Exception(() => _storedCommand = _sqlInbox.Get<MyCommand>(_raisedCommand.Id, null, null));
+            var exception = Catch.Exception(() => _storedCommand = _sqlInbox.Get<MyCommand>(_raisedCommand.Id, null, null, -1));
             //should_not_read_message
             Assert.IsType<RequestNotFoundException<MyCommand>>(exception);
         }

--- a/tests/Paramore.Brighter.MSSQL.Tests/Inbox/When_writing_a_message_to_the_inbox_async.cs
+++ b/tests/Paramore.Brighter.MSSQL.Tests/Inbox/When_writing_a_message_to_the_inbox_async.cs
@@ -52,9 +52,9 @@ namespace Paramore.Brighter.MSSQL.Tests.Inbox
         [Fact]
         public async Task When_Writing_A_Message_To_The_Inbox_Async()
         {
-            await _sqlInbox.AddAsync(_raisedCommand, _contextKey, null);
+            await _sqlInbox.AddAsync(_raisedCommand, _contextKey, null, -1, default);
 
-            _storedCommand = await _sqlInbox.GetAsync<MyCommand>(_raisedCommand.Id, _contextKey, null);
+            _storedCommand = await _sqlInbox.GetAsync<MyCommand>(_raisedCommand.Id, _contextKey, null, -1, default);
 
             Assert.NotNull(_storedCommand);
             Assert.Equal(_raisedCommand.Value, _storedCommand.Value);

--- a/tests/Paramore.Brighter.MySQL.Tests/Inbox/When_the_message_is_already_in_the_inbox.cs
+++ b/tests/Paramore.Brighter.MySQL.Tests/Inbox/When_the_message_is_already_in_the_inbox.cs
@@ -23,25 +23,25 @@ namespace Paramore.Brighter.MySQL.Tests.Inbox
             _mysqlInbox = new MySqlInbox(_mysqlTestHelper.InboxConfiguration);
             _raisedCommand = new MyCommand { Value = "Test" };
             _contextKey = "test-context";
-            _mysqlInbox.Add(_raisedCommand, _contextKey, null);
+            _mysqlInbox.Add(_raisedCommand, _contextKey, null, -1);
         }
 
         [Fact]
         public void When_The_Message_Is_Already_In_The_Inbox()
         {
-            _exception = Catch.Exception(() => _mysqlInbox.Add(_raisedCommand, _contextKey, null));
+            _exception = Catch.Exception(() => _mysqlInbox.Add(_raisedCommand, _contextKey, null, -1));
 
             //_should_succeed_even_if_the_message_is_a_duplicate
             Assert.Null(_exception);
-            Assert.True(_mysqlInbox.Exists<MyCommand>(_raisedCommand.Id, _contextKey, null));
+            Assert.True(_mysqlInbox.Exists<MyCommand>(_raisedCommand.Id, _contextKey, null, -1));
         }
 
         [Fact]
         public void When_The_Message_Is_Already_In_The_Inbox_Different_Context()
         {
-            _mysqlInbox.Add(_raisedCommand, "some other key", null);
+            _mysqlInbox.Add(_raisedCommand, "some other key", null, -1);
 
-            _exception = Catch.Exception(() => _mysqlInbox.Get<MyCommand>(_raisedCommand.Id, "some other key", null));
+            _exception = Catch.Exception(() => _mysqlInbox.Get<MyCommand>(_raisedCommand.Id, "some other key", null, -1));
 
             Assert.IsType<RequestNotFoundException<MyCommand>>(_exception);
         }

--- a/tests/Paramore.Brighter.MySQL.Tests/Inbox/When_the_message_is_already_in_the_inbox_async.cs
+++ b/tests/Paramore.Brighter.MySQL.Tests/Inbox/When_the_message_is_already_in_the_inbox_async.cs
@@ -52,22 +52,22 @@ namespace Paramore.Brighter.MySQL.Tests.Inbox
         [Fact]
         public async Task When_The_Message_Is_Already_In_The_Inbox_Async()
         {
-            await _mysqlInbox.AddAsync(_raisedCommand, _contextKey, null);
+            await _mysqlInbox.AddAsync(_raisedCommand, _contextKey, null, -1, default);
 
-            _exception = await Catch.ExceptionAsync(() => _mysqlInbox.AddAsync(_raisedCommand, _contextKey, null));
+            _exception = await Catch.ExceptionAsync(() => _mysqlInbox.AddAsync(_raisedCommand, _contextKey, null, -1, default));
 
            //_should_succeed_even_if_the_message_is_a_duplicate
             Assert.Null(_exception);
-            var exists = await _mysqlInbox.ExistsAsync<MyCommand>(_raisedCommand.Id, _contextKey, null);
+            var exists = await _mysqlInbox.ExistsAsync<MyCommand>(_raisedCommand.Id, _contextKey, null, -1, default);
             Assert.True(exists);
         }
 
         [Fact]
         public async Task When_The_Message_Is_Already_In_The_Inbox_Different_Context()
         {
-            await _mysqlInbox.AddAsync(_raisedCommand, "some other key", null);
+            await _mysqlInbox.AddAsync(_raisedCommand, "some other key", null, -1, default);
 
-            var storedCommand = _mysqlInbox.Get<MyCommand>(_raisedCommand.Id, "some other key", null);
+            var storedCommand = _mysqlInbox.Get<MyCommand>(_raisedCommand.Id, "some other key", null, -1);
 
             //_should_read_the_command_from_the__dynamo_db_inbox
             Assert.NotNull(storedCommand);

--- a/tests/Paramore.Brighter.MySQL.Tests/Inbox/When_there_Is_no_message_in_the_sql_inbox_async.cs
+++ b/tests/Paramore.Brighter.MySQL.Tests/Inbox/When_there_Is_no_message_in_the_sql_inbox_async.cs
@@ -27,7 +27,7 @@ namespace Paramore.Brighter.MySQL.Tests.Inbox
         public async Task When_There_Is_No_Message_In_The_Sql_Inbox_Get_Async()
         {
             string commandId = Guid.NewGuid().ToString();
-            var exception = await Catch.ExceptionAsync(() => _mysqlInbox.GetAsync<MyCommand>(commandId, _contextKey, null));
+            var exception = await Catch.ExceptionAsync(() => _mysqlInbox.GetAsync<MyCommand>(commandId, _contextKey, null, -1, default));
             Assert.IsType<RequestNotFoundException<MyCommand>>(exception);
         }
 
@@ -35,7 +35,7 @@ namespace Paramore.Brighter.MySQL.Tests.Inbox
         public async Task When_There_Is_No_Message_In_The_Sql_Inbox_Exists_Async()
         {
             string commandId = Guid.NewGuid().ToString();
-            bool exists = await _mysqlInbox.ExistsAsync<MyCommand>(commandId, _contextKey, null);
+            bool exists = await _mysqlInbox.ExistsAsync<MyCommand>(commandId, _contextKey, null, -1, default);
             Assert.False(exists);
         }
 

--- a/tests/Paramore.Brighter.MySQL.Tests/Inbox/When_there_is_no_message_in_the_sql_inbox.cs
+++ b/tests/Paramore.Brighter.MySQL.Tests/Inbox/When_there_is_no_message_in_the_sql_inbox.cs
@@ -26,7 +26,7 @@ namespace Paramore.Brighter.MySQL.Tests.Inbox
         public void When_There_Is_No_Message_In_The_Sql_Inbox_Get()
         {
             string commandId = Guid.NewGuid().ToString();
-            var exception = Catch.Exception(() => _mysqlInBox.Get<MyCommand>(commandId, _contextKey, null));
+            var exception = Catch.Exception(() => _mysqlInBox.Get<MyCommand>(commandId, _contextKey, null, -1));
             Assert.IsType<RequestNotFoundException<MyCommand>>(exception);
         }
 
@@ -34,7 +34,7 @@ namespace Paramore.Brighter.MySQL.Tests.Inbox
         public void When_There_Is_No_Message_In_The_Sql_Inbox_Exists()
         {
             string commandId = Guid.NewGuid().ToString();
-            Assert.False(_mysqlInBox.Exists<MyCommand>(commandId, _contextKey, null));
+            Assert.False(_mysqlInBox.Exists<MyCommand>(commandId, _contextKey, null, -1));
         }
 
         public void Dispose()

--- a/tests/Paramore.Brighter.MySQL.Tests/Inbox/When_writing_a_message_to_the_command_store.cs
+++ b/tests/Paramore.Brighter.MySQL.Tests/Inbox/When_writing_a_message_to_the_command_store.cs
@@ -46,13 +46,13 @@ namespace Paramore.Brighter.MySQL.Tests.Inbox
             _mysqlInbox = new MySqlInbox(_mysqlTestHelper.InboxConfiguration);
             _raisedCommand = new MyCommand { Value = "Test" };
             _contextKey = "test-context";
-            _mysqlInbox.Add(_raisedCommand, _contextKey, null);
+            _mysqlInbox.Add(_raisedCommand, _contextKey, null, -1);
         }
 
         [Fact]
         public void When_Writing_A_Message_To_The_Inbox()
         {
-            _storedCommand = _mysqlInbox.Get<MyCommand>(_raisedCommand.Id, _contextKey, null);
+            _storedCommand = _mysqlInbox.Get<MyCommand>(_raisedCommand.Id, _contextKey, null, -1);
 
             //_should_read_the_command_from_the__sql_inbox
             Assert.NotNull(_storedCommand);

--- a/tests/Paramore.Brighter.MySQL.Tests/Inbox/When_writing_a_message_to_the_inbox_async.cs
+++ b/tests/Paramore.Brighter.MySQL.Tests/Inbox/When_writing_a_message_to_the_inbox_async.cs
@@ -52,9 +52,9 @@ namespace Paramore.Brighter.MySQL.Tests.Inbox
         [Fact]
         public async Task When_Writing_A_Message_To_The_Inbox_Async()
         {
-            await _mysqlInbox.AddAsync(_raisedCommand, _contextKey, null);
+            await _mysqlInbox.AddAsync(_raisedCommand, _contextKey, null, -1, default);
 
-            _storedCommand = await _mysqlInbox.GetAsync<MyCommand>(_raisedCommand.Id, _contextKey, null);
+            _storedCommand = await _mysqlInbox.GetAsync<MyCommand>(_raisedCommand.Id, _contextKey, null, -1, default);
 
             //_should_read_the_command_from_the__sql_inbox
             Assert.NotNull(_storedCommand);

--- a/tests/Paramore.Brighter.PostgresSQL.Tests/Inbox/When_the_message_Is_already_in_the_Inbox_async.cs
+++ b/tests/Paramore.Brighter.PostgresSQL.Tests/Inbox/When_the_message_Is_already_in_the_Inbox_async.cs
@@ -54,22 +54,22 @@ namespace Paramore.Brighter.PostgresSQL.Tests.Inbox
         [Fact]
         public async Task When_The_Message_Is_Already_In_The_Inbox_Async()
         {
-            await _pgSqlInbox.AddAsync(_raisedCommand, _contextKey, null);
+            await _pgSqlInbox.AddAsync(_raisedCommand, _contextKey, null, -1, default);
 
-            _exception = await Catch.ExceptionAsync(() => _pgSqlInbox.AddAsync(_raisedCommand, _contextKey, null));
+            _exception = await Catch.ExceptionAsync(() => _pgSqlInbox.AddAsync(_raisedCommand, _contextKey, null, -1, default));
 
            //_should_succeed_even_if_the_message_is_a_duplicate
             Assert.Null(_exception);
-            var exists = await _pgSqlInbox.ExistsAsync<MyCommand>(_raisedCommand.Id, _contextKey, null);
+            var exists = await _pgSqlInbox.ExistsAsync<MyCommand>(_raisedCommand.Id, _contextKey, null, -1, default);
             Assert.True(exists);
         }
 
         [Fact]
         public async Task When_The_Message_Is_Already_In_The_Inbox_Different_Context()
         {
-            await _pgSqlInbox.AddAsync(_raisedCommand, "some other key", null);
+            await _pgSqlInbox.AddAsync(_raisedCommand, "some other key", null, -1, default);
 
-            var storedCommand = _pgSqlInbox.Get<MyCommand>(_raisedCommand.Id, "some other key", null);
+            var storedCommand = _pgSqlInbox.Get<MyCommand>(_raisedCommand.Id, "some other key", null, -1);
 
             //Should read the command from the dynamo db inbox
             Assert.NotNull(storedCommand);

--- a/tests/Paramore.Brighter.PostgresSQL.Tests/Inbox/When_the_message_is_already_in_the_inbox.cs
+++ b/tests/Paramore.Brighter.PostgresSQL.Tests/Inbox/When_the_message_is_already_in_the_inbox.cs
@@ -53,24 +53,24 @@ namespace Paramore.Brighter.PostgresSQL.Tests.Inbox
         [Fact]
         public void When_The_Message_Is_Already_In_The_Inbox()
         {
-            _pgSqlInbox.Add(_raisedCommand, _contextKey, null);
+            _pgSqlInbox.Add(_raisedCommand, _contextKey, null, -1);
             
-            _exception = Catch.Exception(() => _pgSqlInbox.Add(_raisedCommand, _contextKey, null));
+            _exception = Catch.Exception(() => _pgSqlInbox.Add(_raisedCommand, _contextKey, null, -1));
 
             //_should_succeed_even_if_the_message_is_a_duplicate
             Assert.Null(_exception);
-            Assert.True(_pgSqlInbox.Exists<MyCommand>(_raisedCommand.Id, _contextKey, null));
+            Assert.True(_pgSqlInbox.Exists<MyCommand>(_raisedCommand.Id, _contextKey, null, -1));
         }
 
         [Fact]
         public void When_The_Message_Is_Already_In_The_Inbox_Different_Context()
         {
-            _pgSqlInbox.Add(_raisedCommand, _contextKey, null);
+            _pgSqlInbox.Add(_raisedCommand, _contextKey, null, -1);
 
             var newcontext = Guid.NewGuid().ToString();
-            _pgSqlInbox.Add(_raisedCommand, newcontext, null);
+            _pgSqlInbox.Add(_raisedCommand, newcontext, null, -1);
 
-            var storedCommand = _pgSqlInbox.Get<MyCommand>(_raisedCommand.Id, newcontext, null);
+            var storedCommand = _pgSqlInbox.Get<MyCommand>(_raisedCommand.Id, newcontext, null, -1);
 
             //Should read the command from the dynamo db inbox
             Assert.NotNull(storedCommand);

--- a/tests/Paramore.Brighter.PostgresSQL.Tests/Inbox/When_there_Is_no_message_in_the_sql_inbox_async.cs
+++ b/tests/Paramore.Brighter.PostgresSQL.Tests/Inbox/When_there_Is_no_message_in_the_sql_inbox_async.cs
@@ -51,7 +51,7 @@ namespace Paramore.Brighter.PostgresSQL.Tests.Inbox
         public async Task When_There_Is_No_Message_In_The_Sql_Inbox_And_I_Get_Async()
         {
             string commandId = Guid.NewGuid().ToString();
-            var exception = await Catch.ExceptionAsync(() => _sqlSqlInbox.GetAsync<MyCommand>(commandId, "some-key", null));
+            var exception = await Catch.ExceptionAsync(() => _sqlSqlInbox.GetAsync<MyCommand>(commandId, "some-key", null, -1, default));
             Assert.IsType<RequestNotFoundException<MyCommand>>(exception);
             
         }
@@ -60,7 +60,7 @@ namespace Paramore.Brighter.PostgresSQL.Tests.Inbox
         public async Task When_There_Is_No_Message_In_The_Sql_Inbox_And_I_Check_Exists_Async()
         {
             string commandId = Guid.NewGuid().ToString();
-            bool exists = await _sqlSqlInbox.ExistsAsync<MyCommand>(commandId, "some-key", null);
+            bool exists = await _sqlSqlInbox.ExistsAsync<MyCommand>(commandId, "some-key", null, -1, default);
             Assert.False(exists);
         }
 

--- a/tests/Paramore.Brighter.PostgresSQL.Tests/Inbox/When_there_is_no_message_in_the_sql_inbox.cs
+++ b/tests/Paramore.Brighter.PostgresSQL.Tests/Inbox/When_there_is_no_message_in_the_sql_inbox.cs
@@ -53,7 +53,7 @@ namespace Paramore.Brighter.PostgresSQL.Tests.Inbox
         public void When_There_Is_No_Message_In_The_Sql_Inbox_And_Call_Get()
         {
             string commandId = Guid.NewGuid().ToString();
-            var exception = Catch.Exception(() => _storedCommand = _pgSqlInbox.Get<MyCommand>(commandId, _contextKey, null));
+            var exception = Catch.Exception(() => _storedCommand = _pgSqlInbox.Get<MyCommand>(commandId, _contextKey, null, -1));
 
             Assert.IsType<RequestNotFoundException<MyCommand>>(exception);
         }
@@ -62,7 +62,7 @@ namespace Paramore.Brighter.PostgresSQL.Tests.Inbox
         public void When_There_Is_No_Message_In_The_Sql_Inbox_And_Call_Exists()
         {
             string commandId = Guid.NewGuid().ToString();
-            Assert.False(_pgSqlInbox.Exists<MyCommand>(commandId, _contextKey, null));
+            Assert.False(_pgSqlInbox.Exists<MyCommand>(commandId, _contextKey, null, -1));
         }
 
         public void Dispose()

--- a/tests/Paramore.Brighter.PostgresSQL.Tests/Inbox/When_writing_a_message_to_the_inbox.cs
+++ b/tests/Paramore.Brighter.PostgresSQL.Tests/Inbox/When_writing_a_message_to_the_inbox.cs
@@ -49,13 +49,13 @@ namespace Paramore.Brighter.PostgresSQL.Tests.Inbox
             _pgSqlInbox = new PostgreSqlInbox(_pgTestHelper.InboxConfiguration);
             _raisedCommand = new MyCommand { Value = "Test" };
             _contextKey = "context-key";
-            _pgSqlInbox.Add(_raisedCommand, _contextKey, null);
+            _pgSqlInbox.Add(_raisedCommand, _contextKey, null, -1);
         }
 
         [Fact]
         public void When_Writing_A_Message_To_The_Inbox()
         {
-            _storedCommand = _pgSqlInbox.Get<MyCommand>(_raisedCommand.Id, _contextKey, null);
+            _storedCommand = _pgSqlInbox.Get<MyCommand>(_raisedCommand.Id, _contextKey, null, -1);
 
             //Should read the command from the sql inbox
             Assert.NotNull(_storedCommand);
@@ -68,7 +68,7 @@ namespace Paramore.Brighter.PostgresSQL.Tests.Inbox
         [Fact]
         public void When_Reading_A_Message_From_The_Inbox_And_ContextKey_IsNull()
         {
-            var exception = Catch.Exception(() => _storedCommand = _pgSqlInbox.Get<MyCommand>(_raisedCommand.Id, null, null));
+            var exception = Catch.Exception(() => _storedCommand = _pgSqlInbox.Get<MyCommand>(_raisedCommand.Id, null, null, -1));
             //should_not_read_message
             Assert.IsType<RequestNotFoundException<MyCommand>>(exception);
         }

--- a/tests/Paramore.Brighter.PostgresSQL.Tests/Inbox/When_writing_a_message_to_the_inbox_async.cs
+++ b/tests/Paramore.Brighter.PostgresSQL.Tests/Inbox/When_writing_a_message_to_the_inbox_async.cs
@@ -54,9 +54,9 @@ namespace Paramore.Brighter.PostgresSQL.Tests.Inbox
         [Fact]
         public async Task When_Writing_A_Message_To_The_Inbox_Async()
         {
-            await _pgSqlInbox.AddAsync(_raisedCommand, _contextKey, null);
+            await _pgSqlInbox.AddAsync(_raisedCommand, _contextKey, null, -1, default);
 
-            _storedCommand = await _pgSqlInbox.GetAsync<MyCommand>(_raisedCommand.Id, _contextKey, null);
+            _storedCommand = await _pgSqlInbox.GetAsync<MyCommand>(_raisedCommand.Id, _contextKey, null, -1, default);
 
             //Should read the command from the sql inbox
             Assert.NotNull(_storedCommand);

--- a/tests/Paramore.Brighter.Sqlite.Tests/Inbox/When_the_message_is_already_in_The_inbox_async.cs
+++ b/tests/Paramore.Brighter.Sqlite.Tests/Inbox/When_the_message_is_already_in_The_inbox_async.cs
@@ -28,13 +28,13 @@ namespace Paramore.Brighter.Sqlite.Tests.Inbox
         [Fact]
         public async Task When_The_Message_Is_Already_In_The_Inbox_Async()
         {
-            await _sqlInbox.AddAsync(_raisedCommand, _contextKey, null);
+            await _sqlInbox.AddAsync(_raisedCommand, _contextKey, null, -1, default);
 
-            _exception = await Catch.ExceptionAsync(() => _sqlInbox.AddAsync(_raisedCommand, _contextKey, null));
+            _exception = await Catch.ExceptionAsync(() => _sqlInbox.AddAsync(_raisedCommand, _contextKey, null, -1, default));
 
             //_should_succeed_even_if_the_message_is_a_duplicate
             Assert.Null(_exception);
-            var exists = await _sqlInbox.ExistsAsync<MyCommand>(_raisedCommand.Id, _contextKey, null);
+            var exists = await _sqlInbox.ExistsAsync<MyCommand>(_raisedCommand.Id, _contextKey, null, -1, default);
             Assert.True(exists);
         }
 

--- a/tests/Paramore.Brighter.Sqlite.Tests/Inbox/When_the_message_is_already_in_the_inbox.cs
+++ b/tests/Paramore.Brighter.Sqlite.Tests/Inbox/When_the_message_is_already_in_the_inbox.cs
@@ -22,17 +22,17 @@ namespace Paramore.Brighter.Sqlite.Tests.Inbox
             _sqlInbox = new SqliteInbox(_sqliteTestHelper.InboxConfiguration);
             _raisedCommand = new MyCommand { Value = "Test" };
             _contextKey = "context-key";
-            _sqlInbox.Add(_raisedCommand, _contextKey, null);
+            _sqlInbox.Add(_raisedCommand, _contextKey, null, -1);
         }
 
         [Fact]
         public void When_The_Message_Is_Already_In_The_Inbox()
         {
-            _exception = Catch.Exception(() => _sqlInbox.Add(_raisedCommand, _contextKey, null));
+            _exception = Catch.Exception(() => _sqlInbox.Add(_raisedCommand, _contextKey, null, -1));
 
             //_should_succeed_even_if_the_message_is_a_duplicate
             Assert.Null(_exception);
-            Assert.True(_sqlInbox.Exists<MyCommand>(_raisedCommand.Id, _contextKey, null));
+            Assert.True(_sqlInbox.Exists<MyCommand>(_raisedCommand.Id, _contextKey, null, -1));
         }
 
         public async ValueTask DisposeAsync()

--- a/tests/Paramore.Brighter.Sqlite.Tests/Inbox/When_there_is_no_message_in_the_sql_inbox.cs
+++ b/tests/Paramore.Brighter.Sqlite.Tests/Inbox/When_there_is_no_message_in_the_sql_inbox.cs
@@ -26,7 +26,7 @@ namespace Paramore.Brighter.Sqlite.Tests.Inbox
         public void When_There_Is_No_Message_In_The_Sql_Inbox_Get()
         {
             string commandId = Guid.NewGuid().ToString();
-            var exception = Catch.Exception(() => _sqlInbox.Get<MyCommand>(commandId, _contextKey, null));
+            var exception = Catch.Exception(() => _sqlInbox.Get<MyCommand>(commandId, _contextKey, null, -1));
             Assert.IsType<RequestNotFoundException<MyCommand>>(exception);
         }
 
@@ -34,7 +34,7 @@ namespace Paramore.Brighter.Sqlite.Tests.Inbox
         public void When_There_Is_No_Message_In_The_Sql_Inbox_Exists()
         {
             string commandId = Guid.NewGuid().ToString();
-            Assert.False(_sqlInbox.Exists<MyCommand>(commandId, _contextKey, null));
+            Assert.False(_sqlInbox.Exists<MyCommand>(commandId, _contextKey, null, -1));
         }
 
         public async ValueTask DisposeAsync()

--- a/tests/Paramore.Brighter.Sqlite.Tests/Inbox/When_there_is_no_message_in_the_sql_inbox_async.cs
+++ b/tests/Paramore.Brighter.Sqlite.Tests/Inbox/When_there_is_no_message_in_the_sql_inbox_async.cs
@@ -27,7 +27,7 @@ namespace Paramore.Brighter.Sqlite.Tests.Inbox
         public async Task When_There_Is_No_Message_In_The_Sql_Inbox_Get_Async()
         {
             string commandId = Guid.NewGuid().ToString();
-            var exception = await Catch.ExceptionAsync(() => _sqlInbox.GetAsync<MyCommand>(commandId, _contextKey, null));
+            var exception = await Catch.ExceptionAsync(() => _sqlInbox.GetAsync<MyCommand>(commandId, _contextKey, null, -1, default));
             Assert.IsType<RequestNotFoundException<MyCommand>>(exception);
         }
 
@@ -35,7 +35,7 @@ namespace Paramore.Brighter.Sqlite.Tests.Inbox
         public async Task When_There_Is_No_Message_In_The_Sql_Inbox_Exists_Async()
         {
             string commandId = Guid.NewGuid().ToString();
-            bool exists = await _sqlInbox.ExistsAsync<MyCommand>(commandId, _contextKey, null);
+            bool exists = await _sqlInbox.ExistsAsync<MyCommand>(commandId, _contextKey, null, -1, default);
             Assert.False(exists);
         }
 

--- a/tests/Paramore.Brighter.Sqlite.Tests/Inbox/When_writing_a_message_to_the_inbox.cs
+++ b/tests/Paramore.Brighter.Sqlite.Tests/Inbox/When_writing_a_message_to_the_inbox.cs
@@ -23,13 +23,13 @@ namespace Paramore.Brighter.Sqlite.Tests.Inbox
             _sqlInbox = new SqliteInbox(_sqliteTestHelper.InboxConfiguration);
             _raisedCommand = new MyCommand {Value = "Test"};
             _contextKey = "context-key";
-            _sqlInbox.Add(_raisedCommand, _contextKey, null);
+            _sqlInbox.Add(_raisedCommand, _contextKey, null, -1);
         }
 
         [Fact]
         public void When_Writing_A_Message_To_The_Inbox()
         {
-            _storedCommand = _sqlInbox.Get<MyCommand>(_raisedCommand.Id, _contextKey, null);
+            _storedCommand = _sqlInbox.Get<MyCommand>(_raisedCommand.Id, _contextKey, null, -1);
 
             //_should_read_the_command_from_the__sql_inbox
             Assert.NotNull(_storedCommand);

--- a/tests/Paramore.Brighter.Sqlite.Tests/Inbox/When_writing_a_message_to_the_inbox_async.cs
+++ b/tests/Paramore.Brighter.Sqlite.Tests/Inbox/When_writing_a_message_to_the_inbox_async.cs
@@ -52,9 +52,9 @@ namespace Paramore.Brighter.Sqlite.Tests.Inbox
         [Fact]
         public async Task When_Writing_A_Message_To_The_Inbox_Async()
         {
-            await _sqlInbox.AddAsync(_raisedCommand, _contextKey, null);
+            await _sqlInbox.AddAsync(_raisedCommand, _contextKey, null, -1, default);
 
-            _storedCommand = await _sqlInbox.GetAsync<MyCommand>(_raisedCommand.Id, _contextKey, null);
+            _storedCommand = await _sqlInbox.GetAsync<MyCommand>(_raisedCommand.Id, _contextKey, null, -1, default);
 
             //Should read the command from the sql inbox
             Assert.NotNull(_storedCommand);


### PR DESCRIPTION
For RDBMS implementations of the outbox, we use a base class to house common behaviour that's agnostic of vendor. This made adding OTel implementation to relational database outbox implementations easy for all implementations.

Inboxes, however, have a completely independent implementation per vendor, making the implementation of OTel and any other future maintenance more difficult than it needs to be.

This PR refactors the RDBMS Inbox implementations to use a base class with the common logic, using the same structure as we currently use for outbox implementations.