### PR TITLE
refactor: rewrite BrighterAsyncContext for correctness and modernization

### DIFF
--- a/src/Paramore.Brighter/Tasks/BrighterAsyncContext.cs
+++ b/src/Paramore.Brighter/Tasks/BrighterAsyncContext.cs
@@ -125,24 +125,29 @@ public sealed class BrighterAsyncContext : IDisposable
 
         OperationStarted();
 
-        // Attach completion continuation before queueing. The task cannot start until the
-        // scheduler pulls it from the queue, so no completion race is possible here.
+        if (!_taskQueue.TryAdd(task, propagateExceptions))
+        {
+            // Queue is already completed for adding: the task will never be pulled, so we
+            // must not attach the completion continuation - if a caller later inline-executes
+            // the stranded task via TryExecuteTaskInline, the continuation would fire and
+            // double-decrement the outstanding-operations counter. Balance manually instead.
+            // Record shutdown so Send can distinguish "pump will process this task" from
+            // "task will never run".
+            Volatile.Write(ref _shutdown, 1);
+            OperationCompleted();
+            return;
+        }
+
+        // Task is queued. Attach completion continuation to balance OperationStarted when
+        // the task finishes. ExecuteSynchronously runs the continuation inline if the task
+        // has already completed by the time we attach (e.g. the pump pulled and ran it
+        // between TryAdd and here), so the continuation always fires exactly once.
         task.ContinueWith(
             static (_, state) => ((BrighterAsyncContext)state!).OperationCompleted(),
             this,
             CancellationToken.None,
             TaskContinuationOptions.ExecuteSynchronously,
             _taskScheduler);
-
-        if (!_taskQueue.TryAdd(task, propagateExceptions))
-        {
-            // Queue is already completed for adding: the task will never be pulled, so the
-            // continuation will never fire. Balance the outstanding-operations counter
-            // manually so callers of Execute do not hang. Record shutdown so Send can
-            // distinguish "pump will process this task" from "task will never run".
-            Volatile.Write(ref _shutdown, 1);
-            OperationCompleted();
-        }
     }
 
     /// <summary>

--- a/src/Paramore.Brighter/Tasks/BrighterAsyncContext.cs
+++ b/src/Paramore.Brighter/Tasks/BrighterAsyncContext.cs
@@ -1,8 +1,8 @@
-﻿#region Sources
+#region Sources
 
-// This class is based on Stephen Cleary's AyncContext in https://github.com/StephenCleary/AsyncEx
-// The original code is licensed under the MIT License (MIT) <a href="https://github.com/StephenCleary/AsyncEx/blob/master/LICENSE>AyncEx license</a>
-// Modifies the original approach in Brighter which only provided a synchronization synchronizationHelper, not a scheduler, and thus would
+// This class is based on Stephen Cleary's AsyncContext in https://github.com/StephenCleary/AsyncEx
+// The original code is licensed under the MIT License (MIT) <a href="https://github.com/StephenCleary/AsyncEx/blob/master/LICENSE>AsyncEx license</a>
+// Modifies the original approach in Brighter which only provided a synchronization context, not a scheduler, and thus would
 // not run continuations on the same thread as the async operation if used with ConfigureAwait(false).
 // This is important for the ServiceActivator, as we want to ensure ordering on a single thread and not use the thread pool.
 
@@ -14,64 +14,55 @@
 #endregion
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace Paramore.Brighter.Tasks;
 
 /// <summary>
-/// The Brighter SynchronizationHelper holds the tasks that we need to execute as continuations of an async operation
-/// and the scheduler that we will use to run those tasks. In this case we use a single-threaded scheduler to run the
-/// continuations and not a thread pool scheduler. This is because we want to run the continuations on the same thread.
-/// We also create a task factory that uses the scheduler, so that we can easily create tasks that are queued to the scheduler.
+/// A single-threaded async context that pairs a <see cref="SynchronizationContext"/> with a
+/// cooperating <see cref="TaskScheduler"/>, so continuations of async work run on the same
+/// thread as their originator (not the thread pool).
 /// </summary>
-public class BrighterAsyncContext : IDisposable
+public sealed class BrighterAsyncContext : IDisposable
 {
     private readonly BrighterTaskQueue _taskQueue = new();
-
-    private readonly BrighterSynchronizationContext? _synchronizationContext;
+    private readonly BrighterSynchronizationContext _synchronizationContext;
     private readonly BrighterTaskScheduler _taskScheduler;
     private readonly TaskFactory _taskFactory;
 
     private int _outstandingOperations;
-    
+    private int _executing;
+    private int _shutdown;
+    private int _disposed;
+
     /// <summary>
-    /// Access the task factory
+    /// The <see cref="TaskFactory"/> bound to this context's scheduler. Intended for tests
+    /// and scheduler-aware consumers.
     /// </summary>
-    /// <remarks>
-    ///  Intended for tests
-    /// </remarks>
     public TaskFactory Factory => _taskFactory;
 
     /// <summary>
-    /// This is the same identifier as the context's <see cref="TaskScheduler"/>. Used for testing
+    /// The identifier of the context's <see cref="TaskScheduler"/>. Used for testing.
     /// </summary>
     public int Id => _taskScheduler.Id;
 
     /// <summary>
-    /// How many operations are currently outstanding?
+    /// Current outstanding operation count. Intended for debugging.
     /// </summary>
-    /// <remarks>
-    ///  Intended for debugging
-    /// </remarks>
-    public int OutstandingOperations { get; set; }
+    public int OutstandingOperations => Volatile.Read(ref _outstandingOperations);
 
     /// <summary>
-    /// Access the task scheduler,
+    /// The cooperating task scheduler. Intended for tests.
     /// </summary>
-    /// <remarks>
-    ///  Intended for tests
-    /// </remarks>
     public TaskScheduler TaskScheduler => _taskScheduler;
 
     /// <summary>
-    /// Access the synchoronization context, intended for tests
+    /// The cooperating synchronization context. Intended for tests.
     /// </summary>
-    public SynchronizationContext? SynchronizationContext => _synchronizationContext;
+    public SynchronizationContext SynchronizationContext => _synchronizationContext;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="BrighterAsyncContext"/> class.
@@ -80,310 +71,282 @@ public class BrighterAsyncContext : IDisposable
     {
         _taskScheduler = new BrighterTaskScheduler(this);
         _synchronizationContext = new BrighterSynchronizationContext(this);
-        _taskFactory = new TaskFactory(CancellationToken.None, TaskCreationOptions.HideScheduler, TaskContinuationOptions.HideScheduler, _taskScheduler);
+        _taskFactory = new TaskFactory(
+            CancellationToken.None,
+            TaskCreationOptions.HideScheduler,
+            TaskContinuationOptions.HideScheduler,
+            _taskScheduler);
     }
 
+    /// <summary>
+    /// Returns <c>true</c> once the task queue has stopped accepting work (either because
+    /// <see cref="Dispose"/> has been called, or because <see cref="OperationCompleted"/>
+    /// has drained the last outstanding operation and completed the queue for adding).
+    /// </summary>
+    internal bool IsShutDown => Volatile.Read(ref _shutdown) != 0;
 
     /// <summary>
-    /// Disposes the synchronization helper and clears the task queue.
+    /// Disposes the context, releasing the task queue. Idempotent.
     /// </summary>
+    /// <remarks>
+    /// The associated <see cref="BrighterSynchronizationContext"/> is intentionally not
+    /// disposed here: late <see cref="SynchronizationContext.Post"/> calls from stray
+    /// async continuations may still arrive after <c>Run</c> has returned. Those are
+    /// absorbed silently. Late <see cref="SynchronizationContext.Send"/> calls cannot
+    /// be absorbed (the caller waits for completion) and will throw
+    /// <see cref="ObjectDisposedException"/>.
+    /// </remarks>
     public void Dispose()
     {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            return;
+        Volatile.Write(ref _shutdown, 1);
         _taskQueue.Dispose();
     }
 
     /// <summary>
-    /// Gets the current synchronization helper.
+    /// Gets the current ambient <see cref="BrighterAsyncContext"/>, if any.
     /// </summary>
-    public static BrighterAsyncContext? Current
-    {
-        get
-        {
-            var syncContext = SynchronizationContext.Current as BrighterSynchronizationContext;
-            return syncContext?.AsyncContext;
-        }
-    }
+    public static BrighterAsyncContext? Current =>
+        (SynchronizationContext.Current as BrighterSynchronizationContext)?.AsyncContext;
 
     /// <summary>
-    /// Enqueues a task for execution.
+    /// Enqueues a task for execution by this context.
     /// </summary>
     /// <param name="task">The task to enqueue.</param>
-    /// <param name="propagateExceptions">Indicates whether to propagate exceptions.</param>
-    public void Enqueue(Task task, bool propagateExceptions)
+    /// <param name="propagateExceptions">Whether to propagate exceptions back to <see cref="Execute"/>.</param>
+    internal void Enqueue(Task task, bool propagateExceptions)
     {
 #if DEBUG_CONTEXT
         Debug.IndentLevel = 1;
-        Debug.WriteLine($"BrighterSynchronizationHelper: Enqueueing task {task.Id} on thread {Thread.CurrentThread.ManagedThreadId} for BrighterSynchronizationHelper {Id}");
+        Debug.WriteLine($"BrighterAsyncContext: Enqueueing task {task.Id} on thread {Thread.CurrentThread.ManagedThreadId} for context {Id}");
         Debug.IndentLevel = 0;
 #endif
 
         OperationStarted();
-        task.ContinueWith(_ => OperationCompleted(), CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, _taskScheduler);
-        _taskQueue.TryAdd(task, propagateExceptions);
-        
-        //if we fail to add to the queue, just drop the Task
+
+        // Attach completion continuation before queueing. The task cannot start until the
+        // scheduler pulls it from the queue, so no completion race is possible here.
+        task.ContinueWith(
+            static (_, state) => ((BrighterAsyncContext)state!).OperationCompleted(),
+            this,
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            _taskScheduler);
+
+        if (!_taskQueue.TryAdd(task, propagateExceptions))
+        {
+            // Queue is already completed for adding: the task will never be pulled, so the
+            // continuation will never fire. Balance the outstanding-operations counter
+            // manually so callers of Execute do not hang. Record shutdown so Send can
+            // distinguish "pump will process this task" from "task will never run".
+            Volatile.Write(ref _shutdown, 1);
+            OperationCompleted();
+        }
     }
 
     /// <summary>
-    /// Notifies that an operation has completed.
+    /// Notifies the context that an operation has completed.
     /// </summary>
-    public void OperationCompleted()
+    internal void OperationCompleted()
     {
         var newCount = Interlocked.Decrement(ref _outstandingOperations);
-        
+
 #if DEBUG_CONTEXT
         Debug.IndentLevel = 1;
-        Debug.WriteLine($"BrighterSynchronizationHelper: Operation completed on thread {Thread.CurrentThread.ManagedThreadId} for BrighterSynchronizationHelper {Id}");
-
-        Debug.WriteLine($"BrighterSynchronizationHelper: Outstanding operations: {newCount}");
+        Debug.WriteLine($"BrighterAsyncContext: Operation completed on thread {Thread.CurrentThread.ManagedThreadId} for context {Id}");
+        Debug.WriteLine($"BrighterAsyncContext: Outstanding operations: {newCount}");
         Debug.IndentLevel = 0;
 #endif
 
         if (newCount == 0)
+        {
+            Volatile.Write(ref _shutdown, 1);
             _taskQueue.CompleteAdding();
+        }
     }
 
     /// <summary>
-    /// Notifies that an operation has started.
+    /// Notifies the context that an operation has started.
     /// </summary>
-    public void OperationStarted()
+    internal void OperationStarted()
     {
         var newCount = Interlocked.Increment(ref _outstandingOperations);
 
 #if DEBUG_CONTEXT
         Debug.IndentLevel = 1;
-        Debug.WriteLine($"BrighterSynchronizationHelper: Operation started on thread {Thread.CurrentThread.ManagedThreadId} for BrighterSynchronizationHelper {Id}");
-        Debug.WriteLine($"BrighterSynchronizationHelper: Outstanding operations: {newCount}");
+        Debug.WriteLine($"BrighterAsyncContext: Operation started on thread {Thread.CurrentThread.ManagedThreadId} for context {Id}");
+        Debug.WriteLine($"BrighterAsyncContext: Outstanding operations: {newCount}");
         Debug.IndentLevel = 0;
 #endif
     }
 
     /// <summary>
-    /// Runs a void method and returns after all continuations have run.
-    /// Propagates exceptions.
+    /// Runs a synchronous action on this context and returns after all continuations
+    /// have run. Propagates exceptions.
     /// </summary>
-    /// <param name="action">The action to run.</param>
     public static void Run(Action action)
     {
-#if DEBUG_CONTEXT
-        Debug.WriteLine(string.Empty);
-        Debug.WriteLine("....................................................................................................................");
-        Debug.IndentLevel = 1;
-        Debug.WriteLine($"BrighterSynchronizationHelper: Running action {action.Method.Name} on thread {Thread.CurrentThread.ManagedThreadId}");
-        Debug.IndentLevel = 0;
+#if NET
+        ArgumentNullException.ThrowIfNull(action);
+#else
+        if (action is null) throw new ArgumentNullException(nameof(action));
 #endif
-
-        if (action == null)
-            throw new ArgumentNullException(nameof(action));
 
         using var context = new BrighterAsyncContext();
 
         var task = context._taskFactory.Run(action);
         context.Execute(task);
         task.WaitAndUnwrapException();
-
-#if DEBUG_CONTEXT
-        Debug.IndentLevel = 1;
-        Debug.WriteLine($"BrighterSynchronizationHelper: Action {action.Method.Name} completed on thread {Thread.CurrentThread.ManagedThreadId}");
-        Debug.IndentLevel = 0;
-        Debug.WriteLine("....................................................................................................................");
-#endif
-     }
+    }
 
     /// <summary>
