### PR TITLE
fix: generate all NuGet packages on CI builds

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,4 +1,10 @@
 <Project>
+  <!-- Deterministic builds ensure that the same binary is produced regardless of the machine building it -->
+  <!-- This setting is set on the build server to normalize stored file paths, should not be set for local dev -->
+  <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+  </PropertyGroup>
+
   <PropertyGroup>
     <Company>Brighter Command</Company>
     <Authors>Ian Cooper</Authors>
@@ -34,12 +40,6 @@
     <BrighterFrameworkAndCoreTargetFrameworks>net462;net8.0;net9.0;net10.0</BrighterFrameworkAndCoreTargetFrameworks>
     <BrighterCoreTargetFrameworks>net8.0;net9.0;net10.0</BrighterCoreTargetFrameworks>
     <BrighterNetNineEarlierTargetFrameworks>net8.0;net9.0</BrighterNetNineEarlierTargetFrameworks>
-  </PropertyGroup>
-
-  <!-- Deterministic builds ensure that the same binary is produced regardless of the machine building it -->
-  <!-- This setting is set on the build server to normalize stored file paths, should not be set for local dev -->
-  <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
-    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Paramore.Brighter.Analyzer.Package/Paramore.Brighter.Analyzer.Package.csproj
+++ b/src/Paramore.Brighter.Analyzer.Package/Paramore.Brighter.Analyzer.Package.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(BrighterNetStandardTargetFrameworks)</TargetFrameworks>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Paramore.Brighter.Locking.Azure/Paramore.Brighter.Locking.Azure.csproj
+++ b/src/Paramore.Brighter.Locking.Azure/Paramore.Brighter.Locking.Azure.csproj
@@ -8,7 +8,7 @@
     <Nullable>enable</Nullable>
     <Title>This is the Azure Distributed Locking Provider.</Title>
     <Authors>Paul Reardon</Authors>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Paramore.Brighter.Locking.DynamoDB.V4/Paramore.Brighter.Locking.DynamoDB.V4.csproj
+++ b/src/Paramore.Brighter.Locking.DynamoDB.V4/Paramore.Brighter.Locking.DynamoDB.V4.csproj
@@ -8,7 +8,7 @@
     <Nullable>enable</Nullable>
     <Title>This is the Dynamo DB Distributed Locking Provider.</Title>
     <Authors>Dominic Hickie</Authors>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Paramore.Brighter.Locking.DynamoDB/Paramore.Brighter.Locking.DynamoDB.csproj
+++ b/src/Paramore.Brighter.Locking.DynamoDB/Paramore.Brighter.Locking.DynamoDB.csproj
@@ -8,7 +8,7 @@
     <Nullable>enable</Nullable>
     <Title>This is the Dynamo DB Distributed Locking Provider.</Title>
     <Authors>Dominic Hickie</Authors>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Paramore.Brighter.Locking.MySql/Paramore.Brighter.Locking.MySql.csproj
+++ b/src/Paramore.Brighter.Locking.MySql/Paramore.Brighter.Locking.MySql.csproj
@@ -4,7 +4,7 @@
     <Authors>Rafael Andrade</Authors>
     <TargetFrameworks>$(BrighterNetNineEarlierTargetFrameworks)</TargetFrameworks>
     <PackageTags>MySQL;Distributed Locking;Concurrency;Lock;Command Processor;Database;SQL;Brighter</PackageTags>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Paramore.Brighter.Locking.PostgresSql/Paramore.Brighter.Locking.PostgresSql.csproj
+++ b/src/Paramore.Brighter.Locking.PostgresSql/Paramore.Brighter.Locking.PostgresSql.csproj
@@ -5,7 +5,7 @@
     <Authors>Rafael Andrade</Authors>
     <TargetFrameworks>$(BrighterCoreTargetFrameworks)</TargetFrameworks>
     <PackageTags>PostgreSQL;Postgres;Distributed Locking;Concurrency;Lock;Command Processor;Database;SQL;Brighter</PackageTags>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+
     <Nullable>enable</Nullable>
   </PropertyGroup>
   


### PR DESCRIPTION
## Summary
- Only 6 NuGet packages were being uploaded as build artifacts instead of the full ~82
- `ContinuousIntegrationBuild` was defined **after** `GeneratePackageOnBuild` in `src/Directory.Build.props`, so MSBuild evaluated the condition before the property existed — it was always empty
- Moved the `ContinuousIntegrationBuild` PropertyGroup to the top of the file so it's set before `GeneratePackageOnBuild` references it
- Removed redundant `<GeneratePackageOnBuild>true</GeneratePackageOnBuild>` from the 6 `.csproj` files that had it hardcoded (Locking.*, Analyzer.Package)