### PR TITLE
feat: Enhance context bag with additional message header properties

### DIFF
--- a/src/Paramore.Brighter.Transformers.JustSaying/JustSayingMessageMapper.cs
+++ b/src/Paramore.Brighter.Transformers.JustSaying/JustSayingMessageMapper.cs
@@ -222,40 +222,7 @@ public class JustSayingMessageMapper<TMessage> : IAmAMessageMapper<TMessage>, IA
     {
         if (Context != null)
         {
-            Context.Bag[RequestContextBagNames.Headers] = message.Header.Bag;
-            Context.Bag[RequestContextBagNames.TimeStamp] = message.Header.TimeStamp;
-            Context.Bag[RequestContextBagNames.Source] = message.Header.Source;
-            Context.Bag[RequestContextBagNames.Type] = message.Header.Type;
-            
-            if (!PartitionKey.IsNullOrEmpty(message.Header.PartitionKey))
-            {
-                Context.Bag[RequestContextBagNames.PartitionKey] = message.Header.PartitionKey;
-            }
-
-            if (!Id.IsNullOrEmpty(message.Header.JobId))
-            {
-                Context.Bag[RequestContextBagNames.JobId] = message.Header.JobId;
-            }
-            
-            if (!Id.IsNullOrEmpty(message.Header.WorkflowId))
-            {
-                Context.Bag[RequestContextBagNames.WorkflowId] = message.Header.WorkflowId;
-            }
-            
-            if (!Id.IsNullOrEmpty(message.Header.CorrelationId))
-            {
-                Context.Bag[RequestContextBagNames.CorrelationId] = message.Header.CorrelationId;
-            }
-            
-            if (!string.IsNullOrEmpty(message.Header.Subject))
-            {
-                Context.Bag[RequestContextBagNames.Subject] = message.Header.Subject!;
-            }
-            
-            if (!RoutingKey.IsNullOrEmpty(message.Header.ReplyTo))
-            {
-                Context.Bag[RequestContextBagNames.ReplyTo] = message.Header.ReplyTo;
-            }
+            Context.Bag[JustSayingAttributesName.Conversation] = message.Header.CorrelationId;
         }
         
         return JsonSerializer.Deserialize<TMessage>(message.Body.Bytes, JsonSerialisationOptions.Options)!;

--- a/src/Paramore.Brighter.Transformers.MassTransit/MassTransitMessageMapper.cs
+++ b/src/Paramore.Brighter.Transformers.MassTransit/MassTransitMessageMapper.cs
@@ -209,46 +209,6 @@ public class MassTransitMessageMapper<TMessage> : IAmAMessageMapper<TMessage>, I
         
         if (Context != null)
         {
-            Context.Bag[RequestContextBagNames.Headers] = message.Header.Bag;
-            Context.Bag[RequestContextBagNames.TimeStamp] = message.Header.TimeStamp;
-            Context.Bag[RequestContextBagNames.Source] = message.Header.Source;
-            Context.Bag[RequestContextBagNames.Type] = message.Header.Type;
-            
-            if (!PartitionKey.IsNullOrEmpty(message.Header.PartitionKey))
-            {
-                Context.Bag[RequestContextBagNames.PartitionKey] = message.Header.PartitionKey;
-            }
-
-            if (!Id.IsNullOrEmpty(message.Header.JobId))
-            {
-                Context.Bag[RequestContextBagNames.JobId] = message.Header.JobId;
-            }
-            
-            if (!Id.IsNullOrEmpty(message.Header.WorkflowId))
-            {
-                Context.Bag[RequestContextBagNames.WorkflowId] = message.Header.WorkflowId;
-            }
-            
-            if (!Id.IsNullOrEmpty(message.Header.CorrelationId))
-            {
-                Context.Bag[RequestContextBagNames.CorrelationId] = message.Header.CorrelationId;
-            }
-            
-            if (!string.IsNullOrEmpty(message.Header.Subject))
-            {
-                Context.Bag[RequestContextBagNames.Subject] = message.Header.Subject!;
-            }
-            
-            if (!RoutingKey.IsNullOrEmpty(message.Header.ReplyTo))
-            {
-                Context.Bag[RequestContextBagNames.ReplyTo] = message.Header.ReplyTo;
-            }
-
-            if (!Id.IsNullOrEmpty(envelop.ConversationId))
-            {
-                Context.Bag[MassTransitHeaderNames.ConversationId] = message.Header.CorrelationId;
-            }
-            
             if (envelop.DestinationAddress != null)
             {
                 Context.Bag[MassTransitHeaderNames.DestinationAddress] = envelop.DestinationAddress;

--- a/src/Paramore.Brighter/MessageMappers/CloudEventJsonMessageMapper.cs
+++ b/src/Paramore.Brighter/MessageMappers/CloudEventJsonMessageMapper.cs
@@ -97,44 +97,9 @@ public class CloudEventJsonMessageMapper<TRequest> : IAmAMessageMapper<TRequest>
 
         if (Context != null)
         {
-            Context.Bag[RequestContextBagNames.Headers] = message.Header.Bag;
-            Context.Bag[RequestContextBagNames.TimeStamp] = message.Header.TimeStamp;
-            Context.Bag[RequestContextBagNames.Source] = message.Header.Source;
-            Context.Bag[RequestContextBagNames.Type] = message.Header.Type;
-            
-            if (!PartitionKey.IsNullOrEmpty(message.Header.PartitionKey))
-            {
-                Context.Bag[RequestContextBagNames.PartitionKey] = message.Header.PartitionKey;
-            }
-
-            if (!Id.IsNullOrEmpty(message.Header.JobId))
-            {
-                Context.Bag[RequestContextBagNames.JobId] = message.Header.JobId;
-            }
-            
-            if (!Id.IsNullOrEmpty(message.Header.WorkflowId))
-            {
-                Context.Bag[RequestContextBagNames.WorkflowId] = message.Header.WorkflowId;
-            }
-            
-            if (!Id.IsNullOrEmpty(message.Header.CorrelationId))
-            {
-                Context.Bag[RequestContextBagNames.CorrelationId] = message.Header.CorrelationId;
-            }
-
             if (request.AdditionalProperties != null)
             {
                 Context.Bag[RequestContextBagNames.CloudEventsAdditionalProperties] = request.AdditionalProperties;
-            }
-            
-            if (!string.IsNullOrEmpty(message.Header.Subject))
-            {
-                Context.Bag[RequestContextBagNames.Subject] = message.Header.Subject!;
-            }
-            
-            if (!RoutingKey.IsNullOrEmpty(message.Header.ReplyTo))
-            {
-                Context.Bag[RequestContextBagNames.ReplyTo] = message.Header.ReplyTo;
             }
         }
 

--- a/src/Paramore.Brighter/MessageMappers/JsonMessageMapper.cs
+++ b/src/Paramore.Brighter/MessageMappers/JsonMessageMapper.cs
@@ -70,44 +70,6 @@ public class JsonMessageMapper<TRequest> : IAmAMessageMapper<TRequest>, IAmAMess
             throw new ArgumentException($"Unable to deseralise message body for {message.Header.Topic}");
         }
 
-        if (Context != null)
-        {
-            Context.Bag[RequestContextBagNames.Headers] = message.Header.Bag;
-            Context.Bag[RequestContextBagNames.TimeStamp] = message.Header.TimeStamp;
-            Context.Bag[RequestContextBagNames.Source] = message.Header.Source;
-            Context.Bag[RequestContextBagNames.Type] = message.Header.Type;
-            
-            if (!PartitionKey.IsNullOrEmpty(message.Header.PartitionKey))
-            {
-                Context.Bag[RequestContextBagNames.PartitionKey] = message.Header.PartitionKey;
-            }
-
-            if (!Id.IsNullOrEmpty(message.Header.JobId))
-            {
-                Context.Bag[RequestContextBagNames.JobId] = message.Header.JobId;
-            }
-            
-            if (!Id.IsNullOrEmpty(message.Header.WorkflowId))
-            {
-                Context.Bag[RequestContextBagNames.WorkflowId] = message.Header.WorkflowId;
-            }
-            
-            if (!Id.IsNullOrEmpty(message.Header.CorrelationId))
-            {
-                Context.Bag[RequestContextBagNames.CorrelationId] = message.Header.CorrelationId;
-            }
-            
-            if (!string.IsNullOrEmpty(message.Header.Subject))
-            {
-                Context.Bag[RequestContextBagNames.Subject] = message.Header.Subject!;
-            }
-            
-            if (!RoutingKey.IsNullOrEmpty(message.Header.ReplyTo))
-            {
-                Context.Bag[RequestContextBagNames.ReplyTo] = message.Header.ReplyTo;
-            }
-        }
-
         return request;
     }
 }

