### PR TITLE
Change names of Brighter builder methods

### DIFF
--- a/samples/CommandProcessor/HelloWorldInternalBus/Program.cs
+++ b/samples/CommandProcessor/HelloWorldInternalBus/Program.cs
@@ -25,7 +25,7 @@ var subscriptions = new[]
 var host = Host.CreateDefaultBuilder()
     .ConfigureServices((context, services) =>
     {
-        services.AddServiceActivator(options =>
+        services.AddConsumers(options =>
         {
             options.Subscriptions = subscriptions;
             options.DefaultChannelFactory = new InMemoryChannelFactory(bus, TimeProvider.System);
@@ -35,7 +35,7 @@ var host = Host.CreateDefaultBuilder()
             options.CommandProcessorLifetime = ServiceLifetime.Scoped;
             options.InboxConfiguration = new InboxConfiguration(new InMemoryInbox(TimeProvider.System));
         })
-        .UseExternalBus((config) =>
+        .AddProducers((config) =>
         {
             config.ProducerRegistry = new InMemoryProducerRegistryFactory(bus, publications, InstrumentationOptions.All).Create(); 
             config.Outbox = new InMemoryOutbox(TimeProvider.System);

--- a/samples/Scheduler/AwsTaskQueue/GreetingsPumper/Program.cs
+++ b/samples/Scheduler/AwsTaskQueue/GreetingsPumper/Program.cs
@@ -71,7 +71,7 @@ static class Program
                         ).Create();
 
                         services.AddBrighter()
-                            .UseExternalBus(configure =>
+                            .AddProducers(configure =>
                             {
                                 configure.ProducerRegistry = producerRegistry;
                             })

--- a/samples/Scheduler/AwsTaskQueue/GreetingsReceiverConsole/Program.cs
+++ b/samples/Scheduler/AwsTaskQueue/GreetingsReceiverConsole/Program.cs
@@ -108,12 +108,12 @@ public class Program
                             }
                         });
 
-                    services.AddServiceActivator(options =>
+                    services.AddConsumers(options =>
                         {
                             options.Subscriptions = subscriptions;
                             options.DefaultChannelFactory = new ChannelFactory(awsConnection);
                         })
-                        .UseExternalBus(configure =>
+                        .AddProducers(configure =>
                         {
                             configure.ProducerRegistry = new SnsProducerRegistryFactory(
                                 awsConnection,

--- a/samples/Scheduler/QuartzTaskQueue/GreetingsPumper/Program.cs
+++ b/samples/Scheduler/QuartzTaskQueue/GreetingsPumper/Program.cs
@@ -74,7 +74,7 @@ static class Program
                         ).Create();
 
                         services.AddBrighter()
-                            .UseExternalBus((configure) =>
+                            .AddProducers((configure) =>
                             {
                                 configure.ProducerRegistry = producerRegistry;
                             })

--- a/samples/Scheduler/QuartzTaskQueue/GreetingsReceiverConsole/Program.cs
+++ b/samples/Scheduler/QuartzTaskQueue/GreetingsReceiverConsole/Program.cs
@@ -95,7 +95,7 @@ public class Program
                             }
                         });
 
-                    services.AddServiceActivator(options =>
+                    services.AddConsumers(options =>
                         {
                             options.Subscriptions = subscriptions;
                             options.DefaultChannelFactory = new ChannelFactory(awsConnection);

--- a/samples/TaskQueue/ASBTaskQueue/GreetingsReceiverConsole/Program.cs
+++ b/samples/TaskQueue/ASBTaskQueue/GreetingsReceiverConsole/Program.cs
@@ -52,7 +52,7 @@ namespace GreetingsReceiverConsole
                     var clientProvider = new ServiceBusConnectionStringClientProvider("Endpoint=sb://localhost;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;");
 
                     var asbConsumerFactory = new AzureServiceBusConsumerFactory(clientProvider);
-                    services.AddServiceActivator(options =>
+                    services.AddConsumers(options =>
                     {
                         options.Subscriptions = subscriptions;
                         options.DefaultChannelFactory = new AzureServiceBusChannelFactory(asbConsumerFactory);

--- a/samples/TaskQueue/ASBTaskQueue/GreetingsScopedReceiverConsole/Program.cs
+++ b/samples/TaskQueue/ASBTaskQueue/GreetingsScopedReceiverConsole/Program.cs
@@ -54,7 +54,7 @@ namespace GreetingsScopedReceiverConsole
                     var asbClientProvider = new ServiceBusConnectionStringClientProvider("Endpoint=sb://localhost;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;");
                     var asbConsumerFactory = new AzureServiceBusConsumerFactory(asbClientProvider);
                     services
-                        .AddServiceActivator(options =>
+                        .AddConsumers(options =>
                         {
                             options.Subscriptions = subscriptions;
                             options.DefaultChannelFactory = new AzureServiceBusChannelFactory(asbConsumerFactory);

--- a/samples/TaskQueue/ASBTaskQueue/GreetingsSender.Web/Program.cs
+++ b/samples/TaskQueue/ASBTaskQueue/GreetingsSender.Web/Program.cs
@@ -63,7 +63,7 @@ builder.Services
         r.Add(typeof(GreetingAsyncEvent), typeof(GreetingEventAsyncMessageMapper));
         r.Add(typeof(AddGreetingCommand), typeof(AddGreetingMessageMapper));
     })
-    .UseExternalBus((configure) =>
+    .AddProducers((configure) =>
     {
         configure.ProducerRegistry = producerRegistry;
         configure.Outbox = new MsSqlOutbox(outboxConfig);

--- a/samples/TaskQueue/ASBTaskQueue/GreetingsSender/Program.cs
+++ b/samples/TaskQueue/ASBTaskQueue/GreetingsSender/Program.cs
@@ -39,7 +39,7 @@ namespace GreetingsSender
             ).Create();
             
             serviceCollection.AddBrighter()
-                .UseExternalBus((config) =>
+                .AddProducers((config) =>
                 {
                     config.ProducerRegistry = producerRegistry;
                 })

--- a/samples/TaskQueue/ASBTaskQueue/GreetingsWorker/Program.cs
+++ b/samples/TaskQueue/ASBTaskQueue/GreetingsWorker/Program.cs
@@ -70,7 +70,7 @@ builder.Services.AddDbContext<GreetingsDataContext>(o =>
 var clientProvider = new ServiceBusConnectionStringClientProvider("Endpoint=sb://localhost;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;");
 
 var asbConsumerFactory = new AzureServiceBusConsumerFactory(clientProvider);
-builder.Services.AddServiceActivator(options =>
+builder.Services.AddConsumers(options =>
     {
         options.Subscriptions = subscriptions;
         options.DefaultChannelFactory = new AzureServiceBusChannelFactory(asbConsumerFactory);

--- a/samples/TaskQueue/AWSTaskQueue/GreetingsPumper/Program.cs
+++ b/samples/TaskQueue/AWSTaskQueue/GreetingsPumper/Program.cs
@@ -41,8 +41,7 @@ namespace GreetingsPumper
 
                             var producerRegistry = new SnsProducerRegistryFactory(
                                 awsConnection,
-                                new SnsPublication[]
-                                {
+                                [
                                     new SnsPublication
                                     {
                                         Topic = new RoutingKey(typeof(GreetingEvent).FullName
@@ -54,11 +53,11 @@ namespace GreetingsPumper
                                             typeof(FarewellEvent).FullName.ToValidSNSTopicName(true)),
                                         TopicAttributes = new SnsAttributes { Type = SqsType.Fifo }
                                     }
-                                }
+                                ]
                             ).Create();
 
                             services.AddBrighter()
-                                .UseExternalBus((configure) =>
+                                .AddProducers((configure) =>
                                 {
                                     configure.ProducerRegistry = producerRegistry;
                                 })

--- a/samples/TaskQueue/AWSTaskQueue/GreetingsReceiverConsole/Program.cs
+++ b/samples/TaskQueue/AWSTaskQueue/GreetingsReceiverConsole/Program.cs
@@ -90,7 +90,7 @@ namespace GreetingsReceiverConsole
                                 }
                             });
 
-                        services.AddServiceActivator(options =>
+                        services.AddConsumers(options =>
                             {
                                 options.Subscriptions = subscriptions;
                                 options.DefaultChannelFactory = new ChannelFactory(awsConnection);

--- a/samples/TaskQueue/AWSTaskQueue/GreetingsSender/Program.cs
+++ b/samples/TaskQueue/AWSTaskQueue/GreetingsSender/Program.cs
@@ -82,7 +82,7 @@ namespace GreetingsSender
 
                 serviceCollection
                     .AddBrighter()
-                    .UseExternalBus(configure =>
+                    .AddProducers(configure =>
                     {
                         configure.ProducerRegistry = producerRegistry;
                     })

--- a/samples/TaskQueue/KafkaSchemaRegistry/GreetingsReceiverConsole/Program.cs
+++ b/samples/TaskQueue/KafkaSchemaRegistry/GreetingsReceiverConsole/Program.cs
@@ -70,7 +70,7 @@ var host = Host.CreateDefaultBuilder(args)
         var cachedSchemaRegistryClient = new CachedSchemaRegistryClient(schemaRegistryConfig);
         services.AddSingleton<ISchemaRegistryClient>(cachedSchemaRegistryClient);
 
-        services.AddServiceActivator(options =>
+        services.AddConsumers(options =>
         {
             options.Subscriptions = subscriptions;
             options.DefaultChannelFactory = new ChannelFactory(

--- a/samples/TaskQueue/KafkaSchemaRegistry/GreetingsSender/Program.cs
+++ b/samples/TaskQueue/KafkaSchemaRegistry/GreetingsSender/Program.cs
@@ -80,7 +80,7 @@ var host = Host.CreateDefaultBuilder(args)
             {
                 options.PolicyRegistry = RegisterPolicies();
             })
-            .UseExternalBus((configure) =>
+            .AddProducers((configure) =>
             {
                 configure.ProducerRegistry = producerRegistry;
             })

--- a/samples/TaskQueue/KafkaTaskQueue/GreetingsReceiverConsole/Program.cs
+++ b/samples/TaskQueue/KafkaTaskQueue/GreetingsReceiverConsole/Program.cs
@@ -73,7 +73,7 @@ var host = Host.CreateDefaultBuilder(args)
             }
         );
 
-        services.AddServiceActivator(options =>
+        services.AddConsumers(options =>
         {
             options.Subscriptions = subscriptions;
             options.DefaultChannelFactory = new ChannelFactory(consumerFactory);

--- a/samples/TaskQueue/KafkaTaskQueue/GreetingsSender/Program.cs
+++ b/samples/TaskQueue/KafkaTaskQueue/GreetingsSender/Program.cs
@@ -98,7 +98,7 @@ var host = Host.CreateDefaultBuilder(args)
             {
                 options.PolicyRegistry = policyRegistry;
             })
-            .UseExternalBus((configure) =>
+            .AddProducers((configure) =>
             {
                 configure.ProducerRegistry = producerRegistry;
             })

--- a/samples/TaskQueue/MsSqlMessagingGateway/CompetingReceiverConsole/Program.cs
+++ b/samples/TaskQueue/MsSqlMessagingGateway/CompetingReceiverConsole/Program.cs
@@ -40,7 +40,7 @@ namespace CompetingReceiverConsole
                         queueStoreTable: "QueueData");
                     var messageConsumerFactory = new MsSqlMessageConsumerFactory(messagingConfiguration);
 
-                    services.AddServiceActivator(options =>
+                    services.AddConsumers(options =>
                     {
                         options.Subscriptions = subscriptions;
                         options.DefaultChannelFactory = new ChannelFactory(messageConsumerFactory);

--- a/samples/TaskQueue/MsSqlMessagingGateway/CompetingSender/Program.cs
+++ b/samples/TaskQueue/MsSqlMessagingGateway/CompetingSender/Program.cs
@@ -50,7 +50,7 @@ namespace CompetingSender
                         .Create();
                     
                     services.AddBrighter()
-                        .UseExternalBus((configure) =>
+                        .AddProducers((configure) =>
                         {
                             configure.ProducerRegistry = producerRegistry;
                         })

--- a/samples/TaskQueue/MsSqlMessagingGateway/GreetingsReceiverConsole/Program.cs
+++ b/samples/TaskQueue/MsSqlMessagingGateway/GreetingsReceiverConsole/Program.cs
@@ -66,7 +66,7 @@ namespace GreetingsReceiverConsole
                             databaseName: "BrighterSqlQueue", 
                             queueStoreTable: "QueueData");
                     var messageConsumerFactory = new MsSqlMessageConsumerFactory(messagingConfiguration);
-                    services.AddServiceActivator(options =>
+                    services.AddConsumers(options =>
                     {
                         options.Subscriptions = subscriptions;
                         options.DefaultChannelFactory = new ChannelFactory(messageConsumerFactory);

--- a/samples/TaskQueue/MsSqlMessagingGateway/GreetingsSender/Program.cs
+++ b/samples/TaskQueue/MsSqlMessagingGateway/GreetingsSender/Program.cs
@@ -34,7 +34,7 @@ namespace GreetingsSender
                 .Create();
             
             serviceCollection.AddBrighter()
-                .UseExternalBus((configure) =>
+                .AddProducers((configure) =>
                 {
                     configure.ProducerRegistry = producerRegistry;
                 })

--- a/samples/TaskQueue/MultiBus/GreetingsReceiverConsole/Program.cs
+++ b/samples/TaskQueue/MultiBus/GreetingsReceiverConsole/Program.cs
@@ -91,7 +91,7 @@ var host = Host.CreateDefaultBuilder(args)
         
         var rmqMessageConsumerFactory = new RmqMessageConsumerFactory(rmqConnection);
 
-        services.AddServiceActivator(options =>
+        services.AddConsumers(options =>
         {
             options.Subscriptions = subscriptions;
             options.DefaultChannelFactory = new CombinedChannelFactory([

--- a/samples/TaskQueue/MultiBus/GreetingsSender/Program.cs
+++ b/samples/TaskQueue/MultiBus/GreetingsSender/Program.cs
@@ -117,7 +117,7 @@ var host = Host.CreateDefaultBuilder(args)
             {
                 options.PolicyRegistry = policyRegistry;
             })
-            .UseExternalBus((configure) =>
+            .AddProducers((configure) =>
             {
                 configure.ProducerRegistry = new CombinedProducerRegistryFactory(rmqMessageProducerFactory, kafkaMessageProducerFactory).Create();
             })

--- a/samples/TaskQueue/PostgresTaskQueue/GreetingsReceiverConsole/Program.cs
+++ b/samples/TaskQueue/PostgresTaskQueue/GreetingsReceiverConsole/Program.cs
@@ -69,7 +69,7 @@ public class Program
 
                 var connection = new PostgresMessagingGatewayConnection(new RelationalDatabaseConfiguration("Host=localhost;Username=postgres;Password=password;Database=brightertests;"));
 
-                services.AddServiceActivator(options =>
+                services.AddConsumers(options =>
                     {
                         options.Subscriptions = subscriptions;
                         options.DefaultChannelFactory = new PostgresChannelFactory(connection);

--- a/samples/TaskQueue/PostgresTaskQueue/GreetingsSender/Program.cs
+++ b/samples/TaskQueue/PostgresTaskQueue/GreetingsSender/Program.cs
@@ -68,7 +68,7 @@ public static class Program
             
         serviceCollection
             .AddBrighter()
-            .UseExternalBus((configure) =>
+            .AddProducers((configure) =>
             {
                 configure.ProducerRegistry = producerRegistry;
                 configure.MaxOutStandingMessages = 5;

--- a/samples/TaskQueue/RMQRequestReply/GreetingsClient/Program.cs
+++ b/samples/TaskQueue/RMQRequestReply/GreetingsClient/Program.cs
@@ -72,7 +72,7 @@ namespace GreetingsSender
             
             serviceCollection
                 .AddBrighter()
-                .UseExternalBus((configure) =>
+                .AddProducers((configure) =>
                 {
                     configure.ProducerRegistry = producerRegistry;
                     configure.UseRpc = true;

--- a/samples/TaskQueue/RMQRequestReply/GreetingsServer/Program.cs
+++ b/samples/TaskQueue/RMQRequestReply/GreetingsServer/Program.cs
@@ -83,12 +83,12 @@ namespace GreetingsServer
                             }
                         }).Create();
                     
-                    services.AddServiceActivator(options =>
+                    services.AddConsumers(options =>
                     {
                         options.Subscriptions = subscriptions;
                         options.DefaultChannelFactory = amAChannelFactory;
                     })
-                        .UseExternalBus((configure) =>
+                        .AddProducers((configure) =>
                         {
                             configure.ProducerRegistry = producerRegistry;
                         })    

--- a/samples/TaskQueue/RMQTaskQueue/GreetingsReceiverConsole/Program.cs
+++ b/samples/TaskQueue/RMQTaskQueue/GreetingsReceiverConsole/Program.cs
@@ -79,7 +79,7 @@ namespace GreetingsReceiverConsole
 
                     var rmqMessageConsumerFactory = new RmqMessageConsumerFactory(rmqConnection);
 
-                    services.AddServiceActivator(options =>
+                    services.AddConsumers(options =>
                     {
                         options.Subscriptions = subscriptions;
                         options.DefaultChannelFactory = new ChannelFactory(rmqMessageConsumerFactory);

--- a/samples/TaskQueue/RMQTaskQueue/GreetingsSender/Program.cs
+++ b/samples/TaskQueue/RMQTaskQueue/GreetingsSender/Program.cs
@@ -75,7 +75,7 @@ namespace GreetingsSender
             
             serviceCollection
                 .AddBrighter()
-                .UseExternalBus((configure) =>
+                .AddProducers((configure) =>
                 {
                     configure.ProducerRegistry = producerRegistry;
                     configure.MaxOutStandingMessages = 5;

--- a/samples/TaskQueue/RedisTaskQueue/GreetingsReceiver/Program.cs
+++ b/samples/TaskQueue/RedisTaskQueue/GreetingsReceiver/Program.cs
@@ -44,7 +44,7 @@ namespace GreetingsReceiver
                     };
 
                     var redisConsumerFactory = new RedisMessageConsumerFactory(redisConnection);
-                    services.AddServiceActivator(options =>
+                    services.AddConsumers(options =>
                     {
                         options.Subscriptions = subscriptions;
                         options.DefaultChannelFactory = new ChannelFactory(redisConsumerFactory);

--- a/samples/TaskQueue/RedisTaskQueue/GreetingsSender/Program.cs
+++ b/samples/TaskQueue/RedisTaskQueue/GreetingsSender/Program.cs
@@ -102,7 +102,7 @@ namespace GreetingsSender
                     ).Create();
                     
                     collection.AddBrighter()
-                        .UseExternalBus((configure) =>
+                        .AddProducers((configure) =>
                         {
                             configure.ProducerRegistry = producerRegistry;
                         })

--- a/samples/Transforms/AWSTransfomers/ClaimCheck/GreetingsReceiverConsole/Program.cs
+++ b/samples/Transforms/AWSTransfomers/ClaimCheck/GreetingsReceiverConsole/Program.cs
@@ -75,7 +75,7 @@ namespace GreetingsReceiverConsole
                     {
                         var awsConnection = new AWSMessagingGatewayConnection(credentials, RegionEndpoint.EUWest1);
 
-                        services.AddServiceActivator(options =>
+                        services.AddConsumers(options =>
                         {
                             options.Subscriptions = subscriptions;
                             options.DefaultChannelFactory = new ChannelFactory(awsConnection);

--- a/samples/Transforms/AWSTransfomers/ClaimCheck/GreetingsSender/Program.cs
+++ b/samples/Transforms/AWSTransfomers/ClaimCheck/GreetingsSender/Program.cs
@@ -76,7 +76,7 @@ namespace GreetingsSender
                 ).Create();
                 
                 serviceCollection.AddBrighter()
-                    .UseExternalBus((configure) =>
+                    .AddProducers((configure) =>
                     {
                         configure.ProducerRegistry = producerRegistry;
                     })

--- a/samples/Transforms/AWSTransfomers/CloudEvents/GreetingsReceiverConsole/Program.cs
+++ b/samples/Transforms/AWSTransfomers/CloudEvents/GreetingsReceiverConsole/Program.cs
@@ -71,7 +71,7 @@ namespace GreetingsReceiverConsole
                     {
                         var awsConnection = new AWSMessagingGatewayConnection(credentials, RegionEndpoint.EUWest1);
 
-                        services.AddServiceActivator(options =>
+                        services.AddConsumers(options =>
                         {
                             options.Subscriptions = subscriptions;
                             options.DefaultChannelFactory = new ChannelFactory(awsConnection);

--- a/samples/Transforms/AWSTransfomers/CloudEvents/GreetingsSender/Program.cs
+++ b/samples/Transforms/AWSTransfomers/CloudEvents/GreetingsSender/Program.cs
@@ -74,7 +74,7 @@ namespace GreetingsSender
                 ).Create();
                 
                 serviceCollection.AddBrighter()
-                    .UseExternalBus((configure) =>
+                    .AddProducers((configure) =>
                     {
                         configure.ProducerRegistry = producerRegistry;
                     })

--- a/samples/Transforms/AWSTransfomers/Compression/GreetingsReceiverConsole/Program.cs
+++ b/samples/Transforms/AWSTransfomers/Compression/GreetingsReceiverConsole/Program.cs
@@ -70,7 +70,7 @@ namespace GreetingsReceiverConsole
                     {
                         var awsConnection = new AWSMessagingGatewayConnection(credentials, RegionEndpoint.EUWest1);
 
-                        services.AddServiceActivator(options =>
+                        services.AddConsumers(options =>
                         {
                             options.Subscriptions = subscriptions;
                             options.DefaultChannelFactory = new ChannelFactory(awsConnection);

--- a/samples/Transforms/AWSTransfomers/Compression/GreetingsSender/Program.cs
+++ b/samples/Transforms/AWSTransfomers/Compression/GreetingsSender/Program.cs
@@ -74,7 +74,7 @@ namespace GreetingsSender
                 ).Create();
                 
                 serviceCollection.AddBrighter()
-                    .UseExternalBus((configure) =>
+                    .AddProducers((configure) =>
                     {
                         configure.ProducerRegistry = producerRegistry;
                     })

--- a/samples/Transforms/JustSaying/BrighterSide/Program.cs
+++ b/samples/Transforms/JustSaying/BrighterSide/Program.cs
@@ -26,7 +26,7 @@ var host = new HostBuilder()
         
         service
             .AddHostedService<ServiceActivatorHostedService>()
-            .AddServiceActivator(configure =>
+            .AddConsumers(configure =>
             {
                 configure.Subscriptions = [
                     new SqsSubscription<Greeting>(
@@ -37,7 +37,7 @@ var host = new HostBuilder()
 
                 configure.DefaultChannelFactory = new ChannelFactory(connection);
             })
-            .UseExternalBus(configure =>
+            .AddProducers(configure =>
             {
                 configure.ProducerRegistry = new SnsProducerRegistryFactory(connection, 
                         [

--- a/samples/Transforms/MassTransit/MBrigtherSide/Program.cs
+++ b/samples/Transforms/MassTransit/MBrigtherSide/Program.cs
@@ -26,7 +26,7 @@ var host = new HostBuilder()
         
         service
             .AddHostedService<ServiceActivatorHostedService>()
-            .AddServiceActivator(configure =>
+            .AddConsumers(configure =>
             {
                 configure.Subscriptions = [
                     new SqsSubscription<Greeting>(
@@ -37,7 +37,7 @@ var host = new HostBuilder()
 
                 configure.DefaultChannelFactory = new ChannelFactory(connection);
             })
-            .UseExternalBus(configure =>
+            .AddProducers(configure =>
             {
                 configure.ProducerRegistry = new SnsProducerRegistryFactory(connection, 
                         [

--- a/samples/WebAPI/WebAPI_Dapper/GreetingsWeb/Startup.cs
+++ b/samples/WebAPI/WebAPI_Dapper/GreetingsWeb/Startup.cs
@@ -108,7 +108,7 @@ public class Startup
                 options.MapperLifetime = ServiceLifetime.Singleton;
                 options.PolicyRegistry = new GreetingsPolicy();
             })
-            .UseExternalBus(configure =>
+            .AddProducers(configure =>
             {
                 configure.ProducerRegistry = ConfigureTransport.MakeProducerRegistry<GreetingMade>(messagingTransport);
                 configure.Outbox = makeOutbox.outbox;

--- a/samples/WebAPI/WebAPI_Dapper/Greetings_Sweeper/Program.cs
+++ b/samples/WebAPI/WebAPI_Dapper/Greetings_Sweeper/Program.cs
@@ -83,7 +83,7 @@ var rdbms = DbResolver.GetDatabaseType(dbType);
 builder.Services.AddBrighter(options =>
 {
     options.InstrumentationOptions = InstrumentationOptions.All;
-}).UseExternalBus(configure =>
+}).AddProducers(configure =>
 {
     configure.ProducerRegistry = ConfigureTransport.MakeProducerRegistry<GreetingMade>(messagingTransport);
     configure.Outbox = makeOutbox.outbox;

--- a/samples/WebAPI/WebAPI_Dapper/SalutationAnalytics/Program.cs
+++ b/samples/WebAPI/WebAPI_Dapper/SalutationAnalytics/Program.cs
@@ -105,7 +105,7 @@ static void ConfigureBrighter(HostBuilderContext hostContext, IServiceCollection
     (IAmAnOutbox outbox, Type connectionProvider, Type transactionProvider) makeOutbox =
         OutboxFactory.MakeDapperOutbox(rdbms, outboxConfiguration);
 
-    services.AddServiceActivator(options =>
+    services.AddConsumers(options =>
         {
             options.Subscriptions = subscriptions;
             options.DefaultChannelFactory = ConfigureTransport.GetChannelFactory(messagingTransport);
@@ -124,7 +124,7 @@ static void ConfigureBrighter(HostBuilderContext hostContext, IServiceCollection
             //We don't strictly need this, but added as an example
             options.PropertyNameCaseInsensitive = true;
         })
-        .UseExternalBus(config =>
+        .AddProducers(config =>
         {
             config.ProducerRegistry = ConfigureTransport.MakeProducerRegistry<SalutationReceived>(messagingTransport);
             config.Outbox = makeOutbox.outbox;

--- a/samples/WebAPI/WebAPI_Dapper/Salutation_Sweeper/Program.cs
+++ b/samples/WebAPI/WebAPI_Dapper/Salutation_Sweeper/Program.cs
@@ -81,7 +81,7 @@ var rdbms = DbResolver.GetDatabaseType(dbType);
 builder.Services.AddBrighter(options =>
 {
     options.InstrumentationOptions = InstrumentationOptions.All;
-}).UseExternalBus(configure =>
+}).AddProducers(configure =>
 {
     configure.ProducerRegistry = ConfigureTransport.MakeProducerRegistry<SalutationReceived>(messagingTransport);
     configure.Outbox = makeOutbox.outbox;

--- a/samples/WebAPI/WebAPI_Dynamo/GreetingsWeb/Startup.cs
+++ b/samples/WebAPI/WebAPI_Dynamo/GreetingsWeb/Startup.cs
@@ -99,7 +99,7 @@ namespace GreetingsWeb
                  options.MapperLifetime = ServiceLifetime.Singleton;
                  options.PolicyRegistry = new GreetingsPolicy();
              })
-             .UseExternalBus((configure) =>
+             .AddProducers((configure) =>
              {
                  configure.ProducerRegistry = producerRegistry;
                  configure.Outbox = new DynamoDbOutbox(_client, new DynamoDbConfiguration(), TimeProvider.System);

--- a/samples/WebAPI/WebAPI_Dynamo/Greetings_Sweeper/Program.cs
+++ b/samples/WebAPI/WebAPI_Dynamo/Greetings_Sweeper/Program.cs
@@ -25,7 +25,7 @@ OutboxFactory.MakeDynamoOutbox(client);
 builder.Services.AddBrighter(options =>
 {
     options.InstrumentationOptions = InstrumentationOptions.All;
-}).UseExternalBus(configure =>
+}).AddProducers(configure =>
 {
     configure.ProducerRegistry = ConfigureTransport.MakeProducerRegistry<GreetingMade>(messagingTransport);
     configure.Outbox = new DynamoDbOutbox(client, new DynamoDbConfiguration(), TimeProvider.System);;

--- a/samples/WebAPI/WebAPI_Dynamo/SalutationAnalytics/Program.cs
+++ b/samples/WebAPI/WebAPI_Dynamo/SalutationAnalytics/Program.cs
@@ -92,7 +92,7 @@ static void ConfigureBrighter(
             
     var producerRegistry = ConfigureTransport.MakeProducerRegistry<GreetingMade>(messagingTransport); 
 
-    services.AddServiceActivator(options =>
+    services.AddConsumers(options =>
         {
             options.Subscriptions = subscriptions;
             options.DefaultChannelFactory = new ChannelFactory(rmqMessageConsumerFactory);
@@ -113,7 +113,7 @@ static void ConfigureBrighter(
             //We don't strictly need this, but added as an example
             options.PropertyNameCaseInsensitive = true;
         })
-        .UseExternalBus((configure) =>
+        .AddProducers((configure) =>
             {
                 configure.ProducerRegistry = producerRegistry;
                 configure.Outbox = ConfigureOutbox(dynamoDb);

--- a/samples/WebAPI/WebAPI_EFCore/GreetingsWeb/Startup.cs
+++ b/samples/WebAPI/WebAPI_EFCore/GreetingsWeb/Startup.cs
@@ -102,7 +102,7 @@ namespace GreetingsWeb
                     options.MapperLifetime = ServiceLifetime.Singleton;
                     options.PolicyRegistry = new GreetingsPolicy();
                 })
-                .UseExternalBus((configure) =>
+                .AddProducers((configure) =>
                     {
                         configure.ProducerRegistry = producerRegistry;
                         configure.Outbox = outbox;

--- a/samples/WebAPI/WebAPI_EFCore/Greetings_Sweeper/Program.cs
+++ b/samples/WebAPI/WebAPI_EFCore/Greetings_Sweeper/Program.cs
@@ -36,7 +36,7 @@ var rdbms = DbResolver.GetDatabaseType(dbType);
 builder.Services.AddBrighter(options =>
 {
     options.InstrumentationOptions = InstrumentationOptions.All;
-}).UseExternalBus(configure =>
+}).AddProducers(configure =>
 {
     configure.ProducerRegistry = ConfigureTransport.MakeProducerRegistry<GreetingMade>(messagingTransport);
     configure.Outbox = makeOutbox.outbox;

--- a/samples/WebAPI/WebAPI_EFCore/SalutationAnalytics/Program.cs
+++ b/samples/WebAPI/WebAPI_EFCore/SalutationAnalytics/Program.cs
@@ -110,7 +110,7 @@ static void ConfigureBrighter(HostBuilderContext hostContext, IServiceCollection
         Exchange = new Exchange("paramore.brighter.exchange"),
     });
 
-    services.AddServiceActivator(options =>
+    services.AddConsumers(options =>
         {
             options.Subscriptions = subscriptions;
             options.DefaultChannelFactory = new ChannelFactory(rmqMessageConsumerFactory);
@@ -124,7 +124,7 @@ static void ConfigureBrighter(HostBuilderContext hostContext, IServiceCollection
                 InboxScope.Commands
             );
         })
-        .UseExternalBus((configure) =>
+        .AddProducers((configure) =>
         {
             configure.ProducerRegistry = producerRegistry;
             configure.Outbox = makeOutbox.outbox;

--- a/src/Paramore.Brighter.Extensions.DependencyInjection/IBrighterBuilder.cs
+++ b/src/Paramore.Brighter.Extensions.DependencyInjection/IBrighterBuilder.cs
@@ -96,7 +96,7 @@ namespace Paramore.Brighter.Extensions.DependencyInjection
 
         /// <summary>
         /// The policy registry to use for the command processor and the event bus
-        /// It needs to be here as we need to pass it between AddBrighter and UseExternalBus
+        /// It needs to be here as we need to pass it between AddBrighter and AddProducers
         /// </summary>
         IPolicyRegistry<string>? PolicyRegistry { get; set; }
 

--- a/src/Paramore.Brighter.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Paramore.Brighter.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -142,7 +142,7 @@ namespace Paramore.Brighter.Extensions.DependencyInjection
         /// <param name="configure">A callback that allows you to configure <see cref="ExternalBusConfiguration"/> options</param>
         /// <param name="serviceLifetime">The lifetime of the transaction provider</param>
         /// <returns>The Brighter builder to allow chaining of requests</returns>
-        public static IBrighterBuilder UseExternalBus(
+        public static IBrighterBuilder AddProducers(
             this IBrighterBuilder brighterBuilder,
             Action<ExternalBusConfiguration> configure,
             ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)

--- a/src/Paramore.Brighter.ServiceActivator.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Paramore.Brighter.ServiceActivator.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -23,7 +23,7 @@ namespace Paramore.Brighter.ServiceActivator.Extensions.DependencyInjection
         /// <param name="configure">The configuration of the subscriptions</param>
         /// <returns>A brighter handler builder, used for chaining</returns>
         /// <exception cref="ArgumentNullException">Throws if no .NET IoC container provided</exception>
-        public static IBrighterBuilder AddServiceActivator(
+        public static IBrighterBuilder AddConsumers(
             this IServiceCollection services,
             Action<ServiceActivatorOptions> configure = null)
         {

--- a/tests/Paramore.Brighter.Extensions.Tests/AssemblyResolutionDefaultTransientTests.cs
+++ b/tests/Paramore.Brighter.Extensions.Tests/AssemblyResolutionDefaultTransientTests.cs
@@ -21,7 +21,7 @@ namespace Paramore.Brighter.Extensions.Tests
         {
             _services = new ServiceCollection();
 
-            _services.AddServiceActivator().AutoFromAssemblies();
+            _services.AddConsumers().AutoFromAssemblies();
               
             _provider = _services.BuildServiceProvider();
         }

--- a/tests/Paramore.Brighter.Extensions.Tests/AssemblyResolutionHandlerLifetimeScopedAndMapperLifetimeSingletonTests.cs
+++ b/tests/Paramore.Brighter.Extensions.Tests/AssemblyResolutionHandlerLifetimeScopedAndMapperLifetimeSingletonTests.cs
@@ -21,7 +21,7 @@ namespace Tests
         {
             _services = new ServiceCollection();
 
-            _services.AddServiceActivator(options => { options.CommandProcessorLifetime = ServiceLifetime.Scoped; })
+            _services.AddConsumers(options => { options.CommandProcessorLifetime = ServiceLifetime.Scoped; })
                 .AutoFromAssemblies();
 
             _provider = _services.BuildServiceProvider();

--- a/tests/Paramore.Brighter.Extensions.Tests/AssemblyResolutionMissingDependenciesTests.cs
+++ b/tests/Paramore.Brighter.Extensions.Tests/AssemblyResolutionMissingDependenciesTests.cs
@@ -18,7 +18,7 @@ public class AssemblyResolutionMissingDependenciesTests
 
         var services = new ServiceCollection();
 
-        services.AddServiceActivator().AutoFromAssemblies();
+        services.AddConsumers().AutoFromAssemblies();
         
         //act
         var provider = factory.CreateServiceProvider(services);

--- a/tests/Paramore.Brighter.Extensions.Tests/TestDifferentSetups.cs
+++ b/tests/Paramore.Brighter.Extensions.Tests/TestDifferentSetups.cs
@@ -59,7 +59,7 @@ namespace Tests
 
             serviceCollection
                 .AddBrighter()
-                .UseExternalBus(config =>
+                .AddProducers(config =>
                 {
                     config.ProducerRegistry = producerRegistry;
                     config.MessageMapperRegistry = messageMapperRegistry;


### PR DESCRIPTION
Change names of Brighter builder methods to AddProducers and AddConsumers as existing names are a leaky abstraction