### PR TITLE
fix(samples): make CommandProcessor handlers and commands public (fixes #4041)

### DIFF
--- a/samples/CommandProcessor/HelloWorld/GreetingCommand.cs
+++ b/samples/CommandProcessor/HelloWorld/GreetingCommand.cs
@@ -26,7 +26,7 @@ using Paramore.Brighter;
 
 namespace HelloWorld
 {
-    internal sealed class GreetingCommand(string name) : Command(Id.Random())
+    public sealed class GreetingCommand(string name) : Command(Id.Random())
     {
         public string Name { get; } = name;
     }

--- a/samples/CommandProcessor/HelloWorld/GreetingCommandHandler.cs
+++ b/samples/CommandProcessor/HelloWorld/GreetingCommandHandler.cs
@@ -28,7 +28,7 @@ using Paramore.Brighter.Logging.Attributes;
 
 namespace HelloWorld
 {
-    internal sealed class GreetingCommandHandler : RequestHandler<GreetingCommand>
+    public sealed class GreetingCommandHandler : RequestHandler<GreetingCommand>
     {
         [RequestLogging(step: 1, timing: HandlerTiming.Before)]
         public override GreetingCommand Handle(GreetingCommand greetingCommand)

--- a/samples/CommandProcessor/HelloWorldAsync/GreetingCommand.cs
+++ b/samples/CommandProcessor/HelloWorldAsync/GreetingCommand.cs
@@ -26,7 +26,7 @@ using Paramore.Brighter;
 
 namespace HelloWorldAsync
 {
-    internal sealed class GreetingCommand(string name) : Command(Id.Random())
+    public sealed class GreetingCommand(string name) : Command(Id.Random())
     {
         public string Name { get; } = name;
     }

--- a/samples/CommandProcessor/HelloWorldAsync/GreetingCommandHandlerAsync.cs
+++ b/samples/CommandProcessor/HelloWorldAsync/GreetingCommandHandlerAsync.cs
@@ -30,7 +30,7 @@ using Paramore.Brighter.Logging.Attributes;
 
 namespace HelloWorldAsync
 {
-    internal sealed class GreetingCommandHandlerAsync : RequestHandlerAsync<GreetingCommand>
+    public sealed class GreetingCommandHandlerAsync : RequestHandlerAsync<GreetingCommand>
     {
         [RequestLoggingAsync(step: 1, timing: HandlerTiming.Before)]
         public override async Task<GreetingCommand> HandleAsync(GreetingCommand command, CancellationToken cancellationToken = default)

--- a/samples/CommandProcessor/HelloWorldInternalBus/GreetingCommand.cs
+++ b/samples/CommandProcessor/HelloWorldInternalBus/GreetingCommand.cs
@@ -26,7 +26,7 @@ using Paramore.Brighter;
 
 namespace HelloWorldInternalBus
 {
-    internal sealed class GreetingCommand(string name) : Command(Id.Random())
+    public sealed class GreetingCommand(string name) : Command(Id.Random())
     {
         public string Name { get; } = name;
     }

--- a/samples/CommandProcessor/HelloWorldInternalBus/GreetingCommandHandlerAsync.cs
+++ b/samples/CommandProcessor/HelloWorldInternalBus/GreetingCommandHandlerAsync.cs
@@ -27,7 +27,7 @@ using Paramore.Brighter.Logging.Attributes;
 
 namespace HelloWorldInternalBus
 {
-    internal sealed class GreetingCommandHandlerAsync : RequestHandlerAsync<GreetingCommand>
+    public sealed class GreetingCommandHandlerAsync : RequestHandlerAsync<GreetingCommand>
     {
         [RequestLoggingAsync(step: 1, timing: HandlerTiming.Before)]
         public override async Task<GreetingCommand> HandleAsync(GreetingCommand command, CancellationToken cancellationToken = default)


### PR DESCRIPTION
## Summary

- `AutoFromAssemblies` filters handler discovery to `IsPublic || IsNestedPublic` (see `ServiceCollectionBrighterBuilder.cs:253`), so `internal` handlers are silently skipped at startup
- This caused a `'No command handler was found for typeof command HelloWorld.GreetingCommand'` exception in all three `CommandProcessor` samples
- Fix: change `internal sealed class` → `public sealed class` on handlers and commands in `HelloWorld`, `HelloWorldAsync`, and `HelloWorldInternalBus`

Fixes #4041

## Test plan

- [x] Run `samples/CommandProcessor/HelloWorld` — should print `Hello Ian`
- [x] Run `samples/CommandProcessor/HelloWorldAsync` — should print `Hello Ian`
- [x] Run `samples/CommandProcessor/HelloWorldInternalBus` — should print `Hello Ian`

🤖 Generated with [Claude Code](https://claude.com/claude-code)