### PR TITLE
docs: Corrects comment on default HandlerLifetime

### DIFF
--- a/src/Paramore.Brighter.Extensions.DependencyInjection/BrighterOptions.cs
+++ b/src/Paramore.Brighter.Extensions.DependencyInjection/BrighterOptions.cs
@@ -15,7 +15,7 @@ namespace Paramore.Brighter.Extensions.DependencyInjection
         public IAmAFeatureSwitchRegistry? FeatureSwitchRegistry { get; set; } = null;
 
         /// <summary>
-        /// Configures the lifetime of the Handlers. Defaults to Scoped.
+        /// Configures the lifetime of the Handlers. Defaults to Transient.
         /// </summary>
         public ServiceLifetime HandlerLifetime { get; set; } = ServiceLifetime.Transient;
 


### PR DESCRIPTION
Looking at upgrading our v9 -> v10 and noticed this comment doesn't align with the code. I've updated the comment to match the code, but can switch it if that's incorrect.