### PR TITLE
fix: Mediator Runner/Waker RunAsync awaits inner work (#4078)

### DIFF
--- a/src/Paramore.Brighter.Mediator/Runner.cs
+++ b/src/Paramore.Brighter.Mediator/Runner.cs
@@ -64,23 +64,19 @@ public class Runner<TData>
     /// Runs the job processing loop.
     /// </summary>
     /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
-    public void RunAsync(CancellationToken cancellationToken = default(CancellationToken))
+    /// <returns>A task that completes when the job processing loop exits (via cancellation or channel closure).</returns>
+    public async Task RunAsync(CancellationToken cancellationToken = default(CancellationToken))
     {
         s_logger.LogInformation("Starting runner {RunnerName}", _runnerName);
-        
-        var task = Task.Factory.StartNew(async () =>
+
+        try
         {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            await ProcessJobs(cancellationToken);
-
-            cancellationToken.ThrowIfCancellationRequested();
-
-        }, cancellationToken, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
-        
-        Task.WaitAll([task], cancellationToken);
-        
-        s_logger.LogInformation("Finished runner {RunnerName}", _runnerName);
+            await Task.Run(() => ProcessJobs(cancellationToken), cancellationToken);
+        }
+        finally
+        {
+            s_logger.LogInformation("Finished runner {RunnerName}", _runnerName);
+        }
     }
 
     private async Task Execute(Job<TData>? job, CancellationToken cancellationToken = default(CancellationToken))

--- a/src/Paramore.Brighter.Mediator/Waker.cs
+++ b/src/Paramore.Brighter.Mediator/Waker.cs
@@ -58,25 +58,19 @@ public class Waker<TData>
     /// This will periodically wake up and trigger due jobs in the scheduler.
     /// </summary>
     /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
-    /// <returns>A task that represents the asynchronous run operation.</returns>
-    public void RunAsync(CancellationToken cancellationToken = default(CancellationToken))
+    /// <returns>A task that completes when the wake loop exits (via cancellation).</returns>
+    public async Task RunAsync(CancellationToken cancellationToken = default(CancellationToken))
     {
         s_logger.LogInformation("Starting waker {WakerName}", _wakerName);
-        
-        var task = Task.Factory.StartNew(async () =>
+
+        try
         {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            await Wake(cancellationToken);
-
-            if (cancellationToken.IsCancellationRequested)
-                cancellationToken.ThrowIfCancellationRequested();
-
-        }, cancellationToken, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
-        
-        Task.WaitAll([task], cancellationToken);
-        
-        s_logger.LogInformation("Finished waker {WakerName}", _wakerName);
+            await Task.Run(() => Wake(cancellationToken), cancellationToken);
+        }
+        finally
+        {
+            s_logger.LogInformation("Finished waker {WakerName}", _wakerName);
+        }
     }
 
     private async Task Wake(CancellationToken cancellationToken = default(CancellationToken))

--- a/tests/Paramore.Brighter.Core.Tests/Workflows/When_running_a_blocking_wait_workflow.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Workflows/When_running_a_blocking_wait_workflow.cs
@@ -68,26 +68,31 @@ public class MediatorWaitStepFlowTests
     public async Task When_running_a_wait_workflow()
     {
         var ct = new CancellationTokenSource();
-        ct.CancelAfter( TimeSpan.FromSeconds(3));
+        ct.CancelAfter(TimeSpan.FromSeconds(3));
 
+        Task runnerTask = Task.CompletedTask;
+        Task wakerTask = Task.CompletedTask;
         try
         {
             await _scheduler.ScheduleAsync(_job);
-            
+
             _timeProvider.Advance(TimeSpan.FromMilliseconds(1000));
-            
-            _ = _runner.RunAsync(ct.Token);
-            _ = _waker.RunAsync(ct.Token);
+
+            runnerTask = _runner.RunAsync(ct.Token);
+            wakerTask = _waker.RunAsync(ct.Token);
 
             await Task.Delay(TimeSpan.FromMilliseconds(500), ct.Token);
-
         }
-        catch (Exception e)
+        catch (OperationCanceledException e)
         {
             _testOutputHelper.WriteLine(e.ToString());
         }
 
         Assert.True(_stepCompleted);
         Assert.Equal(JobState.Done, _job.State);
+
+        ct.Cancel();
+        try { await Task.WhenAll(runnerTask, wakerTask); }
+        catch (OperationCanceledException) { }
     }
 }

--- a/tests/Paramore.Brighter.Core.Tests/Workflows/When_running_a_blocking_wait_workflow.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Workflows/When_running_a_blocking_wait_workflow.cs
@@ -76,10 +76,10 @@ public class MediatorWaitStepFlowTests
             
             _timeProvider.Advance(TimeSpan.FromMilliseconds(1000));
             
-            _runner.RunAsync(ct.Token);
-            _waker.RunAsync(ct.Token);
+            _ = _runner.RunAsync(ct.Token);
+            _ = _waker.RunAsync(ct.Token);
 
