### PR TITLE
Replace localstack with jet-stack image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -447,15 +447,13 @@ jobs:
     timeout-minutes: 8
     needs: build
     env:
-      LOCALSTACK_SERVICE_URL: http://localhost.localstack.cloud:4566
+      LOCALSTACK_SERVICE_URL: http://localhost:4566
 
-    services: 
-      localstack: 
-        image: localstack/localstack    
+    services:
+      jet-stack:
+        image: ghcr.io/justeattakeaway/jet-stack:latest
         ports:
           - 4566:4566
-        env: 
-          SERVICES: s3,sqs,sns,sts,dynamodb,iam,scheduler
 
     steps:
       - uses: actions/checkout@v6

--- a/docker-compose-localstack.yaml
+++ b/docker-compose-localstack.yaml
@@ -1,16 +1,7 @@
 version: '3'
 
 services:
-  localstack:
-    image: localstack/localstack:latest
-    environment:
-      # LocalStack configuration: https://docs.localstack.cloud/references/configuration/
-      - "SERVICES=s3,sqs,sns,sts,dynamodb,iam,scheduler"
-      - "USE_SINGLE_REGION=1"
-      - "DEBUG=1"
-      - "PROVIDER_OVERRIDE_EVENTS=v2"
+  jet-stack:
+    image: ghcr.io/justeattakeaway/jet-stack:latest
     ports:
-      - "4566:4566" # LocalStack Gateway
-      - "4510-4559:4510-4559" # External services port range
-    volumes:
-      - "/var/run/docker.sock:/var/run/docker.sock"
+      - "4566:4566" # Gateway

--- a/tests/Paramore.Brighter.AWS.Tests/Helpers/GatewayFactory.cs
+++ b/tests/Paramore.Brighter.AWS.Tests/Helpers/GatewayFactory.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Amazon;
 using Amazon.Runtime;
-using Amazon.S3;
 using Paramore.Brighter.MessagingGateway.AWSSQS;
 using Paramore.Brighter.Transformers.AWS;
 
@@ -37,14 +36,7 @@ public static class GatewayFactory
                 var serviceUrl = Environment.GetEnvironmentVariable("LOCALSTACK_SERVICE_URL");
                 if (!string.IsNullOrWhiteSpace(serviceUrl))
                 {
-                    if (cfg is AmazonS3Config && Uri.TryCreate(serviceUrl, UriKind.Absolute, out var uri))
-                    {
-                        cfg.ServiceURL = $"http://s3.{uri.Authority}";
-                    }
-                    else
-                    {
-                        cfg.ServiceURL = serviceUrl;
-                    }
+                    cfg.ServiceURL = serviceUrl;
                 }
             });
     }
@@ -57,14 +49,7 @@ public static class GatewayFactory
             var serviceUrl = Environment.GetEnvironmentVariable("LOCALSTACK_SERVICE_URL");
             if (!string.IsNullOrWhiteSpace(serviceUrl))
             {
-                if (cfg is AmazonS3Config && Uri.TryCreate(serviceUrl, UriKind.Absolute, out var uri))
-                {
-                    cfg.ServiceURL = $"http://s3.{uri.Authority}";
-                }
-                else
-                {
-                    cfg.ServiceURL = serviceUrl;
-                }
+                cfg.ServiceURL = serviceUrl;
             }
         });
     }

--- a/tests/Paramore.Brighter.AWS.V4.Tests/Helpers/GatewayFactory.cs
+++ b/tests/Paramore.Brighter.AWS.V4.Tests/Helpers/GatewayFactory.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Amazon;
 using Amazon.Runtime;
-using Amazon.S3;
 using Paramore.Brighter.MessagingGateway.AWSSQS.V4;
 using Paramore.Brighter.Transformers.AWS.V4;
 
@@ -37,14 +36,7 @@ public static class GatewayFactory
                 var serviceUrl = Environment.GetEnvironmentVariable("LOCALSTACK_SERVICE_URL");
                 if (!string.IsNullOrWhiteSpace(serviceUrl))
                 {
-                    if (cfg is AmazonS3Config && Uri.TryCreate(serviceUrl, UriKind.Absolute, out var uri))
-                    {
-                        cfg.ServiceURL = $"http://s3.{uri.Authority}";
-                    }
-                    else
-                    {
-                        cfg.ServiceURL = serviceUrl;
-                    }
+                    cfg.ServiceURL = serviceUrl;
                 }
             });
     }
@@ -57,14 +49,7 @@ public static class GatewayFactory
             var serviceUrl = Environment.GetEnvironmentVariable("LOCALSTACK_SERVICE_URL");
             if (!string.IsNullOrWhiteSpace(serviceUrl))
             {
-                if (cfg is AmazonS3Config && Uri.TryCreate(serviceUrl, UriKind.Absolute, out var uri))
-                {
-                    cfg.ServiceURL = $"http://s3.{uri.Authority}";
-                }
-                else
-                {
-                    cfg.ServiceURL = serviceUrl;
-                }
+                cfg.ServiceURL = serviceUrl;
             }
         });
     }


### PR DESCRIPTION
## Summary
- Replace `localstack/localstack` with `ghcr.io/justeattakeaway/jet-stack:latest` in docker-compose and CI
- Simplify service URL configuration — remove localstack-specific S3 URL rewriting and `localhost.localstack.cloud` hostname
- Remove localstack-specific env vars (SERVICES, USE_SINGLE_REGION, DEBUG, PROVIDER_OVERRIDE_EVENTS)

## Test plan
- [ ] CI `localstack-ci` job passes with jet-stack image (SQS/SNS/STS tests)
- [ ] Local `docker-compose -f docker-compose-localstack.yaml up` starts jet-stack successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)