--- a/src/Paramore.Brighter/RequestContextBagNames.cs
+++ b/src/Paramore.Brighter/RequestContextBagNames.cs
@@ -11,7 +11,6 @@ namespace Paramore.Brighter;
 /// </remarks>
 public static class RequestContextBagNames
 {
-  
     /// <summary>
     /// Key used to store additional extension properties for CloudEvents in the request context bag.
     /// </summary>
@@ -45,7 +44,6 @@ public static class RequestContextBagNames
     /// </example>
     /// </remarks>
     public const string CloudEventsAdditionalProperties = "Brighter-CloudEvents-AdditionalProperties";
-    
     
     /// <summary>
     /// Key used to store the job ID, representing an instance of a workflow, in the request context bag.
@@ -124,6 +122,9 @@ public static class RequestContextBagNames
     /// </para>
     /// </remarks>
     public const string Headers = "Brighter-Headers";
+    
+    public const string MessageId = "Brighter-MessageId";
+    public const string Topic = "Brighter-Topic";
 
     /// <summary>
     /// Used to store the worfkflow ID, which indicates which workflow this request belongs to, in the request context bag.

--- a/src/Paramore.Brighter/UnwrapPipeline.cs
+++ b/src/Paramore.Brighter/UnwrapPipeline.cs
@@ -74,8 +74,46 @@ namespace Paramore.Brighter
         /// <returns>a request</returns>
         public TRequest Unwrap(Message message, RequestContext? requestContext)
         {
-            if(requestContext is not null)
+            if (requestContext != null)
+            {
                 requestContext.Span ??= Activity.Current;
+                requestContext.Bag[RequestContextBagNames.MessageId] = message.Header.MessageId;
+                requestContext.Bag[RequestContextBagNames.Topic] = message.Header.Topic;
+                requestContext.Bag[RequestContextBagNames.Headers] = message.Header.Bag;
+                requestContext.Bag[RequestContextBagNames.TimeStamp] = message.Header.TimeStamp;
+                requestContext.Bag[RequestContextBagNames.Source] = message.Header.Source;
+                requestContext.Bag[RequestContextBagNames.Type] = message.Header.Type;
+            
+                if (!PartitionKey.IsNullOrEmpty(message.Header.PartitionKey))
+                {
+                    requestContext.Bag[RequestContextBagNames.PartitionKey] = message.Header.PartitionKey;
+                }
+
+                if (!Id.IsNullOrEmpty(message.Header.JobId))
+                {
+                    requestContext.Bag[RequestContextBagNames.JobId] = message.Header.JobId;
+                }
+            
+                if (!Id.IsNullOrEmpty(message.Header.WorkflowId))
+                {
+                    requestContext.Bag[RequestContextBagNames.WorkflowId] = message.Header.WorkflowId;
+                }
+            
+                if (!Id.IsNullOrEmpty(message.Header.CorrelationId))
+                {
+                    requestContext.Bag[RequestContextBagNames.CorrelationId] = message.Header.CorrelationId;
+                }
+            
+                if (!string.IsNullOrEmpty(message.Header.Subject))
+                {
+                    requestContext.Bag[RequestContextBagNames.Subject] = message.Header.Subject!;
+                }
+            
+                if (!RoutingKey.IsNullOrEmpty(message.Header.ReplyTo))
+                {
+                    requestContext.Bag[RequestContextBagNames.ReplyTo] = message.Header.ReplyTo;
+                }
+            }
             
             var msg = message;
             Transforms.Each(transform =>
@@ -83,7 +121,7 @@ namespace Paramore.Brighter
                 transform.Context = requestContext;
                 msg = transform.Unwrap(msg);
             });
-            
+
             MessageMapper.Context = requestContext;
             return MessageMapper.MapToRequest(msg);
         }

