### PR TITLE
fix: resolve producer lookup failure when posting Reply messages

### DIFF
--- a/Brighter.slnx
+++ b/Brighter.slnx
@@ -34,6 +34,11 @@
     <Project Path="samples/Scheduler/TickerQ/Greeting.ServiceDefaults/Greeting.ServiceDefaults.csproj" />
   </Folder>
   <Folder Name="/samples/TaskQueue/" />
+  <Folder Name="/samples/TaskQueue/ASBRequestReply/">
+    <Project Path="samples/TaskQueue/ASBRequestReply/Greetings/Greetings.csproj" />
+    <Project Path="samples/TaskQueue/ASBRequestReply/GreetingsClient/GreetingsClient.csproj" />
+    <Project Path="samples/TaskQueue/ASBRequestReply/GreetingsServer/GreetingsServer.csproj" />
+  </Folder>
   <Folder Name="/samples/TaskQueue/ASBTaskQueue/">
     <Project Path="samples/TaskQueue/ASBTaskQueue/Greetings/Greetings.csproj" />
     <Project Path="samples/TaskQueue/ASBTaskQueue/GreetingsReceiverConsole/GreetingsReceiverConsole.csproj" />

--- a/Brighter.slnx
+++ b/Brighter.slnx
@@ -34,11 +34,6 @@
     <Project Path="samples/Scheduler/TickerQ/Greeting.ServiceDefaults/Greeting.ServiceDefaults.csproj" />
   </Folder>
   <Folder Name="/samples/TaskQueue/" />
-  <Folder Name="/samples/TaskQueue/ASBRequestReply/">
-    <Project Path="samples/TaskQueue/ASBRequestReply/Greetings/Greetings.csproj" />
-    <Project Path="samples/TaskQueue/ASBRequestReply/GreetingsClient/GreetingsClient.csproj" />
-    <Project Path="samples/TaskQueue/ASBRequestReply/GreetingsServer/GreetingsServer.csproj" />
-  </Folder>
   <Folder Name="/samples/TaskQueue/ASBTaskQueue/">
     <Project Path="samples/TaskQueue/ASBTaskQueue/Greetings/Greetings.csproj" />
     <Project Path="samples/TaskQueue/ASBTaskQueue/GreetingsReceiverConsole/GreetingsReceiverConsole.csproj" />

--- a/src/Paramore.Brighter.MessageScheduler.Azure/AzureServiceBusScheduler.cs
+++ b/src/Paramore.Brighter.MessageScheduler.Azure/AzureServiceBusScheduler.cs
@@ -131,7 +131,9 @@ public class AzureServiceBusScheduler(
             message.Header.HandledCount);
         azureServiceBusMessage.ApplicationProperties.Add(ASBConstants.ReplyToHeaderBagKey, message.Header.ReplyTo);
 
-        foreach (var header in message.Header.Bag.Where(h => !ASBConstants.ReservedHeaders.Contains(h.Key)))
+        foreach (var header in message.Header.Bag.Where(h =>
+                     !ASBConstants.ReservedHeaders.Contains(h.Key)
+                     && !MessageHeader.LocalHeaderNames.Contains(h.Key)))
         {
             azureServiceBusMessage.ApplicationProperties.Add(header.Key, header.Value);
         }

--- a/src/Paramore.Brighter.MessageScheduler.Azure/AzureServiceBusScheduler.cs
+++ b/src/Paramore.Brighter.MessageScheduler.Azure/AzureServiceBusScheduler.cs
@@ -133,7 +133,7 @@ public class AzureServiceBusScheduler(
 
         foreach (var header in message.Header.Bag.Where(h =>
                      !ASBConstants.ReservedHeaders.Contains(h.Key)
-                     && !MessageHeader.LocalHeaderNames.Contains(h.Key)))
+                     && !MessageHeader.IsLocalHeader(h.Key)))
         {
             azureServiceBusMessage.ApplicationProperties.Add(header.Key, header.Value);
         }

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS.V4/SnsMessagePublisher.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS.V4/SnsMessagePublisher.cs
@@ -109,7 +109,7 @@ public class SnsMessagePublisher
         
         message.Header.Bag[HeaderNames.HandledCount] = message.Header.HandledCount.ToString(CultureInfo.InvariantCulture);
 
-        var bagJson = JsonSerializer.Serialize(message.Header.Bag, JsonSerialisationOptions.Options);
+        var bagJson = JsonSerializer.Serialize(message.Header.BagWithoutLocalHeaders(), JsonSerialisationOptions.Options);
         messageAttributes[HeaderNames.Bag] = new MessageAttributeValue { StringValue = Convert.ToString(bagJson), DataType = "String" };
 
         return messageAttributes;

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS.V4/SqsMessageSender.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS.V4/SqsMessageSender.cs
@@ -127,7 +127,7 @@ public partial class SqsMessageSender
 
         message.Header.Bag[HeaderNames.HandledCount] = message.Header.HandledCount.ToString(CultureInfo.InvariantCulture);
 
-        var bagJson = System.Text.Json.JsonSerializer.Serialize(message.Header.Bag, JsonSerialisationOptions.Options);
+        var bagJson = System.Text.Json.JsonSerializer.Serialize(message.Header.BagWithoutLocalHeaders(), JsonSerialisationOptions.Options);
         messageAttributes[HeaderNames.Bag] = new() { StringValue = bagJson, DataType = "String" };
         request.MessageAttributes = messageAttributes;
     }

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS/SnsMessagePublisher.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS/SnsMessagePublisher.cs
@@ -109,7 +109,7 @@ public class SnsMessagePublisher
         
         message.Header.Bag[HeaderNames.HandledCount] = message.Header.HandledCount.ToString(CultureInfo.InvariantCulture);
 
-        var bagJson = JsonSerializer.Serialize(message.Header.Bag, JsonSerialisationOptions.Options);
+        var bagJson = JsonSerializer.Serialize(message.Header.BagWithoutLocalHeaders(), JsonSerialisationOptions.Options);
         messageAttributes[HeaderNames.Bag] = new MessageAttributeValue { StringValue = Convert.ToString(bagJson), DataType = "String" };
 
         return messageAttributes;

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS/SqsMessageSender.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS/SqsMessageSender.cs
@@ -129,7 +129,7 @@ public partial class SqsMessageSender
 
         message.Header.Bag[HeaderNames.HandledCount] = message.Header.HandledCount.ToString(CultureInfo.InvariantCulture);
 
-        var bagJson = System.Text.Json.JsonSerializer.Serialize(message.Header.Bag, JsonSerialisationOptions.Options);
+        var bagJson = System.Text.Json.JsonSerializer.Serialize(message.Header.BagWithoutLocalHeaders(), JsonSerialisationOptions.Options);
         messageAttributes[HeaderNames.Bag] = new() { StringValue = bagJson, DataType = "String" };
         request.MessageAttributes = messageAttributes;
     }

--- a/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusMessagePublisher.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusMessagePublisher.cs
@@ -64,7 +64,7 @@ public class AzureServiceBusMessagePublisher
 
         foreach (var header in message.Header.Bag.Where(h =>
                      !ASBConstants.ReservedHeaders.Contains(h.Key)
-                     && !MessageHeader.LocalHeaderNames.Contains(h.Key)))
+                     && !MessageHeader.IsLocalHeader(h.Key)))
         {
             azureServiceBusMessage.ApplicationProperties[header.Key] = header.Value;
         }

--- a/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusMessagePublisher.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusMessagePublisher.cs
@@ -62,7 +62,9 @@ public class AzureServiceBusMessagePublisher
         if (message.Header.Bag.TryGetValue(ASBConstants.SessionIdKey, out object? value))
             azureServiceBusMessage.SessionId = value.ToString();
 
-        foreach (var header in message.Header.Bag.Where(h => !ASBConstants.ReservedHeaders.Contains(h.Key)))
+        foreach (var header in message.Header.Bag.Where(h =>
+                     !ASBConstants.ReservedHeaders.Contains(h.Key)
+                     && !MessageHeader.LocalHeaderNames.Contains(h.Key)))
         {
             azureServiceBusMessage.ApplicationProperties[header.Key] = header.Value;
         }