-    /// Runs a method that returns a result and returns after all continuations have run.
-    /// Propagates exceptions.
+    /// Runs a synchronous function on this context and returns its result after all
+    /// continuations have run. Propagates exceptions.
     /// </summary>
-    /// <typeparam name="TResult">The result type of the task.</typeparam>
-    /// <param name="func">The function to run.</param>
-    /// <returns>The result of the function.</returns>
     public static TResult Run<TResult>(Func<TResult> func)
     {
-#if DEBUG_CONTEXT
-        Debug.WriteLine(string.Empty);
-        Debug.WriteLine("....................................................................................................................");
-        Debug.IndentLevel = 1;
-        Debug.WriteLine($"BrighterSynchronizationHelper: Running function {func.Method.Name} on thread {Thread.CurrentThread.ManagedThreadId}");
-        Debug.IndentLevel = 0;
+#if NET
+        ArgumentNullException.ThrowIfNull(func);
+#else
+        if (func is null) throw new ArgumentNullException(nameof(func));
 #endif
-
-        if (func == null)
-            throw new ArgumentNullException(nameof(func));
 
         using var context = new BrighterAsyncContext();
 
         var task = context._taskFactory.Run(func);
-
         context.Execute(task);
-
-#if DEBUG_CONTEXT
-        Debug.IndentLevel = 1;
-        Debug.WriteLine($"BrighterSynchronizationHelper: Function {func.Method.Name} completed on thread {Thread.CurrentThread.ManagedThreadId}");
-        Debug.WriteLine($"BrighterSynchronizationHelper: Task Status: {task.Status}");
-        Debug.IndentLevel = 0;
-        Debug.WriteLine("....................................................................................................................");
-        
-#endif
         return task.WaitAndUnwrapException();
-
     }
 
     /// <summary>
-    /// Runs an async void method and returns after all continuations have run.
-    /// Propagates exceptions.
+    /// Runs an async delegate on this context and returns after all continuations have
+    /// run. Propagates exceptions.
     /// </summary>
-    /// <param name="func">The async function to run.</param>
     public static void Run(Func<Task> func)
     {
-#if DEBUG_CONTEXT
-        Debug.WriteLine(string.Empty);
-        Debug.WriteLine("....................................................................................................................");
-        Debug.IndentLevel = 1;
-        Debug.WriteLine($"BrighterSynchronizationHelper: Running function {func.Method.Name} on thread {Thread.CurrentThread.ManagedThreadId}");
-        Debug.IndentLevel = 0;
+#if NET
+        ArgumentNullException.ThrowIfNull(func);
+#else
+        if (func is null) throw new ArgumentNullException(nameof(func));
 #endif
-
-        if (func == null)
-            throw new ArgumentNullException(nameof(func));
 
         using var context = new BrighterAsyncContext();
 
+        // Factory.Run(Func<Task>) returns an Unwrap proxy whose completion trails the
+        // outer StartNew task's, so the outstanding-operations counter could reach zero
+        // (and close the queue) while the async chain is still alive. Register an extra
+        // outstanding operation and release it only when the proxy has actually finished.
         context.OperationStarted();
+        var task = context._taskFactory.Run(func).ContinueWith(
+            static (t, state) =>
+            {
+                try
+                {
+                    t.WaitAndUnwrapException();
+                }
+                finally
+                {
+                    ((BrighterAsyncContext)state!).OperationCompleted();
+                }
+            },
+            context,
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            context._taskScheduler);
 
-        var task = context._taskFactory.Run(func).ContinueWith(t =>
-        {
-            context.OperationCompleted();
-            t.WaitAndUnwrapException();
-        }, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, context._taskScheduler);
         context.Execute(task);
         task.WaitAndUnwrapException();
-
-#if DEBUG_CONTEXT
-        Debug.IndentLevel = 1;
-        Debug.WriteLine($"BrighterSynchronizationHelper: Function {func.Method.Name} completed on thread {Thread.CurrentThread.ManagedThreadId}");
-        Debug.WriteLine($"BrighterSynchronizationHelper: Task Status: {task.Status}");
-        Debug.IndentLevel = 0;
-        Debug.WriteLine("....................................................................................................................");
-#endif
     }
 
     /// <summary>
-    /// Queues a task for execution and begins executing all tasks in the queue.
-    /// Returns the result of the task proxy.
-    /// Propagates exceptions.
+    /// Runs an async delegate on this context and returns its result after all continuations
+    /// have run. Propagates exceptions.
     /// </summary>
-    /// <typeparam name="TResult">The result type of the task.</typeparam>
-    /// <param name="func">The async function to execute.</param>
-    /// <returns>The result of the function.</returns>
     public static TResult Run<TResult>(Func<Task<TResult>> func)
     {
-#if DEBUG_CONTEXT
-        Debug.WriteLine(string.Empty);
-        Debug.WriteLine("....................................................................................................................");
-        Debug.IndentLevel = 1;
-        Debug.WriteLine($"BrighterSynchronizationHelper: Running function {func.Method.Name} on thread {Thread.CurrentThread.ManagedThreadId}");
-        Debug.IndentLevel = 0;
+#if NET
+        ArgumentNullException.ThrowIfNull(func);
+#else
+        if (func is null) throw new ArgumentNullException(nameof(func));
 #endif
-
-        if (func == null)
-            throw new ArgumentNullException(nameof(func));
 
         using var context = new BrighterAsyncContext();
 
+        // See Run(Func<Task>) above for why the outer OperationStarted/Completed pair
+        // is required around the Unwrap proxy.
         context.OperationStarted();
-        var task = context._taskFactory.Run(func).ContinueWith(t =>
-        {
-            context.OperationCompleted();
-            return t.WaitAndUnwrapException();
-        }, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, context._taskScheduler);
+        var task = context._taskFactory.Run(func).ContinueWith(
+            static (t, state) =>
+            {
+                try
+                {
+                    return t.WaitAndUnwrapException();
+                }
+                finally
+                {
+                    ((BrighterAsyncContext)state!).OperationCompleted();
+                }
+            },
+            context,
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            context._taskScheduler);
 
         context.Execute(task);
-
-#if DEBUG_CONTEXT
-        Debug.IndentLevel = 1;
-        Debug.WriteLine($"BrighterSynchronizationHelper: Function {func.Method.Name} completed on thread {Thread.CurrentThread.ManagedThreadId}");
-        Debug.WriteLine($"BrighterSynchronizationHelper: Task Status: {task.Status}");
-        Debug.IndentLevel = 0;
-        Debug.WriteLine("....................................................................................................................");
-#endif
-
         return task.WaitAndUnwrapException();
     }
 
     /// <summary>