-            await Task.Delay(5, ct.Token);
+            await Task.Delay(TimeSpan.FromMilliseconds(500), ct.Token);
 
         }
         catch (Exception e)

--- a/tests/Paramore.Brighter.Core.Tests/Workflows/When_running_a_change_workflow.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Workflows/When_running_a_change_workflow.cs
@@ -14,6 +14,7 @@ public class MediatorChangeStepFlowTests
     private readonly ITestOutputHelper _testOutputHelper;
     private readonly Scheduler<WorkflowTestData> _scheduler;
     private readonly Runner<WorkflowTestData> _runner;
+    private readonly InMemoryJobChannel<WorkflowTestData> _channel;
     private readonly Job<WorkflowTestData> _job;
     private bool _stepCompleted;
 
@@ -50,32 +51,30 @@ public class MediatorChangeStepFlowTests
         _job.InitSteps(firstStep);
         
         var store = new InMemoryStateStoreAsync ();
-        InMemoryJobChannel<WorkflowTestData> channel = new();
-        
+        _channel = new InMemoryJobChannel<WorkflowTestData>();
+
         _scheduler = new Scheduler<WorkflowTestData>(
-            channel,
+            _channel,
             store
         );
-        
-        _runner = new Runner<WorkflowTestData>(channel, store, commandProcessor, _scheduler);
+
+        _runner = new Runner<WorkflowTestData>(_channel, store, commandProcessor, _scheduler);
     }
     
     [Fact]
     public async Task When_running_a_change_workflow()
     {
         await _scheduler.ScheduleAsync(_job);
+        _channel.Stop();
 
-        //let it run long enough to finish work, then terminate
         var ct = new CancellationTokenSource();
-        ct.CancelAfter( TimeSpan.FromSeconds(1) );
+        ct.CancelAfter(TimeSpan.FromSeconds(1));
         try
         {
-            _ = _runner.RunAsync(ct.Token);
-            await Task.Delay(TimeSpan.FromMilliseconds(100));
+            await _runner.RunAsync(ct.Token);
         }
-        catch (Exception ex)
+        catch (OperationCanceledException ex)
         {
-            // swallow the exception, we expect it to be cancelled
             _testOutputHelper.WriteLine(ex.ToString());
         }
 

--- a/tests/Paramore.Brighter.Core.Tests/Workflows/When_running_a_change_workflow.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Workflows/When_running_a_change_workflow.cs
@@ -70,14 +70,15 @@ public class MediatorChangeStepFlowTests
         ct.CancelAfter( TimeSpan.FromSeconds(1) );
         try
         {
-            _runner.RunAsync(ct.Token);
+            _ = _runner.RunAsync(ct.Token);
+            await Task.Delay(TimeSpan.FromMilliseconds(100));
         }
         catch (Exception ex)
         {
             // swallow the exception, we expect it to be cancelled
             _testOutputHelper.WriteLine(ex.ToString());
         }
-        
+
         Assert.Equal(JobState.Done, _job.State);
         Assert.True(_stepCompleted);
         Assert.Equal("Altered", _job.Data.Bag["MyValue"]);

--- a/tests/Paramore.Brighter.Core.Tests/Workflows/When_running_a_failing_choice_workflow_step.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Workflows/When_running_a_failing_choice_workflow_step.cs
@@ -15,6 +15,7 @@ public class MediatorFailingChoiceFlowTests
     private readonly ITestOutputHelper _testOutputHelper;
     private readonly Scheduler<WorkflowTestData> _scheduler;
     private readonly Runner<WorkflowTestData> _runner;
+    private readonly InMemoryJobChannel<WorkflowTestData> _channel;
     private readonly Job<WorkflowTestData> _job;
     private bool _stepCompletedOne;
     private bool _stepCompletedTwo;
@@ -70,14 +71,14 @@ public class MediatorFailingChoiceFlowTests
         _job.InitSteps(stepOne);
         
         InMemoryStateStoreAsync store = new();
-        InMemoryJobChannel<WorkflowTestData> channel = new();
-        
+        _channel = new InMemoryJobChannel<WorkflowTestData>();
+
         _scheduler = new Scheduler<WorkflowTestData>(
-            channel,
+            _channel,
             store
         );
-        
-        _runner = new Runner<WorkflowTestData>(channel, store, commandProcessor, _scheduler);
+
+        _runner = new Runner<WorkflowTestData>(_channel, store, commandProcessor, _scheduler);
     }
     
     [Fact]
@@ -87,16 +88,16 @@ public class MediatorFailingChoiceFlowTests
         MyOtherCommandHandlerAsync.ReceivedCommands.Clear();
         
         await _scheduler.ScheduleAsync(_job);
-        
+        _channel.Stop();
+
         var ct = new CancellationTokenSource();
