### PR TITLE
fix: pin Task.Factory.StartNew to TaskScheduler.Default (#4071)

### DIFF
--- a/src/Paramore.Brighter.Mediator/Runner.cs
+++ b/src/Paramore.Brighter.Mediator/Runner.cs
@@ -71,12 +71,12 @@ public class Runner<TData>
         var task = Task.Factory.StartNew(async () =>
         {
             cancellationToken.ThrowIfCancellationRequested();
-            
+
             await ProcessJobs(cancellationToken);
-            
+
             cancellationToken.ThrowIfCancellationRequested();
-            
-        }, cancellationToken);
+
+        }, cancellationToken, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
         
         Task.WaitAll([task], cancellationToken);
         

--- a/src/Paramore.Brighter.Mediator/Waker.cs
+++ b/src/Paramore.Brighter.Mediator/Waker.cs
@@ -72,7 +72,7 @@ public class Waker<TData>
             if (cancellationToken.IsCancellationRequested)
                 cancellationToken.ThrowIfCancellationRequested();
 
-        }, cancellationToken);
+        }, cancellationToken, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
         
         Task.WaitAll([task], cancellationToken);
         

--- a/src/Paramore.Brighter.ServiceActivator/Dispatcher.cs
+++ b/src/Paramore.Brighter.ServiceActivator/Dispatcher.cs
@@ -27,6 +27,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Paramore.Brighter.Extensions;
@@ -335,7 +336,9 @@ namespace Paramore.Brighter.ServiceActivator
                     Log.DispatcherStopped(s_logger);
                 }
             },
-            TaskCreationOptions.LongRunning);
+            CancellationToken.None,
+            TaskCreationOptions.LongRunning,
+            TaskScheduler.Default);
 
             while (State != DispatcherState.DS_RUNNING)
             {

--- a/src/Paramore.Brighter.ServiceActivator/Performer.cs
+++ b/src/Paramore.Brighter.ServiceActivator/Performer.cs
@@ -23,6 +23,7 @@ THE SOFTWARE. */
 #endregion
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Paramore.Brighter.ServiceActivator
@@ -58,9 +59,13 @@ namespace Paramore.Brighter.ServiceActivator
         /// Runs this instance.
         /// </summary>
         /// <returns>Task.</returns>
-        public async Task Run()
+        public Task Run()
         {
-            await Task.Factory.StartNew(() => _messagePump.Run(), TaskCreationOptions.LongRunning);
+            return Task.Factory.StartNew(
+                () => _messagePump.Run(),
+                CancellationToken.None,
+                TaskCreationOptions.LongRunning,
+                TaskScheduler.Default);
         }
 
         /// <summary>

--- a/src/Paramore.Brighter/Policies/Handlers/TimeoutPolicyHandler.cs
+++ b/src/Paramore.Brighter/Policies/Handlers/TimeoutPolicyHandler.cs
@@ -112,7 +112,7 @@ namespace Paramore.Brighter.Policies.Handlers
                 },
                 cancellationToken: ct,
                 creationOptions: TaskCreationOptions.LongRunning,
-                scheduler: TaskScheduler.Current
+                scheduler: TaskScheduler.Default
                 );
 
             var task = TimeoutAfter(task: timeoutTask, millisecondsTimeout: _milliseconds, cancellationTokenSource: cts);

