### PR TITLE
fix: InternalBus.Enqueue loses messages under concurrent first-write contention (#4098)

### DIFF
--- a/src/Paramore.Brighter/InternalBus.cs
+++ b/src/Paramore.Brighter/InternalBus.cs
@@ -52,16 +52,11 @@ public class InternalBus(int boundedCapacity = -1) : IAmABus
         ValidateMillisecondsTimeout(timeout.Value);
         
         var topic = new RoutingKey(message.Header.Topic);
-        
-        if (!_messages.TryGetValue(topic, out var blockingCollection))
-        {
-            blockingCollection = boundedCapacity > 0 ? 
-                new BlockingCollection<Message>(boundedCapacity) : new BlockingCollection<Message>();
-            
-            if (!_messages.TryAdd(topic, blockingCollection) && !_messages.ContainsKey(topic))
-                throw new InvalidOperationException("Failed to add topic to the bus");
-        }
-        
+
+        var blockingCollection = _messages.GetOrAdd(topic, _ => boundedCapacity > 0
+            ? new BlockingCollection<Message>(boundedCapacity)
+            : new BlockingCollection<Message>());
+
         if (!blockingCollection.TryAdd(message, Convert.ToInt32(timeout.Value.TotalMilliseconds), CancellationToken.None))
             throw new InvalidOperationException("Failed to add message to the bus");
     }

--- a/tests/Paramore.Brighter.InMemory.Tests/Bus/When_concurrently_enqueueing_to_a_fresh_routing_key.cs
+++ b/tests/Paramore.Brighter.InMemory.Tests/Bus/When_concurrently_enqueueing_to_a_fresh_routing_key.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Paramore.Brighter.InMemory.Tests.Bus;
+
+public class InternalBusConcurrentEnqueueTests
+{
+    [Fact]
+    public void When_concurrently_enqueueing_to_a_fresh_routing_key_no_messages_are_lost()
+    {
+        // Reproduces issue #4098: TOCTOU race in InternalBus.Enqueue caused the
+        // losing thread of a concurrent first-write to enqueue into a dangling
+        // BlockingCollection that was never published to the dictionary.
+        const int iterations = 200;
+        const int producersPerIteration = 4;
+        var lostIterations = new List<(string Topic, int Expected, int Actual)>();
+
+        for (var i = 0; i < iterations; i++)
+        {
+            var internalBus = new InternalBus();
+            var routingKey = new RoutingKey($"concurrent-fresh-{Guid.NewGuid():N}");
+            using var startGate = new ManualResetEventSlim(false);
+
+            var producers = Enumerable.Range(0, producersPerIteration)
+                .Select(producerIndex => Task.Run(() =>
+                {
+                    startGate.Wait();
+                    var message = new Message(
+                        new MessageHeader(Guid.NewGuid().ToString(), routingKey, MessageType.MT_COMMAND),
+                        new MessageBody($"body-{producerIndex}"));
+                    internalBus.Enqueue(message);
+                }))
+                .ToArray();
+
+            startGate.Set();
+            Task.WaitAll(producers);
+
+            var observed = internalBus.Stream(routingKey).Count();
+            if (observed != producersPerIteration)
+            {
+                lostIterations.Add((routingKey.Value, producersPerIteration, observed));
+            }
+        }
+
+        Assert.True(
+            lostIterations.Count == 0,
+            $"InternalBus dropped messages on {lostIterations.Count}/{iterations} iterations: " +
+            string.Join("; ", lostIterations.Take(5).Select(l => $"{l.Topic} expected={l.Expected} actual={l.Actual}")));
+    }
+}


### PR DESCRIPTION
## Summary
- Fixes #4098. `InternalBus.Enqueue` had a TOCTOU race where two threads enqueueing to a routing key for the first time could each create their own `BlockingCollection`; the loser of the `TryAdd` race kept its local instance and silently dropped the message, since `Stream`/`Dequeue` only read the winner's collection.
- Replaces the `TryGetValue` + `TryAdd` pattern with `ConcurrentDictionary.GetOrAdd`, so both racers end up enqueuing into the same stored collection. Hot path stays a single dictionary lookup.
- Adds a regression test (200 iterations × 4 concurrent producers per fresh key) that reliably reproduced 6–57 lost-message iterations before the fix and is clean after.

## Test plan
- [x] New test fails on `master` (reproduces message loss)
- [x] New test passes after the fix
- [x] Full `Paramore.Brighter.InMemory.Tests` suite green on net9.0 and net10.0 (125/125)