### PR TITLE
docs: Corrects comment on default HandlerLifetime

### DIFF
--- a/src/Paramore.Brighter.Extensions.DependencyInjection/BrighterOptions.cs
+++ b/src/Paramore.Brighter.Extensions.DependencyInjection/BrighterOptions.cs
@@ -15,7 +15,7 @@ namespace Paramore.Brighter.Extensions.DependencyInjection
         public IAmAFeatureSwitchRegistry? FeatureSwitchRegistry { get; set; } = null;
 
         /// <summary>
-        /// Configures the lifetime of the Handlers. Defaults to Scoped.
+        /// Configures the lifetime of the Handlers. Defaults to Transient.
         /// </summary>
         public ServiceLifetime HandlerLifetime { get; set; } = ServiceLifetime.Transient;
 
@@ -47,7 +47,7 @@ namespace Paramore.Brighter.Extensions.DependencyInjection
         public IAmARequestContextFactory RequestContextFactory { get; set; } = new InMemoryRequestContextFactory();
 
         /// <summary>
-        /// Configures the lifetime of any transformers. Defaults to Singleton
+        /// Configures the lifetime of any transformers. Defaults to Transient
         /// </summary>
         public ServiceLifetime TransformerLifetime { get; set; } = ServiceLifetime.Transient;
     }


### PR DESCRIPTION
Looking at upgrading our v9 -> v10 and noticed this comment doesn't align with the code. I've updated the comment to match the code, but can switch it if that's incorrect.