### PR TITLE
Provide a callback to set ConsumerConfig

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -9,13 +9,13 @@ It isn't wise to build something that can be a part of someone's ecosystem witho
 - Submit a ticket for the issue, using the GitHub Issue Tracker
 - It's worth checking first to see if someone else has raised your issue. We might have responded to them, or someone might be fixing it.
 - If you want to add a feature, as opposed to fixing something that is broken, you should still raise an issue. 
-	- That helps us understand what you want to add, so we can give more specific advice and check it does not conflict with some work in progress on a branch etc. 
-	- If someone else is already working on the suggestion, then hopefully you can collaborate with them.
-	- Add a comment to an issue if you pick it up to work on, so everyone else knows.
+ 	- That helps us understand what you want to add, so we can give more specific advice and check it does not conflict with some work in progress on a branch etc. 
+  - If someone else is already working on the suggestion, then hopefully you can collaborate with them.
+   	- Add a comment to an issue if you pick it up to work on, so everyone else knows.
 - If you have a defect please include the following:
-	- Steps to reproduce the issue
-	- A failing test if possible (see below)
-	- The stacktrace for any errors you encountered
+ 	- Steps to reproduce the issue
+  - A failing test if possible (see below)
+ 	- The stacktrace for any errors you encountered
 
 
 ### Submitting Changes ###

--- a/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaMessageConsumerFactory.cs
+++ b/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaMessageConsumerFactory.cs
@@ -52,7 +52,7 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
             KafkaSubscription kafkaSubscription = subscription as KafkaSubscription;  
             if (kafkaSubscription == null)
                 throw new ConfigurationException("We expect an SQSConnection or SQSConnection<T> as a parameter");
-            
+
             return new KafkaMessageConsumer(
                 configuration: _configuration, 
                 routingKey:kafkaSubscription.RoutingKey, //topic
@@ -68,7 +68,8 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
                 partitionAssignmentStrategy: kafkaSubscription.PartitionAssignmentStrategy,
                 replicationFactor: kafkaSubscription.ReplicationFactor,
                 topicFindTimeoutMs: kafkaSubscription.TopicFindTimeoutMs,
-                makeChannels: kafkaSubscription.MakeChannels
+                makeChannels: kafkaSubscription.MakeChannels,
+                configHook: kafkaSubscription.ConfigHook
                 );
         }
     }

--- a/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaMessageProducer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaMessageProducer.cs
@@ -69,7 +69,7 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
             if (string.IsNullOrEmpty(publication.Topic))
                 throw new ConfigurationException("Topic is required for a publication");
 
-            _clientConfig = new ClientConfig
+            ClientConfig = new ClientConfig
             {
                 Acks = (Confluent.Kafka.Acks)((int)publication.Replication),
                 BootstrapServers = string.Join(",", configuration.BootStrapServers),
@@ -85,7 +85,7 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
 
             };
 
-            _producerConfig = new ProducerConfig(_clientConfig)
+            _producerConfig = new ProducerConfig(ClientConfig)
             {
                 BatchNumMessages = publication.BatchNumberMessages,
                 EnableIdempotence = publication.EnableIdempotence,

--- a/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaMessagingGateway.cs
+++ b/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaMessagingGateway.cs
@@ -17,7 +17,7 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
     public class KafkaMessagingGateway
     {
         protected static readonly ILogger s_logger = ApplicationLogging.CreateLogger<KafkaMessageProducer>();
-        protected ClientConfig _clientConfig;
+        protected ClientConfig ClientConfig;
         protected OnMissingChannel MakeChannels;
         protected RoutingKey Topic;
         protected int NumPartitions;
@@ -43,7 +43,7 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
 
         private async Task MakeTopic()
         {
-            using (var adminClient = new AdminClientBuilder(_clientConfig).Build())
+            using (var adminClient = new AdminClientBuilder(ClientConfig).Build())
             {
                 try
                 {
@@ -72,7 +72,7 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
 
         private bool FindTopic()
         {
-            using (var adminClient = new AdminClientBuilder(_clientConfig).Build())
+            using (var adminClient = new AdminClientBuilder(ClientConfig).Build())
             {
                 try
                 {

--- a/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/When_using_a_consumer_config_hook.cs
+++ b/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/When_using_a_consumer_config_hook.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using Paramore.Brighter.Kafka.Tests.TestDoubles;
+using Paramore.Brighter.MessagingGateway.Kafka;
+using Xunit;
+
+namespace Paramore.Brighter.Kafka.Tests.MessagingGateway;
+
+public class ConsumerConfigHookTests : IDisposable
+{
+    private bool _callbackCalled = false;
+    
+    [Fact]
+    public void When_using_a_consumer_config_hook()
+    {
+        //arrange
+        var subscription = new KafkaSubscription<MyCommand>(
+            channelName: new ChannelName("TestChannel"), 
+            routingKey: new RoutingKey("TestTopic_" + Guid.NewGuid()),
+            groupId: "TestGroup_" + Guid.NewGuid(),
+            numOfPartitions: 1,
+            replicationFactor: 1,
+            makeChannels: OnMissingChannel.Create,
+            configHook: config =>
+            {
+                config.EnableMetricsPush = false; // Disable metrics push for testing
+                _callbackCalled = true; // Set a flag to indicate the hook was called
+            }
+        );
+       
+        //act
+        var consumer = new KafkaMessageConsumerFactory(
+                new KafkaMessagingGatewayConfiguration
+                {
+                    Name = "Kafka Consumer Test",
+                    BootStrapServers = ["localhost:9092"]
+                })
+            .Create(subscription
+            );
+        
+        //assert
+        Assert.NotNull(consumer);
+        Assert.True(_callbackCalled, "The consumer config hook should have been called.");
+    }
+
+    public void Dispose()
+    {
+    }
+}


### PR DESCRIPTION
Because Kafka shifts most of the burden of distributing work to its clients, there are numerous options to configure how those clients operate. Our KafkaPublication wraps some of the most common, makes some choices about commits, and defaults others to simplify the process of using Kafka successfully.

But that means there is a range of "tweaks" that we would hide from you. 

We added a hook to KafkaPublication to allow you to set these "other" values before creating a KafkaProducer.

**Now**, we need to do the same for KafkaSubscription, as there are settings folks want to tweak, in a similar fashion.

This is V9 PR, we will raise another PR to roll into V10.