--- a/tests/Paramore.Brighter.Core.Tests/CloudEvents/CloudEventJsonMessageMapperTests.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CloudEvents/CloudEventJsonMessageMapperTests.cs
@@ -203,23 +203,6 @@ public class CloudEventJsonMessageMapperTests
     }
     
     [Fact]
-    public void When_mapping_message_to_command_set_context()
-    {
-        var command = new MyCommand { Value = Guid.NewGuid().ToString() };
-        var mapper = new CloudEventJsonMessageMapper<MyCommand> { Context = new RequestContext() };
-
-        var message = new Message(new MessageHeader{ PartitionKey = "123" },
-            new MessageBody(
-                JsonSerializer.Serialize(
-                    new CloudEventJsonMessageMapper<MyCommand>.CloudEventMessage { Data = command })));
-        var request = mapper.MapToRequest(message);
-
-        Assert.NotNull(request);
-        Assert.Equal(command.Value, request.Value);
-        Assert.Equal(mapper.Context.Bag[RequestContextBagNames.PartitionKey], message.Header.PartitionKey);
-    }
-
-    [Fact]
     public async Task When_mapping_message_to_command_async()
     {
         var command = new MyCommand { Value = Guid.NewGuid().ToString() };
@@ -232,23 +215,5 @@ public class CloudEventJsonMessageMapperTests
 
         Assert.NotNull(request);
         Assert.Equal(command.Value, request.Value);
-    }
-    
-    [Fact]
-    public async Task When_mapping_message_to_command_set_context_async()
-    {
-        var command = new MyCommand { Value = Guid.NewGuid().ToString() };
-        var mapper = new CloudEventJsonMessageMapper<MyCommand> { Context = new RequestContext() };
-
-        var message = new Message(new MessageHeader{ PartitionKey = "123" },
-            new MessageBody(
-                JsonSerializer.Serialize(
-                    new CloudEventJsonMessageMapper<MyCommand>.CloudEventMessage { Data = command })));
-        var request = await mapper.MapToRequestAsync(message);
-
-        Assert.NotNull(request);
-        Assert.Equal(command.Value, request.Value);
-        Assert.Equal(mapper.Context.Bag[RequestContextBagNames.PartitionKey], message.Header.PartitionKey);
-        
     }
 }

