### PR TITLE
fix: GCP Firestore unit test

### DIFF
--- a/tests/Paramore.Brighter.Gcp.Tests/Firestore/Outbox/When_retrieving_messages_to_archive.cs
+++ b/tests/Paramore.Brighter.Gcp.Tests/Firestore/Outbox/When_retrieving_messages_to_archive.cs
@@ -46,7 +46,15 @@ public class ArchiveFetchTests
         Assert.Contains(allDispatched, x => x.Id == _messageEarliest.Id);
         Assert.Contains(allDispatched, x => x.Id == _messageDispatched.Id);
         Assert.DoesNotContain(allDispatched, x => x.Id == _messageUnDispatched.Id);
-        Assert.Empty(messagesOverAnHour);
-        Assert.Empty(messagesOver4Hours);
+        
+        messagesOverAnHour = messagesOverAnHour.ToList();
+        Assert.DoesNotContain(messagesOverAnHour, x => x.Id == _messageUnDispatched.Id);
+        Assert.DoesNotContain(messagesOverAnHour, x => x.Id == _messageDispatched.Id);
+        Assert.DoesNotContain(messagesOverAnHour, x => x.Id == _messageEarliest.Id);
+
+        messagesOver4Hours = messagesOver4Hours.ToList();
+        Assert.DoesNotContain(messagesOver4Hours, x => x.Id == _messageUnDispatched.Id);
+        Assert.DoesNotContain(messagesOver4Hours, x => x.Id == _messageDispatched.Id);
+        Assert.DoesNotContain(messagesOver4Hours, x => x.Id == _messageEarliest.Id);
     }
 }

--- a/tests/Paramore.Brighter.Gcp.Tests/Firestore/Outbox/When_retrieving_messages_to_archive_async.cs
+++ b/tests/Paramore.Brighter.Gcp.Tests/Firestore/Outbox/When_retrieving_messages_to_archive_async.cs
@@ -54,7 +54,15 @@ public class ArchiveFetchAsyncTests
         Assert.Contains(allDispatched, x => x.Id == _messageEarliest.Id);
         Assert.Contains(allDispatched, x => x.Id == _messageDispatched.Id);
         Assert.DoesNotContain(allDispatched, x => x.Id == _messageUnDispatched.Id);
-        Assert.Empty(messagesOverAnHour);
-        Assert.Empty(messagesOver4Hours);
+        
+        messagesOverAnHour = messagesOverAnHour.ToList();
+        Assert.DoesNotContain(messagesOverAnHour, x => x.Id == _messageUnDispatched.Id);
+        Assert.DoesNotContain(messagesOverAnHour, x => x.Id == _messageDispatched.Id);
+        Assert.DoesNotContain(messagesOverAnHour, x => x.Id == _messageEarliest.Id);
+
+        messagesOver4Hours = messagesOver4Hours.ToList();
+        Assert.DoesNotContain(messagesOver4Hours, x => x.Id == _messageUnDispatched.Id);
+        Assert.DoesNotContain(messagesOver4Hours, x => x.Id == _messageDispatched.Id);
+        Assert.DoesNotContain(messagesOver4Hours, x => x.Id == _messageEarliest.Id);
     }
 }


### PR DESCRIPTION
Firestore run TTL every 24hrs, we need to change how we check the collection