### PR TITLE
fix: Dispatcher shutdown race leaves late-opened Reactor consumers running (#4075)

### DIFF
--- a/src/Paramore.Brighter.ServiceActivator/Consumer.cs
+++ b/src/Paramore.Brighter.ServiceActivator/Consumer.cs
@@ -78,6 +78,13 @@ namespace Paramore.Brighter.ServiceActivator
 
         public int JobId { get; set; }
 
+        // Guards Open/Shut transitions and the _shutRequested intent so that a Shut() arriving
+        // before Open() is honored when Open() runs (the consumer stays Shut and no performer is
+        // started). Without this, a racing Shut on a not-yet-Open consumer would silently no-op
+        // and the late-opened performer would leak — see Dispatcher.Start() and issue #4075.
+        private readonly object _stateLock = new();
+        private bool _shutRequested;
+
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Consumer"/> class.
@@ -99,9 +106,14 @@ namespace Paramore.Brighter.ServiceActivator
         /// </summary>
         public void Open()
         {
-            State = ConsumerState.Open;
-            Job = Performer.Run();
-            JobId = Job.Id;
+            lock (_stateLock)
+            {
+                if (_shutRequested)
+                    return;
+                State = ConsumerState.Open;
+                Job = Performer.Run();
+                JobId = Job.Id;
+            }
         }
 
         /// <summary>
@@ -110,8 +122,11 @@ namespace Paramore.Brighter.ServiceActivator
         /// <param name="topic">The topic we post the quit message to, in order to shut the perfomer</param>
         public void Shut(RoutingKey topic)
         {
-            if (State == ConsumerState.Open)
+            lock (_stateLock)
             {
+                _shutRequested = true;
+                if (State != ConsumerState.Open)
+                    return;
                 Performer.Stop(topic);
                 State = ConsumerState.Shut;
             }

--- a/src/Paramore.Brighter.ServiceActivator/Consumer.cs
+++ b/src/Paramore.Brighter.ServiceActivator/Consumer.cs
@@ -78,10 +78,8 @@ namespace Paramore.Brighter.ServiceActivator
 
         public int JobId { get; set; }
 
-        // Guards Open/Shut transitions and the _shutRequested intent so that a Shut() arriving
-        // before Open() is honored when Open() runs (the consumer stays Shut and no performer is
-        // started). Without this, a racing Shut on a not-yet-Open consumer would silently no-op
-        // and the late-opened performer would leak — see Dispatcher.Start() and issue #4075.
+        // A Shut() arriving before Open() must keep the consumer Shut, otherwise the
+        // late-opened performer leaks with no way to receive a quit message.
         private readonly object _stateLock = new();
         private bool _shutRequested;
 

--- a/src/Paramore.Brighter.ServiceActivator/Dispatcher.cs
+++ b/src/Paramore.Brighter.ServiceActivator/Dispatcher.cs
@@ -306,8 +306,18 @@ namespace Paramore.Brighter.ServiceActivator
 
             Log.DispatcherStarting(s_logger);
 
-            if (!TryOpenConsumers(startup))
-                return;
+            try
+            {
+                OpenConsumers();
+                State = DispatcherState.DS_RUNNING;
+                startup.TrySetResult(true);
+            }
+            catch (Exception ex)
+            {
+                Log.ErrorOnConsumer(s_logger, ex);
+                startup.TrySetException(ex);
+                throw;
+            }
 
             Log.DispatcherStartingPerformers(s_logger, _tasks.Count);
 
@@ -317,26 +327,13 @@ namespace Paramore.Brighter.ServiceActivator
             Log.DispatcherStopped(s_logger);
         }
 
-        private bool TryOpenConsumers(TaskCompletionSource<bool> startup)
+        private void OpenConsumers()
         {
-            try
+            foreach (var consumer in Consumers)
             {
-                foreach (var consumer in Consumers.OfType<Consumer>())
-                {
-                    consumer.Open();
-                    if (consumer.Job is not null)
-                        _tasks.TryAdd(consumer.JobId, consumer.Job);
-                }
-
-                State = DispatcherState.DS_RUNNING;
-                startup.TrySetResult(true);
-                return true;
-            }
-            catch (Exception ex)
-            {
-                Log.ErrorOnConsumer(s_logger, ex);
-                startup.TrySetException(ex);
-                throw;
+                consumer.Open();
+                if (consumer.Job is not null)
+                    _tasks.TryAdd(consumer.JobId, consumer.Job);
             }
         }
 

--- a/src/Paramore.Brighter.ServiceActivator/Dispatcher.cs
+++ b/src/Paramore.Brighter.ServiceActivator/Dispatcher.cs
@@ -282,68 +282,95 @@ namespace Paramore.Brighter.ServiceActivator
 
         private void Start()
         {
+            // Signals when every consumer has been opened. We block the caller of Start()
+            // on this so that Receive()/Open() cannot return until each performer is Open
+            // and registered. Without this, a Shut()/End() racing in immediately after
+            // Receive() returns would no-op against still-Shut consumers (Consumer.Shut
+            // only acts when State == Open) and the late opens would leak as orphaned
+            // performers, hanging End() in Task.WaitAny. (issue #4075)
+            var startup = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
             _controlTask = Task.Factory.StartNew(() =>
             {
-                if (State == DispatcherState.DS_AWAITING || State == DispatcherState.DS_STOPPED)
+                if (State != DispatcherState.DS_AWAITING && State != DispatcherState.DS_STOPPED)
                 {
-                    Log.DispatcherStarting(s_logger);
-                    State = DispatcherState.DS_RUNNING;
+                    startup.TrySetResult(true);
+                    return;
+                }
 
-                    var consumers = Consumers.ToArray();
-                    consumers.Each(consumer => consumer.Open());
-                    consumers.Each(consumer => _tasks.TryAdd(consumer.JobId, consumer.Job!));
+                Log.DispatcherStarting(s_logger);
 
-                    Log.DispatcherStartingPerformers(s_logger, _tasks.Count);
-
-                    while (_tasks.Any())
+                Consumer[] consumers;
+                try
+                {
+                    consumers = Consumers.OfType<Consumer>().ToArray();
+                    foreach (var consumer in consumers)
                     {
-                        try
-                        {
-                            var runningTasks = _tasks.Values.ToArray();
-                            var index = Task.WaitAny(runningTasks);
-                            var stoppingConsumer = runningTasks[index];
-                            Log.PerformerStopped(s_logger, stoppingConsumer.Status);
-
-                            var consumer = Consumers.SingleOrDefault(c => c.JobId == stoppingConsumer.Id);
-                            if (consumer != null)
-                            {
-                                Log.RemovingConsumer(s_logger, consumer.Name);
-
-                                if (_consumers.TryRemove(consumer.Name, out consumer))
-                                {
-                                    consumer.Dispose();
-                                }
-                            }
-
-                            if (_tasks.TryRemove(stoppingConsumer.Id, out var removedTask))
-                            {
-                                removedTask?.Dispose();
-                            }
-
-                            stoppingConsumer.Dispose();
-                        }
-                        catch (AggregateException ae)
-                        {
-                            ae.Handle(ex =>
-                            {
-                                Log.ErrorOnConsumer(s_logger, ex);
-                                return true;
-                            });
-                        }
+                        consumer.Open();
+                        if (consumer.Job is not null)
+                            _tasks.TryAdd(consumer.JobId, consumer.Job);
                     }
 
-                    State = DispatcherState.DS_STOPPED;
-                    Log.DispatcherStopped(s_logger);
+                    // Publish DS_RUNNING only after every consumer is Open. The TCS below
+                    // provides the happens-before edge: callers waiting on startup.Task
+                    // will observe both the state flip and the consumer opens.
+                    State = DispatcherState.DS_RUNNING;
+                    startup.TrySetResult(true);
                 }
+                catch (Exception ex)
+                {
+                    Log.ErrorOnConsumer(s_logger, ex);
+                    startup.TrySetException(ex);
+                    throw;
+                }
+
+                Log.DispatcherStartingPerformers(s_logger, _tasks.Count);
+
+                while (!_tasks.IsEmpty)
+                {
+                    try
+                    {
+                        var runningTasks = _tasks.Values.ToArray();
+                        var index = Task.WaitAny(runningTasks);
+                        var stoppingConsumer = runningTasks[index];
+                        Log.PerformerStopped(s_logger, stoppingConsumer.Status);
+
+                        var consumer = Consumers.SingleOrDefault(c => c.JobId == stoppingConsumer.Id);
+                        if (consumer != null)
+                        {
+                            Log.RemovingConsumer(s_logger, consumer.Name);
+
+                            if (_consumers.TryRemove(consumer.Name, out consumer))
+                            {
+                                consumer.Dispose();
+                            }
+                        }
+
+                        if (_tasks.TryRemove(stoppingConsumer.Id, out var removedTask))
+                        {
+                            removedTask?.Dispose();
+                        }
+
+                        stoppingConsumer.Dispose();
+                    }
+                    catch (AggregateException ae)
+                    {
+                        ae.Handle(ex =>
+                        {
+                            Log.ErrorOnConsumer(s_logger, ex);
+                            return true;
+                        });
+                    }
+                }
+
+                State = DispatcherState.DS_STOPPED;
+                Log.DispatcherStopped(s_logger);
             },
             CancellationToken.None,
             TaskCreationOptions.LongRunning,
             TaskScheduler.Default);
 
-            while (State != DispatcherState.DS_RUNNING)
-            {
-                Thread.Sleep(100); //Block main Dispatcher thread whilst control plane starts
-            }
+            startup.Task.GetAwaiter().GetResult();
         }
 
         private IEnumerable<Consumer> CreateConsumers(IEnumerable<Subscription> subscriptions)

--- a/src/Paramore.Brighter.ServiceActivator/Dispatcher.cs
+++ b/src/Paramore.Brighter.ServiceActivator/Dispatcher.cs
@@ -287,84 +287,107 @@ namespace Paramore.Brighter.ServiceActivator
             // late-opened performer leaks and End() hangs forever in Task.WaitAny.
             var startup = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-            _controlTask = Task.Factory.StartNew(() =>
-            {
-                if (State != DispatcherState.DS_AWAITING && State != DispatcherState.DS_STOPPED)
-                {
-                    startup.TrySetResult(true);
-                    return;
-                }
-
-                Log.DispatcherStarting(s_logger);
-
-                Consumer[] consumers;
-                try
-                {
-                    consumers = Consumers.OfType<Consumer>().ToArray();
-                    foreach (var consumer in consumers)
-                    {
-                        consumer.Open();
-                        if (consumer.Job is not null)
-                            _tasks.TryAdd(consumer.JobId, consumer.Job);
-                    }
-
-                    State = DispatcherState.DS_RUNNING;
-                    startup.TrySetResult(true);
-                }
-                catch (Exception ex)
-                {
-                    Log.ErrorOnConsumer(s_logger, ex);
-                    startup.TrySetException(ex);
-                    throw;
-                }
-
-                Log.DispatcherStartingPerformers(s_logger, _tasks.Count);
-
-                while (!_tasks.IsEmpty)
-                {
-                    try
-                    {
-                        var runningTasks = _tasks.Values.ToArray();
-                        var index = Task.WaitAny(runningTasks);
-                        var stoppingConsumer = runningTasks[index];
-                        Log.PerformerStopped(s_logger, stoppingConsumer.Status);
-
-                        var consumer = Consumers.SingleOrDefault(c => c.JobId == stoppingConsumer.Id);
-                        if (consumer != null)
-                        {
-                            Log.RemovingConsumer(s_logger, consumer.Name);
-
-                            if (_consumers.TryRemove(consumer.Name, out consumer))
-                            {
-                                consumer.Dispose();
-                            }
-                        }
-
-                        if (_tasks.TryRemove(stoppingConsumer.Id, out var removedTask))
-                        {
-                            removedTask?.Dispose();
-                        }
-
-                        stoppingConsumer.Dispose();
-                    }
-                    catch (AggregateException ae)
-                    {
-                        ae.Handle(ex =>
-                        {
-                            Log.ErrorOnConsumer(s_logger, ex);
-                            return true;
-                        });
-                    }
-                }
-
-                State = DispatcherState.DS_STOPPED;
-                Log.DispatcherStopped(s_logger);
-            },
-            CancellationToken.None,
-            TaskCreationOptions.LongRunning,
-            TaskScheduler.Default);
+            _controlTask = Task.Factory.StartNew(
+                () => RunControlLoop(startup),
+                CancellationToken.None,
+                TaskCreationOptions.LongRunning,
+                TaskScheduler.Default);
 
             startup.Task.GetAwaiter().GetResult();
+        }
+
+        private void RunControlLoop(TaskCompletionSource<bool> startup)
+        {
+            if (State != DispatcherState.DS_AWAITING && State != DispatcherState.DS_STOPPED)
+            {
+                startup.TrySetResult(true);
+                return;
+            }
+
+            Log.DispatcherStarting(s_logger);
+
+            if (!TryOpenConsumers(startup))
+                return;
+
+            Log.DispatcherStartingPerformers(s_logger, _tasks.Count);
+
+            WaitForPerformersToStop();
+
+            State = DispatcherState.DS_STOPPED;
+            Log.DispatcherStopped(s_logger);
+        }
+
+        private bool TryOpenConsumers(TaskCompletionSource<bool> startup)
+        {
+            try
+            {
+                foreach (var consumer in Consumers.OfType<Consumer>())
+                {
+                    consumer.Open();
+                    if (consumer.Job is not null)
+                        _tasks.TryAdd(consumer.JobId, consumer.Job);
+                }
+
+                State = DispatcherState.DS_RUNNING;
+                startup.TrySetResult(true);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Log.ErrorOnConsumer(s_logger, ex);
+                startup.TrySetException(ex);
+                throw;
+            }
+        }
+
+        private void WaitForPerformersToStop()
+        {
+            while (!_tasks.IsEmpty)
+            {
+                try
+                {
+                    HandleNextStoppedPerformer();
+                }
+                catch (AggregateException ae)
+                {
+                    ae.Handle(ex =>
+                    {
+                        Log.ErrorOnConsumer(s_logger, ex);
+                        return true;
+                    });
+                }
+            }
+        }
+
+        private void HandleNextStoppedPerformer()
+        {
+            var runningTasks = _tasks.Values.ToArray();
+            var index = Task.WaitAny(runningTasks);
+            var stoppingConsumer = runningTasks[index];
+            Log.PerformerStopped(s_logger, stoppingConsumer.Status);
+
+            RemoveConsumerForTask(stoppingConsumer);
+
+            if (_tasks.TryRemove(stoppingConsumer.Id, out var removedTask))
+            {
+                removedTask?.Dispose();
+            }
+
+            stoppingConsumer.Dispose();
+        }
+
+        private void RemoveConsumerForTask(Task stoppingConsumer)
+        {
+            var consumer = Consumers.SingleOrDefault(c => c.JobId == stoppingConsumer.Id);
+            if (consumer is null)
+                return;
+
+            Log.RemovingConsumer(s_logger, consumer.Name);
+
+            if (_consumers.TryRemove(consumer.Name, out consumer))
+            {
+                consumer.Dispose();
+            }
         }
 
         private IEnumerable<Consumer> CreateConsumers(IEnumerable<Subscription> subscriptions)

