### PR TITLE
Ensure that we dont attempt to ACK if we successfully Reject

### DIFF
--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS/SqsMessageConsumer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS/SqsMessageConsumer.cs
@@ -167,10 +167,10 @@ namespace Paramore.Brighter.MessagingGateway.AWSSQS
         /// Rejects the specified message.
         /// </summary>
         /// <param name="message">The message.</param>
-        public void Reject(Message message)
+        public bool Reject(Message message)
         {
             if (!message.Header.Bag.ContainsKey("ReceiptHandle"))
-                return;
+                return false;
 
             var receiptHandle = message.Header.Bag["ReceiptHandle"].ToString();
 
@@ -193,12 +193,16 @@ namespace Paramore.Brighter.MessagingGateway.AWSSQS
                         client.DeleteMessageAsync(urlResponse.QueueUrl, receiptHandle).Wait();
                     }
                 }
+
+                return true;
             }
             catch (Exception exception)
             {
                 s_logger.LogError(exception, "SqsMessageConsumer: Error during rejecting the message {Id} with receipt handle {ReceiptHandle} on the queue {ChannelName}", message.Id, receiptHandle, _queueName);
                 throw;
             }
+
+            return false;
         }
 
         /// <summary>

--- a/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusConsumer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusConsumer.cs
@@ -236,7 +236,7 @@ namespace Paramore.Brighter.MessagingGateway.AzureServiceBus
         /// Rejects the specified message.
         /// </summary>
         /// <param name="message">The message.</param>
-        public void Reject(Message message)
+        public bool Reject(Message message)
         {
             //Only Reject if ReceiveMode is Peek
             if (_receiveMode.Equals(ServiceBusReceiveMode.PeekLock))
@@ -253,6 +253,7 @@ namespace Paramore.Brighter.MessagingGateway.AzureServiceBus
                     _serviceBusReceiver.DeadLetter(lockToken).Wait();
                     if(_subscriptionConfiguration.RequireSession)
                         _serviceBusReceiver.Close();
+                    return true;
                 }
                 catch (Exception ex)
                 {
@@ -264,6 +265,8 @@ namespace Paramore.Brighter.MessagingGateway.AzureServiceBus
             {
                 s_logger.LogWarning("Dead Lettering Message with Id {Id} is not possible due to receive Mode being set to {ReceiveMode}", message.Id, _receiveMode);
             }
+
+            return false;
         }
 
         /// <summary>

--- a/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaMessageConsumer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaMessageConsumer.cs
@@ -360,7 +360,7 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
         /// <returns>False as no requeue support on Kafka</returns>
         public bool Requeue(Message message, int delayMilliseconds)
         {
-            return false;
+            return true;
         }
         
         private void CheckHasPartitions()

--- a/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaMessageConsumer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaMessageConsumer.cs
@@ -346,9 +346,10 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
         /// Rejects the specified message. This is just a commit of the offset to move past the record without processing it
         /// </summary>
         /// <param name="message">The message.</param>
-        public void Reject(Message message)
+        public bool Reject(Message message)
         {
             Acknowledge(message);
+            return true;
         }
 
         /// <summary>

--- a/src/Paramore.Brighter.MessagingGateway.MsSql/MsSqlMessageConsumer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.MsSql/MsSqlMessageConsumer.cs
@@ -54,11 +54,12 @@ namespace Paramore.Brighter.MessagingGateway.MsSql
         /// Rejects the specified message.
         /// </summary>
         /// <param name="message">The message.</param>
-        public void Reject(Message message)
+        public bool Reject(Message message)
          {
              s_logger.LogInformation(
                  "MsSqlMessagingConsumer: rejecting message with topic {Topic} and id {Id}, NOT IMPLEMENTED",
                  message.Header.Topic, message.Id.ToString());
+             return false;
          }
 
         /// <summary>

--- a/src/Paramore.Brighter.MessagingGateway.RESTMS/RestMsMessageConsumer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RESTMS/RestMsMessageConsumer.cs
@@ -178,16 +178,15 @@ namespace Paramore.Brighter.MessagingGateway.RESTMS
         {
             return false;
         }
- 
+
 
         /// <summary>
         /// Rejects the specified message.
         /// </summary>
         /// <param name="message">The message.</param>
         /// <exception cref="System.NotImplementedException"></exception>
-        public void Reject(Message message)
-        {
-        }
+        public bool Reject(Message message)
+            => false;
 
 
         private void DeleteMessage(RestMSPipe pipe, Message message)

--- a/src/Paramore.Brighter.MessagingGateway.RMQ/RmqMessageConsumer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ/RmqMessageConsumer.cs
@@ -222,7 +222,7 @@ namespace Paramore.Brighter.MessagingGateway.RMQ
         /// Rejects the specified message.
         /// </summary>
         /// <param name="message">The message.</param>
