### PR TITLE
Fixes Kafka Sweeper

### DIFF
--- a/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaMessageConsumer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaMessageConsumer.cs
@@ -174,8 +174,12 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
             _maxBatchSize = commitBatchSize;
             _sweepUncommittedInterval = TimeSpan.FromMilliseconds(sweepUncommittedOffsetsIntervalMs);
             _readCommittedOffsetsTimeoutMs = readCommittedOffsetsTimeoutMs;
+
+            if (timeProvider == null)
+            {
+                timeProvider = TimeProvider.System;
+            }
             
-            timeProvider ??= TimeProvider.System;
             _timer = timeProvider.CreateTimer(_ => SweepOffsets(), null, _sweepUncommittedInterval, _sweepUncommittedInterval);
 
             _consumer = new ConsumerBuilder<string, byte[]>(_consumerConfig)


### PR DESCRIPTION
Currently, the Kafka Sweeper runs only after the Ack method. However, in certain situations, this fails to trigger the Sweeper, causing messages to remain uncommitted for hours.

This fix ensures that the Sweeper strictly respects the _sweepUncommittedInterval configuration, preventing these delays