--- a/src/Paramore.Brighter.ServiceActivator/Dispatcher.cs
+++ b/src/Paramore.Brighter.ServiceActivator/Dispatcher.cs
@@ -282,12 +282,9 @@ namespace Paramore.Brighter.ServiceActivator
 
         private void Start()
         {
-            // Signals when every consumer has been opened. We block the caller of Start()
-            // on this so that Receive()/Open() cannot return until each performer is Open
-            // and registered. Without this, a Shut()/End() racing in immediately after
-            // Receive() returns would no-op against still-Shut consumers (Consumer.Shut
-            // only acts when State == Open) and the late opens would leak as orphaned
-            // performers, hanging End() in Task.WaitAny. (issue #4075)
+            // Block Start() callers until every consumer is Open. A Shut()/End() racing in
+            // immediately after Receive() returns must not see a still-Shut consumer, or the
+            // late-opened performer leaks and End() hangs forever in Task.WaitAny.
             var startup = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             _controlTask = Task.Factory.StartNew(() =>
@@ -311,9 +308,6 @@ namespace Paramore.Brighter.ServiceActivator
                             _tasks.TryAdd(consumer.JobId, consumer.Job);
                     }
 
-                    // Publish DS_RUNNING only after every consumer is Open. The TCS below
-                    // provides the happens-before edge: callers waiting on startup.Task
-                    // will observe both the state flip and the consumer opens.
                     State = DispatcherState.DS_RUNNING;
                     startup.TrySetResult(true);
                 }

