### PR TITLE
fix: replace sync-over-async Task.Delay with Thread.Sleep in sync pumps (#4073)

### DIFF
--- a/src/Paramore.Brighter.MessagingGateway.MsSql/SqlQueues/MsSqlMessageQueue.cs
+++ b/src/Paramore.Brighter.MessagingGateway.MsSql/SqlQueues/MsSqlMessageQueue.cs
@@ -102,9 +102,7 @@ namespace Paramore.Brighter.MessagingGateway.MsSql.SqlQueues
             var timeLeft = timeout.Value.TotalMilliseconds;
             while (!rc.IsDataValid && timeLeft > 0)
             {
-                Task.Delay(RetryDelay)
-                    .GetAwaiter()
-                    .GetResult();
+                Thread.Sleep(RetryDelay);
                 timeLeft -= RetryDelay;
                 rc = TryReceive(topic);
             }

--- a/src/Paramore.Brighter.MessagingGateway.RMQ.Sync/PullConsumer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ.Sync/PullConsumer.cs
@@ -25,6 +25,7 @@ THE SOFTWARE. */
 
 using System;
 using System.Collections.Concurrent;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Paramore.Brighter.Logging;
@@ -75,7 +76,7 @@ namespace Paramore.Brighter.MessagingGateway.RMQ.Sync
                 }
                 else
                 {
-                    Task.Delay(pause).Wait();
+                    Thread.Sleep(pause);
                 }
                 now = DateTime.UtcNow;
             }

--- a/src/Paramore.Brighter.MessagingGateway.RMQ.Sync/PullConsumer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ.Sync/PullConsumer.cs
@@ -26,7 +26,6 @@ THE SOFTWARE. */
 using System;
 using System.Collections.Concurrent;
 using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Paramore.Brighter.Logging;
 using RabbitMQ.Client;

--- a/src/Paramore.Brighter.MessagingGateway.RMQ.Sync/RmqMessageGatewayConnectionPool.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ.Sync/RmqMessageGatewayConnectionPool.cs
@@ -24,6 +24,7 @@ THE SOFTWARE. */
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Paramore.Brighter.Logging;
@@ -148,7 +149,7 @@ namespace Paramore.Brighter.MessagingGateway.RMQ.Sync
 
         private static void DelayReconnecting()
         {
-            Task.Delay(jitter.Next(5, 100)).Wait();
+            Thread.Sleep(jitter.Next(5, 100));
         }
 
 

--- a/src/Paramore.Brighter.MessagingGateway.RMQ.Sync/RmqMessageGatewayConnectionPool.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ.Sync/RmqMessageGatewayConnectionPool.cs
@@ -25,7 +25,6 @@ THE SOFTWARE. */
 using System;
 using System.Collections.Generic;
 using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Paramore.Brighter.Logging;
 using RabbitMQ.Client;

--- a/src/Paramore.Brighter.ServiceActivator/Dispatcher.cs
+++ b/src/Paramore.Brighter.ServiceActivator/Dispatcher.cs
@@ -27,6 +27,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Paramore.Brighter.Extensions;
@@ -339,9 +340,7 @@ namespace Paramore.Brighter.ServiceActivator
 
             while (State != DispatcherState.DS_RUNNING)
             {
-                Task.Delay(100)
-                    .GetAwaiter()
-                    .GetResult(); //Block main Dispatcher thread whilst control plane starts
+                Thread.Sleep(100); //Block main Dispatcher thread whilst control plane starts
             }
         }
 

--- a/src/Paramore.Brighter.ServiceActivator/Reactor.cs
+++ b/src/Paramore.Brighter.ServiceActivator/Reactor.cs
@@ -26,7 +26,6 @@ using System;
 using System.Diagnostics;
 using System.Reflection;
 using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Paramore.Brighter.Actions;
 using Paramore.Brighter.Observability;

--- a/src/Paramore.Brighter.ServiceActivator/Reactor.cs
+++ b/src/Paramore.Brighter.ServiceActivator/Reactor.cs
@@ -120,7 +120,7 @@ namespace Paramore.Brighter.ServiceActivator
                     Log.BrokenCircuitException(s_logger, Channel.Name, Channel.RoutingKey, Environment.CurrentManagedThreadId);
                     var errorSpan = Tracer?.CreateMessagePumpExceptionSpan(ex, Channel.RoutingKey, MessagePumpSpanOperation.Receive, MessagingSystem.InternalBus, InstrumentationOptions);
                     Tracer?.EndSpan(errorSpan);