-        public void Reject(Message message)
+        public bool Reject(Message message)
         {
             try
             {
@@ -230,12 +230,15 @@ namespace Paramore.Brighter.MessagingGateway.RMQ
                 s_logger.LogInformation("RmqMessageConsumer: NoAck message {Id} with delivery tag {DeliveryTag}", message.Id, message.DeliveryTag);
                 //if we have a DLQ, this will force over to the DLQ
                 Channel.BasicReject(message.DeliveryTag, false);
+                return true;
             }
             catch (Exception exception)
             {
                 s_logger.LogError(exception, "RmqMessageConsumer: Error try to NoAck message {Id}", message.Id);
                 throw;
             }
+
+            return false;
         }
 
         /// <summary>

--- a/src/Paramore.Brighter.MessagingGateway.Redis/RedisMessageConsumer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.Redis/RedisMessageConsumer.cs
@@ -152,9 +152,10 @@ namespace Paramore.Brighter.MessagingGateway.Redis
         /// This a 'do nothing operation' as we have already popped
         /// </summary>
         /// <param name="message"></param>
-        public void Reject(Message message)
+        public bool Reject(Message message)
         {
             _inflight.Remove(message.Id);
+            return true;
         }
 
         /// <summary>

--- a/src/Paramore.Brighter.ServiceActivator.Control.Api/Properties/launchSettings.json
+++ b/src/Paramore.Brighter.ServiceActivator.Control.Api/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "Paramore.Brighter.ServiceActivator.Control.Api": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:50477;http://localhost:50478"
+    }
+  }
+}

--- a/src/Paramore.Brighter.ServiceActivator/MessagePump.cs
+++ b/src/Paramore.Brighter.ServiceActivator/MessagePump.cs
@@ -288,12 +288,12 @@ namespace Paramore.Brighter.ServiceActivator
             _unacceptableMessageCount++;
         }
 
-        private void RejectMessage(Message message)
+        private bool RejectMessage(Message message)
         {
             s_logger.LogWarning("MessagePump: Rejecting message {Id} from {ChannelName} on thread # {ManagementThreadId}", message.Id, Channel.Name, Thread.CurrentThread.ManagedThreadId);
             IncrementUnacceptableMessageLimit();
 
-            Channel.Reject(message);
+            return Channel.Reject(message);
         }
 
         /// <summary>
@@ -321,8 +321,7 @@ namespace Paramore.Brighter.ServiceActivator
                         Channel.Name,
                         Thread.CurrentThread.ManagedThreadId);
 
-                    RejectMessage(message);
-                    return false;
+                    return RejectMessage(message);
                 }
             }
 

--- a/src/Paramore.Brighter.ServiceActivator/TestHelpers/FakeChannel.cs
+++ b/src/Paramore.Brighter.ServiceActivator/TestHelpers/FakeChannel.cs
@@ -70,9 +70,10 @@ namespace Paramore.Brighter.ServiceActivator.TestHelpers
             return _messageQueue.TryDequeue(out Message message) ? message : new Message();
         }
 
-        public virtual void Reject(Message message)
+        public virtual bool Reject(Message message)
         {
             RejectCount++;
+            return true;
         }
 
         public virtual bool Requeue(Message message, int delayMilliseconds = 0)

--- a/src/Paramore.Brighter/Channel.cs
+++ b/src/Paramore.Brighter/Channel.cs
@@ -131,10 +131,8 @@ namespace Paramore.Brighter
         ///  Rejects the specified message.
         /// </summary>
         /// <param name="message">The message.</param>
-        public void Reject(Message message)
-        {
-            _messageConsumer.Reject(message);
-        }
+        public bool Reject(Message message)
+         => _messageConsumer.Reject(message);
 
         /// <summary>
         /// Requeues the specified message.

--- a/src/Paramore.Brighter/IAmAChannel.cs
+++ b/src/Paramore.Brighter/IAmAChannel.cs
@@ -61,7 +61,7 @@ namespace Paramore.Brighter
         /// Rejects the specified message.
         /// </summary>
         /// <param name="message">The message.</param>
-        void Reject(Message message);
+        bool Reject(Message message);
         
         /// <summary>
         /// Stops this instance.

--- a/src/Paramore.Brighter/IAmAMessageConsumer.cs
+++ b/src/Paramore.Brighter/IAmAMessageConsumer.cs
@@ -41,7 +41,7 @@ namespace Paramore.Brighter
         /// Rejects the specified message.
         /// </summary>
         /// <param name="message">The message.</param>
-        void Reject(Message message);
+        bool Reject(Message message);
 
         /// <summary>
         /// Purges the specified queue name.


### PR DESCRIPTION
This PR gives the ability for the Consumers to signal if they have successfully Reject a message so that we do not attempt to ACK if the message is no longer on the Channel

Issue #3585