-        ct.CancelAfter( TimeSpan.FromSeconds(1) );
+        ct.CancelAfter(TimeSpan.FromSeconds(1));
 
         try
         {
-            _ = _runner.RunAsync(ct.Token);
-            await Task.Delay(TimeSpan.FromMilliseconds(100));
+            await _runner.RunAsync(ct.Token);
         }
-        catch (Exception e)
+        catch (OperationCanceledException e)
         {
             _testOutputHelper.WriteLine(e.ToString());
         }

--- a/tests/Paramore.Brighter.Core.Tests/Workflows/When_running_a_failing_choice_workflow_step.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Workflows/When_running_a_failing_choice_workflow_step.cs
@@ -93,7 +93,8 @@ public class MediatorFailingChoiceFlowTests
 
         try
         {
-            _runner.RunAsync(ct.Token);
+            _ = _runner.RunAsync(ct.Token);
+            await Task.Delay(TimeSpan.FromMilliseconds(100));
         }
         catch (Exception e)
         {

--- a/tests/Paramore.Brighter.Core.Tests/Workflows/When_running_a_multistep_workflow_with_reply.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Workflows/When_running_a_multistep_workflow_with_reply.cs
@@ -14,6 +14,7 @@ public class MediatorReplyMultiStepFlowTests
     private readonly ITestOutputHelper _testOutputHelper;
     private readonly Scheduler<WorkflowTestData> _scheduler;
     private readonly Runner<WorkflowTestData> _runner;
+    private readonly InMemoryJobChannel<WorkflowTestData> _channel;
     private readonly Job<WorkflowTestData> _job;
     private bool _stepCompletedOne;
     private bool _stepCompletedTwo;
@@ -61,14 +62,14 @@ public class MediatorReplyMultiStepFlowTests
          _job.InitSteps(stepOne); 
         
         InMemoryStateStoreAsync store = new();
-        InMemoryJobChannel<WorkflowTestData> channel = new();
-        
+        _channel = new InMemoryJobChannel<WorkflowTestData>();
+
         _scheduler = new Scheduler<WorkflowTestData>(
-            channel,
+            _channel,
             store
         );
-        
-        _runner = new Runner<WorkflowTestData>(channel, store, commandProcessor, _scheduler);
+
+        _runner = new Runner<WorkflowTestData>(_channel, store, commandProcessor, _scheduler);
     }
     
     [Fact]
@@ -78,16 +79,16 @@ public class MediatorReplyMultiStepFlowTests
         MyEventHandlerAsync.ReceivedEvents.Clear();
         
         await _scheduler.ScheduleAsync(_job);
-        
+        _channel.Stop();
+
         var ct = new CancellationTokenSource();
-        ct.CancelAfter( TimeSpan.FromSeconds(1) );
+        ct.CancelAfter(TimeSpan.FromSeconds(1));
 
         try
         {
-            _ = _runner.RunAsync(ct.Token);
-            await Task.Delay(TimeSpan.FromMilliseconds(100));
+            await _runner.RunAsync(ct.Token);
         }
-        catch (Exception e)
+        catch (OperationCanceledException e)
         {
             _testOutputHelper.WriteLine(e.ToString());
         }

--- a/tests/Paramore.Brighter.Core.Tests/Workflows/When_running_a_multistep_workflow_with_reply.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Workflows/When_running_a_multistep_workflow_with_reply.cs
@@ -84,13 +84,14 @@ public class MediatorReplyMultiStepFlowTests
 
         try
         {
-            _runner.RunAsync(ct.Token);
+            _ = _runner.RunAsync(ct.Token);
+            await Task.Delay(TimeSpan.FromMilliseconds(100));
         }
         catch (Exception e)
         {
             _testOutputHelper.WriteLine(e.ToString());
         }
-        
+
         Assert.True(_stepCompletedOne);
         Assert.True(_stepCompletedTwo);
 

--- a/tests/Paramore.Brighter.Core.Tests/Workflows/When_running_a_passing_choice_workflow_step.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Workflows/When_running_a_passing_choice_workflow_step.cs
@@ -15,6 +15,7 @@ public class MediatorPassingChoiceFlowTests
     private readonly ITestOutputHelper _testOutputHelper;
     private readonly Scheduler<WorkflowTestData> _scheduler;
     private readonly Runner<WorkflowTestData> _runner;
+    private readonly InMemoryJobChannel<WorkflowTestData> _channel;
     private readonly Job<WorkflowTestData> _job;
     private bool _stepCompletedOne;
     private bool _stepCompletedTwo;
@@ -70,14 +71,14 @@ public class MediatorPassingChoiceFlowTests
          _job.InitSteps(stepOne); 
         
         InMemoryStateStoreAsync store = new();
-        InMemoryJobChannel<WorkflowTestData> channel = new();
-        
+        _channel = new InMemoryJobChannel<WorkflowTestData>();
+
         _scheduler = new Scheduler<WorkflowTestData>(
-            channel,
+            _channel,
             store
         );