-                    Task.Delay(ChannelFailureDelay).GetAwaiter().GetResult(); //-- pause pump; blocks consuming thread on empty queue; 
+                    Thread.Sleep(ChannelFailureDelay); //-- pause pump; blocks consuming thread on empty queue;
                     continue;
                 }
                 catch (ChannelFailureException ex)
@@ -128,7 +128,7 @@ namespace Paramore.Brighter.ServiceActivator
                     Log.ChannelFailureException(s_logger, Channel.Name, Channel.RoutingKey, Environment.CurrentManagedThreadId);
                     var errorSpan = Tracer?.CreateMessagePumpExceptionSpan(ex, Channel.RoutingKey, MessagePumpSpanOperation.Receive, MessagingSystem.InternalBus, InstrumentationOptions);
                     Tracer?.EndSpan(errorSpan );
-                    Task.Delay(ChannelFailureDelay).GetAwaiter().GetResult(); //-- pause pump; blocks consuming thread on empty queue; 
+                    Thread.Sleep(ChannelFailureDelay); //-- pause pump; blocks consuming thread on empty queue;
                     continue;
                 }
                 catch (Exception ex)
@@ -152,7 +152,7 @@ namespace Paramore.Brighter.ServiceActivator
                 {
                     span?.SetStatus(ActivityStatusCode.Ok);
                     Tracer?.EndSpan(span);
-                    Task.Delay(EmptyChannelDelay).GetAwaiter().GetResult();  //-- pause pump; blocks consuming thread on empty queue; 
+                    Thread.Sleep(EmptyChannelDelay); //-- pause pump; blocks consuming thread on empty queue;
                     continue;
                 }
 


### PR DESCRIPTION
## Summary

Closes #4073.

Replaces `Task.Delay(x).GetAwaiter().GetResult()` / `.Wait()` with `Thread.Sleep(x)` at sites running on dedicated sync threads (pump loops, Dispatcher control thread, connection-pool retry jitter). Each of these sites explicitly blocks a sync-only thread — there is nothing to yield to — so the async primitive just allocates a `Task`, registers a `TimerQueue` timer, and parks on a `ManualResetEventSlim` to do what `Thread.Sleep` does with a single OS primitive.

Benefits:
- Removes per-iteration allocations and `TimerQueue` registrations from hot pump loops.
- Eliminates the `TimerQueue` as a variable when diagnosing pump-shutdown hangs (see #4073 for context on the Linux CI hang investigation).
- Matches the honest intent of these sites.

## Sites changed

Six from the issue:
- `src/Paramore.Brighter.ServiceActivator/Reactor.cs:123` — broken-circuit retry
- `src/Paramore.Brighter.ServiceActivator/Reactor.cs:131` — channel-failure retry
- `src/Paramore.Brighter.ServiceActivator/Reactor.cs:155` — empty-channel pause
- `src/Paramore.Brighter.ServiceActivator/Dispatcher.cs:342` — `Start()` spin-wait for `DS_RUNNING`
- `src/Paramore.Brighter.MessagingGateway.RMQ.Sync/RmqMessageGatewayConnectionPool.cs:151` — connect-retry jitter
- `src/Paramore.Brighter.MessagingGateway.RMQ.Sync/PullConsumer.cs:78` — pull-consumer pause

One additional found during audit of `src/` for the same anti-pattern:
- `src/Paramore.Brighter.MessagingGateway.MsSql/SqlQueues/MsSqlMessageQueue.cs:105` — `TryReceive(topic, timeout)` sync polling loop

Also dropped `using System.Threading.Tasks;` from the three files where it became unused after the substitution.

`Proactor.cs` and all genuine `await Task.Delay(...)` paths are unchanged — those correctly yield on the async pump. Test-code uses of `Task.Delay(...).Wait()` are out of scope (they run on the test-runner thread, not dedicated pump threads).

## Test plan

- [ ] `Paramore.Brighter.ServiceActivator` builds clean on all TFMs (netstandard2.0, net8.0, net9.0, net10.0) — verified locally.
- [ ] `Paramore.Brighter.MessagingGateway.RMQ.Sync` builds clean on all TFMs — verified locally.
- [ ] `Paramore.Brighter.MessagingGateway.MsSql` builds clean on all TFMs (including net462) — verified locally.
- [ ] Existing ServiceActivator / RMQ.Sync / MsSql test suites pass on CI.
- [ ] Monitor whether `When_A_Message_Dispatcher_Shuts_A_Connection` remains stable in CI after removing the `TimerQueue` from the Reactor pause path.