--- a/tests/Paramore.Brighter.Core.Tests/JsonMapper/JsonMessageMapperTests.cs
+++ b/tests/Paramore.Brighter.Core.Tests/JsonMapper/JsonMessageMapperTests.cs
@@ -121,22 +121,7 @@ public class JsonMessageMapperTests
         Assert.NotNull(request);
         Assert.Equal(command.Value, request.Value);
     }
-    
-    [Fact]
-    public void When_mapping_message_to_command_set_context()
-    {
-        var command = new MyCommand { Value = Guid.NewGuid().ToString() };
-        var mapper = new JsonMessageMapper<MyCommand> { Context = new RequestContext() };
 
-        var message = new Message(new MessageHeader { PartitionKey = "123" },
-            new MessageBody(JsonSerializer.Serialize(command)));
-        var request = mapper.MapToRequest(message);
-
-        Assert.NotNull(request);
-        Assert.Equal(command.Value, request.Value);
-        Assert.Equal(mapper.Context.Bag[RequestContextBagNames.PartitionKey], message.Header.PartitionKey);
-    }
-    
     [Fact]
     public async Task When_mapping_message_to_command_async ()
     {
@@ -146,20 +131,5 @@ public class JsonMessageMapperTests
         var request = await mapper.MapToRequestAsync(new Message(new MessageHeader(), new MessageBody(JsonSerializer.Serialize(command))));
         Assert.NotNull(request);
         Assert.Equal(command.Value, request.Value);
-    }
-    
-    [Fact]
-    public async Task When_mapping_message_to_command_set_context_async()
-    {
-        var command = new MyCommand { Value = Guid.NewGuid().ToString() };
-        var mapper = new JsonMessageMapper<MyCommand> { Context = new RequestContext() };
-
-        var message = new Message(new MessageHeader { PartitionKey = "123" },
-            new MessageBody(JsonSerializer.Serialize(command)));
-        var request = await mapper.MapToRequestAsync(message);
-
-        Assert.NotNull(request);
-        Assert.Equal(command.Value, request.Value);
-        Assert.Equal(mapper.Context.Bag[RequestContextBagNames.PartitionKey], message.Header.PartitionKey);
     }
 }