--- a/tests/Paramore.Brighter.Core.Tests/MessageDispatch/Reactor/When_dispatcher_shuts_immediately_after_receive_should_not_hang.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageDispatch/Reactor/When_dispatcher_shuts_immediately_after_receive_should_not_hang.cs
@@ -11,15 +11,8 @@ using Xunit;
 
 namespace Paramore.Brighter.Core.Tests.MessageDispatch.Reactor
 {
-    // Regression for issue #4075:
-    //   Dispatcher.Start() flips State = DS_RUNNING BEFORE consumers are opened, so Receive()
-    //   can return while some consumers are still in ConsumerState.Shut. A Shut()/End() that
-    //   races into that window is a no-op for those consumers (Consumer.Shut only acts when
-    //   State == Open). The control task subsequently opens them, and they run forever
-    //   without a quit message — End() then hangs in Task.WaitAny.
-    //
-    // Invariant: Receive() must not return until every consumer is Open. After that, an
-    // immediate Shut + End must complete in bounded time.
+    // Regression for #4075: Receive() must not return until every consumer is Open,
+    // so an immediately-following Shut()/End() always reaches a running performer.
     public class DispatcherShutImmediatelyAfterReceiveTests
     {
         private const string ChannelName = "fakeChannel";

--- a/tests/Paramore.Brighter.Core.Tests/MessageDispatch/Reactor/When_dispatcher_shuts_immediately_after_receive_should_not_hang.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageDispatch/Reactor/When_dispatcher_shuts_immediately_after_receive_should_not_hang.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Time.Testing;
+using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
+using Paramore.Brighter.Core.Tests.MessageDispatch.TestDoubles;
+using Paramore.Brighter.Testing;
+using Paramore.Brighter.ServiceActivator;
+using Xunit;
+
+namespace Paramore.Brighter.Core.Tests.MessageDispatch.Reactor
+{
+    // Regression for issue #4075:
+    //   Dispatcher.Start() flips State = DS_RUNNING BEFORE consumers are opened, so Receive()
+    //   can return while some consumers are still in ConsumerState.Shut. A Shut()/End() that
+    //   races into that window is a no-op for those consumers (Consumer.Shut only acts when
+    //   State == Open). The control task subsequently opens them, and they run forever
+    //   without a quit message — End() then hangs in Task.WaitAny.
+    //
+    // Invariant: Receive() must not return until every consumer is Open. After that, an
+    // immediate Shut + End must complete in bounded time.
+    public class DispatcherShutImmediatelyAfterReceiveTests
+    {
+        private const string ChannelName = "fakeChannel";
+        private static readonly RoutingKey RoutingKey = new("fakekey");
+
+        [Fact]
+        public void When_Receive_Returns_All_Consumers_Are_Open()
+        {
+            for (var iteration = 0; iteration < 50; iteration++)
+            {
+                var dispatcher = BuildDispatcher(noOfPerformers: 5, subscriptionName: $"open-{iteration}");
+
+                dispatcher.Receive();
+
+                try
+                {
+                    var notOpen = dispatcher.Consumers
+                        .Where(c => c.State != ConsumerState.Open)
+                        .Select(c => c.Name.ToString())
+                        .ToArray();
+
+                    Assert.True(notOpen.Length == 0,
+                        $"Iteration {iteration}: Receive() returned with consumers still Shut: [{string.Join(", ", notOpen)}]");
+                }
+                finally
+                {
+                    DrainDispatcher(dispatcher);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task When_Shut_Called_Immediately_After_Receive_End_Completes()
+        {
+            var hangTimeout = TimeSpan.FromSeconds(10);
+
+            for (var iteration = 0; iteration < 25; iteration++)
+            {
+                var subscriptionName = new SubscriptionName($"shut-{iteration}");
+                var dispatcher = BuildDispatcher(noOfPerformers: 5, subscriptionName: subscriptionName.Value);
+                var subscription = dispatcher.Subscriptions.Single(s => s.Name == subscriptionName);
+
+                dispatcher.Receive();
+                dispatcher.Shut(subscription);
+
+                var endTask = dispatcher.End();
+                var winner = await Task.WhenAny(endTask, Task.Delay(hangTimeout));
+
+                Assert.True(ReferenceEquals(winner, endTask),
+                    $"Iteration {iteration}: End() did not complete within {hangTimeout}; orphaned performers leaked. " +
+                    $"State={dispatcher.State}, openConsumers={dispatcher.Consumers.Count(c => c.State == ConsumerState.Open)}");
+
+                Assert.Equal(DispatcherState.DS_STOPPED, dispatcher.State);
+                Assert.Empty(dispatcher.Consumers);
+            }
+        }
+
+        [Fact]
+        public async Task When_End_Called_Immediately_After_Receive_End_Completes()
+        {
+            var hangTimeout = TimeSpan.FromSeconds(10);
+
+            for (var iteration = 0; iteration < 25; iteration++)
+            {
+                var dispatcher = BuildDispatcher(noOfPerformers: 5, subscriptionName: $"end-{iteration}");
+
+                dispatcher.Receive();
+
+                var endTask = dispatcher.End();
+                var winner = await Task.WhenAny(endTask, Task.Delay(hangTimeout));
+
+                Assert.True(ReferenceEquals(winner, endTask),
+                    $"Iteration {iteration}: End() did not complete within {hangTimeout}; orphaned performers leaked. " +
+                    $"State={dispatcher.State}, openConsumers={dispatcher.Consumers.Count(c => c.State == ConsumerState.Open)}");
+
+                Assert.Equal(DispatcherState.DS_STOPPED, dispatcher.State);
+                Assert.Empty(dispatcher.Consumers);
+            }
+        }
+
+        private static Dispatcher BuildDispatcher(int noOfPerformers, string subscriptionName)
+        {
+            var bus = new InternalBus();
+            var commandProcessor = new SpyCommandProcessor();
+
+            var messageMapperRegistry = new MessageMapperRegistry(
+                new SimpleMessageMapperFactory(_ => new MyEventMessageMapper()),
+                null);
+            messageMapperRegistry.Register<MyEvent, MyEventMessageMapper>();
+
+            var subscription = new Subscription<MyEvent>(
+                new SubscriptionName(subscriptionName),
+                noOfPerformers: noOfPerformers,
+                timeOut: TimeSpan.FromMilliseconds(100),
+                channelFactory: new InMemoryChannelFactory(bus, new FakeTimeProvider()),
+                channelName: new ChannelName(ChannelName),
+                messagePumpType: MessagePumpType.Reactor,
+                routingKey: RoutingKey
+            );
+
+            return new Dispatcher(commandProcessor, new List<Subscription> { subscription }, messageMapperRegistry);
+        }
+
+        private static void DrainDispatcher(Dispatcher dispatcher)
+        {
+            if (dispatcher.State != DispatcherState.DS_RUNNING)
+                return;
+
+            foreach (var subscription in dispatcher.Subscriptions)
+                dispatcher.Shut(subscription);
+
+            dispatcher.End().Wait(TimeSpan.FromSeconds(10));
+        }
+    }
+}


### PR DESCRIPTION
Fixes #4075.

## Root cause

`Dispatcher.Start()` flipped `State = DS_RUNNING` *before* opening consumers, so `Receive()`'s 100ms busy-wait could return while some consumers were still in `ConsumerState.Shut`. A `Shut(subscription)` or `End()` call racing into that window would no-op against those consumers — `Consumer.Shut()` only enqueues a quit when `State == Open`. The control task then opened them, leaving orphaned Reactor performers parked in `Task.Delay(EmptyChannelDelay).GetAwaiter().GetResult()` with no way to receive a quit message. `End()` returned the control task, which was blocked in `Task.WaitAny` waiting for performers that would never stop.

This matches the hang dump in #4075 exactly: control task in `WaitAny`, two Reactor performers parked in `Task.Delay`.

## Fix

Two layers:

1. **`Dispatcher.Start()`** — open every consumer and register its task *before* publishing `State = DS_RUNNING`. Replaced the 100ms busy-wait poll with a `TaskCompletionSource<bool>`, which gives callers of `Start()` an explicit happens-before edge over the opens — `Receive()` cannot return until every performer is `Open`. Exceptions during open propagate to the caller via `TrySetException` so it never deadlocks.

2. **`Consumer`** — added a state lock + `_shutRequested` flag. A `Shut()` arriving before `Open()` records intent; the subsequent `Open()` honours it and stays `Shut` (no performer is started). `Dispatcher.Start()` filters out consumers whose `Job` is null when registering tasks. This is defence in depth for any future caller path that opens consumers off the control task.

## Verification

New regression test: `tests/Paramore.Brighter.Core.Tests/MessageDispatch/Reactor/When_dispatcher_shuts_immediately_after_receive_should_not_hang.cs` — three invariants, each looped 25–50 iterations to amplify the race:

- `Receive()` post-condition: every consumer is `Open`.
- `Shut` immediately after `Receive` → `End` finishes within 10s.
- `End` immediately after `Receive` → finishes within 10s.

Pre-fix: all three fail (matches reporter's iter-16 local repro). Post-fix: 3/3 green. Full `MessageDispatch` suite (83 tests) passes on both `net9.0` and `net10.0`.

## Test plan

- [x] `dotnet test --filter FullyQualifiedName~DispatcherShutImmediatelyAfterReceiveTests` — green
- [x] `dotnet test --filter FullyQualifiedName~MessageDispatch` — 83/83 green on net9.0 + net10.0
- [x] `dotnet test --filter "FullyQualifiedName~ControlBus|FullyQualifiedName~ServiceActivator"` — green
- [ ] CI run for the originally-flaky `When_A_Message_Dispatcher_Shuts_A_Connection` and `When_A_Message_Dispatcher_Restarts_A_Connection_After_All_Connections_Have_Stopped`