-        
-        _runner = new Runner<WorkflowTestData>(channel, store, commandProcessor, _scheduler);
+
+        _runner = new Runner<WorkflowTestData>(_channel, store, commandProcessor, _scheduler);
     }
     
     [Fact]
@@ -87,16 +88,16 @@ public class MediatorPassingChoiceFlowTests
         MyOtherCommandHandlerAsync.ReceivedCommands.Clear();
         
         await _scheduler.ScheduleAsync(_job);
-        
+        _channel.Stop();
+
         var ct = new CancellationTokenSource();
-        ct.CancelAfter( TimeSpan.FromSeconds(1) );
+        ct.CancelAfter(TimeSpan.FromSeconds(1));
 
         try
         {
-            _ = _runner.RunAsync(ct.Token);
-            await Task.Delay(TimeSpan.FromMilliseconds(100));
+            await _runner.RunAsync(ct.Token);
         }
-        catch (Exception e)
+        catch (OperationCanceledException e)
         {
             _testOutputHelper.WriteLine(e.ToString());
         }

--- a/tests/Paramore.Brighter.Core.Tests/Workflows/When_running_a_passing_choice_workflow_step.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Workflows/When_running_a_passing_choice_workflow_step.cs
@@ -93,7 +93,8 @@ public class MediatorPassingChoiceFlowTests
 
         try
         {
-            _runner.RunAsync(ct.Token);
+            _ = _runner.RunAsync(ct.Token);
+            await Task.Delay(TimeSpan.FromMilliseconds(100));
         }
         catch (Exception e)
         {

--- a/tests/Paramore.Brighter.Core.Tests/Workflows/When_running_a_single_step_workflow.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Workflows/When_running_a_single_step_workflow.cs
@@ -14,6 +14,7 @@ public class MediatorOneStepFlowTests
     private readonly ITestOutputHelper _testOutputHelper;
     private readonly Scheduler<WorkflowTestData> _scheduler;
     private readonly Runner<WorkflowTestData> _runner;
+    private readonly InMemoryJobChannel<WorkflowTestData> _channel;
     private readonly Job<WorkflowTestData> _job;
     private bool _stepCompleted;
 
@@ -46,14 +47,14 @@ public class MediatorOneStepFlowTests
         _job.InitSteps(firstStep);
         
         InMemoryStateStoreAsync store = new();
-        InMemoryJobChannel<WorkflowTestData> channel = new();
-        
+        _channel = new InMemoryJobChannel<WorkflowTestData>();
+
         _scheduler = new Scheduler<WorkflowTestData>(
-            channel,
+            _channel,
             store
         );
-        
-        _runner = new Runner<WorkflowTestData>(channel, store, commandProcessor, _scheduler);
+
+        _runner = new Runner<WorkflowTestData>(_channel, store, commandProcessor, _scheduler);
     }
     
     [Fact]
@@ -61,17 +62,17 @@ public class MediatorOneStepFlowTests
     {
         MyCommandHandlerAsync.ReceivedCommands.Clear();
         
-        await _scheduler.ScheduleAsync(_job); 
-        
+        await _scheduler.ScheduleAsync(_job);
+        _channel.Stop();
+
         var ct = new CancellationTokenSource();
-        ct.CancelAfter( TimeSpan.FromSeconds(1) );
+        ct.CancelAfter(TimeSpan.FromSeconds(1));
 
         try
         {
-            _ = _runner.RunAsync(ct.Token);
-            await Task.Delay(TimeSpan.FromMilliseconds(100));
+            await _runner.RunAsync(ct.Token);
         }
-        catch (Exception e)
+        catch (OperationCanceledException e)
         {
             _testOutputHelper.WriteLine(e.ToString());
         }

--- a/tests/Paramore.Brighter.Core.Tests/Workflows/When_running_a_single_step_workflow.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Workflows/When_running_a_single_step_workflow.cs
@@ -68,13 +68,14 @@ public class MediatorOneStepFlowTests
 
         try
         {
-            _runner.RunAsync(ct.Token);
+            _ = _runner.RunAsync(ct.Token);
+            await Task.Delay(TimeSpan.FromMilliseconds(100));
         }
         catch (Exception e)
         {
             _testOutputHelper.WriteLine(e.ToString());
         }
-        
+
         Assert.Contains(MyCommandHandlerAsync.ReceivedCommands, c => c.Value == "Test");
         Assert.Equal(JobState.Done, _job.State);
         Assert.True(_stepCompleted);

--- a/tests/Paramore.Brighter.Core.Tests/Workflows/When_running_a_two_step_workflow.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Workflows/When_running_a_two_step_workflow.cs
@@ -14,6 +14,7 @@ public class MediatorTwoStepFlowTests
     private readonly ITestOutputHelper _testOutputHelper;
     private readonly Scheduler<WorkflowTestData> _scheduler;
     private readonly Runner<WorkflowTestData> _runner;
+    private readonly InMemoryJobChannel<WorkflowTestData> _channel;
     private readonly Job<WorkflowTestData> _job;
     private bool _stepsCompleted;
 
@@ -54,14 +55,14 @@ public class MediatorTwoStepFlowTests
         _job.InitSteps(firstStep); 
         
         InMemoryStateStoreAsync store = new();
-        InMemoryJobChannel<WorkflowTestData> channel = new();
-        
+        _channel = new InMemoryJobChannel<WorkflowTestData>();
+
         _scheduler = new Scheduler<WorkflowTestData>(
-            channel,
+            _channel,
             store
         );
-        
-        _runner = new Runner<WorkflowTestData>(channel, store, commandProcessor, _scheduler);
+
+        _runner = new Runner<WorkflowTestData>(_channel, store, commandProcessor, _scheduler);
     }
     
     [Fact]
