### PR TITLE
feat: move AWS resource cleanup to dedicated workflow with scheduler support

### DIFF
--- a/.github/workflows/aws-cleanup.yml
+++ b/.github/workflows/aws-cleanup.yml
@@ -9,6 +9,9 @@ on:
     - cron: '0 */6 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   cleanup:
     runs-on: ubuntu-latest
@@ -23,6 +26,9 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Wait for tag propagation
+        # The AWS Resource Groups Tagging API is eventually consistent.
+        # Resources created shortly before CI completes may not yet be discoverable by tag.
+        # 15 seconds provides sufficient margin based on observed propagation times.
         run: sleep 15
 
       - name: Cleanup orphaned test resources

--- a/.github/workflows/aws-cleanup.yml
+++ b/.github/workflows/aws-cleanup.yml
@@ -1,0 +1,31 @@
+name: AWS Test Resource Cleanup
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+  schedule:
+    # Safety net: run every 6 hours to catch any orphaned resources
+    - cron: '0 */6 * * *'
+  workflow_dispatch:
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_REGION: us-west-2
+      AWS_DEFAULT_OUTPUT: json
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Wait for tag propagation
+        run: sleep 15
+
+      - name: Cleanup orphaned test resources
+        run: |
+          chmod +x ./clean_failed_tests_aws_assets.sh
+          ./clean_failed_tests_aws_assets.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -519,12 +519,6 @@ jobs:
         run: |
           dotnet test ./tests/Paramore.Brighter.AWS.Tests/Paramore.Brighter.AWS.Tests.csproj --filter "Fragile!=CI" --configuration Release --logger "console;verbosity=normal" --logger GitHubActions --blame -v n
           dotnet test ./tests/Paramore.Brighter.AWS.V4.Tests/Paramore.Brighter.AWS.V4.Tests.csproj --filter "Fragile!=CI" --configuration Release --logger "console;verbosity=normal" --logger GitHubActions --blame -v n
-      - name: Cleanup orphaned test resources
-        if: always()
-        run: |
-          chmod +x ./clean_failed_tests_aws_assets.sh
-          ./clean_failed_tests_aws_assets.sh
-        continue-on-error: true
 
   aws-scheduler-ci:
     runs-on: ubuntu-latest
@@ -559,12 +553,6 @@ jobs:
         run: |
           dotnet test ./tests/Paramore.Brighter.AWSScheduler.Tests/Paramore.Brighter.AWSScheduler.Tests.csproj --filter "Fragile!=CI" --configuration Release --logger "console;verbosity=normal" --logger GitHubActions --blame -v n
           dotnet test ./tests/Paramore.Brighter.AWSScheduler.V4.Tests/Paramore.Brighter.AWSScheduler.V4.Tests.csproj --filter "Fragile!=CI" --configuration Release --logger "console;verbosity=normal" --logger GitHubActions --blame -v n
-      - name: Cleanup orphaned test resources
-        if: always()
-        run: |
-          chmod +x ./clean_failed_tests_aws_assets.sh
-          ./clean_failed_tests_aws_assets.sh
-        continue-on-error: true
 
   sqlite-ci:
     runs-on: ubuntu-latest

--- a/clean_failed_tests_aws_assets.sh
+++ b/clean_failed_tests_aws_assets.sh
@@ -16,11 +16,11 @@ if [[ "${1:-}" == "--dry-run" ]]; then
 fi
 
 # --- Helper: delete all schedules in a given group ---
