### PR TITLE
fix: correctly wrapping/unwrapping servicebus message user properties

### DIFF
--- a/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusMessagePublisher.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusMessagePublisher.cs
@@ -59,59 +59,57 @@ public class AzureServiceBusMessagePublisher
         if(!string.IsNullOrEmpty(message.Header.CorrelationId))
             azureServiceBusMessage.CorrelationId = message.Header.CorrelationId;
         if (!string.IsNullOrEmpty(message.Header.ReplyTo!))
-            azureServiceBusMessage.ReplyTo = message.Header.ReplyTo!;
+            azureServiceBusMessage.ReplyTo = message.Header.ReplyTo?.Value;
         if (message.Header.Bag.TryGetValue(ASBConstants.SessionIdKey, out object? value))
             azureServiceBusMessage.SessionId = value.ToString();
 
         foreach (var header in message.Header.Bag.Where(h => !ASBConstants.ReservedHeaders.Contains(h.Key)))
         {
-            azureServiceBusMessage.ApplicationProperties.Add(header.Key, header.Value);
+            azureServiceBusMessage.ApplicationProperties[header.Key] = header.Value;
         }
             
-        azureServiceBusMessage.ApplicationProperties.Add(ASBConstants.MessageTypeHeaderBagKey, message.Header.MessageType.ToString());
-        azureServiceBusMessage.ApplicationProperties.Add(ASBConstants.HandledCountHeaderBagKey, message.Header.HandledCount);
-        azureServiceBusMessage.ApplicationProperties.Add(ASBConstants.ReplyToHeaderBagKey, message.Header.ReplyTo);
+        azureServiceBusMessage.ApplicationProperties[ASBConstants.MessageTypeHeaderBagKey] = message.Header.MessageType.ToString();
+        azureServiceBusMessage.ApplicationProperties[ASBConstants.HandledCountHeaderBagKey] = message.Header.HandledCount;
+        azureServiceBusMessage.ApplicationProperties[ASBConstants.ReplyToHeaderBagKey] = message.Header.ReplyTo?.Value;
         
    }
     
     private static void AddCloudEventHeaders(Message message, ServiceBusMessage azureServiceBusMessage)
     {
         //required Cloud Event headers
-        azureServiceBusMessage.ApplicationProperties.Add(ASBConstants.CloudEventsSource, message.Header.Source?.ToString() ?? string.Empty);
-        azureServiceBusMessage.ApplicationProperties.Add(ASBConstants.CloudEventsId, message.Id.ToString());
-        azureServiceBusMessage.ApplicationProperties.Add(ASBConstants.CloudEventsSpecVersion, message.Header.SpecVersion);
-        azureServiceBusMessage.ApplicationProperties.Add(ASBConstants.CloudEventsType, message.Header.Type);
+        azureServiceBusMessage.ApplicationProperties[ASBConstants.CloudEventsSource] = message.Header.Source?.ToString() ?? string.Empty;
+        azureServiceBusMessage.ApplicationProperties[ASBConstants.CloudEventsId] = message.Id.ToString();
+        azureServiceBusMessage.ApplicationProperties[ASBConstants.CloudEventsSpecVersion] = message.Header.SpecVersion;
+        azureServiceBusMessage.ApplicationProperties[ASBConstants.CloudEventsType] = message.Header.Type.Value;
 
         //optional Cloud Event headers
         if (message.Header.ContentType is not null)
-            azureServiceBusMessage.ApplicationProperties.Add(ASBConstants.CloudEventsContentType, message.Header.ContentType.ToString());
+            azureServiceBusMessage.ApplicationProperties[ASBConstants.CloudEventsContentType] = message.Header.ContentType.ToString();
        
         if(message.Header.DataSchema is not null)
-            azureServiceBusMessage.ApplicationProperties.Add(ASBConstants.CloudEventsSchema, message.Header.DataSchema);
+            azureServiceBusMessage.ApplicationProperties[ASBConstants.CloudEventsSchema] = message.Header.DataSchema;
         
         if (!string.IsNullOrEmpty(message.Header.Subject))
-            azureServiceBusMessage.ApplicationProperties.Add(ASBConstants.CloudEventsSubject, message.Header.Subject);
+            azureServiceBusMessage.ApplicationProperties[ASBConstants.CloudEventsSubject] = message.Header.Subject;
        
         if (message.Header.TimeStamp != default)
-            azureServiceBusMessage.ApplicationProperties.Add(ASBConstants.CloudEventsTime, message.Header.TimeStamp.ToRfc3339());
+            azureServiceBusMessage.ApplicationProperties[ASBConstants.CloudEventsTime] = message.Header.TimeStamp.ToRfc3339();
         
         //extension Cloud Event headers
         if (message.Header.DataRef is not null)
-            azureServiceBusMessage.ApplicationProperties.Add(ASBConstants.CloudEventDataRef, message.Header.DataRef);
+            azureServiceBusMessage.ApplicationProperties[ASBConstants.CloudEventDataRef] = message.Header.DataRef;
         
-        azureServiceBusMessage.ApplicationProperties.Add(ASBConstants.CloudEventsParitionKey, message.Header.PartitionKey.Value);
+        azureServiceBusMessage.ApplicationProperties[ASBConstants.CloudEventsParitionKey] = message.Header.PartitionKey.Value;
     }
     
     private static void AddOtelHeaders(Message message, ServiceBusMessage azureServiceBusMessage)
     {
         if(message.Header.TraceParent is not null)
-            azureServiceBusMessage.ApplicationProperties.Add(ASBConstants.OtelTraceParent, message.Header.TraceParent);
+            azureServiceBusMessage.ApplicationProperties[ASBConstants.OtelTraceParent] = message.Header.TraceParent.Value;
         
         if(message.Header.TraceState is not null)
-            azureServiceBusMessage.ApplicationProperties.Add(ASBConstants.OtelTraceState, message.Header.TraceState);
+            azureServiceBusMessage.ApplicationProperties[ASBConstants.OtelTraceState] = message.Header.TraceState.Value;
         
-        
-        azureServiceBusMessage.ApplicationProperties.Add(ASBConstants.Baggage, message.Header.Baggage.ToString());
+        azureServiceBusMessage.ApplicationProperties[ASBConstants.Baggage] = message.Header.Baggage.ToString();
     }