--- a/src/Paramore.Brighter.MessagingGateway.GcpPubSub/Parser.cs
+++ b/src/Paramore.Brighter.MessagingGateway.GcpPubSub/Parser.cs
@@ -349,7 +349,7 @@ internal static class Parser
 
         message.Header.Bag.Each(header =>
         {
-            if (!headers.ContainsKey(header.Key) && !MessageHeader.LocalHeaderNames.Contains(header.Key))
+            if (!headers.ContainsKey(header.Key) && !MessageHeader.IsLocalHeader(header.Key))
             {
                 headers.Add(header.Key, header.Value.ToString()!);
             }

--- a/src/Paramore.Brighter.MessagingGateway.GcpPubSub/Parser.cs
+++ b/src/Paramore.Brighter.MessagingGateway.GcpPubSub/Parser.cs
@@ -349,7 +349,7 @@ internal static class Parser
 
         message.Header.Bag.Each(header =>
         {
-            if (!headers.ContainsKey(header.Key))
+            if (!headers.ContainsKey(header.Key) && !MessageHeader.LocalHeaderNames.Contains(header.Key))
             {
                 headers.Add(header.Key, header.Value.ToString()!);
             }

--- a/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaDefaultMessageHeaderBuilder.cs
+++ b/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaDefaultMessageHeaderBuilder.cs
@@ -113,7 +113,8 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
         private void AddUserDefinedBagHeaders(Headers headers, Message message)
         {
             message.Header.Bag
-                .Where(x => !BrighterDefinedHeaders.HeadersToReset.Contains(x.Key))
+                .Where(x => !BrighterDefinedHeaders.HeadersToReset.Contains(x.Key)
+                            && !MessageHeader.LocalHeaderNames.Contains(x.Key))
                 .Each(header => AddUserDefinedBagHeader(headers, header.Key, header.Value));
         }
 

--- a/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaDefaultMessageHeaderBuilder.cs
+++ b/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaDefaultMessageHeaderBuilder.cs
@@ -114,7 +114,7 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
         {
             message.Header.Bag
                 .Where(x => !BrighterDefinedHeaders.HeadersToReset.Contains(x.Key)
-                            && !MessageHeader.LocalHeaderNames.Contains(x.Key))
+                            && !MessageHeader.IsLocalHeader(x.Key))
                 .Each(header => AddUserDefinedBagHeader(headers, header.Key, header.Value));
         }
 

--- a/src/Paramore.Brighter.MessagingGateway.RMQ.Async/RmqMessagePublisher.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ.Async/RmqMessagePublisher.cs
@@ -228,7 +228,7 @@ internal sealed partial class RmqMessagePublisher
     {
         message.Header.Bag.Each(header =>
         {
-            if (!_headersToReset.Contains(header.Key) && !MessageHeader.LocalHeaderNames.Contains(header.Key))
+            if (!_headersToReset.Contains(header.Key) && !MessageHeader.IsLocalHeader(header.Key))
             {
                 headers[header.Key] = header.Value;
             }

--- a/src/Paramore.Brighter.MessagingGateway.RMQ.Async/RmqMessagePublisher.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ.Async/RmqMessagePublisher.cs
@@ -228,7 +228,7 @@ internal sealed partial class RmqMessagePublisher
     {
         message.Header.Bag.Each(header =>
         {
-            if (!_headersToReset.Contains(header.Key))
+            if (!_headersToReset.Contains(header.Key) && !MessageHeader.LocalHeaderNames.Contains(header.Key))
             {
                 headers[header.Key] = header.Value;
             }

--- a/src/Paramore.Brighter.MessagingGateway.RMQ.Sync/RmqMessagePublisher.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ.Sync/RmqMessagePublisher.cs
@@ -194,7 +194,7 @@ namespace Paramore.Brighter.MessagingGateway.RMQ.Sync
         {
             message.Header.Bag.Each(header =>
             {
-                if (!_headersToReset.Contains(header.Key) && !MessageHeader.LocalHeaderNames.Contains(header.Key))
+                if (!_headersToReset.Contains(header.Key) && !MessageHeader.IsLocalHeader(header.Key))
                 {
                     headers[header.Key] = header.Value;
                 }

--- a/src/Paramore.Brighter.MessagingGateway.RMQ.Sync/RmqMessagePublisher.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ.Sync/RmqMessagePublisher.cs
@@ -194,7 +194,7 @@ namespace Paramore.Brighter.MessagingGateway.RMQ.Sync
         {
             message.Header.Bag.Each(header =>
             {
-                if (!_headersToReset.Contains(header.Key))
+                if (!_headersToReset.Contains(header.Key) && !MessageHeader.LocalHeaderNames.Contains(header.Key))
                 {
                     headers[header.Key] = header.Value;
                 }

--- a/src/Paramore.Brighter.MessagingGateway.Redis/RedisMessagePublisher.cs
+++ b/src/Paramore.Brighter.MessagingGateway.Redis/RedisMessagePublisher.cs
@@ -131,7 +131,7 @@ namespace Paramore.Brighter.MessagingGateway.Redis
 
         private static void WriteMessageBag(MessageHeader messageHeader, Dictionary<string, string> headers)
         {
-            var flatBag = JsonSerializer.Serialize(messageHeader.Bag, JsonSerialisationOptions.Options);
+            var flatBag = JsonSerializer.Serialize(messageHeader.BagWithoutLocalHeaders(), JsonSerialisationOptions.Options);
             headers.Add(HeaderNames.BAG, flatBag);
         }
 

--- a/src/Paramore.Brighter.MessagingGateway.RocketMQ/RocketMqMessageProducer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RocketMQ/RocketMqMessageProducer.cs
@@ -148,7 +148,7 @@ public class RocketMqMessageProducer(
         foreach (var (key, val) in message.Header.Bag
                      .Where(x => x.Key != HeaderNames.Keys
                                  && x.Key != HeaderNames.Tag
-                                 && !MessageHeader.LocalHeaderNames.Contains(x.Key)))
+                                 && !MessageHeader.IsLocalHeader(x.Key)))
         {
             builder.AddProperty(key, val.ToString());
         }

--- a/src/Paramore.Brighter.MessagingGateway.RocketMQ/RocketMqMessageProducer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RocketMQ/RocketMqMessageProducer.cs
@@ -146,7 +146,9 @@ public class RocketMqMessageProducer(
         }
         
         foreach (var (key, val) in message.Header.Bag
-                     .Where(x => x.Key != HeaderNames.Keys && x.Key != HeaderNames.Tag))
+                     .Where(x => x.Key != HeaderNames.Keys
+                                 && x.Key != HeaderNames.Tag
+                                 && !MessageHeader.LocalHeaderNames.Contains(x.Key)))
         {
             builder.AddProperty(key, val.ToString());
         }

--- a/src/Paramore.Brighter/Message.cs
+++ b/src/Paramore.Brighter/Message.cs
@@ -56,7 +56,7 @@ namespace Paramore.Brighter
         /// (e.g. for Reply messages whose topic is the reply address).
         /// Read by the outbox dispatcher so it can still locate the registered producer.
         /// </summary>
-        public const string ProducerTopicHeaderName = "ProducerTopic";
+        public const string ProducerTopicHeaderName = "paramore.brighter.ProducerTopic";
 
         /// <summary>
         /// Gets the header.

--- a/src/Paramore.Brighter/Message.cs
+++ b/src/Paramore.Brighter/Message.cs
@@ -51,8 +51,10 @@ namespace Paramore.Brighter
         public const string RejectionReasonHeaderName = "RejectionReason";
 
         /// <summary>
-        /// Tag name for the producer topic header, used when the message mapper overrides the topic (e.g. for Reply messages)
-        /// so that the outbox dispatcher can still find the correct producer
+        /// Bag key (not a typed header property — lives in <see cref="MessageHeader.Bag"/>)
+        /// carrying the publication topic when the message mapper overrides <see cref="MessageHeader.Topic"/>
+        /// (e.g. for Reply messages whose topic is the reply address).
+        /// Read by the outbox dispatcher so it can still locate the registered producer.
         /// </summary>
         public const string ProducerTopicHeaderName = "ProducerTopic";
 

--- a/src/Paramore.Brighter/Message.cs
+++ b/src/Paramore.Brighter/Message.cs
@@ -51,6 +51,12 @@ namespace Paramore.Brighter
         public const string RejectionReasonHeaderName = "RejectionReason";
 
         /// <summary>
+        /// Tag name for the producer topic header, used when the message mapper overrides the topic (e.g. for Reply messages)
+        /// so that the outbox dispatcher can still find the correct producer
+        /// </summary>
+        public const string ProducerTopicHeaderName = "ProducerTopic";
+
+        /// <summary>
         /// Gets the header.
         /// </summary>
         /// <value>The header.</value>

--- a/src/Paramore.Brighter/MessageHeader.cs
+++ b/src/Paramore.Brighter/MessageHeader.cs
@@ -92,7 +92,9 @@ namespace Paramore.Brighter
         /// Bag keys that are internal to Brighter — set by the framework so a downstream
         /// component (e.g. the outbox dispatcher) can read them, but not intended to travel
         /// over the wire. Transports that copy <see cref="Bag"/> into their wire format must
-        /// skip these keys (or call <see cref="StripLocalHeaders"/> on a copy of the header).
+        /// skip these keys: either filter inline (see ASB / RMQ / Kafka publishers) or
+        /// call <see cref="BagWithoutLocalHeaders"/> when serialising the bag in one go
+        /// (see SNS / SQS / Redis publishers).
         /// </summary>
         /// <remarks>
         /// Pre-populated with <see cref="Message.ProducerTopicHeaderName"/>. Add to this set
@@ -112,6 +114,23 @@ namespace Paramore.Brighter
         {
             foreach (var name in LocalHeaderNames)
                 Bag.Remove(name);
+        }
+
+        /// <summary>
+        /// Returns a new dictionary containing every <see cref="Bag"/> entry whose key
+        /// is not in <see cref="LocalHeaderNames"/>. For transports that serialise the
+        /// whole bag in one go (e.g. SNS/SQS/Redis emit it as a single JSON property),
+        /// pass this to the serialiser instead of <see cref="Bag"/> directly.
+        /// </summary>
+        public Dictionary<string, object> BagWithoutLocalHeaders()
+        {
+            var copy = new Dictionary<string, object>(Bag.Count);
+            foreach (var kv in Bag)
+            {
+                if (!LocalHeaderNames.Contains(kv.Key))
+                    copy[kv.Key] = kv.Value;
+            }
+            return copy;
         }
 
         /// <summary>

--- a/src/Paramore.Brighter/MessageHeader.cs
+++ b/src/Paramore.Brighter/MessageHeader.cs
@@ -135,18 +135,6 @@ namespace Paramore.Brighter
         }
 
         /// <summary>
-        /// Removes every local-header entry (see <see cref="IsLocalHeader"/>) from
-        /// <see cref="Bag"/>. Call on a wire-bound copy of the header to ensure
-        /// local-only bag entries are not serialised onto the transport.
-        /// </summary>
-        public void StripLocalHeaders()
-        {
-            var locals = Volatile.Read(ref s_localHeaderNames);
-            foreach (var name in locals)
-                Bag.Remove(name);
-        }
-
-        /// <summary>
         /// Returns a new dictionary containing every <see cref="Bag"/> entry whose key
         /// is not a local header (see <see cref="IsLocalHeader"/>). For transports that
         /// serialise the whole bag in one go (e.g. SNS/SQS/Redis emit it as a single JSON

--- a/src/Paramore.Brighter/MessageHeader.cs
+++ b/src/Paramore.Brighter/MessageHeader.cs
@@ -26,6 +26,7 @@ THE SOFTWARE. */
 using System;
 using System.Collections.Generic;
 using System.Net.Mime;
+using System.Threading;
 using System.Text.Json.Serialization;
 using Paramore.Brighter.JsonConverters;
 using Paramore.Brighter.NJsonConverters;
@@ -92,42 +93,72 @@ namespace Paramore.Brighter
         /// Bag keys that are internal to Brighter — set by the framework so a downstream
         /// component (e.g. the outbox dispatcher) can read them, but not intended to travel
         /// over the wire. Transports that copy <see cref="Bag"/> into their wire format must
-        /// skip these keys: either filter inline (see ASB / RMQ / Kafka publishers) or
-        /// call <see cref="BagWithoutLocalHeaders"/> when serialising the bag in one go
-        /// (see SNS / SQS / Redis publishers).
+        /// skip keys for which <see cref="IsLocalHeader"/> returns true: either filter inline
+        /// (see ASB / RMQ / Kafka publishers) or call <see cref="BagWithoutLocalHeaders"/>
+        /// when serialising the bag in one go (see SNS / SQS / Redis publishers).
         /// </summary>
         /// <remarks>
-        /// Pre-populated with <see cref="Message.ProducerTopicHeaderName"/>. Add to this set
-        /// from extension code if you introduce additional local-only bag keys.
+        /// Pre-populated with <see cref="Message.ProducerTopicHeaderName"/>. Use
+        /// <see cref="RegisterLocalHeader"/> from extension code to add additional keys.
+        /// The backing <see cref="HashSet{T}"/> is treated as a copy-on-write snapshot —
+        /// never mutated in place after publication — so reads are lock-free on the
+        /// message hot path; registrations are expected at startup and use a CAS loop
+        /// that allocates a new snapshot.
         /// </remarks>
-        public static readonly HashSet<string> LocalHeaderNames = new(StringComparer.Ordinal)
+        private static HashSet<string> s_localHeaderNames = new(StringComparer.Ordinal)
         {
             Message.ProducerTopicHeaderName
         };
 
         /// <summary>
-        /// Removes every <see cref="LocalHeaderNames"/> entry from <see cref="Bag"/>.
-        /// Call on a wire-bound copy of the header to ensure local-only bag entries
-        /// are not serialised onto the transport.
+        /// Returns true when <paramref name="name"/> is a local-only bag key that must
+        /// not travel over the wire.
+        /// </summary>
+        public static bool IsLocalHeader(string name)
+            => Volatile.Read(ref s_localHeaderNames).Contains(name);
+
+        /// <summary>
+        /// Adds <paramref name="name"/> to the set of local bag keys. Idempotent.
+        /// Call once at startup from extension code that introduces a local-only bag key.
+        /// </summary>
+        public static void RegisterLocalHeader(string name)
+        {
+            while (true)
+            {
+                var snapshot = Volatile.Read(ref s_localHeaderNames);
+                if (snapshot.Contains(name))
+                    return;
+                var updated = new HashSet<string>(snapshot, StringComparer.Ordinal) { name };
+                if (ReferenceEquals(Interlocked.CompareExchange(ref s_localHeaderNames, updated, snapshot), snapshot))
+                    return;
+            }
+        }
+
+        /// <summary>
+        /// Removes every local-header entry (see <see cref="IsLocalHeader"/>) from
+        /// <see cref="Bag"/>. Call on a wire-bound copy of the header to ensure
+        /// local-only bag entries are not serialised onto the transport.
         /// </summary>
         public void StripLocalHeaders()
         {
-            foreach (var name in LocalHeaderNames)
+            var locals = Volatile.Read(ref s_localHeaderNames);
+            foreach (var name in locals)
                 Bag.Remove(name);
         }
 
         /// <summary>
         /// Returns a new dictionary containing every <see cref="Bag"/> entry whose key
-        /// is not in <see cref="LocalHeaderNames"/>. For transports that serialise the
-        /// whole bag in one go (e.g. SNS/SQS/Redis emit it as a single JSON property),
-        /// pass this to the serialiser instead of <see cref="Bag"/> directly.
+        /// is not a local header (see <see cref="IsLocalHeader"/>). For transports that
+        /// serialise the whole bag in one go (e.g. SNS/SQS/Redis emit it as a single JSON
+        /// property), pass this to the serialiser instead of <see cref="Bag"/> directly.
         /// </summary>
         public Dictionary<string, object> BagWithoutLocalHeaders()
         {
+            var locals = Volatile.Read(ref s_localHeaderNames);
             var copy = new Dictionary<string, object>(Bag.Count);
             foreach (var kv in Bag)
             {
-                if (!LocalHeaderNames.Contains(kv.Key))
+                if (!locals.Contains(kv.Key))
                     copy[kv.Key] = kv.Value;
             }
             return copy;

--- a/src/Paramore.Brighter/MessageHeader.cs
+++ b/src/Paramore.Brighter/MessageHeader.cs
@@ -87,7 +87,33 @@ namespace Paramore.Brighter
         /// The default Brighter source
         /// </summary>
         public const string DefaultSource = "http://goparamore.io";
-            
+
+        /// <summary>
+        /// Bag keys that are internal to Brighter — set by the framework so a downstream
+        /// component (e.g. the outbox dispatcher) can read them, but not intended to travel
+        /// over the wire. Transports that copy <see cref="Bag"/> into their wire format must
+        /// skip these keys (or call <see cref="StripLocalHeaders"/> on a copy of the header).
+        /// </summary>
+        /// <remarks>
+        /// Pre-populated with <see cref="Message.ProducerTopicHeaderName"/>. Add to this set
+        /// from extension code if you introduce additional local-only bag keys.
+        /// </remarks>
+        public static readonly HashSet<string> LocalHeaderNames = new(StringComparer.Ordinal)
+        {
+            Message.ProducerTopicHeaderName
+        };
+
+        /// <summary>
+        /// Removes every <see cref="LocalHeaderNames"/> entry from <see cref="Bag"/>.
+        /// Call on a wire-bound copy of the header to ensure local-only bag entries
+        /// are not serialised onto the transport.
+        /// </summary>
+        public void StripLocalHeaders()
+        {
+            foreach (var name in LocalHeaderNames)
+                Bag.Remove(name);
+        }
+
         /// <summary>
         /// A property bag that can be used for extended header attributes.
         /// Use camelCase for the key names if you intend to read it yourself, as when converted to and from Json serializers will tend convert the property

--- a/src/Paramore.Brighter/OutboxProducerMediator.cs
+++ b/src/Paramore.Brighter/OutboxProducerMediator.cs
@@ -776,6 +776,8 @@ namespace Paramore.Brighter
 
         private static RoutingKey GetProducerLookupTopic(Message message)
         {
+            // Falls back to Header.Topic when the bag entry is absent — reproducing the
+            // pre-fix behaviour, so publications with a null Topic remain a lookup failure.
             if (message.Header.Bag.TryGetValue(Message.ProducerTopicHeaderName, out var producerTopic)
                 && producerTopic is string topic)
             {
@@ -785,12 +787,8 @@ namespace Paramore.Brighter
             return message.Header.Topic;
         }
 
-        /// <summary>
-        /// Removes the internal <see cref="Message.ProducerTopicHeaderName"/> bag entry so it is
-        /// not serialised onto the wire by transport adapters that include <c>Header.Bag</c> in
-        /// the message envelope (AMQP headers, SNS/SQS attributes, etc.). Call after producer
-        /// lookup and immediately before dispatch.
-        /// </summary>
+        // Strip the internal ProducerTopic bag entry so transports that serialise Header.Bag
+        // (AMQP, SNS/SQS) don't leak it on the wire. Call after lookup, before dispatch.
         private static void StripProducerLookupTopic(Message message)
         {
             message.Header.Bag.Remove(Message.ProducerTopicHeaderName);
@@ -881,7 +879,11 @@ namespace Paramore.Brighter
                     // share the same ProducerTopic bag entry (set by WrapPipelineAsync when the
                     // mapper overrode the topic), so firstMessage is representative of the batch.
                     var firstMessage = topicBatch.First();
-                    var producer = _producerRegistry.LookupBy(GetProducerLookupTopic(firstMessage));
+                    var producerLookupTopic = GetProducerLookupTopic(firstMessage);
+                    Debug.Assert(
+                        topicBatch.All(m => GetProducerLookupTopic(m) == producerLookupTopic),
+                        "all messages in a topicBatch must share the same producer-lookup topic");
+                    var producer = _producerRegistry.LookupBy(producerLookupTopic);
                     StripProducerLookupTopic(topicBatch);
                     var span = _tracer?.CreateProducerSpan(producer.Publication, null, requestContext.Span,
                         _instrumentationOptions);

--- a/src/Paramore.Brighter/OutboxProducerMediator.cs
+++ b/src/Paramore.Brighter/OutboxProducerMediator.cs
@@ -785,6 +785,17 @@ namespace Paramore.Brighter
             return message.Header.Topic;
         }
 
+        /// <summary>
+        /// Removes the internal <see cref="Message.ProducerTopicHeaderName"/> bag entry so it is
+        /// not serialised onto the wire by transport adapters that include <c>Header.Bag</c> in
+        /// the message envelope (AMQP headers, SNS/SQS attributes, etc.). Call after producer
+        /// lookup and immediately before dispatch.
+        /// </summary>
+        private static void StripProducerLookupTopic(Message message)
+        {
+            message.Header.Bag.Remove(Message.ProducerTopicHeaderName);
+        }
+
         private void Dispatch(IEnumerable<Message> posts, RequestContext requestContext, Dictionary<string, object>? args = null)
         {
             var parentSpan = requestContext.Span;
@@ -800,6 +811,7 @@ namespace Paramore.Brighter
                     Log.DecoupledInvocationOfMessage(s_logger, message.Header.Topic, message.Id);
 
                     var producer = _producerRegistry.LookupBy(GetProducerLookupTopic(message), message.Header.Type, requestContext);
+                    StripProducerLookupTopic(message);
                     var span = _tracer?.CreateProducerSpan(producer.Publication, message, requestContext.Span,
                         _instrumentationOptions);
                     producer.Span = span;
@@ -862,6 +874,10 @@ namespace Paramore.Brighter
                     // mapper overrode the topic), so firstMessage is representative of the batch.
                     var firstMessage = topicBatch.First();
                     var producer = _producerRegistry.LookupBy(GetProducerLookupTopic(firstMessage));
+                    foreach (var m in topicBatch)
+                    {
+                        StripProducerLookupTopic(m);
+                    }
                     var span = _tracer?.CreateProducerSpan(producer.Publication, null, requestContext.Span,
                         _instrumentationOptions);
 
@@ -939,6 +955,7 @@ namespace Paramore.Brighter
                     Log.DecoupledInvocationOfMessage(s_logger, message.Header.Topic, message.Id);
 
                     var producer = _producerRegistry.LookupBy(GetProducerLookupTopic(message), message.Header.Type, requestContext);
+                    StripProducerLookupTopic(message);
                     var span = _tracer?.CreateProducerSpan(producer.Publication, message, parentSpan,
                         _instrumentationOptions);
                     producer.Span = span;

--- a/src/Paramore.Brighter/OutboxProducerMediator.cs
+++ b/src/Paramore.Brighter/OutboxProducerMediator.cs
@@ -871,19 +871,14 @@ namespace Paramore.Brighter
             try
             {
                 if (_asyncOutbox is null) throw new ArgumentException(NoAsyncOutboxError);
-                var messagesByTopic = posts.GroupBy(m => m.Header.Topic);
+                // Group by (wire topic, producer-lookup topic) so a batch is guaranteed to
+                // resolve to a single producer — messages with the same wire topic but
+                // different ProducerTopic bag values land in separate batches.
+                var messagesByTopic = posts.GroupBy(m => (WireTopic: m.Header.Topic, LookupTopic: GetProducerLookupTopic(m)));
 
                 foreach (var topicBatch in messagesByTopic)
                 {
-                    // Messages in this batch share Header.Topic (the group key). They therefore
-                    // share the same ProducerTopic bag entry (set by WrapPipelineAsync when the
-                    // mapper overrode the topic), so firstMessage is representative of the batch.
-                    var firstMessage = topicBatch.First();
-                    var producerLookupTopic = GetProducerLookupTopic(firstMessage);
-                    Debug.Assert(
-                        topicBatch.All(m => GetProducerLookupTopic(m) == producerLookupTopic),
-                        "all messages in a topicBatch must share the same producer-lookup topic");
-                    var producer = _producerRegistry.LookupBy(producerLookupTopic);
+                    var producer = _producerRegistry.LookupBy(topicBatch.Key.LookupTopic);
                     StripProducerLookupTopic(topicBatch);
                     var span = _tracer?.CreateProducerSpan(producer.Publication, null, requestContext.Span,
                         _instrumentationOptions);
@@ -891,14 +886,14 @@ namespace Paramore.Brighter
                     if (span is not null)
                     {
                         producer.Span = span;
-                        producerSpans.TryAdd(topicBatch.Key, span);
+                        producerSpans.TryAdd(topicBatch.Key.WireTopic, span);
                     }
 
                     if (producer is IAmABulkMessageProducerAsync bulkMessageProducer and not ISupportPublishConfirmation)
                     {
                         var messages = topicBatch.ToArray();
 
-                        Log.BulkDispatchingMessages(s_logger, messages.Length, topicBatch.Key);
+                        Log.BulkDispatchingMessages(s_logger, messages.Length, topicBatch.Key.WireTopic);
 
                         foreach (var batch in await bulkMessageProducer.CreateBatchesAsync(messages, cancellationToken))
                         {

--- a/src/Paramore.Brighter/OutboxProducerMediator.cs
+++ b/src/Paramore.Brighter/OutboxProducerMediator.cs
@@ -774,6 +774,17 @@ namespace Paramore.Brighter
             return false;
         }
 
+        private static RoutingKey GetProducerLookupTopic(Message message)
+        {
+            if (message.Header.Bag.TryGetValue(Message.ProducerTopicHeaderName, out var producerTopic)
+                && producerTopic is string topic)
+            {
+                return new RoutingKey(topic);
+            }
+
+            return message.Header.Topic;
+        }
+
         private void Dispatch(IEnumerable<Message> posts, RequestContext requestContext, Dictionary<string, object>? args = null)
         {
             var parentSpan = requestContext.Span;
@@ -785,7 +796,7 @@ namespace Paramore.Brighter
                 {
                     Log.DecoupledInvocationOfMessage(s_logger, message.Header.Topic, message.Id);
 
-                    var producer = _producerRegistry.LookupBy(message.Header.Topic, message.Header.Type, requestContext);
+                    var producer = _producerRegistry.LookupBy(GetProducerLookupTopic(message), message.Header.Type, requestContext);
                     var span = _tracer?.CreateProducerSpan(producer.Publication, message, requestContext.Span,
                         _instrumentationOptions);
                     producer.Span = span;
@@ -843,7 +854,8 @@ namespace Paramore.Brighter
 
                 foreach (var topicBatch in messagesByTopic)
                 {
-                    var producer = _producerRegistry.LookupBy(topicBatch.Key);
+                    var firstMessage = topicBatch.First();
+                    var producer = _producerRegistry.LookupBy(GetProducerLookupTopic(firstMessage));
                     var span = _tracer?.CreateProducerSpan(producer.Publication, null, requestContext.Span,
                         _instrumentationOptions);
 
@@ -917,7 +929,7 @@ namespace Paramore.Brighter
                 {
                     Log.DecoupledInvocationOfMessage(s_logger, message.Header.Topic, message.Id);
 
-                    var producer = _producerRegistry.LookupBy(message.Header.Topic, message.Header.Type, requestContext);
+                    var producer = _producerRegistry.LookupBy(GetProducerLookupTopic(message), message.Header.Type, requestContext);
                     var span = _tracer?.CreateProducerSpan(producer.Publication, message, parentSpan,
                         _instrumentationOptions);
                     producer.Span = span;

--- a/src/Paramore.Brighter/OutboxProducerMediator.cs
+++ b/src/Paramore.Brighter/OutboxProducerMediator.cs
@@ -776,8 +776,11 @@ namespace Paramore.Brighter
 
         private static RoutingKey GetProducerLookupTopic(Message message)
         {
-            // Falls back to Header.Topic when the bag entry is absent — reproducing the
-            // pre-fix behaviour, so publications with a null Topic remain a lookup failure.
+            // Reply messages set the ProducerTopic bag entry so the dispatcher can locate
+            // the registered producer even though Header.Topic has been rewritten to the
+            // dynamic reply address. Normal publications don't carry the bag entry, so we
+            // fall back to Header.Topic — and a null/empty Header.Topic remains a lookup
+            // failure, matching pre-fix behaviour.
             if (message.Header.Bag.TryGetValue(Message.ProducerTopicHeaderName, out var producerTopic)
                 && producerTopic is string topic)
             {

--- a/src/Paramore.Brighter/OutboxProducerMediator.cs
+++ b/src/Paramore.Brighter/OutboxProducerMediator.cs
@@ -781,6 +781,14 @@ namespace Paramore.Brighter
             // dynamic reply address. Normal publications don't carry the bag entry, so we
             // fall back to Header.Topic — and a null/empty Header.Topic remains a lookup
             // failure, matching pre-fix behaviour.
+            //
+            // The `is string` cast is safe across persistent outboxes (SQL family,
+            // Mongo, DynamoDB) because Brighter's bag round-trip uses
+            // JsonSerialisationOptions.Options, which registers DictionaryStringObjectJsonConverter
+            // + ObjectToInferredTypesConverter — together they preserve the string runtime
+            // type through serialise/deserialise rather than handing back JsonElement.
+            // See When_Bag_String_Values_Round_Trip_Through_Brighter_Json_Options for
+            // a regression pin on that contract.
             if (message.Header.Bag.TryGetValue(Message.ProducerTopicHeaderName, out var producerTopic)
                 && producerTopic is string topic)
             {

--- a/src/Paramore.Brighter/OutboxProducerMediator.cs
+++ b/src/Paramore.Brighter/OutboxProducerMediator.cs
@@ -796,6 +796,14 @@ namespace Paramore.Brighter
             message.Header.Bag.Remove(Message.ProducerTopicHeaderName);
         }
 
+        private static void StripProducerLookupTopic(IEnumerable<Message> messages)
+        {
+            foreach (var m in messages)
+            {
+                StripProducerLookupTopic(m);
+            }
+        }
+
         private void Dispatch(IEnumerable<Message> posts, RequestContext requestContext, Dictionary<string, object>? args = null)
         {
             var parentSpan = requestContext.Span;
@@ -874,10 +882,7 @@ namespace Paramore.Brighter
                     // mapper overrode the topic), so firstMessage is representative of the batch.
                     var firstMessage = topicBatch.First();
                     var producer = _producerRegistry.LookupBy(GetProducerLookupTopic(firstMessage));
-                    foreach (var m in topicBatch)
-                    {
-                        StripProducerLookupTopic(m);
-                    }
+                    StripProducerLookupTopic(topicBatch);
                     var span = _tracer?.CreateProducerSpan(producer.Publication, null, requestContext.Span,
                         _instrumentationOptions);
 

--- a/src/Paramore.Brighter/OutboxProducerMediator.cs
+++ b/src/Paramore.Brighter/OutboxProducerMediator.cs
@@ -790,41 +790,6 @@ namespace Paramore.Brighter
             return message.Header.Topic;
         }
 
-        // Strip the internal ProducerTopic bag entry so transports that serialise Header.Bag
-        // (AMQP, SNS/SQS) don't leak it on the wire. Returns the prior bag value (or null)
-        // so callers can restore it if dispatch fails — important for InMemoryOutbox, which
-        // stores the message by reference and would otherwise lose the producer hint on retry.
-        private static object? StripProducerLookupTopic(Message message)
-        {
-            message.Header.Bag.TryGetValue(Message.ProducerTopicHeaderName, out var saved);
-            message.Header.Bag.Remove(Message.ProducerTopicHeaderName);
-            return saved;
-        }
-
-        private static void RestoreProducerLookupTopic(Message message, object? saved)
-        {
-            if (saved is not null)
-                message.Header.Bag[Message.ProducerTopicHeaderName] = saved;
-        }
-
-        private static List<(Message Message, object? Saved)> StripProducerLookupTopic(IEnumerable<Message> messages)
-        {
-            var saved = new List<(Message, object?)>();
-            foreach (var m in messages)
-            {
-                saved.Add((m, StripProducerLookupTopic(m)));
-            }
-            return saved;
-        }
-
-        private static void RestoreProducerLookupTopic(IEnumerable<(Message Message, object? Saved)> saved)
-        {
-            foreach (var (message, value) in saved)
-            {
-                RestoreProducerLookupTopic(message, value);
-            }
-        }
-
         private void Dispatch(IEnumerable<Message> posts, RequestContext requestContext, Dictionary<string, object>? args = null)
         {
             var parentSpan = requestContext.Span;
@@ -840,51 +805,40 @@ namespace Paramore.Brighter
                     Log.DecoupledInvocationOfMessage(s_logger, message.Header.Topic, message.Id);
 
                     var producer = _producerRegistry.LookupBy(GetProducerLookupTopic(message), message.Header.Type, requestContext);
-                    var savedProducerTopic = StripProducerLookupTopic(message);
-                    var dispatched = false;
-                    try
-                    {
-                        var span = _tracer?.CreateProducerSpan(producer.Publication, message, requestContext.Span,
-                            _instrumentationOptions);
-                        producer.Span = span;
-                        if (span != null) producerSpans.TryAdd(message.Id, span);
+                    var span = _tracer?.CreateProducerSpan(producer.Publication, message, requestContext.Span,
+                        _instrumentationOptions);
+                    producer.Span = span;
+                    if (span != null) producerSpans.TryAdd(message.Id, span);
 
-                        if (producer is IAmAMessageProducerSync producerSync)
+                    if (producer is IAmAMessageProducerSync producerSync)
+                    {
+                        if (producer is ISupportPublishConfirmation)
                         {
-                            if (producer is ISupportPublishConfirmation)
-                            {
-                                //mark dispatch handled by a callback - set in constructor
-                                ExecuteWithResiliencePipeline(
-                                    () => { producerSync.Send(message); },
-                                    requestContext);
-                                dispatched = true;
-                            }
-                            else
-                            {
-                                var sent = ExecuteWithResiliencePipeline(
-                                    () => { producerSync.Send(message); },
-                                    requestContext
-                                );
-                                if (sent)
-                                {
-                                    ExecuteWithResiliencePipeline(
-                                        () => _outBox.MarkDispatched(message.Id, requestContext, _timeProvider.GetUtcNow(), args),
-                                        requestContext
-                                    );
-                                    dispatched = true;
-                                }
-                            }
+                            //mark dispatch handled by a callback - set in constructor
+                            ExecuteWithResiliencePipeline(
+                                () => { producerSync.Send(message); },
+                                requestContext);
                         }
                         else
-                            throw new InvalidOperationException("No sync message producer defined.");
+                        {
+                            var sent = ExecuteWithResiliencePipeline(
+                                () => { producerSync.Send(message); },
+                                requestContext
+                            );
+                            if (sent)
+                            {
+                                ExecuteWithResiliencePipeline(
+                                    () => _outBox.MarkDispatched(message.Id, requestContext, _timeProvider.GetUtcNow(), args),
+                                    requestContext
+                                );
+                            }
+                        }
+                    }
+                    else
+                        throw new InvalidOperationException("No sync message producer defined.");
 
-                        Activity.Current = parentSpan;
-                        producer.Span = null;
-                    }
-                    finally
-                    {
-                        if (!dispatched) RestoreProducerLookupTopic(message, savedProducerTopic);
-                    }
+                    Activity.Current = parentSpan;
+                    producer.Span = null;
                 }
             }
             finally
@@ -914,70 +868,58 @@ namespace Paramore.Brighter
                 foreach (var topicBatch in messagesByTopic)
                 {
                     var producer = _producerRegistry.LookupBy(topicBatch.Key.LookupTopic);
-                    var savedBatchTopics = StripProducerLookupTopic(topicBatch);
-                    var batchDispatched = false;
-                    try
+                    var span = _tracer?.CreateProducerSpan(producer.Publication, null, requestContext.Span,
+                        _instrumentationOptions);
+
+                    if (span is not null)
                     {
-                        var span = _tracer?.CreateProducerSpan(producer.Publication, null, requestContext.Span,
-                            _instrumentationOptions);
+                        producer.Span = span;
+                        // Key is only used for uniqueness until EndSpans runs; a Uuid avoids
+                        // any risk of collision from composing topic strings.
+                        producerSpans.TryAdd(Uuid.NewAsString(), span);
+                    }
 
-                        if (span is not null)
+                    if (producer is IAmABulkMessageProducerAsync bulkMessageProducer and not ISupportPublishConfirmation)
+                    {
+                        var messages = topicBatch.ToArray();
+
+                        Log.BulkDispatchingMessages(s_logger, messages.Length, topicBatch.Key.WireTopic);
+
+                        foreach (var batch in await bulkMessageProducer.CreateBatchesAsync(messages, cancellationToken))
                         {
-                            producer.Span = span;
-                            // Key is only used for uniqueness until EndSpans runs; a Uuid avoids
-                            // any risk of collision from composing topic strings.
-                            producerSpans.TryAdd(Uuid.NewAsString(), span);
-                        }
+                            var sent = await ExecuteWithResiliencePipelineAsync(
+                                    async _ => await bulkMessageProducer.SendAsync(batch, cancellationToken)
+                                        .ConfigureAwait(continueOnCapturedContext),
+                                    requestContext,
+                                    continueOnCapturedContext,
+                                    cancellationToken
+                                )
+                                .ConfigureAwait(continueOnCapturedContext);
 
-                        if (producer is IAmABulkMessageProducerAsync bulkMessageProducer and not ISupportPublishConfirmation)
-                        {
-                            var messages = topicBatch.ToArray();
-
-                            Log.BulkDispatchingMessages(s_logger, messages.Length, topicBatch.Key.WireTopic);
-
-                            var allSent = true;
-                            foreach (var batch in await bulkMessageProducer.CreateBatchesAsync(messages, cancellationToken))
+                            if (producer is not ISupportPublishConfirmation && sent)
                             {
-                                var sent = await ExecuteWithResiliencePipelineAsync(
-                                        async _ => await bulkMessageProducer.SendAsync(batch, cancellationToken)
-                                            .ConfigureAwait(continueOnCapturedContext),
+                                foreach (var successfulMessage in batch.Ids())
+                                {
+                                    await ExecuteWithResiliencePipelineAsync(async _ =>
+                                            await _asyncOutbox.MarkDispatchedAsync(
+                                                successfulMessage, requestContext, _timeProvider.GetUtcNow(),
+                                                cancellationToken: cancellationToken
+                                            ),
                                         requestContext,
-                                        continueOnCapturedContext,
-                                        cancellationToken
-                                    )
-                                    .ConfigureAwait(continueOnCapturedContext);
-
-                                if (producer is not ISupportPublishConfirmation && sent)
-                                {
-                                    foreach (var successfulMessage in batch.Ids())
-                                    {
-                                        await ExecuteWithResiliencePipelineAsync(async _ =>
-                                                await _asyncOutbox.MarkDispatchedAsync(
-                                                    successfulMessage, requestContext, _timeProvider.GetUtcNow(),
-                                                    cancellationToken: cancellationToken
-                                                ),
-                                            requestContext,
-                                            cancellationToken: cancellationToken
-                                        );
-                                    }
-                                }
-
-                                if (!sent)
-                                {
-                                    allSent = false;
-                                    TripTopic(batch.RoutingKey);
+                                        cancellationToken: cancellationToken
+                                    );
                                 }
                             }
-                            batchDispatched = allSent;
-                        }
-                        else
-                        {
-                            throw new InvalidOperationException("No async bulk message producer defined.");
+
+                            if (!sent)
+                            {
+                                TripTopic(batch.RoutingKey);
+                            }
                         }
                     }
-                    finally
+                    else
                     {
-                        if (!batchDispatched) RestoreProducerLookupTopic(savedBatchTopics);
+                        throw new InvalidOperationException("No async bulk message producer defined.");
                     }
                 }
             }
@@ -1008,50 +950,38 @@ namespace Paramore.Brighter
                     Log.DecoupledInvocationOfMessage(s_logger, message.Header.Topic, message.Id);
 
                     var producer = _producerRegistry.LookupBy(GetProducerLookupTopic(message), message.Header.Type, requestContext);
-                    var savedProducerTopic = StripProducerLookupTopic(message);
-                    var dispatched = false;
-                    try
-                    {
-                        var span = _tracer?.CreateProducerSpan(producer.Publication, message, parentSpan,
-                            _instrumentationOptions);
-                        producer.Span = span;
-                        if (span != null) producerSpans.TryAdd(message.Id, span);
+                    var span = _tracer?.CreateProducerSpan(producer.Publication, message, parentSpan,
+                        _instrumentationOptions);
+                    producer.Span = span;
+                    if (span != null) producerSpans.TryAdd(message.Id, span);
 
-                        if (producer is IAmAMessageProducerAsync producerAsync)
+                    if (producer is IAmAMessageProducerAsync producerAsync)
+                    {
+                        var sent = await ExecuteWithResiliencePipelineAsync(
+                                async _ => await producerAsync.SendAsync(message, cancellationToken)
+                                    .ConfigureAwait(continueOnCapturedContext),
+                                requestContext,
+                                continueOnCapturedContext,
+                                cancellationToken
+                            )
+                            .ConfigureAwait(continueOnCapturedContext);
+
+                        if (producer is not ISupportPublishConfirmation && sent)
                         {
-                            var sent = await ExecuteWithResiliencePipelineAsync(
-                                    async _ => await producerAsync.SendAsync(message, cancellationToken)
-                                        .ConfigureAwait(continueOnCapturedContext),
-                                    requestContext,
-                                    continueOnCapturedContext,
-                                    cancellationToken
-                                )
-                                .ConfigureAwait(continueOnCapturedContext);
-
-                            if (producer is not ISupportPublishConfirmation && sent)
-                            {
-                                await ExecuteWithResiliencePipelineAsync(
-                                    async _ => await _asyncOutbox.MarkDispatchedAsync(
-                                        message.Id, requestContext, _timeProvider.GetUtcNow(),
-                                        cancellationToken: cancellationToken
-                                    ),
-                                    requestContext,
+                            await ExecuteWithResiliencePipelineAsync(
+                                async _ => await _asyncOutbox.MarkDispatchedAsync(
+                                    message.Id, requestContext, _timeProvider.GetUtcNow(),
                                     cancellationToken: cancellationToken
-                                );
-                            }
-
-                            dispatched = sent || producer is ISupportPublishConfirmation;
-
-                            if(!sent) TripTopic(message.Header.Topic);
-
+                                ),
+                                requestContext,
+                                cancellationToken: cancellationToken
+                            );
                         }
-                        else
-                            throw new InvalidOperationException("No async message producer defined.");
+
+                        if(!sent) TripTopic(message.Header.Topic);
                     }
-                    finally
-                    {
-                        if (!dispatched) RestoreProducerLookupTopic(message, savedProducerTopic);
-                    }
+                    else
+                        throw new InvalidOperationException("No async message producer defined.");
                 }
             }
             finally

--- a/src/Paramore.Brighter/OutboxProducerMediator.cs
+++ b/src/Paramore.Brighter/OutboxProducerMediator.cs
@@ -789,6 +789,10 @@ namespace Paramore.Brighter
 
         // Strip the internal ProducerTopic bag entry so transports that serialise Header.Bag
         // (AMQP, SNS/SQS) don't leak it on the wire. Call after lookup, before dispatch.
+        // Persistent outboxes (SQL, Mongo, Dynamo) re-hydrate a fresh object per drain so
+        // this mutation is harmless; InMemoryOutbox stores the reference, so a dispatch that
+        // fails after strip and then retries via the outbox will fall back to Header.Topic
+        // and miss the producer — acceptable since InMemoryOutbox is primarily dev/test.
         private static void StripProducerLookupTopic(Message message)
         {
             message.Header.Bag.Remove(Message.ProducerTopicHeaderName);
@@ -886,7 +890,10 @@ namespace Paramore.Brighter
                     if (span is not null)
                     {
                         producer.Span = span;
-                        producerSpans.TryAdd(topicBatch.Key.WireTopic, span);
+                        // Compose the dictionary key from both grouping keys so two
+                        // batches that share a WireTopic but differ by LookupTopic
+                        // don't collide (their spans must both be ended later).
+                        producerSpans.TryAdd($"{topicBatch.Key.WireTopic}|{topicBatch.Key.LookupTopic}", span);
                     }
 
                     if (producer is IAmABulkMessageProducerAsync bulkMessageProducer and not ISupportPublishConfirmation)

--- a/src/Paramore.Brighter/OutboxProducerMediator.cs
+++ b/src/Paramore.Brighter/OutboxProducerMediator.cs
@@ -794,6 +794,9 @@ namespace Paramore.Brighter
                 if (_outBox is null) throw new ArgumentException(NoSyncOutboxError);
                 foreach (var message in posts)
                 {
+                    // Log the wire topic (Header.Topic) — where the message is going. Producer
+                    // lookup uses GetProducerLookupTopic, which may differ from Header.Topic when
+                    // a mapper overrode it (e.g. Reply messages routed to a dynamic reply address).
                     Log.DecoupledInvocationOfMessage(s_logger, message.Header.Topic, message.Id);
 
                     var producer = _producerRegistry.LookupBy(GetProducerLookupTopic(message), message.Header.Type, requestContext);
@@ -854,6 +857,9 @@ namespace Paramore.Brighter
 
                 foreach (var topicBatch in messagesByTopic)
                 {
+                    // Messages in this batch share Header.Topic (the group key). They therefore
+                    // share the same ProducerTopic bag entry (set by WrapPipelineAsync when the
+                    // mapper overrode the topic), so firstMessage is representative of the batch.
                     var firstMessage = topicBatch.First();
                     var producer = _producerRegistry.LookupBy(GetProducerLookupTopic(firstMessage));
                     var span = _tracer?.CreateProducerSpan(producer.Publication, null, requestContext.Span,
@@ -927,6 +933,9 @@ namespace Paramore.Brighter
                 if (_asyncOutbox is null) throw new ArgumentException(NoAsyncOutboxError);
                 foreach (var message in posts)
                 {
+                    // Log the wire topic (Header.Topic) — where the message is going. Producer
+                    // lookup uses GetProducerLookupTopic, which may differ from Header.Topic when
+                    // a mapper overrode it (e.g. Reply messages routed to a dynamic reply address).
                     Log.DecoupledInvocationOfMessage(s_logger, message.Header.Topic, message.Id);
 
                     var producer = _producerRegistry.LookupBy(GetProducerLookupTopic(message), message.Header.Type, requestContext);

--- a/src/Paramore.Brighter/OutboxProducerMediator.cs
+++ b/src/Paramore.Brighter/OutboxProducerMediator.cs
@@ -788,21 +788,37 @@ namespace Paramore.Brighter
         }
 
         // Strip the internal ProducerTopic bag entry so transports that serialise Header.Bag
-        // (AMQP, SNS/SQS) don't leak it on the wire. Call after lookup, before dispatch.
-        // Persistent outboxes (SQL, Mongo, Dynamo) re-hydrate a fresh object per drain so
-        // this mutation is harmless; InMemoryOutbox stores the reference, so a dispatch that
-        // fails after strip and then retries via the outbox will fall back to Header.Topic
-        // and miss the producer — acceptable since InMemoryOutbox is primarily dev/test.
-        private static void StripProducerLookupTopic(Message message)
+        // (AMQP, SNS/SQS) don't leak it on the wire. Returns the prior bag value (or null)
+        // so callers can restore it if dispatch fails — important for InMemoryOutbox, which
+        // stores the message by reference and would otherwise lose the producer hint on retry.
+        private static object? StripProducerLookupTopic(Message message)
         {
+            message.Header.Bag.TryGetValue(Message.ProducerTopicHeaderName, out var saved);
             message.Header.Bag.Remove(Message.ProducerTopicHeaderName);
+            return saved;
         }
 
-        private static void StripProducerLookupTopic(IEnumerable<Message> messages)
+        private static void RestoreProducerLookupTopic(Message message, object? saved)
         {
+            if (saved is not null)
+                message.Header.Bag[Message.ProducerTopicHeaderName] = saved;
+        }
+
+        private static List<(Message Message, object? Saved)> StripProducerLookupTopic(IEnumerable<Message> messages)
+        {
+            var saved = new List<(Message, object?)>();
             foreach (var m in messages)
             {
-                StripProducerLookupTopic(m);
+                saved.Add((m, StripProducerLookupTopic(m)));
+            }
+            return saved;
+        }
+
+        private static void RestoreProducerLookupTopic(IEnumerable<(Message Message, object? Saved)> saved)
+        {
+            foreach (var (message, value) in saved)
+            {
+                RestoreProducerLookupTopic(message, value);
             }
         }
 
@@ -821,39 +837,51 @@ namespace Paramore.Brighter
                     Log.DecoupledInvocationOfMessage(s_logger, message.Header.Topic, message.Id);
 
                     var producer = _producerRegistry.LookupBy(GetProducerLookupTopic(message), message.Header.Type, requestContext);
-                    StripProducerLookupTopic(message);
-                    var span = _tracer?.CreateProducerSpan(producer.Publication, message, requestContext.Span,
-                        _instrumentationOptions);
-                    producer.Span = span;
-                    if (span != null) producerSpans.TryAdd(message.Id, span);
-
-                    if (producer is IAmAMessageProducerSync producerSync)
+                    var savedProducerTopic = StripProducerLookupTopic(message);
+                    var dispatched = false;
+                    try
                     {
-                        if (producer is ISupportPublishConfirmation)
+                        var span = _tracer?.CreateProducerSpan(producer.Publication, message, requestContext.Span,
+                            _instrumentationOptions);
+                        producer.Span = span;
+                        if (span != null) producerSpans.TryAdd(message.Id, span);
+
+                        if (producer is IAmAMessageProducerSync producerSync)
                         {
-                            //mark dispatch handled by a callback - set in constructor
-                            ExecuteWithResiliencePipeline(
-                                () => { producerSync.Send(message); },
-                                requestContext);
-                        }
-                        else
-                        {
-                            var sent = ExecuteWithResiliencePipeline(
-                                () => { producerSync.Send(message); },
-                                requestContext
-                            );
-                            if (sent)
+                            if (producer is ISupportPublishConfirmation)
+                            {
+                                //mark dispatch handled by a callback - set in constructor
                                 ExecuteWithResiliencePipeline(
-                                    () => _outBox.MarkDispatched(message.Id, requestContext, _timeProvider.GetUtcNow(), args),
+                                    () => { producerSync.Send(message); },
+                                    requestContext);
+                                dispatched = true;
+                            }
+                            else
+                            {
+                                var sent = ExecuteWithResiliencePipeline(
+                                    () => { producerSync.Send(message); },
                                     requestContext
                                 );
+                                if (sent)
+                                {
+                                    ExecuteWithResiliencePipeline(
+                                        () => _outBox.MarkDispatched(message.Id, requestContext, _timeProvider.GetUtcNow(), args),
+                                        requestContext
+                                    );
+                                    dispatched = true;
+                                }
+                            }
                         }
-                    }
-                    else
-                        throw new InvalidOperationException("No sync message producer defined.");
+                        else
+                            throw new InvalidOperationException("No sync message producer defined.");
 
-                    Activity.Current = parentSpan;
-                    producer.Span = null;
+                        Activity.Current = parentSpan;
+                        producer.Span = null;
+                    }
+                    finally
+                    {
+                        if (!dispatched) RestoreProducerLookupTopic(message, savedProducerTopic);
+                    }
                 }
             }
             finally
@@ -883,57 +911,70 @@ namespace Paramore.Brighter
                 foreach (var topicBatch in messagesByTopic)
                 {
                     var producer = _producerRegistry.LookupBy(topicBatch.Key.LookupTopic);
-                    StripProducerLookupTopic(topicBatch);
-                    var span = _tracer?.CreateProducerSpan(producer.Publication, null, requestContext.Span,
-                        _instrumentationOptions);
-
-                    if (span is not null)
+                    var savedBatchTopics = StripProducerLookupTopic(topicBatch);
+                    var batchDispatched = false;
+                    try
                     {
-                        producer.Span = span;
-                        // Compose the dictionary key from both grouping keys so two
-                        // batches that share a WireTopic but differ by LookupTopic
-                        // don't collide (their spans must both be ended later).
-                        producerSpans.TryAdd($"{topicBatch.Key.WireTopic}|{topicBatch.Key.LookupTopic}", span);
-                    }
+                        var span = _tracer?.CreateProducerSpan(producer.Publication, null, requestContext.Span,
+                            _instrumentationOptions);
 
-                    if (producer is IAmABulkMessageProducerAsync bulkMessageProducer and not ISupportPublishConfirmation)
-                    {
-                        var messages = topicBatch.ToArray();
-
-                        Log.BulkDispatchingMessages(s_logger, messages.Length, topicBatch.Key.WireTopic);
-
-                        foreach (var batch in await bulkMessageProducer.CreateBatchesAsync(messages, cancellationToken))
+                        if (span is not null)
                         {
-                            var sent = await ExecuteWithResiliencePipelineAsync(
-                                    async _ => await bulkMessageProducer.SendAsync(batch, cancellationToken)
-                                        .ConfigureAwait(continueOnCapturedContext),
-                                    requestContext,
-                                    continueOnCapturedContext,
-                                    cancellationToken
-                                )
-                                .ConfigureAwait(continueOnCapturedContext);
+                            producer.Span = span;
+                            // Key is only used for uniqueness until EndSpans runs; a Uuid avoids
+                            // any risk of collision from composing topic strings.
+                            producerSpans.TryAdd(Uuid.NewAsString(), span);
+                        }
 
-                            if (producer is not ISupportPublishConfirmation && sent)
+                        if (producer is IAmABulkMessageProducerAsync bulkMessageProducer and not ISupportPublishConfirmation)
+                        {
+                            var messages = topicBatch.ToArray();
+
+                            Log.BulkDispatchingMessages(s_logger, messages.Length, topicBatch.Key.WireTopic);
+
+                            var allSent = true;
+                            foreach (var batch in await bulkMessageProducer.CreateBatchesAsync(messages, cancellationToken))
                             {
-                                foreach (var successfulMessage in batch.Ids())
-                                {
-                                    await ExecuteWithResiliencePipelineAsync(async _ =>
-                                            await _asyncOutbox.MarkDispatchedAsync(
-                                                successfulMessage, requestContext, _timeProvider.GetUtcNow(),
-                                                cancellationToken: cancellationToken
-                                            ),
+                                var sent = await ExecuteWithResiliencePipelineAsync(
+                                        async _ => await bulkMessageProducer.SendAsync(batch, cancellationToken)
+                                            .ConfigureAwait(continueOnCapturedContext),
                                         requestContext,
-                                        cancellationToken: cancellationToken
-                                    );
+                                        continueOnCapturedContext,
+                                        cancellationToken
+                                    )
+                                    .ConfigureAwait(continueOnCapturedContext);
+
+                                if (producer is not ISupportPublishConfirmation && sent)
+                                {
+                                    foreach (var successfulMessage in batch.Ids())
+                                    {
+                                        await ExecuteWithResiliencePipelineAsync(async _ =>
+                                                await _asyncOutbox.MarkDispatchedAsync(
+                                                    successfulMessage, requestContext, _timeProvider.GetUtcNow(),
+                                                    cancellationToken: cancellationToken
+                                                ),
+                                            requestContext,
+                                            cancellationToken: cancellationToken
+                                        );
+                                    }
+                                }
+
+                                if (!sent)
+                                {
+                                    allSent = false;
+                                    TripTopic(batch.RoutingKey);
                                 }
                             }
-
-                            if (!sent) TripTopic(batch.RoutingKey);
+                            batchDispatched = allSent;
+                        }
+                        else
+                        {
+                            throw new InvalidOperationException("No async bulk message producer defined.");
                         }
                     }
-                    else
+                    finally
                     {
-                        throw new InvalidOperationException("No async bulk message producer defined.");
+                        if (!batchDispatched) RestoreProducerLookupTopic(savedBatchTopics);
                     }
                 }
             }
@@ -964,40 +1005,50 @@ namespace Paramore.Brighter
                     Log.DecoupledInvocationOfMessage(s_logger, message.Header.Topic, message.Id);
 
                     var producer = _producerRegistry.LookupBy(GetProducerLookupTopic(message), message.Header.Type, requestContext);
-                    StripProducerLookupTopic(message);
-                    var span = _tracer?.CreateProducerSpan(producer.Publication, message, parentSpan,
-                        _instrumentationOptions);
-                    producer.Span = span;
-                    if (span != null) producerSpans.TryAdd(message.Id, span);
-
-                    if (producer is IAmAMessageProducerAsync producerAsync)
+                    var savedProducerTopic = StripProducerLookupTopic(message);
+                    var dispatched = false;
+                    try
                     {
-                        var sent = await ExecuteWithResiliencePipelineAsync(
-                                async _ => await producerAsync.SendAsync(message, cancellationToken)
-                                    .ConfigureAwait(continueOnCapturedContext),
-                                requestContext,
-                                continueOnCapturedContext,
-                                cancellationToken
-                            )
-                            .ConfigureAwait(continueOnCapturedContext);
+                        var span = _tracer?.CreateProducerSpan(producer.Publication, message, parentSpan,
+                            _instrumentationOptions);
+                        producer.Span = span;
+                        if (span != null) producerSpans.TryAdd(message.Id, span);
 
-                        if (producer is not ISupportPublishConfirmation && sent)
+                        if (producer is IAmAMessageProducerAsync producerAsync)
                         {
-                            await ExecuteWithResiliencePipelineAsync(
-                                async _ => await _asyncOutbox.MarkDispatchedAsync(
-                                    message.Id, requestContext, _timeProvider.GetUtcNow(),
-                                    cancellationToken: cancellationToken
-                                ),
-                                requestContext,
-                                cancellationToken: cancellationToken
-                            );
-                        }
+                            var sent = await ExecuteWithResiliencePipelineAsync(
+                                    async _ => await producerAsync.SendAsync(message, cancellationToken)
+                                        .ConfigureAwait(continueOnCapturedContext),
+                                    requestContext,
+                                    continueOnCapturedContext,
+                                    cancellationToken
+                                )
+                                .ConfigureAwait(continueOnCapturedContext);
 
-                        if(!sent) TripTopic(message.Header.Topic);
-   
+                            if (producer is not ISupportPublishConfirmation && sent)
+                            {
+                                await ExecuteWithResiliencePipelineAsync(
+                                    async _ => await _asyncOutbox.MarkDispatchedAsync(
+                                        message.Id, requestContext, _timeProvider.GetUtcNow(),
+                                        cancellationToken: cancellationToken
+                                    ),
+                                    requestContext,
+                                    cancellationToken: cancellationToken
+                                );
+                            }
+
+                            dispatched = sent || producer is ISupportPublishConfirmation;
+
+                            if(!sent) TripTopic(message.Header.Topic);
+
+                        }
+                        else
+                            throw new InvalidOperationException("No async message producer defined.");
                     }
-                    else
-                        throw new InvalidOperationException("No async message producer defined.");
+                    finally
+                    {
+                        if (!dispatched) RestoreProducerLookupTopic(message, savedProducerTopic);
+                    }
                 }
             }
             finally

--- a/src/Paramore.Brighter/WrapPipeline.cs
+++ b/src/Paramore.Brighter/WrapPipeline.cs
@@ -93,6 +93,8 @@ namespace Paramore.Brighter
             if (message.Header.Topic != publication.Topic)
             {
                 Log.DifferentPublicationAndMessageTopic(s_logger, publication.Topic?.Value ?? string.Empty, message.Header.Topic);
+                if (publication.Topic is not null)
+                    message.Header.Bag[Message.ProducerTopicHeaderName] = publication.Topic.Value;
             }
 
             BrighterTracer.WriteMapperEvent(message, publication, requestContext.Span, MessageMapper.GetType().Name, false, _instrumentationOptions, true);

--- a/src/Paramore.Brighter/WrapPipeline.cs
+++ b/src/Paramore.Brighter/WrapPipeline.cs
@@ -94,7 +94,9 @@ namespace Paramore.Brighter
             {
                 Log.DifferentPublicationAndMessageTopic(s_logger, publication.Topic?.Value ?? string.Empty, message.Header.Topic);
                 if (publication.Topic is not null)
+                {
                     message.Header.Bag[Message.ProducerTopicHeaderName] = publication.Topic.Value;
+                }
             }
 
             BrighterTracer.WriteMapperEvent(message, publication, requestContext.Span, MessageMapper.GetType().Name, false, _instrumentationOptions, true);

--- a/src/Paramore.Brighter/WrapPipelineAsync.cs
+++ b/src/Paramore.Brighter/WrapPipelineAsync.cs
@@ -100,6 +100,8 @@ namespace Paramore.Brighter
             if (message.Header.Topic != publication.Topic)
             {
                 Log.DifferentPublicationAndMessageTopic(s_logger, publication.Topic?.Value ?? string.Empty, message.Header.Topic);
+                if (publication.Topic is not null)
+                    message.Header.Bag[Message.ProducerTopicHeaderName] = publication.Topic.Value;
             }
             
             BrighterTracer.WriteMapperEvent(message, publication, requestContext.Span, MessageMapper.GetType().Name, true, _instrumentationOptions, true);

--- a/src/Paramore.Brighter/WrapPipelineAsync.cs
+++ b/src/Paramore.Brighter/WrapPipelineAsync.cs
@@ -101,7 +101,9 @@ namespace Paramore.Brighter
             {
                 Log.DifferentPublicationAndMessageTopic(s_logger, publication.Topic?.Value ?? string.Empty, message.Header.Topic);
                 if (publication.Topic is not null)
+                {
                     message.Header.Bag[Message.ProducerTopicHeaderName] = publication.Topic.Value;
+                }
             }
             
             BrighterTracer.WriteMapperEvent(message, publication, requestContext.Span, MessageMapper.GetType().Name, true, _instrumentationOptions, true);

--- a/tests/Paramore.Brighter.AzureServiceBus.Tests/MessagingGateway/When_Converting_A_Message_With_Local_Headers.cs
+++ b/tests/Paramore.Brighter.AzureServiceBus.Tests/MessagingGateway/When_Converting_A_Message_With_Local_Headers.cs
@@ -1,0 +1,32 @@
+using System;
+using Paramore.Brighter.MessagingGateway.AzureServiceBus;
+using Xunit;
+
+namespace Paramore.Brighter.AzureServiceBus.Tests.MessagingGateway;
+
+[Trait("Category", "ASB")]
+[Trait("Fragile", "CI")]
+public class AzureServiceBusMessagePublisherLocalHeaderTests
+{
+    [Fact]
+    public void When_Converting_A_Message_The_ProducerTopic_Local_Header_Is_Stripped()
+    {
+        var header = new MessageHeader(
+            messageId: Guid.NewGuid().ToString(),
+            topic: new RoutingKey("reply.address"),
+            messageType: MessageType.MT_COMMAND);
+        header.Bag[Message.ProducerTopicHeaderName] = "the.real.producer.topic";
+        header.Bag["customer.header"] = "should.survive";
+
+        var message = new Message(header, new MessageBody("body"));
+
+        var asbMessage = AzureServiceBusMessagePublisher.ConvertToServiceBusMessage(message);
+
+        // local header is stripped from the wire form...
+        Assert.False(asbMessage.ApplicationProperties.ContainsKey(Message.ProducerTopicHeaderName));
+        // ...but the original message keeps it (so InMemoryOutbox-by-reference retries still work)
+        Assert.True(message.Header.Bag.ContainsKey(Message.ProducerTopicHeaderName));
+        // unrelated bag entries still travel on the wire
+        Assert.True(asbMessage.ApplicationProperties.ContainsKey("customer.header"));
+    }
+}

--- a/tests/Paramore.Brighter.AzureServiceBus.Tests/MessagingGateway/When_Converting_A_Message_With_Local_Headers.cs
+++ b/tests/Paramore.Brighter.AzureServiceBus.Tests/MessagingGateway/When_Converting_A_Message_With_Local_Headers.cs
@@ -5,7 +5,6 @@ using Xunit;
 namespace Paramore.Brighter.AzureServiceBus.Tests.MessagingGateway;
 
 [Trait("Category", "ASB")]
-[Trait("Fragile", "CI")]
 public class AzureServiceBusMessagePublisherLocalHeaderTests
 {
     [Fact]

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Post/When_Bulk_Dispatching_Reply_Messages_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Post/When_Bulk_Dispatching_Reply_Messages_Async.cs
@@ -12,11 +12,10 @@ using Xunit;
 
 namespace Paramore.Brighter.Core.Tests.CommandProcessors.Post
 {
-    // Gap: BulkDispatchAsync groups by Header.Topic (the mapper-set reply topic) but
-    // looks up the producer using the first message's bag. The single-message Dispatch
-    // paths are covered; this pins the bulk-outbox-clear path so a future refactor of
-    // GetProducerLookupTopic or the firstMessage assumption cannot silently regress and
-    // fail to locate the producer when draining the outbox via the bulk sweep.
+    // Pins the bulk-outbox-clear path: reply messages drained via BulkDispatchAsync
+    // are grouped by (WireTopic, LookupTopic) and dispatched to the producer resolved
+    // from LookupTopic. Prevents regression to a Header.Topic-only lookup that would
+    // fail to locate the producer for reply messages during outbox sweeps.
     public class CommandProcessorBulkDispatchReplyAsyncTests
     {
         private const string ProducerTopic = "Reply";

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Post/When_Bulk_Dispatching_Reply_Messages_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Post/When_Bulk_Dispatching_Reply_Messages_Async.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Transactions;
+using Microsoft.Extensions.Time.Testing;
+using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
+using Paramore.Brighter.Extensions;
+using Paramore.Brighter.Observability;
+using Polly.Registry;
+using Xunit;
+
+namespace Paramore.Brighter.Core.Tests.CommandProcessors.Post
+{
+    // Gap: BulkDispatchAsync groups by Header.Topic (the mapper-set reply topic) but
+    // looks up the producer using the first message's bag. The single-message Dispatch
+    // paths are covered; this pins the bulk-outbox-clear path so a future refactor of
+    // GetProducerLookupTopic or the firstMessage assumption cannot silently regress and
+    // fail to locate the producer when draining the outbox via the bulk sweep.
+    public class CommandProcessorBulkDispatchReplyAsyncTests
+    {
+        private const string ProducerTopic = "Reply";
+        private readonly CommandProcessor _commandProcessor;
+        private readonly IAmAnOutboxProducerMediator _mediator;
+        private readonly MyResponse _replyOne;
+        private readonly MyResponse _replyTwo;
+        private readonly InternalBus _internalBus = new();
+        private readonly RoutingKey _replyTopic;
+
+        public CommandProcessorBulkDispatchReplyAsyncTests()
+        {
+            var timeProvider = new FakeTimeProvider();
+            var producerRoutingKey = new RoutingKey(ProducerTopic);
+
+            _replyTopic = new RoutingKey(Uuid.NewAsString());
+            var replyAddress = new ReplyAddress(_replyTopic, Uuid.NewAsString());
+            _replyOne = new MyResponse(replyAddress) { ReplyValue = "Hello" };
+            _replyTwo = new MyResponse(replyAddress) { ReplyValue = "World" };
+
+            InMemoryMessageProducer messageProducer = new(_internalBus,
+                new Publication
+                {
+                    Topic = producerRoutingKey,
+                    RequestType = typeof(MyResponse)
+                });
+
+            var messageMapperRegistry = new MessageMapperRegistry(
+                null,
+                new SimpleMessageMapperFactoryAsync(_ => new MyResponseMessageMapperAsync()));
+            messageMapperRegistry.RegisterAsync<MyResponse, MyResponseMessageMapperAsync>();
+
+            var resiliencePipelineRegistry = new ResiliencePipelineRegistry<string>()
+                .AddBrighterDefault();
+
+            var producerRegistry = new ProducerRegistry(
+                new Dictionary<RoutingKey, IAmAMessageProducer>
+                {
+                    { producerRoutingKey, messageProducer }
+                });
+
+            var tracer = new BrighterTracer(timeProvider);
+            var outbox = new InMemoryOutbox(timeProvider) { Tracer = tracer };
+
+            _mediator = new OutboxProducerMediator<Message, CommittableTransaction>(
+                producerRegistry,
+                resiliencePipelineRegistry,
+                messageMapperRegistry,
+                new EmptyMessageTransformerFactory(),
+                new EmptyMessageTransformerFactoryAsync(),
+                tracer,
+                new FindPublicationByPublicationTopicOrRequestType(),
+                outbox,
+                maxOutStandingMessages: -1
+            );
+
+            _commandProcessor = new CommandProcessor(
+                new InMemoryRequestContextFactory(),
+                new DefaultPolicy(),
+                resiliencePipelineRegistry,
+                _mediator,
+                new InMemorySchedulerFactory()
+            );
+        }
+
+        [Fact]
+        public async Task When_Bulk_Dispatching_Reply_Messages_Async()
+        {
+            //arrange - deposit two replies whose mapper sets Header.Topic to the reply
+            //address, not the registered producer topic
+            var context = new RequestContext();
+            await _commandProcessor.DepositPostAsync<MyResponse>([_replyOne, _replyTwo], context);
+
+            //act - drain via the bulk path (exercised by background outbox sweeps)
+            await _mediator.ClearOutstandingFromOutboxAsync(
+                amountToClear: 10,
+                minimumAge: TimeSpan.Zero,
+                useBulk: true,
+                requestContext: context);
+
+            //allow background clear to run
+            await Task.Delay(500);
+
+            //assert - messages landed on the reply topic. If producer lookup had used
+            //Header.Topic (reply address) instead of the bag's ProducerTopic, LookupBy
+            //would have thrown and nothing would arrive on the bus.
+            var messages = _internalBus.Stream(_replyTopic).ToArray();
+            Assert.Equal(2, messages.Length);
+        }
+    }
+}

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Post/When_Bulk_Dispatching_Reply_Messages_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Post/When_Bulk_Dispatching_Reply_Messages_Async.cs
@@ -90,25 +90,21 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.Post
             var context = new RequestContext();
             await _commandProcessor.DepositPostAsync<MyResponse>([_replyOne, _replyTwo], context);
 
-            //act - drain via the bulk path (exercised by background outbox sweeps)
+            //act - drain via the bulk path (exercised by background outbox sweeps).
+            //ClearOutstandingFromOutboxAsync awaits BackgroundDispatchUsingAsync which
+            //awaits BulkDispatchAsync, so dispatch is complete when this returns.
             await _mediator.ClearOutstandingFromOutboxAsync(
                 amountToClear: 10,
                 minimumAge: TimeSpan.Zero,
                 useBulk: true,
                 requestContext: context);
 
-            //poll until the background clear drains the outbox (bounded to avoid flake in CI)
-            var deadline = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(5);
-            while (_internalBus.Stream(_replyTopic).Count() < 2 && DateTimeOffset.UtcNow < deadline)
-            {
-                await Task.Delay(25);
-            }
-
             //assert - messages landed on the reply topic. If producer lookup had used
             //Header.Topic (reply address) instead of the bag's ProducerTopic, LookupBy
             //would have thrown and nothing would arrive on the bus.
             var messages = _internalBus.Stream(_replyTopic).ToArray();
-            Assert.Equal(2, messages.Length);
+            Assert.True(messages.Length == 2,
+                $"expected 2 reply messages on the bus after bulk dispatch, got {messages.Length} — bulk dispatch or producer lookup failed");
 
             //assert - internal ProducerTopic bag entry was stripped on every message
             //in the batch so transports that serialise Header.Bag don't leak it

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Post/When_Bulk_Dispatching_Reply_Messages_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Post/When_Bulk_Dispatching_Reply_Messages_Async.cs
@@ -107,7 +107,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.Post
 
             //assert - the ProducerTopic bag entry survives bulk dispatch so an InMemoryOutbox
             //(which holds the message by reference) keeps the producer hint for retries.
-            //Wire-format stripping is the transport's responsibility (see MessageHeader.LocalHeaderNames).
+            //Wire-format stripping is the transport's responsibility (see MessageHeader.IsLocalHeader).
             Assert.All(messages, m =>
                 Assert.True(m.Header.Bag.ContainsKey(Message.ProducerTopicHeaderName)));
         }

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Post/When_Bulk_Dispatching_Reply_Messages_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Post/When_Bulk_Dispatching_Reply_Messages_Async.cs
@@ -97,8 +97,12 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.Post
                 useBulk: true,
                 requestContext: context);
 
-            //allow background clear to run
-            await Task.Delay(500);
+            //poll until the background clear drains the outbox (bounded to avoid flake in CI)
+            var deadline = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(5);
+            while (_internalBus.Stream(_replyTopic).Count() < 2 && DateTimeOffset.UtcNow < deadline)
+            {
+                await Task.Delay(25);
+            }
 
             //assert - messages landed on the reply topic. If producer lookup had used
             //Header.Topic (reply address) instead of the bag's ProducerTopic, LookupBy

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Post/When_Bulk_Dispatching_Reply_Messages_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Post/When_Bulk_Dispatching_Reply_Messages_Async.cs
@@ -109,6 +109,11 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.Post
             //would have thrown and nothing would arrive on the bus.
             var messages = _internalBus.Stream(_replyTopic).ToArray();
             Assert.Equal(2, messages.Length);
+
+            //assert - internal ProducerTopic bag entry was stripped on every message
+            //in the batch so transports that serialise Header.Bag don't leak it
+            Assert.All(messages, m =>
+                Assert.False(m.Header.Bag.ContainsKey(Message.ProducerTopicHeaderName)));
         }
     }
 }

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Post/When_Bulk_Dispatching_Reply_Messages_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Post/When_Bulk_Dispatching_Reply_Messages_Async.cs
@@ -105,10 +105,11 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.Post
             Assert.True(messages.Length == 2,
                 $"expected 2 reply messages on the bus after bulk dispatch, got {messages.Length} — bulk dispatch or producer lookup failed");
 
-            //assert - internal ProducerTopic bag entry was stripped on every message
-            //in the batch so transports that serialise Header.Bag don't leak it
+            //assert - the ProducerTopic bag entry survives bulk dispatch so an InMemoryOutbox
+            //(which holds the message by reference) keeps the producer hint for retries.
+            //Wire-format stripping is the transport's responsibility (see MessageHeader.LocalHeaderNames).
             Assert.All(messages, m =>
-                Assert.False(m.Header.Bag.ContainsKey(Message.ProducerTopicHeaderName)));
+                Assert.True(m.Header.Bag.ContainsKey(Message.ProducerTopicHeaderName)));
         }
     }
 }

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Post/When_Posting_A_Reply_Message_To_The_Command_Processor.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Post/When_Posting_A_Reply_Message_To_The_Command_Processor.cs
@@ -90,9 +90,10 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.Post
             //assert - message topic is the reply address
             Assert.Equal(_myResponse.SendersAddress.Topic, outboxMessage.Header.Topic);
 
-            //assert - internal ProducerTopic bag entry was stripped before dispatch so
-            //transports that serialise Header.Bag don't leak it onto the wire
-            Assert.False(messages[0].Header.Bag.ContainsKey(Message.ProducerTopicHeaderName));
+            //assert - the ProducerTopic bag entry survives dispatch so an InMemoryOutbox
+            //(which holds the message by reference) keeps the producer hint for retries.
+            //Wire-format stripping is the transport's responsibility (see MessageHeader.LocalHeaderNames).
+            Assert.True(messages[0].Header.Bag.ContainsKey(Message.ProducerTopicHeaderName));
         }
     }
 }

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Post/When_Posting_A_Reply_Message_To_The_Command_Processor.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Post/When_Posting_A_Reply_Message_To_The_Command_Processor.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Transactions;
+using Microsoft.Extensions.Time.Testing;
+using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
+using Paramore.Brighter.Extensions;
+using Paramore.Brighter.Observability;
+using Polly.Registry;
+using Xunit;
+
+namespace Paramore.Brighter.Core.Tests.CommandProcessors.Post
+{
+    public class CommandProcessorPostReplyTests
+    {
+        private const string ProducerTopic = "Reply";
+        private readonly CommandProcessor _commandProcessor;
+        private readonly MyResponse _myResponse;
+        private readonly InMemoryOutbox _outbox;
+        private readonly InternalBus _internalBus = new();
+
+        public CommandProcessorPostReplyTests()
+        {
+            var timeProvider = new FakeTimeProvider();
+            var producerRoutingKey = new RoutingKey(ProducerTopic);
+
+            var replyTopic = new RoutingKey(Uuid.NewAsString());
+            var replyAddress = new ReplyAddress(replyTopic, Uuid.NewAsString());
+            _myResponse = new MyResponse(replyAddress) { ReplyValue = "Hello World" };
+
+            InMemoryMessageProducer messageProducer = new(_internalBus,
+                new Publication
+                {
+                    Topic = producerRoutingKey,
+                    RequestType = typeof(MyResponse)
+                });
+
+            var messageMapperRegistry = new MessageMapperRegistry(
+                new SimpleMessageMapperFactory(_ => new MyResponseMessageMapper()),
+                null);
+            messageMapperRegistry.Register<MyResponse, MyResponseMessageMapper>();
+
+            var resiliencePipelineRegistry = new ResiliencePipelineRegistry<string>()
+                .AddBrighterDefault();
+
+            var producerRegistry = new ProducerRegistry(
+                new Dictionary<RoutingKey, IAmAMessageProducer>
+                {
+                    { producerRoutingKey, messageProducer }
+                });
+
+            var tracer = new BrighterTracer(timeProvider);
+            _outbox = new InMemoryOutbox(timeProvider) { Tracer = tracer };
+
+            IAmAnOutboxProducerMediator bus = new OutboxProducerMediator<Message, CommittableTransaction>(
+                producerRegistry,
+                resiliencePipelineRegistry,
+                messageMapperRegistry,
+                new EmptyMessageTransformerFactory(),
+                new EmptyMessageTransformerFactoryAsync(),
+                tracer,
+                new FindPublicationByPublicationTopicOrRequestType(),
+                _outbox
+            );
+
+            _commandProcessor = new CommandProcessor(
+                new InMemoryRequestContextFactory(),
+                new DefaultPolicy(),
+                resiliencePipelineRegistry,
+                bus,
+                new InMemorySchedulerFactory()
+            );
+        }
+
+        [Fact]
+        public void When_Posting_A_Reply_Message_To_The_Command_Processor()
+        {
+            //act - post a Reply whose mapper sets a dynamic topic (reply address)
+            //different from the producer's registered topic
+            _commandProcessor.Post(_myResponse);
+
+            //assert - message was dispatched to the reply topic, not the producer topic
+            var messages = _internalBus.Stream(_myResponse.SendersAddress.Topic).ToArray();
+            Assert.Single(messages);
+
+            //assert - message was stored in the outbox
+            var outboxMessage = _outbox.Get(_myResponse.Id, new RequestContext());
+            Assert.NotNull(outboxMessage);
+
+            //assert - message topic is the reply address
+            Assert.Equal(_myResponse.SendersAddress.Topic, outboxMessage.Header.Topic);
+        }
+    }
+}

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Post/When_Posting_A_Reply_Message_To_The_Command_Processor.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Post/When_Posting_A_Reply_Message_To_The_Command_Processor.cs
@@ -92,7 +92,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.Post
 
             //assert - the ProducerTopic bag entry survives dispatch so an InMemoryOutbox
             //(which holds the message by reference) keeps the producer hint for retries.
-            //Wire-format stripping is the transport's responsibility (see MessageHeader.LocalHeaderNames).
+            //Wire-format stripping is the transport's responsibility (see MessageHeader.IsLocalHeader).
             Assert.True(messages[0].Header.Bag.ContainsKey(Message.ProducerTopicHeaderName));
         }
     }

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Post/When_Posting_A_Reply_Message_To_The_Command_Processor.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Post/When_Posting_A_Reply_Message_To_The_Command_Processor.cs
@@ -89,6 +89,10 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.Post
 
             //assert - message topic is the reply address
             Assert.Equal(_myResponse.SendersAddress.Topic, outboxMessage.Header.Topic);
+
+            //assert - internal ProducerTopic bag entry was stripped before dispatch so
+            //transports that serialise Header.Bag don't leak it onto the wire
+            Assert.False(messages[0].Header.Bag.ContainsKey(Message.ProducerTopicHeaderName));
         }
     }
 }

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Post/When_Posting_A_Reply_Message_To_The_Command_Processor_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Post/When_Posting_A_Reply_Message_To_The_Command_Processor_Async.cs
@@ -91,9 +91,10 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.Post
             //assert - message topic is the reply address
             Assert.Equal(_myResponse.SendersAddress.Topic, outboxMessage.Header.Topic);
 
-            //assert - internal ProducerTopic bag entry was stripped before dispatch so
-            //transports that serialise Header.Bag don't leak it onto the wire
-            Assert.False(messages[0].Header.Bag.ContainsKey(Message.ProducerTopicHeaderName));
+            //assert - the ProducerTopic bag entry survives dispatch so an InMemoryOutbox
+            //(which holds the message by reference) keeps the producer hint for retries.
+            //Wire-format stripping is the transport's responsibility (see MessageHeader.LocalHeaderNames).
+            Assert.True(messages[0].Header.Bag.ContainsKey(Message.ProducerTopicHeaderName));
         }
     }
 }

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Post/When_Posting_A_Reply_Message_To_The_Command_Processor_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Post/When_Posting_A_Reply_Message_To_The_Command_Processor_Async.cs
@@ -90,6 +90,10 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.Post
 
             //assert - message topic is the reply address
             Assert.Equal(_myResponse.SendersAddress.Topic, outboxMessage.Header.Topic);
+
+            //assert - internal ProducerTopic bag entry was stripped before dispatch so
+            //transports that serialise Header.Bag don't leak it onto the wire
+            Assert.False(messages[0].Header.Bag.ContainsKey(Message.ProducerTopicHeaderName));
         }
     }
 }

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Post/When_Posting_A_Reply_Message_To_The_Command_Processor_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Post/When_Posting_A_Reply_Message_To_The_Command_Processor_Async.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Transactions;
+using Microsoft.Extensions.Time.Testing;
+using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
+using Paramore.Brighter.Extensions;
+using Paramore.Brighter.Observability;
+using Polly.Registry;
+using Xunit;
+
+namespace Paramore.Brighter.Core.Tests.CommandProcessors.Post
+{
+    public class CommandProcessorPostReplyAsyncTests
+    {
+        private const string ProducerTopic = "Reply";
+        private readonly CommandProcessor _commandProcessor;
+        private readonly MyResponse _myResponse;
+        private readonly InMemoryOutbox _outbox;
+        private readonly InternalBus _internalBus = new();
+
+        public CommandProcessorPostReplyAsyncTests()
+        {
+            var timeProvider = new FakeTimeProvider();
+            var producerRoutingKey = new RoutingKey(ProducerTopic);
+
+            var replyTopic = new RoutingKey(Uuid.NewAsString());
+            var replyAddress = new ReplyAddress(replyTopic, Uuid.NewAsString());
+            _myResponse = new MyResponse(replyAddress) { ReplyValue = "Hello World" };
+
+            InMemoryMessageProducer messageProducer = new(_internalBus,
+                new Publication
+                {
+                    Topic = producerRoutingKey,
+                    RequestType = typeof(MyResponse)
+                });
+
+            var messageMapperRegistry = new MessageMapperRegistry(
+                null,
+                new SimpleMessageMapperFactoryAsync(_ => new MyResponseMessageMapperAsync()));
+            messageMapperRegistry.RegisterAsync<MyResponse, MyResponseMessageMapperAsync>();
+
+            var resiliencePipelineRegistry = new ResiliencePipelineRegistry<string>()
+                .AddBrighterDefault();
+
+            var producerRegistry = new ProducerRegistry(
+                new Dictionary<RoutingKey, IAmAMessageProducer>
+                {
+                    { producerRoutingKey, messageProducer }
+                });
+
+            var tracer = new BrighterTracer(timeProvider);
+            _outbox = new InMemoryOutbox(timeProvider) { Tracer = tracer };
+
+            IAmAnOutboxProducerMediator bus = new OutboxProducerMediator<Message, CommittableTransaction>(
+                producerRegistry,
+                resiliencePipelineRegistry,
+                messageMapperRegistry,
+                new EmptyMessageTransformerFactory(),
+                new EmptyMessageTransformerFactoryAsync(),
+                tracer,
+                new FindPublicationByPublicationTopicOrRequestType(),
+                _outbox
+            );
+
+            _commandProcessor = new CommandProcessor(
+                new InMemoryRequestContextFactory(),
+                new DefaultPolicy(),
+                resiliencePipelineRegistry,
+                bus,
+                new InMemorySchedulerFactory()
+            );
+        }
+
+        [Fact]
+        public async Task When_Posting_A_Reply_Message_To_The_Command_Processor_Async()
+        {
+            //act - post a Reply whose mapper sets a dynamic topic (reply address)
+            //different from the producer's registered topic
+            await _commandProcessor.PostAsync(_myResponse);
+
+            //assert - message was dispatched to the reply topic, not the producer topic
+            var messages = _internalBus.Stream(_myResponse.SendersAddress.Topic).ToArray();
+            Assert.Single(messages);
+
+            //assert - message was stored in the outbox
+            var outboxMessage = await _outbox.GetAsync(_myResponse.Id, new RequestContext());
+            Assert.NotNull(outboxMessage);
+
+            //assert - message topic is the reply address
+            Assert.Equal(_myResponse.SendersAddress.Topic, outboxMessage.Header.Topic);
+        }
+    }
+}

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Post/When_Posting_A_Reply_Message_To_The_Command_Processor_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/Post/When_Posting_A_Reply_Message_To_The_Command_Processor_Async.cs
@@ -93,7 +93,7 @@ namespace Paramore.Brighter.Core.Tests.CommandProcessors.Post
 
             //assert - the ProducerTopic bag entry survives dispatch so an InMemoryOutbox
             //(which holds the message by reference) keeps the producer hint for retries.