--- a/tests/Paramore.Brighter.Core.Tests/MessageSerialisation/When_Unwrapping_A_Message_MapperAsync.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageSerialisation/When_Unwrapping_A_Message_MapperAsync.cs
@@ -32,7 +32,13 @@ public class AsyncMessageUnwrapRequestTests
         _pipelineBuilder = new TransformPipelineBuilderAsync(mapperRegistry, messageTransformerFactory, InstrumentationOptions.All);
 
         _message = new Message(
-            new MessageHeader(myCommand.Id, new("transform.event"), MessageType.MT_COMMAND, timeStamp: DateTime.UtcNow),
+            new MessageHeader(myCommand.Id, 
+                new("transform.event"), 
+                MessageType.MT_COMMAND,
+                timeStamp: DateTime.UtcNow,
+                partitionKey: new PartitionKey("some-partition-key"),
+                type: new CloudEventsType("some-type"),
+                subject: "some-subject"),
             new MessageBody(JsonSerializer.Serialize(myCommand, new JsonSerializerOptions(JsonSerializerDefaults.General)))
         );
 
@@ -42,11 +48,20 @@ public class AsyncMessageUnwrapRequestTests
     [Fact]
     public async Task When_Unwrapping_A_Message_Mapper()
     {
+        var requestContext = new RequestContext();
+        
         //act
         _transformPipeline = _pipelineBuilder.BuildUnwrapPipeline<MyTransformableCommand>();
-        var request = await _transformPipeline.UnwrapAsync(_message, new RequestContext());
+        var request = await _transformPipeline.UnwrapAsync(_message, requestContext);
         
         //assert
         Assert.Equal(MySimpleTransformAsync.TRANSFORM_VALUE, request.Value);
+        Assert.Equal(_message.Header.MessageId, requestContext.Bag[RequestContextBagNames.MessageId]);
+        Assert.Equal(_message.Header.PartitionKey, requestContext.Bag[RequestContextBagNames.PartitionKey]);
+        Assert.Equal(_message.Header.Topic, requestContext.Bag[RequestContextBagNames.Topic]);
+        Assert.Equal(_message.Header.TimeStamp, requestContext.Bag[RequestContextBagNames.TimeStamp]);
+        Assert.Equal(_message.Header.Source, requestContext.Bag[RequestContextBagNames.Source]);
+        Assert.Equal(_message.Header.Type, requestContext.Bag[RequestContextBagNames.Type]);
+        Assert.Equal(_message.Header.Subject, requestContext.Bag[RequestContextBagNames.Subject]);
     }
 }


### PR DESCRIPTION
When MapToRequest is invoked, it ensures the Context Bag is filled with data derived from the properties of the incoming message. This makes key message details accessible during the request processing.