-    /// Executes the specified parent task and all tasks in the queue.
+    /// Executes the specified parent task plus every task in the queue until the queue drains.
     /// </summary>
-    /// <param name="parentTask">The parent task to execute.</param>
+    /// <exception cref="InvalidOperationException">
+    /// <see cref="Execute"/> is already running on another thread. The single-thread invariant
+    /// forbids concurrent execution.
+    /// </exception>
     public void Execute(Task parentTask)
     {
+        if (Interlocked.CompareExchange(ref _executing, 1, 0) != 0)
+        {
+            throw new InvalidOperationException(
+                $"{nameof(BrighterAsyncContext)}.{nameof(Execute)} is not re-entrant and cannot be called concurrently on the same context.");
+        }
+
 #if DEBUG_CONTEXT
-        Debug.WriteLine(string.Empty);
         Debug.WriteLine(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>");
         Debug.IndentLevel = 1;
-        Debug.WriteLine($"BrighterSynchronizationHelper: Executing tasks on thread {Thread.CurrentThread.ManagedThreadId} for BrighterSynchronizationHelper {Id}");
+        Debug.WriteLine($"BrighterAsyncContext: Executing tasks on thread {Thread.CurrentThread.ManagedThreadId} for context {Id}");
         Debug.IndentLevel = 0;
 #endif
 
-        BrighterSynchronizationContextScope.ApplyContext(_synchronizationContext, parentTask, () =>
+        try
         {
-
-            foreach (var (task, propagateExceptions) in _taskQueue.GetConsumingEnumerable())
+            BrighterSynchronizationContextScope.ApplyContext(_synchronizationContext, parentTask, () =>
             {
-                _taskScheduler.DoTryExecuteTask(task);
+                foreach (var (task, propagateExceptions) in _taskQueue.GetConsumingEnumerable())
+                {
+                    _taskScheduler.DoTryExecuteTask(task);
 
-                if (propagateExceptions)
-                    task.WaitAndUnwrapException();
-            }
-        });
+                    if (propagateExceptions)
+                        task.WaitAndUnwrapException();
+                }
+            });
+        }
+        finally
+        {
+            Volatile.Write(ref _executing, 0);
+        }
 
 #if DEBUG_CONTEXT
         Debug.IndentLevel = 1;
-        Debug.WriteLine($"BrighterSynchronizationHelper: Execution completed on thread {Thread.CurrentThread.ManagedThreadId} for BrighterSynchronizationHelper {Id}");
+        Debug.WriteLine($"BrighterAsyncContext: Execution completed on thread {Thread.CurrentThread.ManagedThreadId} for context {Id}");
         Debug.IndentLevel = 0;
         Debug.WriteLine("<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<");
 #endif
     }
 
     /// <summary>
-    /// Executes a task immediately on the current thread.
+    /// The tasks currently scheduled in this context.
     /// </summary>
-    /// <param name="callback">The task to execute.</param>
-    /// <param name="state">The state object to pass to the task.</param>
-    public void ExecuteImmediately(ContextCallback callback, object? state)
-    {
-#if DEBUG_CONTEXT
-        Debug.WriteLine(string.Empty);
-        Debug.WriteLine("++++++++++++++++++++++++++++++++++++++++++++++++++++++");
-        Debug.IndentLevel = 1;
-        Debug.WriteLine($"BrighterSynchronizationHelper: Executing task immediately on thread {Thread.CurrentThread.ManagedThreadId} for BrighterSynchronizationHelper {Id}");
-        Debug.WriteLine($"BrighterSynchronizationHelper: Task {callback.Method.Name}");
-        Debug.IndentLevel = 0;
-#endif
-
-        try
-        {
-           callback.Invoke(state);
-        }
-        catch (Exception e)
-        {
-            Debug.WriteLine($"BrighterSynchronizationHelper: Execution errored on thread {Thread.CurrentThread.ManagedThreadId} for BrighterSynchronizationHelper {Id} with exception {e.Message}");
-        }
-
-#if DEBUG_CONTEXT
-        Debug.IndentLevel = 1;
-        Debug.WriteLine($"BrighterSynchronizationHelper: Execution completed on thread {Thread.CurrentThread.ManagedThreadId} for BrighterSynchronizationHelper {Id}");
-        Debug.IndentLevel = 0;
-        Debug.WriteLine("++++++++++++++++++++++++++++++++++++++++++++++++++++++");
-        
-#endif
-    }
-
-    /// <summary>
-    /// Gets an enumerable of the tasks currently scheduled.
-    /// </summary>
-    /// <returns>An enumerable of the scheduled tasks.</returns>
-    public IEnumerable<Task> GetScheduledTasks()
-    {
-        return _taskQueue.GetScheduledTasks();
-    }
+    internal IEnumerable<Task> GetScheduledTasks() => _taskQueue.GetScheduledTasks();
 }

--- a/src/Paramore.Brighter/Tasks/BrighterSynchronizationContext.cs
+++ b/src/Paramore.Brighter/Tasks/BrighterSynchronizationContext.cs
@@ -1,8 +1,8 @@
 #region Sources
 
-// This class is based on Stephen Cleary's AyncContext in https://github.com/StephenCleary/AsyncEx
-// The original code is licensed under the MIT License (MIT) <a href="https://github.com/StephenCleary/AsyncEx/blob/master/LICENSE>AyncEx license</a>
-// Modifies the original approach in Brighter which only provided a synchronization synchronizationHelper, not a scheduler, and thus would
+// This class is based on Stephen Cleary's AsyncContext in https://github.com/StephenCleary/AsyncEx
+// The original code is licensed under the MIT License (MIT) <a href="https://github.com/StephenCleary/AsyncEx/blob/master/LICENSE>AsyncEx license</a>
+// Modifies the original approach in Brighter which only provided a synchronization context, not a scheduler, and thus would
 // not run continuations on the same thread as the async operation if used with ConfigureAwait(false).
 // This is important for the ServiceActivator, as we want to ensure ordering on a single thread and not use the thread pool.
 
@@ -13,174 +13,171 @@
 
 #endregion
 
-
 using System;
 using System.Diagnostics;
 using System.Threading;
 