-    
 }

--- a/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusMesssageCreator.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusMesssageCreator.cs
@@ -76,6 +76,7 @@ public class AzureServiceBusMesssageCreator(AzureServiceBusSubscription subscrip
         var traceParent = GetTraceParent(azureServiceBusMessage);
         var traceState = GetTraceState(azureServiceBusMessage);
         var baggage = GetBaggage(azureServiceBusMessage);
+        var partitionKey = GetPartitionKey(azureServiceBusMessage);
             
         // TODO: We only support  a header based approach to Cloud Events at the moment, so we don't
         // have support here for Cloud Events JSON as the body. We should probably support that as well in the future.
@@ -97,7 +98,8 @@ public class AzureServiceBusMesssageCreator(AzureServiceBusSubscription subscrip
             delayed: TimeSpan.Zero,
             traceParent: traceParent,
             traceState: traceState,
-            baggage: baggage
+            baggage: baggage,
+            partitionKey: partitionKey
         );
 
         headers.Bag.Add(ASBConstants.LockTokenHeaderBagKey, azureServiceBusMessage.LockToken);
@@ -176,6 +178,17 @@ public class AzureServiceBusMesssageCreator(AzureServiceBusSubscription subscrip
 
         s_logger.LogWarning("Invalid Cloud Events time format in message from topic {Topic} via subscription {SubscriptionName}", _topic, subscription.Name);
         return DateTimeOffset.UtcNow;
+    }
+
+    private PartitionKey GetPartitionKey(IBrokeredMessageWrapper azureServiceBusMessage)
+    {
+        if (!azureServiceBusMessage.ApplicationProperties.TryGetValue(ASBConstants.CloudEventsParitionKey, out object? property))
+        {
+            s_logger.LogWarning("No Cloud Events type found in message from topic {Topic} via subscription {SubscriptionName}", _topic, subscription.Name);
+            return PartitionKey.Empty;
+        }
+
+        return new PartitionKey(property.ToString() ?? string.Empty);
     }
 
     private CloudEventsType GetCloudEventsType(IBrokeredMessageWrapper azureServiceBusMessage)

--- a/tests/Paramore.Brighter.AzureServiceBus.Tests/MessagingGateway/When_consuming_a_message_via_the_consumer.cs
+++ b/tests/Paramore.Brighter.AzureServiceBus.Tests/MessagingGateway/When_consuming_a_message_via_the_consumer.cs
@@ -67,7 +67,6 @@ namespace Paramore.Brighter.AzureServiceBus.Tests.MessagingGateway
                     type: new CloudEventsType("goparamore.io.test.command"),
                     timeStamp: DateTimeOffset.UtcNow,
                     correlationId: _correlationId,
-                    replyTo: testReplyTo,
                     contentType: _contentType,
                     partitionKey: testPartitionKey,
                     dataSchema: testSchema,


### PR DESCRIPTION
Fixes 3 bugs

# issue 1 service bus User Properties only support value types

We're incorrectly setting user properties with complex types. Servicebus message user properties only supports value types.

<img width="870" height="362" alt="image" src="https://github.com/user-attachments/assets/4dc7df77-ed35-4149-9dec-1c50e0834d31" />

ref : https://learn.microsoft.com/en-us/dotnet/api/microsoft.azure.servicebus.message.userproperties?view=azure-dotnet-legacy&viewFallbackFrom=azure-dotnet

# issue 2 Partition key not set

# issue 2 duplicate keys when re-enqueing service bus messages