-            //Wire-format stripping is the transport's responsibility (see MessageHeader.LocalHeaderNames).
+            //Wire-format stripping is the transport's responsibility (see MessageHeader.IsLocalHeader).
             Assert.True(messages[0].Header.Bag.ContainsKey(Message.ProducerTopicHeaderName));
         }
     }

--- a/tests/Paramore.Brighter.Core.Tests/CommandProcessors/TestDoubles/MyResponseMessageMapperAsync.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CommandProcessors/TestDoubles/MyResponseMessageMapperAsync.cs
@@ -1,0 +1,36 @@
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Paramore.Brighter.Extensions;
+using Paramore.Brighter.JsonConverters;
+
+namespace Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles
+{
+    public class MyResponseMessageMapperAsync : IAmAMessageMapperAsync<MyResponse>
+    {
+        public IRequestContext Context { get; set; }
+
+        public Task<Message> MapToMessageAsync(MyResponse request, Publication publication, CancellationToken cancellationToken = default)
+        {
+            var header = new MessageHeader(
+                messageId: request.Id,
+                topic: request.SendersAddress.Topic,
+                messageType: request.RequestToMessageType(),
+                correlationId: request.SendersAddress.CorrelationId);
+
+            var body = new MessageBody(JsonSerializer.Serialize(new MyResponseObject(request.Id.ToString(), request.ReplyValue), JsonSerialisationOptions.Options));
+            var message = new Message(header, body);
+            return Task.FromResult(message);
+        }
+
+        public Task<MyResponse> MapToRequestAsync(Message message, CancellationToken cancellationToken = default)
+        {
+            var replyAddress = new ReplyAddress(topic: message.Header.ReplyTo, correlationId: message.Header.CorrelationId);
+            var command = new MyResponse(replyAddress);
+            var messageBody = JsonSerializer.Deserialize<MyResponseObject>(message.Body.Value, JsonSerialisationOptions.Options);
+            command.Id = messageBody.Id;
+            command.ReplyValue = messageBody.ReplyValue;
+            return Task.FromResult(command);
+        }
+    }
+}