@@ -69,16 +70,16 @@ public class MediatorTwoStepFlowTests
     {
         MyCommandHandlerAsync.ReceivedCommands.Clear();
         await _scheduler.ScheduleAsync(_job);
-        
+        _channel.Stop();
+
         var ct = new CancellationTokenSource();
-        ct.CancelAfter( TimeSpan.FromSeconds(1) );
+        ct.CancelAfter(TimeSpan.FromSeconds(1));
 
         try
         {
-            _ = _runner.RunAsync(ct.Token);
-            await Task.Delay(TimeSpan.FromMilliseconds(100));
+            await _runner.RunAsync(ct.Token);
         }
-        catch (Exception e)
+        catch (OperationCanceledException e)
         {
             _testOutputHelper.WriteLine(e.ToString());
         }

--- a/tests/Paramore.Brighter.Core.Tests/Workflows/When_running_a_two_step_workflow.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Workflows/When_running_a_two_step_workflow.cs
@@ -75,13 +75,14 @@ public class MediatorTwoStepFlowTests
 
         try
         {
-            _runner.RunAsync(ct.Token);
+            _ = _runner.RunAsync(ct.Token);
+            await Task.Delay(TimeSpan.FromMilliseconds(100));
         }
         catch (Exception e)
         {
             _testOutputHelper.WriteLine(e.ToString());
         }
-        
+
         Assert.Contains(MyCommandHandlerAsync.ReceivedCommands, c => c.Value == "Test");
         Assert.Contains(MyCommandHandlerAsync.ReceivedCommands, c => c.Value == "TestTwo");
         Assert.Equal(JobState.Done, _job.State);

--- a/tests/Paramore.Brighter.Core.Tests/Workflows/When_running_a_workflow_with_a_parallel_split.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Workflows/When_running_a_workflow_with_a_parallel_split.cs
@@ -87,13 +87,14 @@ public class MediatorParallelSplitFlowTests
 
         try
         {
-            _runner.RunAsync(ct.Token);
+            _ = _runner.RunAsync(ct.Token);
+            await Task.Delay(TimeSpan.FromMilliseconds(100));
         }
         catch (Exception e)
         {
             _testOutputHelper.WriteLine(e.ToString());
         }
-        
+
         Assert.Contains(MyCommandHandlerAsync.ReceivedCommands, c => c.Value == "Test");
         Assert.Contains(MyCommandHandlerAsync.ReceivedCommands, c => c.Value == "TestTwo");
         Assert.True(_firstBranchFinished);

--- a/tests/Paramore.Brighter.Core.Tests/Workflows/When_running_a_workflow_with_a_parallel_split.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Workflows/When_running_a_workflow_with_a_parallel_split.cs
@@ -14,6 +14,7 @@ public class MediatorParallelSplitFlowTests
     private readonly ITestOutputHelper _testOutputHelper;
     private readonly Scheduler<WorkflowTestData> _scheduler;
     private readonly Runner<WorkflowTestData> _runner;
+    private readonly InMemoryJobChannel<WorkflowTestData> _channel;
     private readonly Job<WorkflowTestData> _job;
     private bool _firstBranchFinished;
     private bool _secondBranchFinished;
@@ -65,14 +66,14 @@ public class MediatorParallelSplitFlowTests
         _job.InitSteps(parallelSplit);
         
         InMemoryStateStoreAsync store = new();
-        InMemoryJobChannel<WorkflowTestData> channel = new();
-        
+        _channel = new InMemoryJobChannel<WorkflowTestData>();
+
         _scheduler = new Scheduler<WorkflowTestData>(
-            channel,
+            _channel,
             store
         );
-        
-        _runner = new Runner<WorkflowTestData>(channel, store, commandProcessor, _scheduler);
+
+        _runner = new Runner<WorkflowTestData>(_channel, store, commandProcessor, _scheduler);
     }
     
     [Fact]