-# Uses --no-paginate to ensure all schedules are returned (not just first page of 100).
+# AWS CLI v2 auto-paginates by default, so all schedules are returned across pages.
 delete_schedules_in_group() {
     local group_name="$1"
     local schedules
-    schedules=$(aws scheduler list-schedules --group-name "$group_name" --no-paginate \
+    schedules=$(aws scheduler list-schedules --group-name "$group_name" \
         --query 'Schedules[*].Name' --output text 2>&1 || echo "")
     for sched_name in $schedules; do
         [[ -z "$sched_name" || "$sched_name" == "None" ]] && continue
@@ -176,10 +176,11 @@ if [[ ${#SCHEDULE_GROUPS[@]} -gt 0 ]]; then
 fi
 
 # --- Also clean up Brighter-tagged schedule groups (Source=Brighter) not caught above ---
-# The AwsSchedulerFactory tags groups with Source=Brighter but tests may not add Environment=Test.
+# The AwsSchedulerFactory tags groups with Source=Brighter. We require both Source=Brighter
+# AND Environment=Test to avoid accidentally deleting non-test resources in shared accounts.
 echo "Checking for Brighter-tagged schedule groups ..."
 BRIGHTER_GROUPS=$(aws resourcegroupstaggingapi get-resources \
-    --tag-filters Key=Source,Values=Brighter \
+    --tag-filters Key=Source,Values=Brighter Key=Environment,Values=Test \
     --resource-type-filters scheduler:schedule-group \
     --query 'ResourceTagMappingList[*].ResourceARN' \
     --output text 2>&1 || echo "")

--- a/clean_failed_tests_aws_assets.sh
+++ b/clean_failed_tests_aws_assets.sh
@@ -15,6 +15,25 @@ if [[ "${1:-}" == "--dry-run" ]]; then
     echo "[DRY RUN] No resources will be deleted"
 fi
 
+# --- Helper: delete all schedules in a given group ---
+# Uses --no-paginate to ensure all schedules are returned (not just first page of 100).
+delete_schedules_in_group() {
+    local group_name="$1"
+    local schedules
+    schedules=$(aws scheduler list-schedules --group-name "$group_name" --no-paginate \
+        --query 'Schedules[*].Name' --output text 2>&1 || echo "")
+    for sched_name in $schedules; do
+        [[ -z "$sched_name" || "$sched_name" == "None" ]] && continue
+        if $DRY_RUN; then
+            echo "    [DRY RUN] Would delete schedule: $sched_name (group: $group_name)"
+        else
+            echo "    Deleting schedule: $sched_name (group: $group_name)"
+            aws scheduler delete-schedule --name "$sched_name" --group-name "$group_name" 2>&1 \
+                || echo "      WARNING: failed to delete schedule $sched_name"
+        fi
+    done
+}
+
 # --- Discover tagged resources via Resource Groups Tagging API ---
 # Note: AWS CLI v2 auto-paginates by default. The --query/--output flags are applied
 # after all pages are aggregated, so this handles >100 resources without manual pagination.
@@ -136,40 +155,19 @@ if [[ ${#SCHEDULE_GROUPS[@]} -gt 0 ]]; then
         # Extract group name from ARN (last segment after schedule-group/)
         GROUP_NAME="${arn##*/}"
 
-        # Skip the 'default' group — it cannot be deleted
+        # Skip the 'default' group — it cannot be deleted, but we clean its schedules
         if [[ "$GROUP_NAME" == "default" ]]; then
             echo "  Cleaning schedules in default group (group itself cannot be deleted)"
-            SCHEDULES=$(aws scheduler list-schedules --group-name "$GROUP_NAME" \
-                --query 'Schedules[*].Name' --output text 2>&1 || echo "")
-            if $DRY_RUN; then
-                for sched_name in $SCHEDULES; do
-                    [[ -z "$sched_name" || "$sched_name" == "None" ]] && continue
-                    echo "    [DRY RUN] Would delete schedule: $sched_name (group: $GROUP_NAME)"
-                done
-            else
-                for sched_name in $SCHEDULES; do
-                    [[ -z "$sched_name" || "$sched_name" == "None" ]] && continue
-                    echo "    Deleting schedule: $sched_name (group: $GROUP_NAME)"
-                    aws scheduler delete-schedule --name "$sched_name" --group-name "$GROUP_NAME" 2>&1 \
-                        || echo "      WARNING: failed to delete schedule $sched_name"
-                done
-            fi
+            delete_schedules_in_group "$GROUP_NAME"
             continue
         fi
+
+        echo "  Processing schedule group: $GROUP_NAME"
+        delete_schedules_in_group "$GROUP_NAME"
 
         if $DRY_RUN; then
             echo "  [DRY RUN] Would delete schedule group: $GROUP_NAME"
         else
-            # Delete all schedules in the group first
-            SCHEDULES=$(aws scheduler list-schedules --group-name "$GROUP_NAME" \
-                --query 'Schedules[*].Name' --output text 2>&1 || echo "")
-            for sched_name in $SCHEDULES; do
-                [[ -z "$sched_name" || "$sched_name" == "None" ]] && continue
-                echo "    Deleting schedule: $sched_name (group: $GROUP_NAME)"
-                aws scheduler delete-schedule --name "$sched_name" --group-name "$GROUP_NAME" 2>&1 \
-                    || echo "      WARNING: failed to delete schedule $sched_name"
-            done
-
             echo "  Deleting schedule group: $GROUP_NAME"
             aws scheduler delete-schedule-group --name "$GROUP_NAME" 2>&1 \
                 || echo "    WARNING: failed to delete schedule group $GROUP_NAME"
@@ -196,18 +194,12 @@ if [[ -n "$BRIGHTER_GROUPS" && "$BRIGHTER_GROUPS" != "None" ]]; then
             continue
         fi
 
+        echo "  Processing Brighter schedule group: $GROUP_NAME"
+        delete_schedules_in_group "$GROUP_NAME"
+
         if $DRY_RUN; then
             echo "  [DRY RUN] Would delete Brighter schedule group: $GROUP_NAME"
         else
-            SCHEDULES=$(aws scheduler list-schedules --group-name "$GROUP_NAME" \
-                --query 'Schedules[*].Name' --output text 2>&1 || echo "")
-            for sched_name in $SCHEDULES; do
-                [[ -z "$sched_name" || "$sched_name" == "None" ]] && continue
-                echo "    Deleting schedule: $sched_name (group: $GROUP_NAME)"
-                aws scheduler delete-schedule --name "$sched_name" --group-name "$GROUP_NAME" 2>&1 \
-                    || echo "      WARNING: failed to delete schedule $sched_name"
-            done
-
             echo "  Deleting Brighter schedule group: $GROUP_NAME"
             aws scheduler delete-schedule-group --name "$GROUP_NAME" 2>&1 \
                 || echo "    WARNING: failed to delete schedule group $GROUP_NAME"

--- a/clean_failed_tests_aws_assets.sh
+++ b/clean_failed_tests_aws_assets.sh
@@ -22,7 +22,7 @@ echo "Querying resources tagged Environment=Test ..."
 
 RESOURCE_ARNS=$(aws resourcegroupstaggingapi get-resources \
     --tag-filters Key=Environment,Values=Test \
-    --resource-type-filters sqs:queue sns:topic \
+    --resource-type-filters sqs:queue sns:topic scheduler:schedule-group \
     --query 'ResourceTagMappingList[*].ResourceARN' \
     --output text 2>&1)
 TAG_API_EXIT=$?
@@ -35,7 +35,6 @@ fi
 
 if [[ -z "$RESOURCE_ARNS" || "$RESOURCE_ARNS" == "None" ]]; then
     echo "No resources found with Environment=Test tag."
-    exit 0
 fi
 
 # --- Categorise ARNs by resource type ---
@@ -45,30 +44,36 @@ fi
 SUBSCRIPTIONS=()
 TOPICS=()
 QUEUES=()
+SCHEDULE_GROUPS=()
 
-for arn in $RESOURCE_ARNS; do
-    # Count colons to distinguish SNS topics (5 colons) from subscriptions (6 colons)
-    COLON_COUNT=$(echo "$arn" | tr -cd ':' | wc -c | tr -d ' ')
-    case "$arn" in
-        *:sns:*)
-            if [[ "$COLON_COUNT" -ge 6 ]]; then
-                SUBSCRIPTIONS+=("$arn")
-            else
-                TOPICS+=("$arn")
-            fi
-            ;;
-        *:sqs:*)
-            QUEUES+=("$arn")
-            ;;
-        *)
-            echo "  Skipping unknown resource type: $arn"
-            ;;
-    esac
-done
+if [[ -n "$RESOURCE_ARNS" && "$RESOURCE_ARNS" != "None" ]]; then
+    for arn in $RESOURCE_ARNS; do
+        # Count colons to distinguish SNS topics (5 colons) from subscriptions (6 colons)
+        COLON_COUNT=$(echo "$arn" | tr -cd ':' | wc -c | tr -d ' ')
+        case "$arn" in
+            *:sns:*)
+                if [[ "$COLON_COUNT" -ge 6 ]]; then
+                    SUBSCRIPTIONS+=("$arn")
+                else
+                    TOPICS+=("$arn")
+                fi
+                ;;
+            *:sqs:*)
+                QUEUES+=("$arn")
+                ;;
+            *:scheduler:*/schedule-group/*)
+                SCHEDULE_GROUPS+=("$arn")
+                ;;
+            *)
+                echo "  Skipping unknown resource type: $arn"
+                ;;
+        esac
+    done
+fi
 
-echo "Found: ${#SUBSCRIPTIONS[@]} subscription(s), ${#TOPICS[@]} topic(s), ${#QUEUES[@]} queue(s)"
+echo "Found: ${#SUBSCRIPTIONS[@]} subscription(s), ${#TOPICS[@]} topic(s), ${#QUEUES[@]} queue(s), ${#SCHEDULE_GROUPS[@]} schedule group(s)"
 
-# --- Delete in order: subscriptions, then topics, then queues ---
+# --- Delete in order: subscriptions, then topics, then queues, then schedule groups ---
 
 # 1. Subscriptions
 if [[ ${#SUBSCRIPTIONS[@]} -gt 0 ]]; then
@@ -123,6 +128,93 @@ if [[ ${#QUEUES[@]} -gt 0 ]]; then
             fi
         fi
     done
+fi
+
+# 4. EventBridge Scheduler — delete schedules within groups, then the groups themselves
+if [[ ${#SCHEDULE_GROUPS[@]} -gt 0 ]]; then
+    for arn in "${SCHEDULE_GROUPS[@]}"; do
+        # Extract group name from ARN (last segment after schedule-group/)
+        GROUP_NAME="${arn##*/}"
+
+        # Skip the 'default' group — it cannot be deleted
+        if [[ "$GROUP_NAME" == "default" ]]; then
+            echo "  Cleaning schedules in default group (group itself cannot be deleted)"
+            SCHEDULES=$(aws scheduler list-schedules --group-name "$GROUP_NAME" \
+                --query 'Schedules[*].Name' --output text 2>&1 || echo "")
+            if $DRY_RUN; then
+                for sched_name in $SCHEDULES; do
+                    [[ -z "$sched_name" || "$sched_name" == "None" ]] && continue
+                    echo "    [DRY RUN] Would delete schedule: $sched_name (group: $GROUP_NAME)"
+                done
+            else
+                for sched_name in $SCHEDULES; do
+                    [[ -z "$sched_name" || "$sched_name" == "None" ]] && continue
+                    echo "    Deleting schedule: $sched_name (group: $GROUP_NAME)"
+                    aws scheduler delete-schedule --name "$sched_name" --group-name "$GROUP_NAME" 2>&1 \
+                        || echo "      WARNING: failed to delete schedule $sched_name"
+                done
+            fi
+            continue
+        fi
+
+        if $DRY_RUN; then
+            echo "  [DRY RUN] Would delete schedule group: $GROUP_NAME"
+        else
+            # Delete all schedules in the group first
+            SCHEDULES=$(aws scheduler list-schedules --group-name "$GROUP_NAME" \
+                --query 'Schedules[*].Name' --output text 2>&1 || echo "")
+            for sched_name in $SCHEDULES; do
+                [[ -z "$sched_name" || "$sched_name" == "None" ]] && continue
+                echo "    Deleting schedule: $sched_name (group: $GROUP_NAME)"
+                aws scheduler delete-schedule --name "$sched_name" --group-name "$GROUP_NAME" 2>&1 \
+                    || echo "      WARNING: failed to delete schedule $sched_name"
+            done
+
+            echo "  Deleting schedule group: $GROUP_NAME"
+            aws scheduler delete-schedule-group --name "$GROUP_NAME" 2>&1 \
+                || echo "    WARNING: failed to delete schedule group $GROUP_NAME"
+        fi
+    done
+fi
+
+# --- Also clean up Brighter-tagged schedule groups (Source=Brighter) not caught above ---
+# The AwsSchedulerFactory tags groups with Source=Brighter but tests may not add Environment=Test.
+echo "Checking for Brighter-tagged schedule groups ..."
+BRIGHTER_GROUPS=$(aws resourcegroupstaggingapi get-resources \
+    --tag-filters Key=Source,Values=Brighter \
+    --resource-type-filters scheduler:schedule-group \
+    --query 'ResourceTagMappingList[*].ResourceARN' \
+    --output text 2>&1 || echo "")
+
+if [[ -n "$BRIGHTER_GROUPS" && "$BRIGHTER_GROUPS" != "None" ]]; then
+    for arn in $BRIGHTER_GROUPS; do
+        GROUP_NAME="${arn##*/}"
+        [[ "$GROUP_NAME" == "default" ]] && continue
+
+        # Skip if already processed above
+        if [[ ${#SCHEDULE_GROUPS[@]} -gt 0 ]] && printf '%s\n' "${SCHEDULE_GROUPS[@]}" | grep -qF "$arn"; then
+            continue
+        fi
+
+        if $DRY_RUN; then
+            echo "  [DRY RUN] Would delete Brighter schedule group: $GROUP_NAME"
+        else
+            SCHEDULES=$(aws scheduler list-schedules --group-name "$GROUP_NAME" \
+                --query 'Schedules[*].Name' --output text 2>&1 || echo "")
+            for sched_name in $SCHEDULES; do
+                [[ -z "$sched_name" || "$sched_name" == "None" ]] && continue
+                echo "    Deleting schedule: $sched_name (group: $GROUP_NAME)"
+                aws scheduler delete-schedule --name "$sched_name" --group-name "$GROUP_NAME" 2>&1 \
+                    || echo "      WARNING: failed to delete schedule $sched_name"
+            done
+
+            echo "  Deleting Brighter schedule group: $GROUP_NAME"
+            aws scheduler delete-schedule-group --name "$GROUP_NAME" 2>&1 \
+                || echo "    WARNING: failed to delete schedule group $GROUP_NAME"
+        fi
+    done
+else
+    echo "  No additional Brighter schedule groups found."
 fi
 
 echo "Cleanup complete."

--- a/test_clean_failed_tests_aws_assets.sh
+++ b/test_clean_failed_tests_aws_assets.sh
@@ -14,6 +14,8 @@ TAGGED_QUEUE_URL=""
 UNTAGGED_QUEUE_URL=""
 TAGGED_TOPIC_ARN=""
 UNTAGGED_TOPIC_ARN=""
+TAGGED_SCHEDULE_GROUP=""
+TAGGED_SCHEDULE_NAME=""
 
 cleanup_test_resources() {
     echo ""
@@ -22,6 +24,12 @@ cleanup_test_resources() {
     [[ -n "$UNTAGGED_TOPIC_ARN" ]] && aws sns delete-topic --topic-arn "$UNTAGGED_TOPIC_ARN" 2>/dev/null || true
     [[ -n "$TAGGED_QUEUE_URL" ]] && aws sqs delete-queue --queue-url "$TAGGED_QUEUE_URL" 2>/dev/null || true
     [[ -n "$TAGGED_TOPIC_ARN" ]] && aws sns delete-topic --topic-arn "$TAGGED_TOPIC_ARN" 2>/dev/null || true
+    if [[ -n "$TAGGED_SCHEDULE_NAME" && -n "$TAGGED_SCHEDULE_GROUP" ]]; then
+        aws scheduler delete-schedule --name "$TAGGED_SCHEDULE_NAME" --group-name "$TAGGED_SCHEDULE_GROUP" 2>/dev/null || true
+    fi
+    if [[ -n "$TAGGED_SCHEDULE_GROUP" ]]; then
+        aws scheduler delete-schedule-group --name "$TAGGED_SCHEDULE_GROUP" 2>/dev/null || true
+    fi
     echo "  Cleaned up test fixtures"
 }
 trap cleanup_test_resources EXIT
@@ -109,8 +117,26 @@ SUBSCRIPTION_ARN=$(aws sns subscribe \
     --query 'SubscriptionArn' --output text)
 echo "  Created subscription: $SUBSCRIPTION_ARN"
 
+# Tagged EventBridge Scheduler group with a schedule
+TAGGED_SCHEDULE_GROUP="$PREFIX-tagged-group"
+aws scheduler create-schedule-group \
+    --name "$TAGGED_SCHEDULE_GROUP" \
+    --tags Key=Environment,Value=Test Key=Source,Value=Brighter 2>&1
+echo "  Created tagged schedule group: $TAGGED_SCHEDULE_GROUP"
+
+TAGGED_SCHEDULE_NAME="$PREFIX-tagged-schedule"
+aws scheduler create-schedule \
+    --name "$TAGGED_SCHEDULE_NAME" \
+    --group-name "$TAGGED_SCHEDULE_GROUP" \
+    --schedule-expression "at(2099-01-01T00:00:00)" \
+    --schedule-expression-timezone "UTC" \
+    --flexible-time-window '{"Mode":"OFF"}' \
+    --target '{"Arn":"arn:aws:sqs:us-west-2:000000000000:fake-queue","RoleArn":"arn:aws:iam::000000000000:role/fake-role","Input":"test"}' \
+    --action-after-completion DELETE 2>&1
+echo "  Created tagged schedule: $TAGGED_SCHEDULE_NAME"
+
 # Allow time for tag propagation — the Resource Groups Tagging API is eventually consistent
-sleep 5
+sleep 15
 
 # --- Test 1: --dry-run lists tagged resources without deleting ---
 echo ""
@@ -123,6 +149,7 @@ assert_eq "0" "$DRY_RUN_EXIT" "dry-run exits with 0"
 assert_contains "$DRY_RUN_OUTPUT" "DRY RUN" "output indicates dry-run mode"
 assert_contains "$DRY_RUN_OUTPUT" "$TAGGED_QUEUE" "output lists tagged queue"
 assert_contains "$DRY_RUN_OUTPUT" "$TAGGED_TOPIC" "output lists tagged topic"
+assert_contains "$DRY_RUN_OUTPUT" "$TAGGED_SCHEDULE_GROUP" "output lists tagged schedule group"
 
 # Tagged queue must still exist after dry-run
 QUEUE_CHECK=$(aws sqs get-queue-url --queue-name "$TAGGED_QUEUE" --query 'QueueUrl' --output text 2>/dev/null || echo "")
@@ -163,7 +190,7 @@ echo ""
 echo "=== Test 4: tagged resources were deleted ==="
 
 # Allow time for eventual consistency — SQS/SNS deletions may take a few seconds to propagate
-sleep 5
+sleep 10
 
 TAGGED_QUEUE_CHECK=$(aws sqs get-queue-url --queue-name "$TAGGED_QUEUE" 2>&1 || true)
 assert_contains "$TAGGED_QUEUE_CHECK" "NonExistentQueue|does not exist" "tagged queue was deleted"
@@ -180,6 +207,13 @@ assert_not_empty "$UNTAGGED_QUEUE_CHECK" "untagged queue was NOT deleted"
 
 UNTAGGED_TOPIC_CHECK=$(aws sns get-topic-attributes --topic-arn "$UNTAGGED_TOPIC_ARN" --query 'Attributes.TopicArn' --output text 2>/dev/null || echo "")
 assert_not_empty "$UNTAGGED_TOPIC_CHECK" "untagged topic was NOT deleted"
+
+# --- Test 6: tagged schedule group and schedules were deleted ---
+echo ""
+echo "=== Test 6: tagged schedule group was deleted ==="
+
+SCHEDULE_GROUP_CHECK=$(aws scheduler get-schedule-group --name "$TAGGED_SCHEDULE_GROUP" 2>&1 || true)
+assert_contains "$SCHEDULE_GROUP_CHECK" "ResourceNotFoundException|not found|Not Found" "tagged schedule group was deleted"
 
 # Teardown is handled by the EXIT trap defined at the top of the script.
 

--- a/test_clean_failed_tests_aws_assets.sh
+++ b/test_clean_failed_tests_aws_assets.sh
@@ -16,6 +16,7 @@ TAGGED_TOPIC_ARN=""
 UNTAGGED_TOPIC_ARN=""
 TAGGED_SCHEDULE_GROUP=""
 TAGGED_SCHEDULE_NAME=""
+UNTAGGED_SCHEDULE_GROUP=""
 
 cleanup_test_resources() {
     echo ""
@@ -29,6 +30,9 @@ cleanup_test_resources() {
     fi
     if [[ -n "$TAGGED_SCHEDULE_GROUP" ]]; then
         aws scheduler delete-schedule-group --name "$TAGGED_SCHEDULE_GROUP" 2>/dev/null || true
+    fi
+    if [[ -n "$UNTAGGED_SCHEDULE_GROUP" ]]; then
+        aws scheduler delete-schedule-group --name "$UNTAGGED_SCHEDULE_GROUP" 2>/dev/null || true
     fi
     echo "  Cleaned up test fixtures"
 }
@@ -126,15 +130,24 @@ aws scheduler create-schedule-group \
 echo "  Created tagged schedule group: $TAGGED_SCHEDULE_GROUP"
 
 TAGGED_SCHEDULE_NAME="$PREFIX-tagged-schedule"
-aws scheduler create-schedule \
+if ! aws scheduler create-schedule \
     --name "$TAGGED_SCHEDULE_NAME" \
     --group-name "$TAGGED_SCHEDULE_GROUP" \
     --schedule-expression "at(2099-01-01T00:00:00)" \
     --schedule-expression-timezone "UTC" \
     --flexible-time-window '{"Mode":"OFF"}' \
     --target "{\"Arn\":\"arn:aws:sqs:us-west-2:${ACCOUNT_ID}:fake-queue\",\"RoleArn\":\"arn:aws:iam::${ACCOUNT_ID}:role/fake-role\",\"Input\":\"test\"}" \
-    --action-after-completion DELETE 2>&1
+    --action-after-completion DELETE 2>&1; then
+    echo "  WARNING: Failed to create schedule (target ARN validation). Schedule group tests may be incomplete."
+    TAGGED_SCHEDULE_NAME=""
+fi
 echo "  Created tagged schedule: $TAGGED_SCHEDULE_NAME"
+
+# Untagged EventBridge Scheduler group (should NOT be deleted)
+UNTAGGED_SCHEDULE_GROUP="$PREFIX-untagged-group"
+aws scheduler create-schedule-group \
+    --name "$UNTAGGED_SCHEDULE_GROUP" 2>&1
+echo "  Created untagged schedule group: $UNTAGGED_SCHEDULE_GROUP"
 
 # Allow time for tag propagation — the Resource Groups Tagging API is eventually consistent
 sleep 15
@@ -215,6 +228,13 @@ echo "=== Test 6: tagged schedule group was deleted ==="
 
 SCHEDULE_GROUP_CHECK=$(aws scheduler get-schedule-group --name "$TAGGED_SCHEDULE_GROUP" 2>&1 || true)
 assert_contains "$SCHEDULE_GROUP_CHECK" "ResourceNotFoundException|not found|Not Found" "tagged schedule group was deleted"
+
+# --- Test 7: untagged schedule group was NOT deleted ---
+echo ""
+echo "=== Test 7: untagged schedule group was NOT deleted ==="
+
+UNTAGGED_GROUP_CHECK=$(aws scheduler get-schedule-group --name "$UNTAGGED_SCHEDULE_GROUP" --query 'Name' --output text 2>/dev/null || echo "")
+assert_not_empty "$UNTAGGED_GROUP_CHECK" "untagged schedule group was NOT deleted"
 
 # Teardown is handled by the EXIT trap defined at the top of the script.
 

--- a/test_clean_failed_tests_aws_assets.sh
+++ b/test_clean_failed_tests_aws_assets.sh
@@ -73,7 +73,8 @@ assert_not_empty() {
 
 # --- Setup: create tagged and untagged resources ---
 PREFIX="cleanup-test-$(date +%s)"
-echo "=== Setup: creating test resources (prefix: $PREFIX) ==="
+ACCOUNT_ID=$(aws sts get-caller-identity --query 'Account' --output text)
+echo "=== Setup: creating test resources (prefix: $PREFIX, account: $ACCOUNT_ID) ==="
 
 # Tagged SQS queue
 TAGGED_QUEUE="$PREFIX-tagged-queue"
@@ -131,7 +132,7 @@ aws scheduler create-schedule \
     --schedule-expression "at(2099-01-01T00:00:00)" \
     --schedule-expression-timezone "UTC" \
     --flexible-time-window '{"Mode":"OFF"}' \
-    --target '{"Arn":"arn:aws:sqs:us-west-2:000000000000:fake-queue","RoleArn":"arn:aws:iam::000000000000:role/fake-role","Input":"test"}' \
+    --target "{\"Arn\":\"arn:aws:sqs:us-west-2:${ACCOUNT_ID}:fake-queue\",\"RoleArn\":\"arn:aws:iam::${ACCOUNT_ID}:role/fake-role\",\"Input\":\"test\"}" \
     --action-after-completion DELETE 2>&1
 echo "  Created tagged schedule: $TAGGED_SCHEDULE_NAME"
 


### PR DESCRIPTION
## Summary

- Moves AWS test resource cleanup from inline CI steps to a dedicated workflow (`aws-cleanup.yml`) triggered on CI completion, every 6 hours via cron, and manually via `workflow_dispatch`
- Adds EventBridge Scheduler resource cleanup (schedule groups and schedules) to the cleanup script — these were previously never cleaned up
- Fixes a `set -u` bug and adds proper dry-run support for all resource types
- Adds scheduler resource coverage to the integration test and increases wait times for tag propagation consistency

## Motivation

CI was hitting AWS SNS topic quota limits because:
1. Cleanup only ran as a post-step within each job — couldn't catch resources from concurrent runs
2. EventBridge Scheduler groups/schedules were never cleaned up
3. Tag propagation delay meant recently-created resources could be missed

## Changes

| File | Change |
|------|--------|
| `.github/workflows/aws-cleanup.yml` | New dedicated cleanup workflow |
| `.github/workflows/ci.yml` | Remove inline cleanup steps from `aws-ci` and `aws-scheduler-ci` |
| `clean_failed_tests_aws_assets.sh` | Add scheduler cleanup, fix `set -u` bug, add dry-run for default group |
| `test_clean_failed_tests_aws_assets.sh` | Add scheduler test coverage, increase sleep timers |