### PR TITLE
feat: allow configuration of Kafka ConsumerConfig through a KafkaSubscription.cs callback

### DIFF
--- a/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaMessageConsumer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaMessageConsumer.cs
@@ -87,6 +87,7 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
         /// <param name="replicationFactor">If we are creating missing infrastructure, how many in-sync replicas do we need. Defaults to 1</param>
         /// <param name="topicFindTimeout">If we are checking for the existence of the topic, what is the timeout. Defaults to 10000ms</param>
         /// <param name="makeChannels">Should we create infrastructure (topics) where it does not exist or check. Defaults to Create</param>
+        /// <param name="configHook">Allows you to modify the Kafka client configuration before a consumer is created.</param>
         /// <exception cref="ConfigurationException">Throws an exception if required parameters missing</exception>
         public KafkaMessageConsumer(
             KafkaMessagingGatewayConfiguration configuration,
@@ -103,7 +104,8 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
             PartitionAssignmentStrategy partitionAssignmentStrategy = PartitionAssignmentStrategy.CooperativeSticky,
             short replicationFactor = 1,
             TimeSpan? topicFindTimeout = null,
-            OnMissingChannel makeChannels = OnMissingChannel.Create
+            OnMissingChannel makeChannels = OnMissingChannel.Create,
+            Action<ConsumerConfig>? configHook = null
             )
         {
             if (configuration is null)
@@ -162,6 +164,9 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
                 // https://www.confluent.io/blog/cooperative-rebalancing-in-kafka-streams-consumer-ksqldb/
                 PartitionAssignmentStrategy = partitionAssignmentStrategy,
             };
+            
+            if (configHook != null)
+                configHook(_consumerConfig);
 
             _maxBatchSize = commitBatchSize;
             _sweepUncommittedInterval = sweepUncommittedOffsetsInterval.Value;

--- a/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaMessageConsumerFactory.cs
+++ b/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaMessageConsumerFactory.cs
@@ -69,7 +69,8 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
                 partitionAssignmentStrategy: kafkaSubscription.PartitionAssignmentStrategy,
                 replicationFactor: kafkaSubscription.ReplicationFactor,
                 topicFindTimeout: kafkaSubscription.TopicFindTimeout,
-                makeChannels: kafkaSubscription.MakeChannels
+                makeChannels: kafkaSubscription.MakeChannels,
+                configHook: kafkaSubscription.ConfigHook
                 );
         }
 

--- a/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/Reactor/When_using_a_consumer_config_hook.cs
+++ b/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/Reactor/When_using_a_consumer_config_hook.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using Paramore.Brighter.Kafka.Tests.TestDoubles;
+using Paramore.Brighter.MessagingGateway.Kafka;
+using Xunit;
+
+namespace Paramore.Brighter.Kafka.Tests.MessagingGateway.Reactor;
+
+public class ConsumerConfigHookTests 
+{
+    private bool _callbackCalled = false;
+    
+    [Fact]
+    public void When_using_a_consumer_config_hook()
+    {
+        //arrange
+        var subscription = new KafkaSubscription<MyCommand>(
+            channelName: new ChannelName("TestChannel"), 
+            routingKey: new RoutingKey("TestTopic_" + Guid.NewGuid()),
+            groupId: "TestGroup_" + Guid.NewGuid(),
+            numOfPartitions: 1,
+            replicationFactor: 1,
+            makeChannels: OnMissingChannel.Create,
+            configHook: config =>
+            {
+                config.EnableMetricsPush = false; // Disable metrics push for testing
+                _callbackCalled = true; // Set a flag to indicate the hook was called
+            }
+        );
+       
+        //act
+        var consumer = new KafkaMessageConsumerFactory(
+                new KafkaMessagingGatewayConfiguration
+                {
+                    Name = "Kafka Consumer Test",
+                    BootStrapServers = ["localhost:9092"]
+                })
+            .Create(subscription
+            );
+        
+        //assert
+        Assert.NotNull(consumer);
+        Assert.True(_callbackCalled, "The consumer config hook should have been called.");
+    }
+}


### PR DESCRIPTION
Copies the feature from V9