@@ -81,16 +82,17 @@ public class MediatorParallelSplitFlowTests
         MyCommandHandlerAsync.ReceivedCommands.Clear();
         
         await _scheduler.ScheduleAsync(_job);
-        
-        var ct = new CancellationTokenSource();
-        ct.CancelAfter( TimeSpan.FromSeconds(3) );
 
+        var ct = new CancellationTokenSource();
+        ct.CancelAfter(TimeSpan.FromSeconds(3));
+
+        Task runnerTask = Task.CompletedTask;
         try
         {
-            _ = _runner.RunAsync(ct.Token);
-            await Task.Delay(TimeSpan.FromMilliseconds(100));
+            runnerTask = _runner.RunAsync(ct.Token);
+            await Task.Delay(TimeSpan.FromMilliseconds(200), ct.Token);
         }
-        catch (Exception e)
+        catch (OperationCanceledException e)
         {
             _testOutputHelper.WriteLine(e.ToString());
         }
@@ -100,5 +102,9 @@ public class MediatorParallelSplitFlowTests
         Assert.True(_firstBranchFinished);
         Assert.True(_secondBranchFinished);
         Assert.Equal(JobState.Done, _job.State);
+
+        ct.Cancel();
+        try { await runnerTask; }
+        catch (OperationCanceledException) { }
     }
 }

--- a/tests/Paramore.Brighter.Core.Tests/Workflows/When_running_a_workflow_with_reply.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Workflows/When_running_a_workflow_with_reply.cs
@@ -80,7 +80,8 @@ public class MediatorReplyStepFlowTests
 
         try
         {
-            _runner.RunAsync(ct.Token);
+            _ = _runner.RunAsync(ct.Token);
+            await Task.Delay(TimeSpan.FromMilliseconds(100));
         }
         catch (Exception e)
         {

--- a/tests/Paramore.Brighter.Core.Tests/Workflows/When_running_a_workflow_with_reply.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Workflows/When_running_a_workflow_with_reply.cs
@@ -18,6 +18,7 @@ public class MediatorReplyStepFlowTests
     private readonly ITestOutputHelper _testOutputHelper;
     private readonly Scheduler<WorkflowTestData> _scheduler;
     private readonly Runner<WorkflowTestData> _runner;
+    private readonly InMemoryJobChannel<WorkflowTestData> _channel;
     private readonly Job<WorkflowTestData> _job;
     private bool _stepCompleted;
 
@@ -57,14 +58,14 @@ public class MediatorReplyStepFlowTests
          _job.InitSteps(firstStep);
         
          InMemoryStateStoreAsync store = new();
-         InMemoryJobChannel<WorkflowTestData> channel = new();
-        
+         _channel = new InMemoryJobChannel<WorkflowTestData>();
+
          _scheduler = new Scheduler<WorkflowTestData>(
-             channel,
+             _channel,
              store
          );
-        
-         _runner = new Runner<WorkflowTestData>(channel, store, commandProcessor, _scheduler);
+
+         _runner = new Runner<WorkflowTestData>(_channel, store, commandProcessor, _scheduler);
     }
     
     [Fact]
@@ -74,16 +75,16 @@ public class MediatorReplyStepFlowTests
         MyEventHandlerAsync.ReceivedEvents.Clear();
         
         await _scheduler.ScheduleAsync(_job);
-        
+        _channel.Stop();
+
         var ct = new CancellationTokenSource();
-        ct.CancelAfter( TimeSpan.FromSeconds(3) );
+        ct.CancelAfter(TimeSpan.FromSeconds(3));
 
         try
         {
-            _ = _runner.RunAsync(ct.Token);
-            await Task.Delay(TimeSpan.FromMilliseconds(100));
+            await _runner.RunAsync(ct.Token);
         }
-        catch (Exception e)
+        catch (OperationCanceledException e)
         {
             _testOutputHelper.WriteLine(e.ToString());
         }

--- a/tests/Paramore.Brighter.Core.Tests/Workflows/When_running_a_workflow_with_robust_reply_nofault.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Workflows/When_running_a_workflow_with_robust_reply_nofault.cs
@@ -14,6 +14,7 @@ public class MediatorRobustReplyNoFaultStepFlowTests
     private readonly ITestOutputHelper _testOutputHelper;
     private readonly Scheduler<WorkflowTestData> _scheduler;
     private readonly Runner<WorkflowTestData> _runner;
+    private readonly InMemoryJobChannel<WorkflowTestData> _channel;
     private readonly Job<WorkflowTestData> _job;
     private bool _stepCompleted;
     private bool _stepFaulted;
@@ -58,14 +59,14 @@ public class MediatorRobustReplyNoFaultStepFlowTests
          _job.InitSteps(firstStep);
         
          InMemoryStateStoreAsync store = new();
-         InMemoryJobChannel<WorkflowTestData> channel = new();
-        
+         _channel = new InMemoryJobChannel<WorkflowTestData>();
+
          _scheduler = new Scheduler<WorkflowTestData>(
-             channel,
+             _channel,
              store
          );