--- a/tests/Paramore.Brighter.Core.Tests/MessageSerialisation/When_Bag_String_Values_Round_Trip_Through_Brighter_Json_Options.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageSerialisation/When_Bag_String_Values_Round_Trip_Through_Brighter_Json_Options.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using Paramore.Brighter.JsonConverters;
+using Xunit;
+
+namespace Paramore.Brighter.Core.Tests.MessageSerialisation;
+
+// Regression pin for the contract that OutboxProducerMediator.GetProducerLookupTopic
+// relies on: when Header.Bag is round-tripped through Brighter's JsonSerialisationOptions
+// the values come back as their runtime types (string here), NOT as JsonElement.
+// If a future change drops DictionaryStringObjectJsonConverter or
+// ObjectToInferredTypesConverter from the options, the `producerTopic is string` cast in
+// GetProducerLookupTopic would silently fail for persistent outboxes (SQL, Mongo,
+// DynamoDB) and reply-message dispatch would regress to the bug this PR fixes.
+public class BagStringValueRoundTripTests
+{
+    [Fact]
+    public void When_Round_Tripping_A_Bag_String_Value_It_Survives_As_String_Not_JsonElement()
+    {
+        var bag = new Dictionary<string, object>
+        {
+            [Message.ProducerTopicHeaderName] = "the.publication.topic",
+            ["customer.header"] = "customer.value"
+        };
+
+        var json = JsonSerializer.Serialize(bag, JsonSerialisationOptions.Options);
+        var roundTripped = JsonSerializer.Deserialize<Dictionary<string, object>>(json, JsonSerialisationOptions.Options);
+
+        Assert.NotNull(roundTripped);
+        Assert.IsType<string>(roundTripped![Message.ProducerTopicHeaderName]);
+        Assert.Equal("the.publication.topic", roundTripped[Message.ProducerTopicHeaderName]);
+        Assert.IsType<string>(roundTripped["customer.header"]);
+    }
+}

