### PR TITLE
docs: improve documentation visibility across GitHub touchpoints

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,6 +4,8 @@ about: Create a report about something that is not working
 labels: 'bug'
 ---
 
+> 📖 **Before filing a bug**, please check the [documentation](https://brightercommand.gitbook.io/paramore-brighter-documentation/) to see if your issue is covered.
+
 ### Describe the bug
 A clear and concise description of what the bug is.
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,6 +7,8 @@ assignees: ''
 
 ---
 
+> 📖 **Before requesting a feature**, please check the [documentation](https://brightercommand.gitbook.io/paramore-brighter-documentation/) to see if the functionality already exists.
+
 **Is your feature request related to a problem? Please describe.**
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,9 +6,16 @@
 
 <!-- Link any related issues: Fixes #123, Closes #456 -->
 
+## Type of Change
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+- [ ] Documentation update
+
 ## Checklist
 
-- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
+- [ ] I have read the [Contributing Guide](CONTRIBUTING.md)
 - [ ] I have checked the [documentation](https://brightercommand.gitbook.io/paramore-brighter-documentation/) for relevant guidance
 - [ ] I have added/updated XML documentation for any public API changes
 - [ ] I have added/updated tests as appropriate

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## Description
+
+<!-- Briefly describe what this PR does and why -->
+
+## Related Issues
+
+<!-- Link any related issues: Fixes #123, Closes #456 -->
+
+## Checklist
+
+- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
+- [ ] I have checked the [documentation](https://brightercommand.gitbook.io/paramore-brighter-documentation/) for relevant guidance
+- [ ] I have added/updated XML documentation for any public API changes
+- [ ] I have added/updated tests as appropriate
+- [ ] My changes follow the existing code style and conventions
+
+## Additional Notes
+
+<!-- Any additional context, screenshots, or notes for reviewers -->

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@
 [![Coverity Scan Build Status](https://scan.coverity.com/projects/2900/badge.svg)](https://scan.coverity.com/projects/2900)
 [![CodeScene Code Health](https://codescene.io/projects/32198/status-badges/code-health)](https://codescene.io/projects/32198)
 ![CodeScene System Mastery](https://codescene.io/projects/32198/status-badges/system-mastery)
+[![Documentation](https://img.shields.io/badge/docs-GitBook-blue?logo=gitbook)](https://brightercommand.gitbook.io/paramore-brighter-documentation/)
+
+> 📖 **New to Brighter?** Check out the **[full documentation](https://brightercommand.gitbook.io/paramore-brighter-documentation/)** for guides, tutorials, and API reference.
 
 **Brighter is a Command Dispatcher and Command Processor framework for .NET**. It enables you to build loosely coupled, maintainable applications using the Command pattern and supports both in-process and out-of-process messaging for microservices architectures. Its companion project, **[Darker](https://github.com/BrighterCommand/Darker)**, provides the query side for CQRS architectures.
 


### PR DESCRIPTION
## Summary

- **README**: Added a GitBook documentation badge in the badge row and a callout banner directing new users to the full docs
- **Issue templates**: Added documentation links to both bug report and feature request templates so users check docs before filing
- **PR template**: Created `.github/PULL_REQUEST_TEMPLATE.md` with a docs checklist item