-        
-         _runner = new Runner<WorkflowTestData>(channel, store, commandProcessor, _scheduler);
+
+         _runner = new Runner<WorkflowTestData>(_channel, store, commandProcessor, _scheduler);
     }
     
     [Fact]
@@ -76,17 +77,16 @@ public class MediatorRobustReplyNoFaultStepFlowTests
         MyFaultHandlerAsync.ReceivedFaults.Clear();
         
         await _scheduler.ScheduleAsync(_job);
+        _channel.Stop();
 
-        
         var ct = new CancellationTokenSource();
-        ct.CancelAfter( TimeSpan.FromSeconds(1) );
+        ct.CancelAfter(TimeSpan.FromSeconds(1));
 
         try
         {
-            _ = _runner.RunAsync(ct.Token);
-            await Task.Delay(TimeSpan.FromMilliseconds(100));
+            await _runner.RunAsync(ct.Token);
         }
-        catch (Exception e)
+        catch (OperationCanceledException e)
         {
             _testOutputHelper.WriteLine(e.ToString());
         }

--- a/tests/Paramore.Brighter.Core.Tests/Workflows/When_running_a_workflow_with_robust_reply_nofault.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Workflows/When_running_a_workflow_with_robust_reply_nofault.cs
@@ -83,13 +83,14 @@ public class MediatorRobustReplyNoFaultStepFlowTests
 
         try
         {
-            _runner.RunAsync(ct.Token);
+            _ = _runner.RunAsync(ct.Token);
+            await Task.Delay(TimeSpan.FromMilliseconds(100));
         }
         catch (Exception e)
         {
             _testOutputHelper.WriteLine(e.ToString());
         }
-        
+
         Assert.Contains(MyCommandHandlerAsync.ReceivedCommands, c => c.Value == "Test");
         Assert.Contains(MyEventHandlerAsync.ReceivedEvents, e => e.Value == "Test");
         Assert.Empty(MyFaultHandlerAsync.ReceivedFaults);

--- a/tests/Paramore.Brighter.Core.Tests/Workflows/When_running_a_workflow_with_robust_reply_with_fault.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Workflows/When_running_a_workflow_with_robust_reply_with_fault.cs
@@ -14,6 +14,7 @@ public class MediatorRobustReplyFaultStepFlowTests
     private readonly ITestOutputHelper _testOutputHelper;
     private readonly Scheduler<WorkflowTestData> _scheduler;
     private readonly Runner<WorkflowTestData> _runner;
+    private readonly InMemoryJobChannel<WorkflowTestData> _channel;
     private readonly Job<WorkflowTestData> _job;
     private bool _stepCompleted;
     private bool _stepFaulted;
@@ -60,14 +61,14 @@ public class MediatorRobustReplyFaultStepFlowTests
          _job.InitSteps(firstStep);
         
          InMemoryStateStoreAsync store = new();
-         InMemoryJobChannel<WorkflowTestData> channel = new();
-        
+         _channel = new InMemoryJobChannel<WorkflowTestData>();
+
          _scheduler = new Scheduler<WorkflowTestData>(
-             channel,
+             _channel,
              store
          );
-        
-         _runner = new Runner<WorkflowTestData>(channel, store, commandProcessor, _scheduler);
+
+         _runner = new Runner<WorkflowTestData>(_channel, store, commandProcessor, _scheduler);
     }
     
     [Fact]
@@ -78,17 +79,16 @@ public class MediatorRobustReplyFaultStepFlowTests
         MyFaultHandlerAsync.ReceivedFaults.Clear();
         
         await _scheduler.ScheduleAsync(_job);
+        _channel.Stop();
 
-        
         var ct = new CancellationTokenSource();
-        ct.CancelAfter( TimeSpan.FromSeconds(1) );
+        ct.CancelAfter(TimeSpan.FromSeconds(1));
 
         try
         {
-            _ = _runner.RunAsync(ct.Token);
-            await Task.Delay(TimeSpan.FromMilliseconds(100));
+            await _runner.RunAsync(ct.Token);
         }
-        catch (Exception e)
+        catch (OperationCanceledException e)
         {
             _testOutputHelper.WriteLine(e.ToString());
         }

--- a/tests/Paramore.Brighter.Core.Tests/Workflows/When_running_a_workflow_with_robust_reply_with_fault.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Workflows/When_running_a_workflow_with_robust_reply_with_fault.cs
@@ -85,13 +85,14 @@ public class MediatorRobustReplyFaultStepFlowTests
 
         try
         {
-            _runner.RunAsync(ct.Token);
+            _ = _runner.RunAsync(ct.Token);
+            await Task.Delay(TimeSpan.FromMilliseconds(100));
         }
         catch (Exception e)
         {
             _testOutputHelper.WriteLine(e.ToString());
         }
