### PR TITLE
[Fix] Handle Expired SQS Receipt Handles To Prevent Dispatcher Crash

### DIFF
--- a/.slopwatch/config.json
+++ b/.slopwatch/config.json
@@ -23,7 +23,7 @@
     {
       "ruleId": "SW003",
       "pattern": "**/SqsMessageConsumer.cs",
-      "justification": "ReceiptHandleIsInvalidException catch blocks intentionally swallow expired receipt handle errors to prevent dispatcher crash (GitHub issue #4031)"
+      "justification": "ReceiptHandleIsInvalidException catch blocks intentionally catch and log invalid receipt handle errors to prevent dispatcher crash (GitHub issue #4031)"
     }
   ],
   "globalSuppressions": []

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS.V4/SqsMessageConsumer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS.V4/SqsMessageConsumer.cs
@@ -352,7 +352,7 @@ public partial class SqsMessageConsumer : IAmAMessageConsumerSync, IAmAMessageCo
         }
         catch (ReceiptHandleIsInvalidException ex)
         {
-            // Receipt handle has expired - the visibility timeout elapsed during processing.
+            // Receipt handle is invalid (most likely because the visibility timeout elapsed).
             // SQS has already made the message visible again for redelivery by another consumer.
             // Nack sets visibility to zero for immediate redelivery — but the message is already
             // visible again, so the net effect is the same. Log a warning and continue.
@@ -403,7 +403,7 @@ public partial class SqsMessageConsumer : IAmAMessageConsumerSync, IAmAMessageCo
         }
         catch (ReceiptHandleIsInvalidException ex)
         {
-            // Receipt handle has expired - the visibility timeout elapsed during processing.
+            // Receipt handle is invalid (most likely because the visibility timeout elapsed).
             // SQS has already made the message visible again for redelivery by another consumer,
             // but without the intended delay. Log a warning so operators are aware.
             Log.RequeueFailedReceiptHandleExpired(s_logger, ex, message.Id, receiptHandle, _queueName, delay.Value);
@@ -518,7 +518,7 @@ public partial class SqsMessageConsumer : IAmAMessageConsumerSync, IAmAMessageCo
         }
         catch (ReceiptHandleIsInvalidException ex)
         {
-            // Receipt handle has expired - the visibility timeout elapsed during processing.
+            // Receipt handle is invalid (most likely because the visibility timeout elapsed).
             // SQS has already made the message visible again for redelivery by another consumer.
             // This is an error because the message was not deleted and may be processed again;
             // handlers should be idempotent, but an operator may need to investigate.
@@ -572,13 +572,13 @@ public partial class SqsMessageConsumer : IAmAMessageConsumerSync, IAmAMessageCo
         [LoggerMessage(LogLevel.Error, "SqsMessageConsumer: Error during deleting the message {Id} with receipt handle {ReceiptHandle} on the queue {ChannelName}")]
         public static partial void ErrorDeletingMessage(ILogger logger, Exception exception, string id, string? receiptHandle, string channelName);
 
-        [LoggerMessage(LogLevel.Error, "SqsMessageConsumer: Could not delete message {Id} with receipt handle {ReceiptHandle} on queue {ChannelName} because the receipt handle has expired. The message visibility timeout elapsed and SQS has already re-presented it for delivery; if the handler is not idempotent this may result in duplicate processing.")]
+        [LoggerMessage(LogLevel.Error, "SqsMessageConsumer: Could not delete message {Id} with receipt handle {ReceiptHandle} on queue {ChannelName} because the receipt handle is invalid (most likely because the visibility timeout elapsed). SQS has already re-presented it for delivery; if the handler is not idempotent this may result in duplicate processing.")]
         public static partial void DeleteFailedReceiptHandleExpired(ILogger logger, Exception exception, string id, string? receiptHandle, string channelName);
 
-        [LoggerMessage(LogLevel.Warning, "SqsMessageConsumer: Could not requeue message {Id} with receipt handle {ReceiptHandle} on queue {ChannelName} because the receipt handle has expired. The message visibility timeout elapsed and SQS has already re-presented it for delivery without the intended delay of {Delay}.")]
+        [LoggerMessage(LogLevel.Warning, "SqsMessageConsumer: Could not requeue message {Id} with receipt handle {ReceiptHandle} on queue {ChannelName} because the receipt handle is invalid (most likely because the visibility timeout elapsed). SQS has already re-presented it for delivery without the intended delay of {Delay}.")]
         public static partial void RequeueFailedReceiptHandleExpired(ILogger logger, Exception exception, string id, string? receiptHandle, string channelName, TimeSpan delay);
 
-        [LoggerMessage(LogLevel.Warning, "SqsMessageConsumer: Could not nack message {Id} with receipt handle {ReceiptHandle} on queue {ChannelName} because the receipt handle has expired. The message visibility timeout elapsed and SQS has already re-presented it for delivery.")]
+        [LoggerMessage(LogLevel.Warning, "SqsMessageConsumer: Could not nack message {Id} with receipt handle {ReceiptHandle} on queue {ChannelName} because the receipt handle is invalid (most likely because the visibility timeout elapsed). SQS has already re-presented it for delivery.")]
         public static partial void NackFailedReceiptHandleExpired(ILogger logger, Exception exception, string id, string? receiptHandle, string channelName);
 
         [LoggerMessage(LogLevel.Information, "SqsMessageConsumer: Rejecting the message {Id} with receipt handle {ReceiptHandle} on the queue {ChannelName} due to {Reason} because of {Description}")]

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS/SqsMessageConsumer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS/SqsMessageConsumer.cs
@@ -353,6 +353,8 @@ namespace Paramore.Brighter.MessagingGateway.AWSSQS
             }
             catch (ReceiptHandleIsInvalidException ex)
             {
+                // Receipt handle is invalid (most likely because the visibility timeout elapsed).
+                // SQS has already made the message visible again for redelivery by another consumer.
                 // Nack sets visibility to zero for immediate redelivery — but the message is already
                 // visible again, so the net effect is the same. Log a warning and continue.
                 Log.NackFailedReceiptHandleExpired(s_logger, ex, message.Id, receiptHandle, _queueName);
@@ -408,7 +410,7 @@ namespace Paramore.Brighter.MessagingGateway.AWSSQS
             }
             catch (ReceiptHandleIsInvalidException ex)
             {
-                // Receipt handle has expired - the visibility timeout elapsed during processing.
+                // Receipt handle is invalid (most likely because the visibility timeout elapsed).
                 // SQS has already made the message visible again for redelivery by another consumer,
                 // but without the intended delay. Log a warning so operators are aware.
                 Log.RequeueFailedReceiptHandleExpired(s_logger, ex, message.Id, receiptHandle, _queueName, delay.Value);
@@ -523,7 +525,7 @@ namespace Paramore.Brighter.MessagingGateway.AWSSQS
             }
             catch (ReceiptHandleIsInvalidException ex)
             {
-                // Receipt handle has expired - the visibility timeout elapsed during processing.
+                // Receipt handle is invalid (most likely because the visibility timeout elapsed).
                 // SQS has already made the message visible again for redelivery by another consumer.
                 // This is an error because the message was not deleted and may be processed again;
                 // handlers should be idempotent, but an operator may need to investigate.
@@ -577,13 +579,13 @@ namespace Paramore.Brighter.MessagingGateway.AWSSQS
             [LoggerMessage(LogLevel.Error, "SqsMessageConsumer: Error during deleting the message {Id} with receipt handle {ReceiptHandle} on the queue {ChannelName}")]
             public static partial void ErrorDeletingMessage(ILogger logger, Exception exception, string id, string? receiptHandle, string channelName);
 
-            [LoggerMessage(LogLevel.Error, "SqsMessageConsumer: Could not delete message {Id} with receipt handle {ReceiptHandle} on queue {ChannelName} because the receipt handle has expired. The message visibility timeout elapsed and SQS has already re-presented it for delivery; if the handler is not idempotent this may result in duplicate processing.")]
+            [LoggerMessage(LogLevel.Error, "SqsMessageConsumer: Could not delete message {Id} with receipt handle {ReceiptHandle} on queue {ChannelName} because the receipt handle is invalid (most likely because the visibility timeout elapsed). SQS has already re-presented it for delivery; if the handler is not idempotent this may result in duplicate processing.")]
             public static partial void DeleteFailedReceiptHandleExpired(ILogger logger, Exception exception, string id, string? receiptHandle, string channelName);
 
-            [LoggerMessage(LogLevel.Warning, "SqsMessageConsumer: Could not requeue message {Id} with receipt handle {ReceiptHandle} on queue {ChannelName} because the receipt handle has expired. The message visibility timeout elapsed and SQS has already re-presented it for delivery without the intended delay of {Delay}.")]
+            [LoggerMessage(LogLevel.Warning, "SqsMessageConsumer: Could not requeue message {Id} with receipt handle {ReceiptHandle} on queue {ChannelName} because the receipt handle is invalid (most likely because the visibility timeout elapsed). SQS has already re-presented it for delivery without the intended delay of {Delay}.")]
             public static partial void RequeueFailedReceiptHandleExpired(ILogger logger, Exception exception, string id, string? receiptHandle, string channelName, TimeSpan delay);
 
-            [LoggerMessage(LogLevel.Warning, "SqsMessageConsumer: Could not nack message {Id} with receipt handle {ReceiptHandle} on queue {ChannelName} because the receipt handle has expired. The message visibility timeout elapsed and SQS has already re-presented it for delivery.")]
+            [LoggerMessage(LogLevel.Warning, "SqsMessageConsumer: Could not nack message {Id} with receipt handle {ReceiptHandle} on queue {ChannelName} because the receipt handle is invalid (most likely because the visibility timeout elapsed). SQS has already re-presented it for delivery.")]
             public static partial void NackFailedReceiptHandleExpired(ILogger logger, Exception exception, string id, string? receiptHandle, string channelName);
 
             [LoggerMessage(LogLevel.Information, "SqsMessageConsumer: Rejecting the message {Id} with receipt handle {ReceiptHandle} on the queue {ChannelName} due to {Reason} because of {Description}")]


### PR DESCRIPTION
Closes #4031 

When the SQS visibility timeout elapses during message processing, the receipt handle expires, and subsequent Delete/Nack/Requeue calls throw ReceiptHandleIsInvalidException. Previously, this propagated unhandled and killed the dispatcher pump.

Catch ReceiptHandleIsInvalidException specifically in DeleteSourceMessageAsync, NackAsync, and RequeueAsync in both V4 and non-V4 SQS consumers. Log severity reflects the operational risk of each scenario:
- Delete: Error — message was not deleted, may be processed again
- Nack: Warning — message is already visible, net effect is the same
- Requeue: Warning — message is visible but without the intended delay