-namespace Paramore.Brighter.Tasks
+namespace Paramore.Brighter.Tasks;
+
+/// <summary>
+/// <see cref="SynchronizationContext"/> that dispatches callbacks to a <see cref="BrighterAsyncContext"/>.
+/// </summary>
+/// <remarks>
+/// Adopts a single-threaded apartment model. All work - messages and callbacks - is queued to a single
+/// work queue. When a callback is signalled, it is queued next and picked up when the current message
+/// completes or waits. Strict ordering of messages may be lost as there is no guarantee what order I/O
+/// operations will complete - do not use if strict ordering is required. Only uses one thread, so
+/// predictable performance, but the queue may grow under load.
+/// <para>
+/// Lifecycle: after the owning <see cref="BrighterAsyncContext"/> has finished draining,
+/// stray async continuations may still <see cref="Post"/> callbacks back. Those are absorbed
+/// silently (the queue is closed, so the callback is dropped). <see cref="Send"/> cannot be
+/// absorbed the same way because the caller blocks on completion; a post-shutdown
+/// <see cref="Send"/> throws <see cref="ObjectDisposedException"/>.
+/// </para>
+/// </remarks>
+public sealed class BrighterSynchronizationContext : SynchronizationContext
 {
     /// <summary>
-    /// Provides a Tasks that processes work on a single thread.
+    /// The async context this synchronization context dispatches to.
     /// </summary>
-    /// <remarks>
-    /// Adopts a single-threaded apartment model. We have one thread, all work - messages and callbacks are queued to a single work queue.
-    /// When a callback is signaled, it is queued next and will be picked up when the current message completes or waits itself.
-    /// Strict ordering of messages will be lost as there is no guarantee what order I/O operations will complete -
-    /// do not use if strict ordering is required.
-    /// Only uses one thread, so predictable performance, but may have many messages queued. Once queue length exceeds
-    /// buffer size, we will stop reading new work.
-    /// </remarks>
-    public class BrighterSynchronizationContext : SynchronizationContext, IDisposable
+    public BrighterAsyncContext AsyncContext { get; }
+
+    /// <summary>
+    /// The id of the parent task inside a <see cref="BrighterAsyncContext.Run(Action)"/> invocation.
+    /// </summary>
+    /// <remarks>Used for debugging - records which task created this synchronization context.</remarks>
+    internal int ParentTaskId { get; set; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BrighterSynchronizationContext"/> class.
+    /// </summary>
+    /// <param name="asyncContext">The async context to dispatch to.</param>
+    public BrighterSynchronizationContext(BrighterAsyncContext asyncContext)
     {
-        private bool _disposed;
-        
-        /// <summary>
-        /// Gets the synchronization helper.
-        /// </summary>
-        public BrighterAsyncContext AsyncContext { get; }
-
-        /// <summary>
-        /// Gets or sets the timeout for send operations.
-        /// </summary>
-        public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(30);
-        
-        /// <summary>
-        /// The Id of the parent task in Run, if any. 
-        /// </summary>
-        /// <remarks>
-        ///  Used for debugging, tells us which task created any SynchronizationContext
-        /// </remarks>
-        public int ParentTaskId { get; set; }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="BrighterSynchronizationContext"/> class.
-        /// </summary>
-        /// <param name="asyncContext">The synchronization helper.</param>
-        public BrighterSynchronizationContext(BrighterAsyncContext asyncContext)
-        {
-            AsyncContext = asyncContext;
-        }
-        
-        public void Dispose()
-        {
-            //SynchronizationHelper.Dispose();
-            _disposed = true;
-        }
-
-        /// <summary>
-        /// Creates a copy of the synchronization context.
-        /// </summary>
-        /// <returns>A new <see cref="System.Threading.SynchronizationContext"/> object.</returns>
-        public override SynchronizationContext CreateCopy()
-        {
-            return new BrighterSynchronizationContext(AsyncContext);
-        }
-        
-        ///inheritdoc /> 
-        public override bool Equals(object? obj)
-        {
-            var other = obj as BrighterSynchronizationContext;
-            if (other == null)
-                return false;
-            return (AsyncContext == other.AsyncContext);
-        }
-        
-        ///inheritdoc /> 
-        public override int GetHashCode()
-        {
-            return AsyncContext.GetHashCode();
-        }
-
-        /// <summary>
-        /// Notifies the context that an operation has completed.
-        /// </summary>
-        public override void OperationCompleted()
-        {
-            if (_disposed)
-                throw new ObjectDisposedException(nameof(BrighterSynchronizationContext));
-
-#if DEBUG_CONTEXT
-            Debug.WriteLine(string.Empty);
-            Debug.IndentLevel = 1;
-            Debug.WriteLine($"BrighterSynchronizationContext: OperationCompleted on thread {Thread.CurrentThread.ManagedThreadId}");
-            Debug.WriteLine($"BrighterSynchronizationContext: Parent Task {ParentTaskId}");
-            Debug.IndentLevel = 0;
-            
+#if NET
+        ArgumentNullException.ThrowIfNull(asyncContext);
+#else
+        if (asyncContext is null) throw new ArgumentNullException(nameof(asyncContext));
 #endif
-            AsyncContext.OperationCompleted();
-        }
+        AsyncContext = asyncContext;
+    }
 
-        /// <summary>
-        /// Notifies the context that an operation has started.
-        /// </summary>
-        public override void OperationStarted()
-        {
-            if (_disposed)
-                throw new ObjectDisposedException(nameof(BrighterSynchronizationContext));
+    /// <inheritdoc />
+    /// <remarks>
+    /// The copy shares the original's <see cref="AsyncContext"/> reference, so callbacks
+    /// posted or sent through the copy still route to the original pump. <see cref="Equals"/>
+    /// and <see cref="GetHashCode"/> treat the copy and the original as equal.
+    /// </remarks>
+    public override SynchronizationContext CreateCopy() => new BrighterSynchronizationContext(AsyncContext);
 
+    /// <inheritdoc />
+    public override bool Equals(object? obj) =>
+        obj is BrighterSynchronizationContext other && AsyncContext == other.AsyncContext;
+
+    /// <inheritdoc />
+    public override int GetHashCode() => AsyncContext.GetHashCode();
+
+    /// <inheritdoc />
+    public override void OperationCompleted()
+    {
 #if DEBUG_CONTEXT
-            Debug.WriteLine(string.Empty);
-            Debug.IndentLevel = 1;
-            Debug.WriteLine($"BrighterSynchronizationContext: OperationStarted on thread {Thread.CurrentThread.ManagedThreadId}");
-            Debug.WriteLine($"BrighterSynchronizationContext: Parent Task {ParentTaskId}");
-            Debug.IndentLevel = 0;
+        Debug.IndentLevel = 1;
+        Debug.WriteLine($"BrighterSynchronizationContext: OperationCompleted on thread {Thread.CurrentThread.ManagedThreadId}");
+        Debug.WriteLine($"BrighterSynchronizationContext: Parent Task {ParentTaskId}");
+        Debug.IndentLevel = 0;
 #endif
 
-            AsyncContext.OperationStarted();
-        }
+        AsyncContext.OperationCompleted();
+    }
 
-        /// <summary>
-        /// Dispatches an asynchronous message to the synchronization context.
-        /// </summary>
-        /// <param name="callback">The delegate to call.</param>
-        /// <param name="state">The object passed to the delegate.</param>
-        public override void Post(SendOrPostCallback callback, object? state)
-        {
-            if (_disposed)
-                throw new ObjectDisposedException(nameof(BrighterSynchronizationContext));
-            
-            if (callback == null) throw new ArgumentNullException(nameof(callback));
+    /// <inheritdoc />
+    public override void OperationStarted()
+    {
+#if DEBUG_CONTEXT
+        Debug.IndentLevel = 1;
+        Debug.WriteLine($"BrighterSynchronizationContext: OperationStarted on thread {Thread.CurrentThread.ManagedThreadId}");
+        Debug.WriteLine($"BrighterSynchronizationContext: Parent Task {ParentTaskId}");
+        Debug.IndentLevel = 0;
+#endif
+
+        AsyncContext.OperationStarted();
+    }
+
+    /// <inheritdoc />
+    public override void Post(SendOrPostCallback callback, object? state)
+    {
+#if NET
+        ArgumentNullException.ThrowIfNull(callback);
+#else
+        if (callback is null) throw new ArgumentNullException(nameof(callback));
+#endif
 
 #if DEBUG_CONTEXT
-            Debug.WriteLine(string.Empty);
-            Debug.IndentLevel = 1;
-            Debug.WriteLine($"BrighterSynchronizationContext: Post {callback.Method.Name} on thread {Thread.CurrentThread.ManagedThreadId}");
-            Debug.WriteLine($"BrighterSynchronizationContext: Parent Task {ParentTaskId}");
-            Debug.IndentLevel = 0;
+        Debug.IndentLevel = 1;
+        Debug.WriteLine($"BrighterSynchronizationContext: Post {callback.Method.Name} on thread {Thread.CurrentThread.ManagedThreadId}");
+        Debug.WriteLine($"BrighterSynchronizationContext: Parent Task {ParentTaskId}");
+        Debug.IndentLevel = 0;
 #endif
-            
-            AsyncContext.Enqueue(AsyncContext.Factory.Run(() => callback(state)), true);
-        }
 
-        /// <summary>
-        /// Dispatches a synchronous message to the synchronization context.
-        /// </summary>
-        /// <param name="callback">The delegate to call.</param>
-        /// <param name="state">The object passed to the delegate.</param>
-        public override void Send(SendOrPostCallback callback, object? state)
-        {
-            if (_disposed)
-                throw new ObjectDisposedException(nameof(BrighterSynchronizationContext));
+        // Factory.Run schedules the callback via our scheduler, which enqueues it with
+        // propagateExceptions=false. The outer Enqueue re-adds the same task with
+        // propagateExceptions=true so the pump's drain loop rethrows any exception the
+        // callback raised (matching ASP.NET SynchronizationContext semantics).
+        //
+        // This is deliberate: the task runs once (the second queue pull finds it already
+        // completed and TryExecuteTask no-ops), but the second entry is what triggers
+        // WaitAndUnwrapException. Queueing once with propagateExceptions=true would
+        // require bypassing the scheduler, but TaskScheduler.TryExecuteTask rejects tasks
+        // that were not associated with it via Start/StartNew, leaving such tasks
+        // un-runnable.
+        AsyncContext.Enqueue(AsyncContext.Factory.Run(() => callback(state)), propagateExceptions: true);
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Throws <see cref="ObjectDisposedException"/> instead of blocking when the pump has
+    /// shut down. A caller may also observe a spurious <see cref="ObjectDisposedException"/>
+    /// when another thread closes the pump between this call's successful enqueue and its
+    /// completion wait: the callback was delivered and will be processed, but this caller
+    /// sees the shutdown signal and aborts. Callers racing shutdown must be prepared for
+    /// this exception.
+    /// </remarks>
+    public override void Send(SendOrPostCallback callback, object? state)
+    {
+#if NET
+        ArgumentNullException.ThrowIfNull(callback);
+#else
+        if (callback is null) throw new ArgumentNullException(nameof(callback));
+#endif
 
 #if DEBUG_CONTEXT
-            Debug.WriteLine(string.Empty);
-            Debug.IndentLevel = 1;
-            Debug.WriteLine($"BrighterSynchronizationContext: Send {callback.Method.Name} on thread {Thread.CurrentThread.ManagedThreadId}");
-            Debug.WriteLine($"BrighterSynchronizationContext: Parent Task {ParentTaskId}");
-            Debug.IndentLevel = 0;
+        Debug.IndentLevel = 1;
+        Debug.WriteLine($"BrighterSynchronizationContext: Send {callback.Method.Name} on thread {Thread.CurrentThread.ManagedThreadId}");
+        Debug.WriteLine($"BrighterSynchronizationContext: Parent Task {ParentTaskId}");
+        Debug.IndentLevel = 0;
 #endif
-            
-            // current thread already owns the context, so just execute inline to prevent deadlocks
-            if (BrighterAsyncContext.Current == AsyncContext)
-            {
-                callback(state);
-            }
-            else
-            {
-                var task = AsyncContext.Factory.Run(() => callback(state));
-                task.WaitAndUnwrapException();
-            }
+
+        // Current thread already owns the context - execute inline to prevent self-deadlock.
+        if (BrighterAsyncContext.Current == AsyncContext)
+        {
+            callback(state);
+            return;
         }
+
+        var task = AsyncContext.Factory.Run(() => callback(state));
+
+        // Factory.Run calls Enqueue synchronously on this thread. If the queue has shut
+        // down (either before this call, or during it because Enqueue's TryAdd failed),
+        // the task will never be pulled from the queue and WaitAndUnwrapException would
+        // block forever. Throw so the caller can react to the shutdown race.
+        if (AsyncContext.IsShutDown && !task.IsCompleted)
+        {
+            throw new ObjectDisposedException(
+                nameof(BrighterAsyncContext),
+                "BrighterAsyncContext has shut down; Send cannot deliver the callback to its pump.");
+        }
+
+        task.WaitAndUnwrapException();
     }
 }

--- a/src/Paramore.Brighter/Tasks/BrighterSynchronizationContextScope.cs
+++ b/src/Paramore.Brighter/Tasks/BrighterSynchronizationContextScope.cs
@@ -1,8 +1,8 @@
-﻿#region Sources
+#region Sources
 
-// This class is based on Stephen Cleary's AyncContext in https://github.com/StephenCleary/AsyncEx
-// The original code is licensed under the MIT License (MIT) <a href="https://github.com/StephenCleary/AsyncEx/blob/master/LICENSE>AyncEx license</a>
-// Modifies the original approach in Brighter which only provided a synchronization synchronizationHelper, not a scheduler, and thus would
+// This class is based on Stephen Cleary's AsyncContext in https://github.com/StephenCleary/AsyncEx
+// The original code is licensed under the MIT License (MIT) <a href="https://github.com/StephenCleary/AsyncEx/blob/master/LICENSE>AsyncEx license</a>
+// Modifies the original approach in Brighter which only provided a synchronization context, not a scheduler, and thus would
 // not run continuations on the same thread as the async operation if used with ConfigureAwait(false).
 // This is important for the ServiceActivator, as we want to ensure ordering on a single thread and not use the thread pool.
 
@@ -21,79 +21,63 @@ using System.Threading.Tasks;
 namespace Paramore.Brighter.Tasks;
 
 /// <summary>
-/// A utility for managing context changes.
+/// RAII-style scope that installs a <see cref="BrighterSynchronizationContext"/> on the
+/// current thread and restores the prior context on dispose.
 /// </summary>
-internal sealed class  BrighterSynchronizationContextScope :  SingleDisposable<object>
+internal sealed class BrighterSynchronizationContextScope : SingleDisposable<object>
 {
     private readonly SynchronizationContext? _originalContext;
     private BrighterSynchronizationContext? _newContext;
-    private readonly bool _hasOriginalContext;
 
-    /// <summary>
-    /// Initializes a new instance of the <see cref="BrighterSynchronizationContextScope"/> struct.
-    /// </summary>
-    /// <param name="newContext">The new synchronization context to set.</param>
-    /// <param name="parentTask"></param>
     private BrighterSynchronizationContextScope(BrighterSynchronizationContext newContext, Task parentTask)
         : base(new object())
     {
 #if DEBUG_CONTEXT
-        Debug.WriteLine(string.Empty);
-        Debug.WriteLine("{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{");
+        Debug.WriteLine("{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{}");
         Debug.IndentLevel = 1;
-        Debug.WriteLine($"Entering BrighterSynchronizationContext on thread {Thread.CurrentThread.ManagedThreadId}");
-        Debug.WriteLine($"BrighterSynchronizationContext: Parent Task {parentTask.Id}");
+        Debug.WriteLine($"Entering BrighterSynchronizationContextScope on thread {Thread.CurrentThread.ManagedThreadId}");
+        Debug.WriteLine($"BrighterSynchronizationContextScope: Parent Task {parentTask.Id}");
         Debug.IndentLevel = 0;
 #endif
 
-        
         _newContext = newContext;
         _newContext.ParentTaskId = parentTask.Id;
-            
-        // Save the original synchronization context
-        _originalContext = SynchronizationContext.Current;
-        _hasOriginalContext = _originalContext != null;
 
-        // Set the new synchronization context
+        _originalContext = SynchronizationContext.Current;
         SynchronizationContext.SetSynchronizationContext(newContext);
     }
 
-    /// <summary>
-    /// Restores the original synchronization context.
-    /// </summary>
     protected override void Dispose(object context)
     {
 #if DEBUG_CONTEXT
         Debug.IndentLevel = 1;
         Debug.WriteLine($"Exiting BrighterSynchronizationContextScope for task {_newContext?.ParentTaskId}");
-        Debug.WriteLine($"BrighterSynchronizationContext: Parent Task {_newContext?.ParentTaskId}");
         Debug.IndentLevel = 0;
-        Debug.WriteLine("}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}");
+        Debug.WriteLine("}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}");
 #endif
 
         if (_newContext is not null)
         {
             _newContext.ParentTaskId = 0;
-            _newContext.Dispose();
             _newContext = null;
         }
 
-        // Restore the original synchronization context
-        SynchronizationContext.SetSynchronizationContext(_hasOriginalContext ? _originalContext : null);
-        
+        SynchronizationContext.SetSynchronizationContext(_originalContext);
     }
 
     /// <summary>
-    /// Executes a method with the specified synchronization context, and then restores the original context.
+    /// Runs <paramref name="action"/> with <paramref name="context"/> installed as the ambient
+    /// synchronization context, restoring the previous context on return.
     /// </summary>
-    /// <param name="context">The original synchronization context</param>
-    /// <param name="parentTask"></param>
-    /// <param name="action">The action to take within the context</param>
-    /// <exception cref="System.ArgumentNullException">If the action passed was null</exception>
     public static void ApplyContext(BrighterSynchronizationContext? context, Task parentTask, Action action)
     {
+#if NET
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(action);
+#else
         if (context is null) throw new ArgumentNullException(nameof(context));
         if (action is null) throw new ArgumentNullException(nameof(action));
+#endif
 
         using (new BrighterSynchronizationContextScope(context, parentTask))
             action();

--- a/src/Paramore.Brighter/Tasks/BrighterTaskQueue.cs
+++ b/src/Paramore.Brighter/Tasks/BrighterTaskQueue.cs
@@ -1,8 +1,8 @@
 #region Sources
 
-// This class is based on Stephen Cleary's AyncContext in https://github.com/StephenCleary/AsyncEx
-// The original code is licensed under the MIT License (MIT) <a href="https://github.com/StephenCleary/AsyncEx/blob/master/LICENSE>AyncEx license</a>
-// Modifies the original approach in Brighter which only provided a synchronization synchronizationHelper, not a scheduler, and thus would
+// This class is based on Stephen Cleary's AsyncContext in https://github.com/StephenCleary/AsyncEx
+// The original code is licensed under the MIT License (MIT) <a href="https://github.com/StephenCleary/AsyncEx/blob/master/LICENSE>AsyncEx license</a>
+// Modifies the original approach in Brighter which only provided a synchronization context, not a scheduler, and thus would
 // not run continuations on the same thread as the async operation if used with ConfigureAwait(false).
 // This is important for the ServiceActivator, as we want to ensure ordering on a single thread and not use the thread pool.
 
@@ -17,85 +17,91 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace Paramore.Brighter.Tasks;
 
 /// <summary>
-/// Represents a task queue that allows tasks to be added and consumed in a thread-safe manner.
+/// Thread-safe queue of tasks awaiting execution, paired with a flag indicating whether
+/// exceptions should be propagated back to the executor.
 /// </summary>
 internal sealed class BrighterTaskQueue : IDisposable
 {
-    private readonly BlockingCollection<Tuple<Task, bool>> _queue = new();
+    private readonly BlockingCollection<(Task Task, bool PropagateExceptions)> _queue = new();
 
     /// <summary>
-    /// Gets an enumerable that consumes and removes items from the queue.
+    /// Enumerates and removes items as they become available. Blocks until the queue is
+    /// completed for adding.
     /// </summary>
-    /// <returns>An enumerable that consumes and removes items from the queue.</returns>
-    public IEnumerable<Tuple<Task, bool>> GetConsumingEnumerable()
-    {
-        return _queue.GetConsumingEnumerable();
-    }
+    public IEnumerable<(Task Task, bool PropagateExceptions)> GetConsumingEnumerable() =>
+        _queue.GetConsumingEnumerable();
 
     /// <summary>
-    /// Gets an enumerable of the tasks currently scheduled in the queue.
+    /// A snapshot of tasks currently scheduled in the queue. Returns an empty enumerable if
+    /// the queue has already been disposed.
     /// </summary>
-    /// <returns>An enumerable of the scheduled tasks.</returns>
     internal IEnumerable<Task> GetScheduledTasks()
     {
-        foreach (var item in _queue)
-            yield return item.Item1;
+        try
+        {
+            // ToArray is thread-safe against concurrent Add/Take on BlockingCollection;
+            // enumerating the live queue directly via foreach is not.
+            return _queue.ToArray().Select(static item => item.Task);
+        }
+        catch (ObjectDisposedException)
+        {
+            return Array.Empty<Task>();
+        }
     }
 
     /// <summary>
     /// Attempts to add a task to the queue.
     /// </summary>
-    /// <param name="item">The task to be added.</param>
-    /// <param name="propagateExceptions">Indicates whether to propagate exceptions.</param>
-    /// <returns>True if the task was added successfully; otherwise, false.</returns>
+    /// <returns>
+    /// <c>true</c> if the task was added; <c>false</c> if the queue has been completed for
+    /// adding or already disposed.
+    /// </returns>
     public bool TryAdd(Task item, bool propagateExceptions)
     {
+#if DEBUG_CONTEXT
+        Debug.IndentLevel = 1;
+        Debug.WriteLine($"BrighterTaskQueue: Adding task {item.Id} to queue");
+        Debug.IndentLevel = 0;
+#endif
         try
         {
-#if DEBUG_CONTEXT
-            Debug.IndentLevel = 1;
-            Debug.WriteLine($"BrighterTaskQueue; Adding task: {item.Id} to queue");
-            Debug.IndentLevel = 0;
-#endif
-            
-            return _queue.TryAdd(Tuple.Create(item, propagateExceptions));
+            return _queue.TryAdd((item, propagateExceptions));
         }
-        catch (InvalidOperationException)
-        {
-#if DEBUG_CONTEXT
-            Debug.IndentLevel = 1;
-            Debug.WriteLine($"BrighterTaskQueue; TaskQueue is already marked as complete for adding. Failed to add task: {item.Id}");
-            Debug.IndentLevel = 0;
-#endif
-            
-            return false;
-        }
+        // ObjectDisposedException : InvalidOperationException - catch the derived type first.
+        // Owning context has been disposed; absorb so stray async continuations posting back
+        // after Run returns do not crash the caller.
+        catch (ObjectDisposedException) { return false; }
+        // Completed for adding - queue is still alive but no longer accepting.
+        catch (InvalidOperationException) { return false; }
     }
 
     /// <summary>
-    /// Marks the queue as not accepting any more additions.
+    /// Marks the queue as not accepting any further additions. Idempotent and safe to call
+    /// after <see cref="Dispose"/>.
     /// </summary>
     public void CompleteAdding()
     {
 #if DEBUG_CONTEXT
         Debug.IndentLevel = 1;
-        Debug.WriteLine($"BrighterTaskQueue; Complete adding to queue");
+        Debug.WriteLine("BrighterTaskQueue: Complete adding to queue");
         Debug.IndentLevel = 0;
 #endif
-        
-        _queue.CompleteAdding();
+        try
+        {
+            _queue.CompleteAdding();
+        }
+        catch (ObjectDisposedException)
+        {
+            // Already disposed - nothing to do.
+        }
     }
 
-    /// <summary>
-    /// Disposes the task queue and releases all resources.
-    /// </summary>
-    public void Dispose()
-    {
-        _queue.Dispose();
-    }
+    /// <inheritdoc />
+    public void Dispose() => _queue.Dispose();
 }

--- a/src/Paramore.Brighter/Tasks/BrighterTaskScheduler.cs
+++ b/src/Paramore.Brighter/Tasks/BrighterTaskScheduler.cs
@@ -1,9 +1,9 @@
-﻿#region Sources
+#region Sources
 
-// This class is based on Stephen Cleary's AyncContext in https://github.com/StephenCleary/AsyncEx
-// The original code is licensed under the MIT License (MIT) <a href="https://github.com/StephenCleary/AsyncEx/blob/master/LICENS>AyncEx license</a>
-// Modifies the original approach in Brighter which only provided a synchronization synchronizationHelper, not a scheduler, and thus would
-// not run continuations on the same thread as the async operation if used with ConfigureAwait(false.
+// This class is based on Stephen Cleary's AsyncContext in https://github.com/StephenCleary/AsyncEx
+// The original code is licensed under the MIT License (MIT) <a href="https://github.com/StephenCleary/AsyncEx/blob/master/LICENSE>AsyncEx license</a>
+// Modifies the original approach in Brighter which only provided a synchronization context, not a scheduler, and thus would
+// not run continuations on the same thread as the async operation if used with ConfigureAwait(false).
 // This is important for the ServiceActivator, as we want to ensure ordering on a single thread and not use the thread pool.
 
 //Also based on:
@@ -22,35 +22,27 @@ using System.Threading.Tasks;
 namespace Paramore.Brighter.Tasks;
 
 /// <summary>
-/// This class provides a task scheduler that causes all tasks to be executed synchronously on the current thread.
-/// The synchronizationHelper and scheduler are used to run continuations on the same thread as the async operation.
+/// Task scheduler that queues tasks to a <see cref="BrighterAsyncContext"/> so they execute
+/// on that context's single thread.
 /// </summary>
 internal sealed class BrighterTaskScheduler : TaskScheduler
 {
     private readonly BrighterAsyncContext _asyncContext;
 
-    /// <summary>
-    /// Initializes a new instance of the <see cref="BrighterTaskScheduler"/> class.
-    /// </summary>
-    /// <param name="asyncContext">The synchronizationHelper in which tasks should be executed.</param>
     public BrighterTaskScheduler(BrighterAsyncContext asyncContext)
     {
+#if NET
+        ArgumentNullException.ThrowIfNull(asyncContext);
+#else
+        if (asyncContext is null) throw new ArgumentNullException(nameof(asyncContext));
+#endif
         _asyncContext = asyncContext;
     }
 
-    /// <summary>
-    /// Gets an enumerable of the tasks currently scheduled.
-    /// </summary>
-    /// <returns>An enumerable of the scheduled tasks.</returns>
-    protected override IEnumerable<Task> GetScheduledTasks()
-    {
-        return _asyncContext.GetScheduledTasks();
-    }
+    /// <inheritdoc />
+    protected override IEnumerable<Task> GetScheduledTasks() => _asyncContext.GetScheduledTasks();
 
-    /// <summary>
-    /// Queues a task to the scheduler.
-    /// </summary>
-    /// <param name="task">The task to be queued.</param>
+    /// <inheritdoc />
     protected override void QueueTask(Task task)
     {
 #if DEBUG_CONTEXT
@@ -58,18 +50,11 @@ internal sealed class BrighterTaskScheduler : TaskScheduler
         Debug.WriteLine($"BrighterTaskScheduler: QueueTask on thread {Thread.CurrentThread.ManagedThreadId}");
         Debug.IndentLevel = 0;
 #endif
-        
-       _asyncContext.Enqueue((Task)task, false);
-       
-       // If we fail to add to the queue, just drop the Task.
+
+        _asyncContext.Enqueue(task, propagateExceptions: false);
     }
-    
-    /// <summary>
-    /// Attempts to execute the specified task on the current thread.
-    /// </summary>
-    /// <param name="task">The task to be executed.</param>
-    /// <param name="taskWasPreviouslyQueued">A boolean indicating whether the task was previously queued.</param>
-    /// <returns>True if the task was executed; otherwise, false.</returns>
+
+    /// <inheritdoc />
     protected override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued)
     {
 #if DEBUG_CONTEXT
@@ -81,18 +66,12 @@ internal sealed class BrighterTaskScheduler : TaskScheduler
         return BrighterAsyncContext.Current == _asyncContext && TryExecuteTask(task);
     }
 
-    /// <summary>
-    /// Gets the maximum concurrency level supported by this scheduler.
-    /// </summary>
-    public override int MaximumConcurrencyLevel
-    {
-        get { return 1; }
-    }
+    /// <inheritdoc />
+    public override int MaximumConcurrencyLevel => 1;
 
     /// <summary>
-    /// Attempts to execute the specified task.
+    /// Executes the specified task on the calling thread.
     /// </summary>
-    /// <param name="task">The task to be executed.</param>
     public void DoTryExecuteTask(Task task)
     {
 #if DEBUG_CONTEXT
@@ -100,33 +79,7 @@ internal sealed class BrighterTaskScheduler : TaskScheduler
         Debug.WriteLine($"BrighterTaskScheduler: DoTryExecuteTask on thread {Thread.CurrentThread.ManagedThreadId}");
         Debug.IndentLevel = 0;
 #endif
-        
-        TryExecuteTask(task);
-    }
-    
-    /// <summary>
-    /// In a new thread, attempts to execute the specified task.
-    /// </summary>
-    /// <remarks>
-    /// This is a little "Hail Mary" to try and execute a task that has failed to queue because we have already completed the synchronization context.
-    /// Seems to be caused by an Exection Context that has our scheduler as the default, as it fools ConfigureAwait
-    /// </remarks>
-    /// <param name="obj"></param>
-    /// <exception cref="ArgumentNullException"></exception>
-    private void TryExecuteNewThread(object? obj)
-    {
-        var task = obj as Task;
-        if (task  == null)
-        {
-            throw new ArgumentNullException(nameof(obj));
-        }
 
-#if DEBUG_CONTEXT
-        Debug.IndentLevel = 1;
-        Debug.WriteLine($"BrighterTaskScheduler: Use TryExecuteNewThread for {task} on thread {Thread.CurrentThread.ManagedThreadId}");
-        Debug.IndentLevel = 0;
-#endif
-        
         TryExecuteTask(task);
     }
 }

--- a/src/Paramore.Brighter/Tasks/TaskExtensions.cs
+++ b/src/Paramore.Brighter/Tasks/TaskExtensions.cs
@@ -1,3 +1,11 @@
+#region Sources
+
+// These extension methods are based on Stephen Cleary's Nito.AsyncEx synchronous task
+// extensions, see https://github.com/StephenCleary/AsyncEx/blob/master/src/Nito.AsyncEx.Tasks/SynchronousTaskExtensions.cs
+// The original code is licensed under the MIT License (MIT).
+
+#endregion
+
 using System;
 using System.Runtime.ExceptionServices;
 using System.Threading;
@@ -8,83 +16,96 @@ namespace Paramore.Brighter.Tasks;
 public static class TaskExtensions
 {
     /// <summary>
-    /// Waits for the task to complete, unwrapping any exceptions.
+    /// Waits for the task to complete, unwrapping any exception (the original exception is
+    /// rethrown directly, not wrapped in an <see cref="AggregateException"/>).
     /// </summary>
-    /// <param name="task">The task. May not be <c>null</c>.</param>
     public static void WaitAndUnwrapException(this Task task)
     {
-        if (task == null)
-            throw new ArgumentNullException(nameof(task));
+#if NET
+        ArgumentNullException.ThrowIfNull(task);
+#else
+        if (task is null) throw new ArgumentNullException(nameof(task));
+#endif
         task.GetAwaiter().GetResult();
     }
 
     /// <summary>
-    /// Waits for the task to complete, unwrapping any exceptions.
+    /// Waits for the task to complete, unwrapping any exception. Observes the supplied
+    /// <paramref name="cancellationToken"/>.
     /// </summary>
-    /// <param name="task">The task. May not be <c>null</c>.</param>
-    /// <param name="cancellationToken">A cancellation token to observe while waiting for the task to complete.</param>
-    /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was cancelled before the <paramref name="task"/> completed, or the <paramref name="task"/> raised an <see cref="OperationCanceledException"/>.</exception>
+    /// <exception cref="OperationCanceledException">
+    /// The <paramref name="cancellationToken"/> was cancelled before the task completed, or
+    /// the task itself raised an <see cref="OperationCanceledException"/>.
+    /// </exception>
     public static void WaitAndUnwrapException(this Task task, CancellationToken cancellationToken)
     {
-        if (task == null)
-            throw new ArgumentNullException(nameof(task));
+#if NET
+        ArgumentNullException.ThrowIfNull(task);
+        task.WaitAsync(cancellationToken).GetAwaiter().GetResult();
+#else
+        if (task is null) throw new ArgumentNullException(nameof(task));
         try
         {
             task.Wait(cancellationToken);
         }
-        catch (AggregateException ex)
+        catch (AggregateException ex) when (ex.InnerException is not null)
         {
-            ExceptionDispatchInfo.Capture(ex).Throw();
+            ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
         }
+#endif
     }
 
     /// <summary>
-    /// Waits for the task to complete, unwrapping any exceptions.
+    /// Waits for the task to complete, unwrapping any exception and returning its result.
     /// </summary>
-    /// <typeparam name="TResult">The type of the result of the task.</typeparam>
-    /// <param name="task">The task. May not be <c>null</c>.</param>
-    /// <returns>The result of the task.</returns>
     public static TResult WaitAndUnwrapException<TResult>(this Task<TResult> task)
     {
-        if (task == null)
-            throw new ArgumentNullException(nameof(task));
+#if NET
+        ArgumentNullException.ThrowIfNull(task);
+#else
+        if (task is null) throw new ArgumentNullException(nameof(task));
+#endif
         return task.GetAwaiter().GetResult();
     }
 
     /// <summary>
-    /// Waits for the task to complete, unwrapping any exceptions.
+    /// Waits for the task to complete, unwrapping any exception and returning its result.
+    /// Observes the supplied <paramref name="cancellationToken"/>.
     /// </summary>
-    /// <typeparam name="TResult">The type of the result of the task.</typeparam>
-    /// <param name="task">The task. May not be <c>null</c>.</param>
-    /// <param name="cancellationToken">A cancellation token to observe while waiting for the task to complete.</param>
-    /// <returns>The result of the task.</returns>
-    /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was cancelled before the <paramref name="task"/> completed, or the <paramref name="task"/> raised an <see cref="OperationCanceledException"/>.</exception>
+    /// <exception cref="OperationCanceledException">
+    /// The <paramref name="cancellationToken"/> was cancelled before the task completed, or
+    /// the task itself raised an <see cref="OperationCanceledException"/>.
+    /// </exception>
     public static TResult WaitAndUnwrapException<TResult>(this Task<TResult> task, CancellationToken cancellationToken)
     {
-        if (task == null)
-            throw new ArgumentNullException(nameof(task));
+#if NET
+        ArgumentNullException.ThrowIfNull(task);
+        return task.WaitAsync(cancellationToken).GetAwaiter().GetResult();
+#else
+        if (task is null) throw new ArgumentNullException(nameof(task));
         try
         {
             task.Wait(cancellationToken);
             return task.Result;
         }
-        catch (AggregateException ex)
+        catch (AggregateException ex) when (ex.InnerException is not null)
         {
-            ExceptionDispatchInfo.Capture(ex).Throw();
+            ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+            throw; // unreachable
         }
-
-        // This should never be reached
-        return task.Result;
+#endif
     }
 
     /// <summary>
-    /// Waits for the task to complete, but does not raise task exceptions. The task exception (if any) is unobserved.
+    /// Waits for the task to complete, silently observing and discarding any exception.
     /// </summary>
-    /// <param name="task">The task. May not be <c>null</c>.</param>
     public static void WaitWithoutException(this Task task)
     {
-        if (task == null)
-            throw new ArgumentNullException(nameof(task));
+#if NET
+        ArgumentNullException.ThrowIfNull(task);
+#else
+        if (task is null) throw new ArgumentNullException(nameof(task));
+#endif
         try
         {
             task.Wait();
@@ -95,15 +116,19 @@ public static class TaskExtensions
     }
 
     /// <summary>
-    /// Waits for the task to complete, but does not raise task exceptions. The task exception (if any) is unobserved.
+    /// Waits for the task to complete, silently observing and discarding any exception.
+    /// Observes the supplied <paramref name="cancellationToken"/>.
     /// </summary>
-    /// <param name="task">The task. May not be <c>null</c>.</param>
-    /// <param name="cancellationToken">A cancellation token to observe while waiting for the task to complete.</param>
-    /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was cancelled before the <paramref name="task"/> completed.</exception>
+    /// <exception cref="OperationCanceledException">
+    /// The <paramref name="cancellationToken"/> was cancelled before the task completed.
+    /// </exception>
     public static void WaitWithoutException(this Task task, CancellationToken cancellationToken)
     {
-        if (task == null)
-            throw new ArgumentNullException(nameof(task));
+#if NET
+        ArgumentNullException.ThrowIfNull(task);
+#else
+        if (task is null) throw new ArgumentNullException(nameof(task));
+#endif
         try
         {
             task.Wait(cancellationToken);

--- a/src/Paramore.Brighter/Tasks/TaskFactoryExtensions.cs
+++ b/src/Paramore.Brighter/Tasks/TaskFactoryExtensions.cs
@@ -1,8 +1,8 @@
 #region Sources
 
-// This class is based on Stephen Cleary's AyncContext in https://github.com/StephenCleary/AsyncEx
-// The original code is licensed under the MIT License (MIT) <a href="https://github.com/StephenCleary/AsyncEx/blob/master/LICENSE>AyncEx license</a>
-// Modifies the original approach in Brighter which only provided a synchronization synchronizationHelper, not a scheduler, and thus would
+// This class is based on Stephen Cleary's AsyncContext in https://github.com/StephenCleary/AsyncEx
+// The original code is licensed under the MIT License (MIT) <a href="https://github.com/StephenCleary/AsyncEx/blob/master/LICENSE>AsyncEx license</a>
+// Modifies the original approach in Brighter which only provided a synchronization context, not a scheduler, and thus would
 // not run continuations on the same thread as the async operation if used with ConfigureAwait(false).
 // This is important for the ServiceActivator, as we want to ensure ordering on a single thread and not use the thread pool.
 
@@ -16,81 +16,91 @@
 using System;
 using System.Threading.Tasks;
 
-namespace Paramore.Brighter.Tasks
+namespace Paramore.Brighter.Tasks;
+
+/// <summary>
+/// Extension methods that add <c>Task.Run</c>-style overloads to <see cref="TaskFactory"/>,
+/// honouring the factory's own cancellation token, creation options and scheduler.
+/// </summary>
+public static class TaskFactoryExtensions
 {
     /// <summary>
-    /// Provides extension methods for the TaskFactory class to run tasks with various actions and functions.
+    /// Runs <paramref name="action"/> on the factory's scheduler.
     /// </summary>
-    public static class TaskFactoryExtensions
+    public static Task Run(this TaskFactory @this, Action action)
     {
-        /// <summary>
-        /// Runs a task with the specified action.
-        /// </summary>
-        /// <param name="this">The TaskFactory instance.</param>
-        /// <param name="action">The action to run.</param>
-        /// <returns>A Task that represents the asynchronous operation.</returns>
-        /// <exception cref="ArgumentNullException">Thrown when the TaskFactory or action is null.</exception>
-        public static Task Run(this TaskFactory @this, Action action)
-        {
-            if (@this == null)
-                throw new ArgumentNullException(nameof(@this));
-            if (action == null)
-                throw new ArgumentNullException(nameof(action));
+#if NET
+        ArgumentNullException.ThrowIfNull(@this);
+        ArgumentNullException.ThrowIfNull(action);
+#else
+        if (@this is null) throw new ArgumentNullException(nameof(@this));
+        if (action is null) throw new ArgumentNullException(nameof(action));
+#endif
 
-            return @this.StartNew(action, @this.CancellationToken, @this.CreationOptions | TaskCreationOptions.DenyChildAttach, @this.Scheduler ?? TaskScheduler.Default);
-        }
+        return @this.StartNew(
+            action,
+            @this.CancellationToken,
+            @this.CreationOptions | TaskCreationOptions.DenyChildAttach,
+            @this.Scheduler ?? TaskScheduler.Default);
+    }
 
-        /// <summary>
-        /// Runs a task with the specified function that returns a result.
-        /// </summary>
-        /// <typeparam name="TResult">The type of the result.</typeparam>
-        /// <param name="this">The TaskFactory instance.</param>
-        /// <param name="action">The function to run.</param>
-        /// <returns>A Task that represents the asynchronous operation and contains the result.</returns>
-        /// <exception cref="ArgumentNullException">Thrown when the TaskFactory or action is null.</exception>
-        public static Task<TResult> Run<TResult>(this TaskFactory @this, Func<TResult> action)
-        {
-            if (@this == null)
-                throw new ArgumentNullException(nameof(@this));
-            if (action == null)
-                throw new ArgumentNullException(nameof(action));
+    /// <summary>
+    /// Runs <paramref name="action"/> on the factory's scheduler and returns its result.
+    /// </summary>
+    public static Task<TResult> Run<TResult>(this TaskFactory @this, Func<TResult> action)
+    {
+#if NET
+        ArgumentNullException.ThrowIfNull(@this);
+        ArgumentNullException.ThrowIfNull(action);
+#else
+        if (@this is null) throw new ArgumentNullException(nameof(@this));
+        if (action is null) throw new ArgumentNullException(nameof(action));
+#endif
 
-            return @this.StartNew(action, @this.CancellationToken, @this.CreationOptions | TaskCreationOptions.DenyChildAttach, @this.Scheduler ?? TaskScheduler.Default);
-        }
+        return @this.StartNew(
+            action,
+            @this.CancellationToken,
+            @this.CreationOptions | TaskCreationOptions.DenyChildAttach,
+            @this.Scheduler ?? TaskScheduler.Default);
+    }
 
-        /// <summary>
-        /// Runs a task with the specified asynchronous function.
-        /// </summary>
-        /// <param name="this">The TaskFactory instance.</param>
-        /// <param name="action">The asynchronous function to run.</param>
-        /// <returns>A Task that represents the asynchronous operation.</returns>
-        /// <exception cref="ArgumentNullException">Thrown when the TaskFactory or action is null.</exception>
-        public static Task Run(this TaskFactory @this, Func<Task> action)
-        {
-            if (@this == null)
-                throw new ArgumentNullException(nameof(@this));
-            if (action == null)
-                throw new ArgumentNullException(nameof(action));
+    /// <summary>
+    /// Runs the async delegate <paramref name="action"/> on the factory's scheduler.
+    /// </summary>
+    public static Task Run(this TaskFactory @this, Func<Task> action)
+    {
+#if NET
+        ArgumentNullException.ThrowIfNull(@this);
+        ArgumentNullException.ThrowIfNull(action);
+#else
+        if (@this is null) throw new ArgumentNullException(nameof(@this));
+        if (action is null) throw new ArgumentNullException(nameof(action));
+#endif
 
-            return @this.StartNew(action, @this.CancellationToken, @this.CreationOptions | TaskCreationOptions.DenyChildAttach, @this.Scheduler ?? TaskScheduler.Default).Unwrap();
-        }
+        return @this.StartNew(
+            action,
+            @this.CancellationToken,
+            @this.CreationOptions | TaskCreationOptions.DenyChildAttach,
+            @this.Scheduler ?? TaskScheduler.Default).Unwrap();
+    }
 
-        /// <summary>
-        /// Runs a task with the specified asynchronous function that returns a result.
-        /// </summary>
-        /// <typeparam name="TResult">The type of the result.</typeparam>
-        /// <param name="this">The TaskFactory instance.</param>
-        /// <param name="action">The asynchronous function to run.</param>
-        /// <returns>A Task that represents the asynchronous operation and contains the result.</returns>
-        /// <exception cref="ArgumentNullException">Thrown when the TaskFactory or action is null.</exception>
-        public static Task<TResult> Run<TResult>(this TaskFactory @this, Func<Task<TResult>> action)
-        {
-            if (@this == null)
-                throw new ArgumentNullException(nameof(@this));
-            if (action == null)
-                throw new ArgumentNullException(nameof(action));
+    /// <summary>
+    /// Runs the async delegate <paramref name="action"/> on the factory's scheduler and returns its result.
+    /// </summary>
+    public static Task<TResult> Run<TResult>(this TaskFactory @this, Func<Task<TResult>> action)
+    {
+#if NET
+        ArgumentNullException.ThrowIfNull(@this);
+        ArgumentNullException.ThrowIfNull(action);
+#else
+        if (@this is null) throw new ArgumentNullException(nameof(@this));
+        if (action is null) throw new ArgumentNullException(nameof(action));
+#endif
 
-            return @this.StartNew(action, @this.CancellationToken, @this.CreationOptions | TaskCreationOptions.DenyChildAttach, @this.Scheduler ?? TaskScheduler.Default).Unwrap();
-        }
+        return @this.StartNew(
+            action,
+            @this.CancellationToken,
+            @this.CreationOptions | TaskCreationOptions.DenyChildAttach,
+            @this.Scheduler ?? TaskScheduler.Default).Unwrap();
     }
 }

--- a/tests/Paramore.Brighter.Core.Tests/Tasks/BrighterSynchronizationContextsTests.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Tasks/BrighterSynchronizationContextsTests.cs
@@ -455,4 +455,149 @@ public class BrighterSynchronizationContextsTests
         var context = new BrighterAsyncContext();
         Assert.Equal(context.TaskScheduler.Id, context.Id);
     }
+
+    [Fact]
+    public void Post_AfterContextDisposed_DoesNotThrow()
+    {
+        SynchronizationContext? captured = null;
+        BrighterAsyncContext.Run(() =>
+        {
+            captured = SynchronizationContext.Current;
+        });
+
+        // At this point the BrighterAsyncContext's 'using' scope has already disposed the
+        // underlying task queue. A stray callback that captured the SynchronizationContext
+        // during Run must not crash the posting thread.
+        Assert.NotNull(captured);
+        var exception = Record.Exception(() => captured!.Post(_ => { }, null));
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void Send_AfterContextDisposed_Throws()
+    {
+        SynchronizationContext? captured = null;
+        BrighterAsyncContext.Run(() =>
+        {
+            captured = SynchronizationContext.Current;
+        });
+
+        Assert.NotNull(captured);
+
+        // Send from a different thread than the one that ran the pump: must not hang.
+        // Post-shutdown, the pump is gone, so Send cannot deliver - it should throw.
+        var thrown = Task.Run(() =>
+        {
+            try
+            {
+                captured!.Send(_ => { }, null);
+                return (Exception?)null;
+            }
+            catch (Exception ex)
+            {
+                return ex;
+            }
+        });
+
+        Assert.True(thrown.Wait(TimeSpan.FromSeconds(5)), "Send hung after context disposal");
+        Assert.IsType<ObjectDisposedException>(thrown.Result);
+    }
+
+    [Fact]
+    public void Send_AfterShutdown_StressIterations_NeverHangsAndOnlyThrowsObjectDisposed()
+    {
+        // Stress the post-shutdown Send path: for many iterations, run and fully dispose
+        // a context, then fire a Send from a ThreadPool thread against the captured
+        // SynchronizationContext. Every Send must either complete normally or throw
+        // ObjectDisposedException within a bounded time - never hang, never surface
+        // a different exception type. A regression that re-introduces the Send-hang
+        // would blow the per-iteration timeout.
+        const int iterations = 1000;
+        for (var i = 0; i < iterations; i++)
+        {
+            SynchronizationContext? captured = null;
+            BrighterAsyncContext.Run(() =>
+            {
+                captured = SynchronizationContext.Current;
+            });
+
+            Assert.NotNull(captured);
+
+            var sent = Task.Run(() =>
+            {
+                try
+                {
+                    captured!.Send(_ => { }, null);
+                    return (Exception?)null;
+                }
+                catch (Exception e)
+                {
+                    return e;
+                }
+            });
+
+            Assert.True(sent.Wait(TimeSpan.FromSeconds(5)), $"Send hung on iteration {i}");
+            if (sent.Result is not null)
+                Assert.IsType<ObjectDisposedException>(sent.Result);
+        }
+    }
+
+    [Fact]
+    public void Dispose_CalledTwice_DoesNotThrow()
+    {
+        var context = new BrighterAsyncContext();
+        context.Dispose();
+        var exception = Record.Exception(() => context.Dispose());
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void Run_NestedInsideOuterRun_DoesNotDeadlock()
+    {
+        var innerThread = 0;
+        var outerThread = BrighterAsyncContext.Run(() =>
+        {
+            // HideScheduler on the outer factory means a nested Run creates a fresh
+            // context rather than piggy-backing the outer pump; this must not deadlock.
+            innerThread = BrighterAsyncContext.Run(() => Thread.CurrentThread.ManagedThreadId);
+            return Thread.CurrentThread.ManagedThreadId;
+        });
+
+        Assert.NotEqual(0, innerThread);
+        Assert.NotEqual(0, outerThread);
+    }
+
+    [Fact]
+    public void Execute_CalledConcurrently_ThrowsInvalidOperationException()
+    {
+        var context = new BrighterAsyncContext();
+
+        var firstStarted = new ManualResetEventSlim(false);
+        var releaseFirst = new ManualResetEventSlim(false);
+
+        var blockingTask = context.Factory.StartNew(
+            () =>
+            {
+                firstStarted.Set();
+                releaseFirst.Wait();
+            },
+            context.Factory.CancellationToken,
+            context.Factory.CreationOptions | TaskCreationOptions.DenyChildAttach,
+            context.TaskScheduler);
+
+        var firstExecute = Task.Run(() => context.Execute(blockingTask));
+
+        try
+        {
+            Assert.True(firstStarted.Wait(TimeSpan.FromSeconds(5)), "First Execute did not start");
+
+            var ex = Assert.Throws<InvalidOperationException>(() => context.Execute(blockingTask));
+            Assert.Contains("not re-entrant", ex.Message);
+        }
+        finally
+        {
+            releaseFirst.Set();
+            firstExecute.Wait(TimeSpan.FromSeconds(5));
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Rewrites `BrighterAsyncContext` and its collaborators in `src/Paramore.Brighter/Tasks/` to fix correctness bugs inherited from the AsyncEx-derived original implementation and modernize the code for current .NET conventions. Adds a thorough test suite covering shutdown races, concurrent-Execute, nested Run, and a 1000-iteration stress test.

## Correctness fixes

- **Outstanding-operations counter leak** — `Enqueue` now balances the counter when `TryAdd` fails on a closed queue. The previous code left the counter stuck and `Run` would hang forever.
- **Late `Post` after shutdown** — `BrighterTaskQueue.TryAdd` / `CompleteAdding` / `GetScheduledTasks` tolerate both `InvalidOperationException` (completed-for-adding) and `ObjectDisposedException` (queue disposed), in the correct subclass-first catch order. Stray async continuations posting back after `Run` returns are absorbed silently.
- **Late `Send` after shutdown** — now throws `ObjectDisposedException` instead of blocking indefinitely on a task the pump will never execute.
- **Exception swallowing in `Run(Func<Task>)` / `Run<T>(Func<Task<T>>)`** — continuation now does `try { WaitAndUnwrapException } finally { OperationCompleted }`, so `OperationCompleted` cannot mask the user's exception.
- **Concurrent `Execute`** — enforces the single-thread invariant via `Interlocked.CompareExchange`, throwing `InvalidOperationException` on re-entry instead of silently violating it.
- **Idempotent `Dispose`** — guarded by `Interlocked.Exchange(ref _disposed, 1)`; double-dispose no longer throws `ObjectDisposedException` from the underlying `BlockingCollection`.
- **`GetScheduledTasks`** — takes a `ToArray()` snapshot rather than iterating the live `BlockingCollection` (which is undocumented against concurrent Add/Take), and absorbs `ObjectDisposedException`.
- **`TaskExtensions.WaitAndUnwrapException(CancellationToken)`** — uses `Task.WaitAsync(ct)` on `net6+`; on `netstandard2.0` unwraps via `ex.InnerException` (the previous code captured the wrapping `AggregateException` instead, double-wrapping the thrown exception).

## Modernization

- `BrighterAsyncContext` and `BrighterSynchronizationContext` are now `sealed`.
- `Enqueue`, `OperationStarted`, `OperationCompleted`, `GetScheduledTasks` on `BrighterAsyncContext` moved from `public` to `internal`.
- `Tuple<Task, bool>` replaced with `(Task, bool)` `ValueTuple` on the hot path.
- Static lambdas with state params eliminate per-`Enqueue` closure allocations.
- `ArgumentNullException.ThrowIfNull` under `#if NET` with netstandard2.0 fallbacks.
- XML docs rewritten for accuracy; MIT attribution block added to `TaskExtensions`.
- Removed dead code: `ExecuteImmediately`, `TryExecuteNewThread`, `BrighterSynchronizationContext.Timeout`, `OutstandingOperations` setter.

## ⚠️ Breaking changes (major bump)

- `BrighterAsyncContext` and `BrighterSynchronizationContext` are now `sealed`.
- `Enqueue`, `OperationStarted`, `OperationCompleted`, `GetScheduledTasks` went from `public` to `internal`.
- `ExecuteImmediately` removed.
- `BrighterSynchronizationContext.Timeout` property removed.
- `OutstandingOperations` setter removed (getter kept and now returns a correct `Volatile.Read` of the internal counter; before, the setter was a dead auto-prop that always returned 0).

No in-repo consumers use any of the removed/tightened surfaces beyond `Run(...)` and `Current`.

## Test coverage

**Added (6 cases):**
- `Post_AfterContextDisposed_DoesNotThrow`
- `Send_AfterContextDisposed_Throws`
- `Send_AfterShutdown_StressIterations_NeverHangsAndOnlyThrowsObjectDisposed` — 1000 iterations, 5s bounded wait per iteration
- `Dispose_CalledTwice_DoesNotThrow`
- `Run_NestedInsideOuterRun_DoesNotDeadlock`
- `Execute_CalledConcurrently_ThrowsInvalidOperationException`

## Test plan

- [x] Build clean across all TFMs: `netstandard2.0`, `net8.0`, `net9.0`, `net10.0`.
- [x] `BrighterSynchronizationContextsTests` — **31/31 passed** in ~1s.
- [x] Proactor regression smoke — **38/38 passed** in ~30s.

## Commits

1. `build: bump OpenTelemetry packages to 1.15.3 for GHSA-g94r-2vxg-569j` — CVE fix required for master to restore. Happy to split into a separate PR if preferred.
2. `refactor: rewrite BrighterAsyncContext for correctness and modernization` — the rewrite itself.

## Review process

This PR was developed with multiple review passes (code-reuse, code-quality, efficiency, and three thorough correctness passes). Each pass surfaced specific findings that were addressed before the next. Review trail visible in the commit history if useful.