--- a/tests/Paramore.Brighter.Core.Tests/MessageDispatch/Proactor/When_dispatcher_started_on_limited_concurrency_scheduler_should_not_deadlock.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageDispatch/Proactor/When_dispatcher_started_on_limited_concurrency_scheduler_should_not_deadlock.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
+using Paramore.Brighter.Core.Tests.MessageDispatch.TestDoubles;
+using Paramore.Brighter.ServiceActivator;
+using Paramore.Brighter.Testing;
+using Xunit;
+
+namespace Paramore.Brighter.Core.Tests.MessageDispatch.Proactor;
+
+/// <summary>Regression test for issue #4071: dispatcher must not deadlock on a limited-concurrency TaskScheduler.</summary>
+public class DispatcherOnLimitedConcurrencySchedulerTests
+{
+    private const string Topic = "myTopic";
+    private const string ChannelName = "myChannel";
+
+    [Fact]
+    public void When_Dispatcher_Started_On_Limited_Concurrency_Scheduler_Should_Not_Deadlock()
+    {
+        var routingKey = new RoutingKey(Topic);
+        var bus = new InternalBus();
+        var consumer = new InMemoryMessageConsumer(routingKey, bus, TimeProvider.System, ackTimeout: TimeSpan.FromMilliseconds(1000));
+
+        IAmAChannelSync channel = new Channel(new(ChannelName), new(Topic), consumer, 6);
+        IAmACommandProcessor commandProcessor = new SpyCommandProcessor();
+
+        var messageMapperRegistry = new MessageMapperRegistry(
+            null,
+            new SimpleMessageMapperFactoryAsync(_ => new MyEventMessageMapperAsync()));
+        messageMapperRegistry.RegisterAsync<MyEvent, MyEventMessageMapperAsync>();
+
+        var subscription = new Subscription<MyEvent>(
+            new SubscriptionName("test"),
+            noOfPerformers: 3,
+            timeOut: TimeSpan.FromMilliseconds(100),
+            channelFactory: new InMemoryChannelFactory(bus, TimeProvider.System),
+            channelName: new ChannelName("fakeChannel"),
+            messagePumpType: MessagePumpType.Proactor,
+            routingKey: routingKey
+        );
+        var dispatcher = new Dispatcher(commandProcessor, new List<Subscription> { subscription }, messageMapperRegistryAsync: messageMapperRegistry);
+
+        var @event = new MyEvent();
+        var message = new MyEventMessageMapperAsync()
+            .MapToMessageAsync(@event, new Publication { Topic = subscription.RoutingKey })
+            .GetAwaiter()
+            .GetResult();
+
+        for (var i = 0; i < 6; i++)
+            channel.Enqueue(message);
+
+        Assert.Equal(DispatcherState.DS_AWAITING, dispatcher.State);
+
+        var pair = new ConcurrentExclusiveSchedulerPair();
+        var factory = new TaskFactory(pair.ExclusiveScheduler);
+
+        var completed = factory.StartNew(() =>
+        {
+            dispatcher.Receive();
+            return dispatcher.End();
+        }).Unwrap();
+
+        var finishedInTime = completed.Wait(TimeSpan.FromSeconds(30));
+        Assert.True(finishedInTime, "Dispatcher deadlocked when started on a limited-concurrency TaskScheduler");
+        Assert.Equal(DispatcherState.DS_STOPPED, dispatcher.State);
+    }
+}


### PR DESCRIPTION
Closes #4071.

## Summary
- `Dispatcher.Start`, `Performer.Run`, `TimeoutPolicyHandler`, `Mediator.Runner`, and `Mediator.Waker` called `Task.Factory.StartNew` without an explicit `TaskScheduler`, inheriting `TaskScheduler.Current`. Under any limited-concurrency scheduler (`BrighterAsyncContext`, ASP.NET, async test hosts), the control task / message pump queued behind the very thread waiting for them and `End()` / `await` never returned. `TaskCreationOptions.LongRunning` is only a hint — only `TaskScheduler.Default` guarantees a fresh thread.
- Pass `TaskScheduler.Default` explicitly at every affected call site. `Performer.Run` also dropped its redundant `async`/`await` wrapper.
- Added regression test `DispatcherOnLimitedConcurrencySchedulerTests` using `ConcurrentExclusiveSchedulerPair` — verified red without the fix (30 s deadlock) and green with it (~600 ms).

## Test plan
- [x] New regression test fails with `TaskCreationOptions.LongRunning`-only call (deadlock at 30 s) and passes with `TaskScheduler.Default` pin.
- [x] All 81 `MessageDispatch` tests pass on `net9.0`.
- [x] All 40 Policy / Mediator / Workflow tests pass on `net9.0` (2 pre-existing skips on obsolete Timeout API).
- [x] `Paramore.Brighter.ServiceActivator` and `Paramore.Brighter.Mediator` build clean.