### PR TITLE
Utilize that SqlDataReaders currently return MemoryStream to avoid manual stream copy

### DIFF
--- a/src/Paramore.Brighter.MessagingGateway.Postgres/PostgresMessageConsumer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.Postgres/PostgresMessageConsumer.cs
@@ -375,7 +375,7 @@ public partial class PostgresMessageConsumer(
     {
         var id = reader.GetInt64(0);
 
-        using var content = reader.GetStream(3);
+        var content = reader.GetStream(3);
         var message = JsonSerializer.Deserialize<Message>(content, JsonSerialisationOptions.Options)!;
         
         message.Header.Bag["ReceiptHandle"] = id;
@@ -386,7 +386,7 @@ public partial class PostgresMessageConsumer(
     {
         var id = reader.GetInt64(0);
 
-        using var content = reader.GetStream(3);
+        var content = reader.GetStream(3);
         var message = await JsonSerializer.DeserializeAsync<Message>(content, JsonSerialisationOptions.Options, cancellationToken);
         
         message!.Header.Bag["ReceiptHandle"] = id;

--- a/src/Paramore.Brighter.MessagingGateway.Postgres/PostgresMessageConsumer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.Postgres/PostgresMessageConsumer.cs
@@ -375,7 +375,7 @@ public partial class PostgresMessageConsumer(
     {
         var id = reader.GetInt64(0);
 
-        var content = reader.GetStream(3);
+        using var content = reader.GetStream(3);
         var message = JsonSerializer.Deserialize<Message>(content, JsonSerialisationOptions.Options)!;
         
         message.Header.Bag["ReceiptHandle"] = id;
@@ -386,7 +386,7 @@ public partial class PostgresMessageConsumer(
     {
         var id = reader.GetInt64(0);
 
-        var content = reader.GetStream(3);
+        using var content = reader.GetStream(3);
         var message = await JsonSerializer.DeserializeAsync<Message>(content, JsonSerialisationOptions.Options, cancellationToken);
         
         message!.Header.Bag["ReceiptHandle"] = id;

--- a/src/Paramore.Brighter.Outbox.MsSql/MsSqlOutbox.cs
+++ b/src/Paramore.Brighter.Outbox.MsSql/MsSqlOutbox.cs
@@ -356,18 +356,19 @@ namespace Paramore.Brighter.Outbox.MsSql
             return partitionKey;
         }
 
-        private static byte[] GetBodyAsBytes(DbDataReader dr)
+        private static byte[] GetBodyAsBytes(SqlDataReader dr)
         {
             var ordinal = dr.GetOrdinal("Body");
             if (dr.IsDBNull(ordinal)) return null;
 
-            // No need to dispose a MemoryStream, I do not think they dare to ever change that
             var body = dr.GetStream(ordinal);
-            if (body is not MemoryStream memoryStream) // The current implementation returns a MemoryStream
-                // If the type of returned Stream is ever changed, please check if it requires disposal, also other places in the code base that uses GetStream
-                throw new NotImplementedException(nameof(DbDataReader.GetStream) + " no longer returns " + nameof(MemoryStream));
-            
-            return memoryStream.ToArray(); // Then we can just return its value, instead of copying manually
+            if (body is MemoryStream memoryStream) // No need to dispose a MemoryStream, I do not think they dare to ever change that
+                return memoryStream.ToArray(); // Then we can just return its value, instead of copying manually
+
+            MemoryStream ms = new();
+            body.CopyTo(ms);
+            body.Dispose();
+            return ms.ToArray();
         }
 
         private static string GetBodyAsText(DbDataReader dr)

--- a/src/Paramore.Brighter.Outbox.MsSql/MsSqlOutbox.cs
+++ b/src/Paramore.Brighter.Outbox.MsSql/MsSqlOutbox.cs
@@ -27,6 +27,7 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
+using System.IO;
 using Microsoft.Data.SqlClient;
 using System.Text.Json;
 using System.Threading;
@@ -360,7 +361,10 @@ namespace Paramore.Brighter.Outbox.MsSql
             var ordinal = dr.GetOrdinal("Body");
             if (dr.IsDBNull(ordinal)) return null;
 
-            var body = dr.GetStream(ordinal);
+            using var body = dr.GetStream(ordinal);
+            if (body is MemoryStream memoryStream) // the current implementation returns a MemoryStream
+                return memoryStream.ToArray(); // then we can just return its value
+
             long bodyLength = body.Length;
             var buffer = new byte[bodyLength];
             var bytesRemaining = bodyLength;

--- a/src/Paramore.Brighter.Outbox.MySql/MySqlOutbox.cs
+++ b/src/Paramore.Brighter.Outbox.MySql/MySqlOutbox.cs
@@ -426,16 +426,13 @@ namespace Paramore.Brighter.Outbox.MySql
 
         private static byte[] GetBodyAsBytes(MySqlDataReader dr)
         {
-            using var stream = dr.GetStream("Body");
-            if (stream is MemoryStream memoryStream) // the current implementation returns a MemoryStream
-                return memoryStream.ToArray(); // then we can just return its value
-
-            using var ms = new MemoryStream();
-            stream.CopyTo(ms);
-
-            ms.Flush();
-            var body = ms.ToArray();
-            return body;
+            // No need to dispose a MemoryStream, I do not think they dare to ever change that
+            var stream = dr.GetStream("Body");
+            if (stream is not MemoryStream memoryStream) // the current implementation returns a MemoryStream
+                // If the type of returned Stream is ever changed, please check if it requires disposal, also other places in the code base that uses GetStream
+                throw new NotImplementedException(nameof(DbDataReader.GetStream) + " no longer returns " + nameof(MemoryStream));
+            
+            return memoryStream.ToArray(); // Then we can just return its value, instead of copying manually
         }
 
         private static string GetBodyAsString(IDataReader dr)

--- a/src/Paramore.Brighter.Outbox.MySql/MySqlOutbox.cs
+++ b/src/Paramore.Brighter.Outbox.MySql/MySqlOutbox.cs
@@ -378,7 +378,7 @@ namespace Paramore.Brighter.Outbox.MySql
             return sqlException.Number == MySqlDuplicateKeyError;
         }
 
-        private Message MapAMessage(IDataReader dr)
+        private Message MapAMessage(DbDataReader dr)
         {
             var id = GetMessageId(dr);
             var messageType = GetMessageType(dr);
@@ -430,7 +430,7 @@ namespace Paramore.Brighter.Outbox.MySql
             var stream = dr.GetStream("Body");
             if (stream is not MemoryStream memoryStream) // the current implementation returns a MemoryStream
                 // If the type of returned Stream is ever changed, please check if it requires disposal, also other places in the code base that uses GetStream
-                throw new NotImplementedException(nameof(DbDataReader.GetStream) + " no longer returns " + nameof(MemoryStream));
+                throw new NotImplementedException(nameof(MySqlDataReader.GetStream) + " no longer returns " + nameof(MemoryStream));
             
             return memoryStream.ToArray(); // Then we can just return its value, instead of copying manually
         }

--- a/src/Paramore.Brighter.Outbox.Sqlite/SqliteOutbox.cs
+++ b/src/Paramore.Brighter.Outbox.Sqlite/SqliteOutbox.cs
@@ -28,6 +28,7 @@ using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
 using System.Globalization;
+using System.IO;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -445,7 +446,10 @@ namespace Paramore.Brighter.Outbox.Sqlite
         private static byte[] GetBodyAsBytes(DbDataReader dr)
         {
             var i = dr.GetOrdinal("Body");
-            var body = dr.GetStream(i);
+            using var body = dr.GetStream(i);
+            if (body is MemoryStream memoryStream) // the current implementation returns a MemoryStream
+                return memoryStream.ToArray(); // then we can just return its value
+
             var buffer = new byte[body.Length];
             
 #if NETSTANDARD

--- a/src/Paramore.Brighter.Outbox.Sqlite/SqliteOutbox.cs
+++ b/src/Paramore.Brighter.Outbox.Sqlite/SqliteOutbox.cs
@@ -443,17 +443,18 @@ namespace Paramore.Brighter.Outbox.Sqlite
         }
 
 
-        private static byte[] GetBodyAsBytes(DbDataReader dr)
+        private static byte[] GetBodyAsBytes(SqliteDataReader dr)
         {
             var i = dr.GetOrdinal("Body");
-            // No need to dispose a MemoryStream, I do not think they dare to ever change that
             var body = dr.GetStream(i);
             
-            if (body is not MemoryStream memoryStream) // The current implementation returns a MemoryStream
-                // If the type of returned Stream is ever changed, please check if it requires disposal, also other places in the code base that uses GetStream
-                throw new NotImplementedException(nameof(DbDataReader.GetStream) + " no longer returns " + nameof(MemoryStream));
-            
-            return memoryStream.ToArray(); // Then we can just return its value, instead of copying manually
+            if (body is MemoryStream memoryStream) // No need to dispose a MemoryStream, I do not think they dare to ever change that
+                return memoryStream.ToArray(); // Then we can just return its value, instead of copying manually
+
+            MemoryStream ms = new();
+            body.CopyTo(ms);
+            body.Dispose();
+            return ms.ToArray();
         }
 
         private static Dictionary<string, object> GetContextBag(IDataReader dr)


### PR DESCRIPTION
- Utilize that SqlDataReaders currently return MemoryStream to avoid manual stream copy.
The internal stream `ToArray` has black magic array allocation for large arrays & `Copy` method uses `ArrayPool` for buffers instead of allocation.

- Dispose streams in case they change implementation or type to require disposing.
MemoryStream does not currently leak anything and does not require disposing.

I considered to change the implementation to only consider MemoryStream and throw exceptions if it is not.
Something like `throw new NotImplementedExpection("GetStream no longer returns MemoryStream")`
Then the unit tests would fail, if the type of returned stream ever changes.
Then the code will be much simpler, as we do not need the fallback code.

Should I change the pull request to only consider MemoryStream and simplify the code?