### PR TITLE
ADR: Optional RabbitMQ mutual TLS support

### DIFF
--- a/docs/adr/00xx-rabbitmq-mutual-tls.md
+++ b/docs/adr/00xx-rabbitmq-mutual-tls.md
@@ -107,7 +107,7 @@ These may be revisited in future ADRs if requirements evolve.
 
 - Brighter Contributing Guide (`Contributing.md`)
 - Existing Architecture Decision Records under `docs/adr`
-- Issue #3902: RabbitMQ Mutual TLS support
+- Issue #3902: RabbitMQ Mutual TLS support (https://github.com/BrighterCommand/Brighter/issues/3902)
 - PATH-210X extracted Critical Review Guidelines for Brighter
 
 ---


### PR DESCRIPTION
Proposes an ADR for adding optional, opt-in mutual TLS (mTLS) support to RabbitMQ messaging gateways.

This PR is intentionally ADR-only to align on scope, constraints, and non-goals before implementation.

Related issue: #3902.