### PR TITLE
fix: use TimeProvider for span end time in BrighterTracer (#4087)

### DIFF
--- a/src/Paramore.Brighter/Observability/BrighterTracer.cs
+++ b/src/Paramore.Brighter/Observability/BrighterTracer.cs
@@ -620,9 +620,11 @@ public class BrighterTracer : IAmABrighterTracer
     /// <param name="span">The span to end</param>
     public void EndSpan(Activity? span)
     {
-        if (span?.Status == ActivityStatusCode.Unset)
+        if (span is null) return;
+        if (span.Status == ActivityStatusCode.Unset)
             span.SetStatus(ActivityStatusCode.Ok);
-        span?.Dispose();
+        span.SetEndTime(_timeProvider.GetUtcNow().UtcDateTime);
+        span.Dispose();
     }
 
     /// <summary>

--- a/tests/Paramore.Brighter.Core.Tests/Observability/Common/When_Ending_A_Span_Use_TimeProvider_For_End_Time.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Observability/Common/When_Ending_A_Span_Use_TimeProvider_For_End_Time.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Diagnostics;
+using Microsoft.Extensions.Time.Testing;
+using OpenTelemetry;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+using Paramore.Brighter.Core.Tests.CommandProcessors.TestDoubles;
+using Paramore.Brighter.Observability;
+using Xunit;
+
+namespace Paramore.Brighter.Core.Tests.Observability.Common;
+
+public class BrighterTracerEndSpanTimeProviderTests : IDisposable
+{
+    private readonly TracerProvider _traceProvider;
+    private readonly Activity _parentActivity;
+
+    public BrighterTracerEndSpanTimeProviderTests()
+    {
+        _traceProvider = Sdk.CreateTracerProviderBuilder()
+            .AddSource("Paramore.Brighter.Tests", "Paramore.Brighter")
+            .ConfigureResource(r => r.AddService("in-memory-tracer"))
+            .Build();
+
+        _parentActivity = new ActivitySource("Paramore.Brighter.Tests")
+            .StartActivity("BrighterTracerEndSpanTimeProviderTests");
+    }
+
+    [Fact]
+    public void When_Ending_A_Span_Duration_Reflects_TimeProvider()
+    {
+        //arrange
+        var fakeTime = new FakeTimeProvider(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        var tracer = new BrighterTracer(fakeTime);
+        var command = new MyCommand { Value = "duration" };
+
+        //act
+        var span = tracer.CreateSpan(
+            CommandProcessorSpanOperation.Send,
+            command,
+            _parentActivity,
+            options: InstrumentationOptions.All);
+
+        fakeTime.Advance(TimeSpan.FromSeconds(5));
+
+        tracer.EndSpan(span);
+
+        //assert
+        Assert.NotNull(span);
+        Assert.Equal(TimeSpan.FromSeconds(5), span!.Duration);
+    }
+
+    public void Dispose()
+    {
+        _parentActivity.Dispose();
+        _traceProvider.Dispose();
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #4087.

`BrighterTracer.EndSpan` disposed the `Activity` without setting an explicit end time, so `Activity.Stop` (called from `Dispose`) fell back to raw `DateTime.UtcNow` and ignored the injected `TimeProvider`. Span start times use `_timeProvider.GetUtcNow()`, but end times did not — under any non-system `TimeProvider` (e.g. `FakeTimeProvider` in tests) the start used simulated time and the end used real wall clock, so `Activity.Duration` was wildly wrong (often hundreds of days off, depending on how far the simulated clock was from real time).

## Change

`src/Paramore.Brighter/Observability/BrighterTracer.cs` — `EndSpan` now calls `span.SetEndTime(_timeProvider.GetUtcNow().UtcDateTime)` before `Dispose()`. `Activity.Stop` honours the explicit end time when one has been set, so the duration is now `(end via TimeProvider) - (start via TimeProvider)` and is correct under both `TimeProvider.System` (production) and any custom provider (tests, deterministic replay, scheduling integration).

`EndSpans` flows through `EndSpan`, so it is covered without further change.

## Test plan

- [x] New test `BrighterTracerEndSpanTimeProviderTests.When_Ending_A_Span_Duration_Reflects_TimeProvider` creates a span under `FakeTimeProvider`, advances by 5s, ends the span, and asserts `Duration == TimeSpan.FromSeconds(5)`.
- [x] Confirmed RED before the fix: failed with `Expected 00:00:05, Actual 115.13:19:00…` (wall-clock leak).
- [x] Confirmed GREEN after the fix.
- [x] Full Observability suite still passes (61 passed, 2 pre-existing skips, 0 failures) on `net9.0`.

## Notes

The issue also called out an optional secondary fix — moving the `now` snapshot to immediately before `StartActivity` in each `Create*Span` method so tag-construction overhead (`JsonSerializer.Serialize(...)` for `Header`/`Body`) is excluded from span start. That is acknowledged in the issue as "negligible in production" and is not addressed here to keep this change minimal and focused on the correctness bug. Happy to follow up in a separate PR if desired.