--- a/tests/Paramore.Brighter.Core.Tests/MessageSerialisation/When_Stripping_Local_Headers_From_A_Message_Header.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageSerialisation/When_Stripping_Local_Headers_From_A_Message_Header.cs
@@ -2,10 +2,10 @@ using Xunit;
 
 namespace Paramore.Brighter.Core.Tests.MessageSerialisation;
 
-public class MessageHeaderStripLocalHeadersTests
+public class MessageHeaderLocalHeadersTests
 {
     [Fact]
-    public void When_Stripping_Local_Headers_The_ProducerTopic_Bag_Entry_Is_Removed_And_Other_Entries_Survive()
+    public void When_BagWithoutLocalHeaders_Removes_Local_Entries_And_Other_Entries_Survive()
     {
         var header = new MessageHeader(
             messageId: "id-1",
@@ -14,14 +14,16 @@ public class MessageHeaderStripLocalHeadersTests
         header.Bag[Message.ProducerTopicHeaderName] = "lookup.topic";
         header.Bag["user.key"] = "user.value";
 
-        header.StripLocalHeaders();
+        var wireBag = header.BagWithoutLocalHeaders();
 
-        Assert.False(header.Bag.ContainsKey(Message.ProducerTopicHeaderName));
-        Assert.True(header.Bag.ContainsKey("user.key"));
+        Assert.False(wireBag.ContainsKey(Message.ProducerTopicHeaderName));
+        Assert.True(wireBag.ContainsKey("user.key"));
+        // original is untouched — InMemoryOutbox-by-reference keeps the local entry for retries
+        Assert.True(header.Bag.ContainsKey(Message.ProducerTopicHeaderName));
     }
 
     [Fact]
-    public void When_Stripping_Local_Headers_With_No_Local_Bag_Entries_Then_The_Bag_Is_Unchanged()
+    public void When_BagWithoutLocalHeaders_With_No_Local_Entries_Returns_Equivalent_Copy()
     {
         var header = new MessageHeader(
             messageId: "id-2",
@@ -29,10 +31,10 @@ public class MessageHeaderStripLocalHeadersTests
             messageType: MessageType.MT_EVENT);
         header.Bag["user.key"] = "user.value";
 
-        header.StripLocalHeaders();
+        var wireBag = header.BagWithoutLocalHeaders();
 
-        Assert.Single(header.Bag);
-        Assert.Equal("user.value", header.Bag["user.key"]);
+        Assert.Single(wireBag);
+        Assert.Equal("user.value", wireBag["user.key"]);
     }
 
     [Fact]
@@ -44,7 +46,7 @@ public class MessageHeaderStripLocalHeadersTests
     [Fact]
     public void When_RegisterLocalHeader_Adds_A_Custom_Key_It_Is_Recognised_And_Is_Idempotent()
     {
-        const string customKey = "custom.local.header." + nameof(MessageHeaderStripLocalHeadersTests);
+        const string customKey = "custom.local.header." + nameof(MessageHeaderLocalHeadersTests);
 
         MessageHeader.RegisterLocalHeader(customKey);
         MessageHeader.RegisterLocalHeader(customKey); // idempotent

--- a/tests/Paramore.Brighter.Core.Tests/MessageSerialisation/When_Stripping_Local_Headers_From_A_Message_Header.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageSerialisation/When_Stripping_Local_Headers_From_A_Message_Header.cs
@@ -1,0 +1,43 @@
+using Xunit;
+
+namespace Paramore.Brighter.Core.Tests.MessageSerialisation;
+
+public class MessageHeaderStripLocalHeadersTests
+{
+    [Fact]
+    public void When_Stripping_Local_Headers_The_ProducerTopic_Bag_Entry_Is_Removed_And_Other_Entries_Survive()
+    {
+        var header = new MessageHeader(
+            messageId: "id-1",
+            topic: new RoutingKey("a.topic"),
+            messageType: MessageType.MT_COMMAND);
+        header.Bag[Message.ProducerTopicHeaderName] = "lookup.topic";
+        header.Bag["user.key"] = "user.value";
+
+        header.StripLocalHeaders();
+
+        Assert.False(header.Bag.ContainsKey(Message.ProducerTopicHeaderName));
+        Assert.True(header.Bag.ContainsKey("user.key"));
+    }
+
+    [Fact]
+    public void When_Stripping_Local_Headers_With_No_Local_Bag_Entries_Then_The_Bag_Is_Unchanged()
+    {
+        var header = new MessageHeader(
+            messageId: "id-2",
+            topic: new RoutingKey("a.topic"),
+            messageType: MessageType.MT_EVENT);
+        header.Bag["user.key"] = "user.value";
+
+        header.StripLocalHeaders();
+
+        Assert.Single(header.Bag);
+        Assert.Equal("user.value", header.Bag["user.key"]);
+    }
+
+    [Fact]
+    public void When_The_Producer_Topic_Header_Name_Is_In_The_Local_Header_Names_Set()
+    {
+        Assert.Contains(Message.ProducerTopicHeaderName, MessageHeader.LocalHeaderNames);
+    }
+}

--- a/tests/Paramore.Brighter.Core.Tests/MessageSerialisation/When_Stripping_Local_Headers_From_A_Message_Header.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageSerialisation/When_Stripping_Local_Headers_From_A_Message_Header.cs
@@ -36,8 +36,31 @@ public class MessageHeaderStripLocalHeadersTests
     }
 
     [Fact]
-    public void When_The_Producer_Topic_Header_Name_Is_In_The_Local_Header_Names_Set()
+    public void When_The_Producer_Topic_Header_Name_Is_A_Local_Header()
     {
-        Assert.Contains(Message.ProducerTopicHeaderName, MessageHeader.LocalHeaderNames);
+        Assert.True(MessageHeader.IsLocalHeader(Message.ProducerTopicHeaderName));
+    }
+
+    [Fact]
+    public void When_RegisterLocalHeader_Adds_A_Custom_Key_It_Is_Recognised_And_Is_Idempotent()
+    {
+        const string customKey = "custom.local.header." + nameof(MessageHeaderStripLocalHeadersTests);
+
+        MessageHeader.RegisterLocalHeader(customKey);
+        MessageHeader.RegisterLocalHeader(customKey); // idempotent
+
+        Assert.True(MessageHeader.IsLocalHeader(customKey));
+
+        var header = new MessageHeader(
+            messageId: "id-3",
+            topic: new RoutingKey("a.topic"),
+            messageType: MessageType.MT_COMMAND);
+        header.Bag[customKey] = "value";
+        header.Bag["user.key"] = "user.value";
+
+        var wireBag = header.BagWithoutLocalHeaders();
+
+        Assert.False(wireBag.ContainsKey(customKey));
+        Assert.True(wireBag.ContainsKey("user.key"));
     }
 }

--- a/tests/Paramore.Brighter.Core.Tests/MessageSerialisation/When_Wrapping_A_Message_Whose_Topic_Matches_The_Publication.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageSerialisation/When_Wrapping_A_Message_Whose_Topic_Matches_The_Publication.cs
@@ -1,0 +1,45 @@
+using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
+using Xunit;
+
+namespace Paramore.Brighter.Core.Tests.MessageSerialisation;
+
+// Fallback path for OutboxProducerMediator.GetProducerLookupTopic: when a mapper does
+// NOT override Header.Topic (the normal-publication case), no ProducerTopic bag entry
+// is written. Producer lookup then falls back to Header.Topic. Without this pin, a
+// future change that always wrote the bag entry would leave persistent outbox rows
+// across a rolling upgrade with stale producer hints — exactly the failure mode the
+// pre-fix bug had, just inverted.
+public class WrapMatchingPublicationTopicTests
+{
+    [Fact]
+    public void When_The_Mapper_Topic_Matches_The_Publication_No_Producer_Topic_Bag_Entry_Is_Written()
+    {
+        TransformPipelineBuilder.ClearPipelineCache();
+
+        var mapperRegistry = new MessageMapperRegistry(
+            new SimpleMessageMapperFactory(_ => new MyCommandMessageMapper()),
+            null);
+        mapperRegistry.Register<MyCommand, MyCommandMessageMapper>();
+
+        var publicationTopic = new RoutingKey("normal.publication.topic");
+        var publication = new Publication
+        {
+            Topic = publicationTopic,
+            RequestType = typeof(MyCommand)
+        };
+
+        var pipelineBuilder = new TransformPipelineBuilder(
+            mapperRegistry,
+            new SimpleMessageTransformerFactory(_ => null));
+
+        var message = pipelineBuilder
+            .BuildWrapPipeline<MyCommand>()
+            .Wrap(new MyCommand(), new RequestContext(), publication);
+
+        // mapper produced a topic identical to publication.Topic — fallback path
+        Assert.Equal(publicationTopic, message.Header.Topic);
+
+        // no bag entry → producer lookup falls back to Header.Topic
+        Assert.False(message.Header.Bag.ContainsKey(Message.ProducerTopicHeaderName));
+    }
+}

--- a/tests/Paramore.Brighter.Core.Tests/MessageSerialisation/When_Wrapping_A_Reply_Message_Mapper.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageSerialisation/When_Wrapping_A_Reply_Message_Mapper.cs
@@ -1,0 +1,52 @@
+using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
+using Xunit;
+
+namespace Paramore.Brighter.Core.Tests.MessageSerialisation;
+
+public class ReplyMessageWrapRequestTests
+{
+    private readonly TransformPipelineBuilder _pipelineBuilder;
+    private readonly MyResponse _myResponse;
+    private readonly Publication _publication;
+
+    public ReplyMessageWrapRequestTests()
+    {
+        //arrange
+        TransformPipelineBuilder.ClearPipelineCache();
+
+        var mapperRegistry = new MessageMapperRegistry(
+            new SimpleMessageMapperFactory(_ => new MyResponseMessageMapper()),
+            null);
+        mapperRegistry.Register<MyResponse, MyResponseMessageMapper>();
+
+        var replyTopic = new RoutingKey(Uuid.NewAsString());
+        var replyAddress = new ReplyAddress(replyTopic, Uuid.NewAsString());
+        _myResponse = new MyResponse(replyAddress) { ReplyValue = "Hello World" };
+
+        var messageTransformerFactory = new SimpleMessageTransformerFactory(_ => null);
+
+        _publication = new Publication
+        {
+            Topic = new RoutingKey("Reply"),
+            RequestType = typeof(MyResponse)
+        };
+
+        _pipelineBuilder = new TransformPipelineBuilder(mapperRegistry, messageTransformerFactory);
+    }
+
+    [Fact]
+    public void When_Wrapping_A_Reply_Message_Mapper()
+    {
+        //act
+        var transformPipeline = _pipelineBuilder.BuildWrapPipeline<MyResponse>();
+        var message = transformPipeline.Wrap(_myResponse, new RequestContext(), _publication);
+
+        //assert - message topic is the reply address, not the publication topic
+        Assert.Equal(_myResponse.SendersAddress.Topic, message.Header.Topic);
+        Assert.NotEqual(_publication.Topic, message.Header.Topic);
+
+        //assert - publication topic stored in bag for producer lookup
+        Assert.True(message.Header.Bag.ContainsKey(Message.ProducerTopicHeaderName));
+        Assert.Equal(_publication.Topic!.Value, message.Header.Bag[Message.ProducerTopicHeaderName]);
+    }
+}

--- a/tests/Paramore.Brighter.Core.Tests/MessageSerialisation/When_Wrapping_A_Reply_Message_MapperAsync.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageSerialisation/When_Wrapping_A_Reply_Message_MapperAsync.cs
@@ -1,0 +1,54 @@
+using System.Threading.Tasks;
+using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
+using Paramore.Brighter.Observability;
+using Xunit;
+
+namespace Paramore.Brighter.Core.Tests.MessageSerialisation;
+
+public class AsyncReplyMessageWrapRequestTests
+{
+    private readonly TransformPipelineBuilderAsync _pipelineBuilder;
+    private readonly MyResponse _myResponse;
+    private readonly Publication _publication;
+
+    public AsyncReplyMessageWrapRequestTests()
+    {
+        //arrange
+        TransformPipelineBuilder.ClearPipelineCache();
+
+        var mapperRegistry = new MessageMapperRegistry(
+            null,
+            new SimpleMessageMapperFactoryAsync(_ => new MyResponseMessageMapperAsync()));
+        mapperRegistry.RegisterAsync<MyResponse, MyResponseMessageMapperAsync>();
+
+        var replyTopic = new RoutingKey(Uuid.NewAsString());
+        var replyAddress = new ReplyAddress(replyTopic, Uuid.NewAsString());
+        _myResponse = new MyResponse(replyAddress) { ReplyValue = "Hello World" };
+
+        var messageTransformerFactory = new SimpleMessageTransformerFactoryAsync(_ => null);
+
+        _publication = new Publication
+        {
+            Topic = new RoutingKey("Reply"),
+            RequestType = typeof(MyResponse)
+        };
+
+        _pipelineBuilder = new TransformPipelineBuilderAsync(mapperRegistry, messageTransformerFactory, InstrumentationOptions.All);
+    }
+
+    [Fact]
+    public async Task When_Wrapping_A_Reply_Message_Mapper()
+    {
+        //act
+        var transformPipeline = _pipelineBuilder.BuildWrapPipeline<MyResponse>();
+        var message = await transformPipeline.WrapAsync(_myResponse, new RequestContext(), _publication);
+
+        //assert - message topic is the reply address, not the publication topic
+        Assert.Equal(_myResponse.SendersAddress.Topic, message.Header.Topic);
+        Assert.NotEqual(_publication.Topic, message.Header.Topic);
+
+        //assert - publication topic stored in bag for producer lookup
+        Assert.True(message.Header.Bag.ContainsKey(Message.ProducerTopicHeaderName));
+        Assert.Equal(_publication.Topic!.Value, message.Header.Bag[Message.ProducerTopicHeaderName]);
+    }
+}

--- a/tests/Paramore.Brighter.Core.Tests/MessageSerialisation/When_Wrapping_A_Reply_Message_MapperAsync.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageSerialisation/When_Wrapping_A_Reply_Message_MapperAsync.cs
@@ -37,7 +37,7 @@ public class AsyncReplyMessageWrapRequestTests
     }
 
     [Fact]