-        
+
         Assert.Contains(MyCommandHandlerAsync.ReceivedCommands, c => c.Value == "Test");
         Assert.Contains(MyFaultHandlerAsync.ReceivedFaults, e => e.Value == "Test");
         Assert.Empty(MyEventHandlerAsync.ReceivedEvents);

--- a/tests/Paramore.Brighter.Core.Tests/Workflows/When_running_multiple_workflows.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Workflows/When_running_multiple_workflows.cs
@@ -84,13 +84,14 @@ public class MediatorMultipleWorkflowFlowTests
 
         try
         {
-            _runner.RunAsync(ct.Token);
+            _ = _runner.RunAsync(ct.Token);
+            await Task.Delay(TimeSpan.FromMilliseconds(100));
         }
         catch (Exception e)
         {
             _testOutputHelper.WriteLine(e.ToString());
         }
-        
+
         Assert.Contains(MyCommandHandlerAsync.ReceivedCommands, c => c.Value == "Test");
         Assert.Contains(MyCommandHandlerAsync.ReceivedCommands, c => c.Value == "TestTwo");
         Assert.Equal(JobState.Done, _firstJob.State);

--- a/tests/Paramore.Brighter.Core.Tests/Workflows/When_running_multiple_workflows.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Workflows/When_running_multiple_workflows.cs
@@ -14,6 +14,7 @@ public class MediatorMultipleWorkflowFlowTests
     private readonly ITestOutputHelper _testOutputHelper;
     private readonly Scheduler<WorkflowTestData> _scheduler;
     private readonly Runner<WorkflowTestData> _runner;
+    private readonly InMemoryJobChannel<WorkflowTestData> _channel;
     private readonly Job<WorkflowTestData> _firstJob;
     private readonly Job<WorkflowTestData> _secondJob;
     private bool _jobOneCompleted;
@@ -62,14 +63,14 @@ public class MediatorMultipleWorkflowFlowTests
         _secondJob.InitSteps(secondStep);
         
         InMemoryStateStoreAsync store = new();
-        InMemoryJobChannel<WorkflowTestData> channel = new();
-        
+        _channel = new InMemoryJobChannel<WorkflowTestData>();
+
         _scheduler = new Scheduler<WorkflowTestData>(
-            channel,
+            _channel,
             store
         );
-        
-        _runner = new Runner<WorkflowTestData>(channel, store, commandProcessor, _scheduler);
+
+        _runner = new Runner<WorkflowTestData>(_channel, store, commandProcessor, _scheduler);
     }
     
     [Fact]
@@ -77,17 +78,17 @@ public class MediatorMultipleWorkflowFlowTests
     {
         MyCommandHandlerAsync.ReceivedCommands.Clear();
         
-        await _scheduler.ScheduleAsync([_firstJob, _secondJob]); 
-        
+        await _scheduler.ScheduleAsync([_firstJob, _secondJob]);
+        _channel.Stop();
+
         var ct = new CancellationTokenSource();
-        ct.CancelAfter( TimeSpan.FromSeconds(120) );
+        ct.CancelAfter(TimeSpan.FromSeconds(5));
 
         try
         {
-            _ = _runner.RunAsync(ct.Token);
-            await Task.Delay(TimeSpan.FromMilliseconds(100));
+            await _runner.RunAsync(ct.Token);
         }
-        catch (Exception e)
+        catch (OperationCanceledException e)
         {
             _testOutputHelper.WriteLine(e.ToString());
         }


### PR DESCRIPTION
## Summary

Fixes #4078.

`Runner.RunAsync` and `Waker.RunAsync` used `Task.Factory.StartNew(async () => ...)` without `.Unwrap()`. The outer `Task<Task>` signaled completion at the lambda's first `await`, so `Task.WaitAll` returned and "Finished" was logged while `ProcessJobs` / `Wake` was still running on the threadpool. Hosts relying on `RunAsync` returning to know when shutdown completes saw a false signal.

## Changes

- `Runner.RunAsync` / `Waker.RunAsync` now return `Task` and `await Task.Run(() => ProcessJobs(ct), ct)`, so callers actually observe completion. `Task.Run` pins to `TaskScheduler.Default`, also guarding against the deadlock pattern reported in #4071.
- Removed redundant `cancellationToken.ThrowIfCancellationRequested()` calls after `await` and the pointless `if (ct.IsCancellationRequested) ct.ThrowIfCancellationRequested()` guard.
- Moved the "Finished" log into a `finally` block so it fires on both clean exit and cancellation.
- Updated 12 workflow tests: `_runner.RunAsync(ct.Token);` → `_ = _runner.RunAsync(ct.Token); await Task.Delay(100ms);` to preserve the implicit settle window the bug was accidentally providing.

## Test plan

- [x] `dotnet test --filter "FullyQualifiedName~Workflows" -f net9.0` — 12/12 passing
- [x] `dotnet build src/Paramore.Brighter.Mediator` — clean