### PR TITLE
chore: bump OpenTelemetry to 1.15.3 for CVE fixes

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -110,8 +110,8 @@
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.14.0-beta.1" />
     <PackageVersion Include="OpenTelemetry.Exporter.Zipkin" Version="1.14.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http"  Version="1.15.0"/>
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime"  Version="1.15.0"/>
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.0" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.1" />
     <PackageVersion Include="Paramore.Darker" Version="4.1.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -107,7 +107,6 @@
     <PackageVersion Include="OpenTelemetry.Api.ProviderBuilderExtensions" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.15.3" />
-    <PackageVersion Include="OpenTelemetry.Exporter.Jaeger" Version="1.5.1" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.14.0-beta.1" />
     <PackageVersion Include="OpenTelemetry.Exporter.Zipkin" Version="1.14.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -102,18 +102,18 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
     <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />
-    <PackageVersion Include="OpenTelemetry" Version="1.15.2" />
+    <PackageVersion Include="OpenTelemetry" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Process" Version="1.14.0-beta.2" />
-    <PackageVersion Include="OpenTelemetry.Api.ProviderBuilderExtensions" Version="1.15.2" />
-    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.15.2" />
-    <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.15.2" />
+    <PackageVersion Include="OpenTelemetry.Api.ProviderBuilderExtensions" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Exporter.Jaeger" Version="1.5.1" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.2" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.14.0-beta.1" />
     <PackageVersion Include="OpenTelemetry.Exporter.Zipkin" Version="1.14.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http"  Version="1.15.0"/>
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime"  Version="1.15.0"/>    
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.2" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime"  Version="1.15.0"/>
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.1" />
     <PackageVersion Include="Paramore.Darker" Version="4.1.1" />
     <PackageVersion Include="Paramore.Darker.AspNetCore" Version="4.1.1" />


### PR DESCRIPTION
  ## Summary
  Bumps OpenTelemetry packages from 1.15.2 → 1.15.3 in `Directory.Packages.props` to pick up upstream CVE fixes, and removes the unused `OpenTelemetry.Exporter.Jaeger` 1.5.1 pin.

  Addresses CVEs:
  - CVE-2026-40894
  - CVE-2026-40891
  - CVE-2026-40182

  Packages bumped to 1.15.3:
  - OpenTelemetry
  - OpenTelemetry.Api.ProviderBuilderExtensions
  - OpenTelemetry.Exporter.Console
  - OpenTelemetry.Exporter.InMemory
  - OpenTelemetry.Exporter.OpenTelemetryProtocol
  - OpenTelemetry.Extensions.Hosting

  Packages removed:
  - `OpenTelemetry.Exporter.Jaeger` 1.5.1 — deprecated upstream, and had zero references in `src/`, `samples/`, or `tests/` (dangling version pin only).

  `dotnet list package --vulnerable` against the 1.15.3 set comes back clean (one unrelated hit on `Oracle.ManagedDataAccess.Core` in the Dapper samples via `FluentMigrator.Extensions.Oracle`, tracked separately).