-    public async Task When_Wrapping_A_Reply_Message_Mapper()
+    public async Task When_Wrapping_A_Reply_Message_Mapper_Async()
     {
         //act
         var transformPipeline = _pipelineBuilder.BuildWrapPipeline<MyResponse>();

--- a/tests/Paramore.Brighter.Core.Tests/MessageSerialisation/When_Wrapping_With_Null_Publication_Topic.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageSerialisation/When_Wrapping_With_Null_Publication_Topic.cs
@@ -1,0 +1,55 @@
+using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
+using Xunit;
+
+namespace Paramore.Brighter.Core.Tests.MessageSerialisation;
+
+// Gap: WrapPipeline.Wrap now writes publication.Topic into Header.Bag when the
+// mapper-set topic differs from the publication topic. The fix guards against a
+// null publication.Topic before writing. Without this test, a future refactor that
+// drops the null-check would NRE at runtime for publications that legitimately
+// have no topic (dynamic routing scenarios).
+public class WrapNullPublicationTopicTests
+{
+    private readonly TransformPipelineBuilder _pipelineBuilder;
+    private readonly MyResponse _myResponse;
+    private readonly Publication _publication;
+
+    public WrapNullPublicationTopicTests()
+    {
+        TransformPipelineBuilder.ClearPipelineCache();
+
+        var mapperRegistry = new MessageMapperRegistry(
+            new SimpleMessageMapperFactory(_ => new MyResponseMessageMapper()),
+            null);
+        mapperRegistry.Register<MyResponse, MyResponseMessageMapper>();
+
+        var replyTopic = new RoutingKey(Uuid.NewAsString());
+        var replyAddress = new ReplyAddress(replyTopic, Uuid.NewAsString());
+        _myResponse = new MyResponse(replyAddress) { ReplyValue = "Hello World" };
+
+        var messageTransformerFactory = new SimpleMessageTransformerFactory(_ => null);
+
+        //publication with no topic — mapper still sets its own topic from the reply address
+        _publication = new Publication
+        {
+            Topic = null,
+            RequestType = typeof(MyResponse)
+        };
+
+        _pipelineBuilder = new TransformPipelineBuilder(mapperRegistry, messageTransformerFactory);
+    }
+
+    [Fact]
+    public void When_Wrapping_With_Null_Publication_Topic()
+    {
+        //act
+        var transformPipeline = _pipelineBuilder.BuildWrapPipeline<MyResponse>();
+        var message = transformPipeline.Wrap(_myResponse, new RequestContext(), _publication);
+
+        //assert - topic came from the mapper
+        Assert.Equal(_myResponse.SendersAddress.Topic, message.Header.Topic);
+
+        //assert - no ProducerTopic entry was written to the bag (the guard held)
+        Assert.False(message.Header.Bag.ContainsKey(Message.ProducerTopicHeaderName));
+    }
+}

--- a/tests/Paramore.Brighter.Core.Tests/MessageSerialisation/When_Wrapping_With_Null_Publication_Topic_Async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageSerialisation/When_Wrapping_With_Null_Publication_Topic_Async.cs
@@ -1,0 +1,53 @@
+using System.Threading.Tasks;
+using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
+using Paramore.Brighter.Observability;
+using Xunit;
+
+namespace Paramore.Brighter.Core.Tests.MessageSerialisation;
+
+// Async twin of WrapNullPublicationTopicTests — pins the null-publication-topic
+// guard in WrapPipelineAsync so refactors cannot silently NRE.
+public class AsyncWrapNullPublicationTopicTests
+{
+    private readonly TransformPipelineBuilderAsync _pipelineBuilder;
+    private readonly MyResponse _myResponse;
+    private readonly Publication _publication;
+
+    public AsyncWrapNullPublicationTopicTests()
+    {
+        TransformPipelineBuilder.ClearPipelineCache();
+
+        var mapperRegistry = new MessageMapperRegistry(
+            null,
+            new SimpleMessageMapperFactoryAsync(_ => new MyResponseMessageMapperAsync()));
+        mapperRegistry.RegisterAsync<MyResponse, MyResponseMessageMapperAsync>();
+
+        var replyTopic = new RoutingKey(Uuid.NewAsString());
+        var replyAddress = new ReplyAddress(replyTopic, Uuid.NewAsString());
+        _myResponse = new MyResponse(replyAddress) { ReplyValue = "Hello World" };
+
+        var messageTransformerFactory = new SimpleMessageTransformerFactoryAsync(_ => null);
+
+        _publication = new Publication
+        {
+            Topic = null,
+            RequestType = typeof(MyResponse)
+        };
+
+        _pipelineBuilder = new TransformPipelineBuilderAsync(mapperRegistry, messageTransformerFactory, InstrumentationOptions.All);
+    }
+
+    [Fact]
+    public async Task When_Wrapping_With_Null_Publication_Topic_Async()
+    {
+        //act
+        var transformPipeline = _pipelineBuilder.BuildWrapPipeline<MyResponse>();
+        var message = await transformPipeline.WrapAsync(_myResponse, new RequestContext(), _publication);
+
+        //assert - topic came from the mapper
+        Assert.Equal(_myResponse.SendersAddress.Topic, message.Header.Topic);
+
+        //assert - no ProducerTopic entry was written to the bag (the guard held)
+        Assert.False(message.Header.Bag.ContainsKey(Message.ProducerTopicHeaderName));
+    }
+}


### PR DESCRIPTION
## Summary

  When a message mapper sets `Message.Header.Topic` to a value different from the registered publication topic (as Reply mappers do, using the reply address), the outbox dispatcher was looking up the producer by the mapper-set topic and failing to find it.

  Fix: the wrap pipeline stashes the publication topic in `Header.Bag[ProducerTopicHeaderName]` when it differs from the mapper-set topic. The outbox dispatcher reads that bag entry for producer lookup (falling back to `Header.Topic` when absent). Stripping the bag entry on the wire is the **transport's** responsibility — the message itself keeps the entry so
   an `InMemoryOutbox`-by-reference retry still locates the producer.

  ## Changes

  ### Core
  - `Message.ProducerTopicHeaderName` constant (namespaced as `paramore.brighter.ProducerTopic`)
  - `WrapPipeline.Wrap` / `WrapPipelineAsync.WrapAsync`: write `publication.Topic` into bag when topics differ (guarded for null publication topic)
  - `OutboxProducerMediator.GetProducerLookupTopic`: new private helper used by `Dispatch`, `DispatchAsync`, `BulkDispatchAsync`. The mediator no longer mutates the bag — no strip-and-restore dance, no `dispatched` book-keeping that existed only to drive the restore
  - `MessageHeader.IsLocalHeader(name)` / `MessageHeader.RegisterLocalHeader(name)`: public extension seam for marking bag keys as local (must not be serialised onto the wire). Pre-populated with `ProducerTopicHeaderName`. Backed by a copy-on-write `HashSet<string>` snapshot — lock-free reads on the per-bag-entry hot path, CAS-loop registrations expected at
  startup. No new package dependency.
  - `MessageHeader.BagWithoutLocalHeaders()`: returns a filtered copy of the bag for transports that JSON-serialise the whole bag in one go

  ### Transport sweep
  Every transport that copies `Header.Bag` onto its wire format now skips local headers via `MessageHeader.IsLocalHeader(...)`:
  - AzureServiceBus publisher + Scheduler.Azure
  - AWSSQS V3 + V4 (SNS publisher + SQS sender — use `BagWithoutLocalHeaders()` because they JSON-serialise the whole bag in one go)
  - RMQ.Async + RMQ.Sync publishers
  - Redis publisher (`BagWithoutLocalHeaders()`)
  - Kafka header builder
  - GcpPubSub parser
  - RocketMQ producer

  Followed iancooper's review preference: stripping happens at the wire-conversion step in each transport, not centrally in the mediator. This preserves the bag entry on the original message reference held by `InMemoryOutbox`, so retries still resolve the correct producer.

  ## Deployment note — rolling upgrade

  During a rolling upgrade, outbox rows persisted by an old instance won't have the `ProducerTopic` bag entry. When a new instance drains them, producer lookup falls back to `Header.Topic` (the reply address) and will fail for reply messages. Either drain the outbox before upgrading, or accept that stuck reply rows may need to be re-posted after the rollout
  completes.

  ## Tests

  - `When_Posting_A_Reply_Message_To_The_Command_Processor` (+ async) — end-to-end post + asserts bag entry **survives** dispatch on the original message (transports do the wire-form stripping)
  - `When_Wrapping_A_Reply_Message_Mapper` (+ async) — verifies bag is populated with publication topic
  - `When_Bulk_Dispatching_Reply_Messages_Async` — pins `BulkDispatchAsync` path
  - `When_Wrapping_With_Null_Publication_Topic` (+ async) — pins the null-publication-topic guard
  - `MessageHeaderLocalHeadersTests` — `BagWithoutLocalHeaders` + `IsLocalHeader` + `RegisterLocalHeader` idempotency, asserts the original header is untouched
  - `AzureServiceBusMessagePublisherLocalHeaderTests` — confirms ASB wire form drops `ProducerTopic` while the original message keeps it, and unrelated bag entries still travel

  ## Test plan

  - [x] New tests pass locally
  - [x] Existing test suite builds clean
  - [x] CI green

  Co-Authored-By: Claude (claude-opus-4-7) <noreply@anthropic.com>