### PR TITLE
Fix RMQ producer channel disposal

### DIFF
--- a/src/Paramore.Brighter.MessagingGateway.RMQ.Async/RmqMessageGateway.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ.Async/RmqMessageGateway.cs
@@ -58,7 +58,7 @@ public partial class RmqMessageGateway : IDisposable, IAsyncDisposable
     private readonly AsyncPolicy _circuitBreakerPolicy;
     private readonly ConnectionFactory _connectionFactory;
     private readonly AsyncPolicy _retryPolicy;
-    private bool _disposed;
+    private int _disposed;
     protected readonly RmqMessagingGatewayConnection Connection;
     protected IChannel? Channel;
 
@@ -190,8 +190,7 @@ public partial class RmqMessageGateway : IDisposable, IAsyncDisposable
 
     public virtual async ValueTask DisposeAsync()
     {
-        if (_disposed) return;
-        _disposed = true;
+        if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
 
         if (Channel != null)
         {
@@ -205,6 +204,8 @@ public partial class RmqMessageGateway : IDisposable, IAsyncDisposable
 
     protected virtual void Dispose(bool disposing)
     {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
+
         if (disposing)
         {
             Channel?.AbortAsync().Wait();

--- a/src/Paramore.Brighter.MessagingGateway.RMQ.Async/RmqMessageProducer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ.Async/RmqMessageProducer.cs
@@ -57,6 +57,7 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
     private readonly object _pendingConfirmationsLock = new();
     private readonly int _waitForConfirmsTimeOutInMilliseconds;
     private TaskCompletionSource<bool> _publisherConfirmationsCompleted = CompletedPublisherConfirmationsTask();
+    // Producer disposal has confirmation-specific work; the base guard separately protects channel and pool cleanup.
     private int _disposed;
 
     /// <summary>
@@ -213,6 +214,7 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
         }
 
         base.Dispose();
+        GC.SuppressFinalize(this);
     }
 
     public sealed override async ValueTask DisposeAsync()
@@ -276,15 +278,17 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
 
         lock (_pendingConfirmationsLock)
         {
-            foreach (var pendingConfirmation in _pendingConfirmations)
+            var deliveryTagsToRemove = new List<ulong>();
+
+            foreach (var pendingDeliveryTag in _pendingConfirmations.Keys)
             {
-                if (multiple && pendingConfirmation.Key > deliveryTag)
-                    continue;
+                if (multiple ? pendingDeliveryTag <= deliveryTag : pendingDeliveryTag == deliveryTag)
+                    deliveryTagsToRemove.Add(pendingDeliveryTag);
+            }
 
-                if (!multiple && pendingConfirmation.Key != deliveryTag)
-                    continue;
-
-                if (_pendingConfirmations.TryRemove(pendingConfirmation.Key, out var messageId))
+            foreach (var pendingDeliveryTag in deliveryTagsToRemove)
+            {
+                if (_pendingConfirmations.TryRemove(pendingDeliveryTag, out var messageId))
                     messageIds.Add(messageId);
             }
 

--- a/src/Paramore.Brighter.MessagingGateway.RMQ.Async/RmqMessageProducer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ.Async/RmqMessageProducer.cs
@@ -162,8 +162,6 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
                 Channel.BasicNacksAsync += OnPublishFailed;
             }
 
-            var rmqMessagePublisher = new RmqMessagePublisher(Channel, Connection);
-
             message.Persist = Connection.PersistMessages;
             
             BrighterTracer.WriteProducerEvent(Span, MessagingSystem.RabbitMQ, message, _instrumentationOptions);
@@ -171,13 +169,13 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
             Log.PublishingMessageAsync(s_logger, Connection.Exchange.Name, Connection.AmpqUri.GetSanitizedUri(), delay.Value.TotalMilliseconds,
                 message.Header.Topic, message.Persist, message.Id, message.Body.Value);
 
-            AddPendingConfirmation(await Channel.GetNextPublishSequenceNumberAsync(cancellationToken), message.Id);
-
-            if (delay == TimeSpan.Zero || DelaySupported || Scheduler == null)
+            if (PublishesOnChannel(delay.Value))
             {
+                var rmqMessagePublisher = new RmqMessagePublisher(Channel, Connection);
+                AddPendingConfirmation(await Channel.GetNextPublishSequenceNumberAsync(cancellationToken), message.Id);
                 await rmqMessagePublisher.PublishMessageAsync(message, delay.Value, cancellationToken);
             }
-            else if(useSchedulerAsync)
+            else if (useSchedulerAsync)
             {
                 var schedulerAsync = (IAmAMessageSchedulerAsync)Scheduler!;
                 await schedulerAsync.ScheduleAsync(message, delay.Value, cancellationToken);
@@ -222,6 +220,7 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
                 await channel.AbortAsync();
                 await channel.DisposeAsync();
             });
+            // The base dispose still removes the pooled connection; the producer has already disposed the channel.
             Channel = null;
         }
 
@@ -242,6 +241,7 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
         {
             await channel.AbortAsync();
             await channel.DisposeAsync();
+            // The base async dispose still removes the pooled connection; the producer has already disposed the channel.
             Channel = null;
         }
 
@@ -324,7 +324,6 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
             return;
         }
 
-        await timeout;
         Log.FailedToAwaitPublisherConfirms(s_logger);
     }
 
@@ -335,9 +334,11 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
             if (_pendingConfirmations.Count == 0)
                 _publisherConfirmationsCompleted = PendingTask();
 
-            _pendingConfirmations.TryAdd(deliveryTag, messageId);
+            _pendingConfirmations.Add(deliveryTag, messageId);
         }
     }
+
+    private bool PublishesOnChannel(TimeSpan delay) => delay == TimeSpan.Zero || DelaySupported || Scheduler == null;
 
     private IReadOnlyCollection<string> RemovePendingConfirmations(ulong deliveryTag, bool multiple)
     {

--- a/src/Paramore.Brighter.MessagingGateway.RMQ.Async/RmqMessageProducer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ.Async/RmqMessageProducer.cs
@@ -55,8 +55,8 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
     private readonly Dictionary<ulong, string> _pendingConfirmations = new();
     private readonly object _stateLock = new();
     private readonly int _waitForConfirmsTimeOutInMilliseconds;
-    private TaskCompletionSource<bool> _activeSendsCompleted = CompletedTask();
-    private TaskCompletionSource<bool> _publisherConfirmationsCompleted = CompletedTask();
+    private TaskCompletionSource<bool> _activeSendsCompleted = NewCompletedTaskCompletionSource();
+    private TaskCompletionSource<bool> _publisherConfirmationsCompleted = NewCompletedTaskCompletionSource();
     // Producer disposal has confirmation-specific work, so it has its own guard.
     // The base guard separately protects channel and pool cleanup after producer shutdown.
     private int _activeSends;
@@ -257,7 +257,7 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
             ThrowIfDisposed();
 
             if (_activeSends == 0)
-                _activeSendsCompleted = PendingTask();
+                _activeSendsCompleted = NewPendingTaskCompletionSource();
 
             _activeSends++;
         }
@@ -332,9 +332,9 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
         lock (_stateLock)
         {
             if (_pendingConfirmations.Count == 0)
-                _publisherConfirmationsCompleted = PendingTask();
+                _publisherConfirmationsCompleted = NewPendingTaskCompletionSource();
 
-            _pendingConfirmations.Add(deliveryTag, messageId);
+            _pendingConfirmations[deliveryTag] = messageId;
         }
     }
 
@@ -386,14 +386,14 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
     private static bool IsConfirmedBy(ulong pendingDeliveryTag, ulong deliveryTag, bool multiple)
         => multiple ? pendingDeliveryTag <= deliveryTag : pendingDeliveryTag == deliveryTag;
 
-    private static TaskCompletionSource<bool> CompletedTask()
+    private static TaskCompletionSource<bool> NewCompletedTaskCompletionSource()
     {
-        var taskCompletionSource = PendingTask();
+        var taskCompletionSource = NewPendingTaskCompletionSource();
         taskCompletionSource.SetResult(true);
         return taskCompletionSource;
     }
 
-    private static TaskCompletionSource<bool> PendingTask()
+    private static TaskCompletionSource<bool> NewPendingTaskCompletionSource()
         => new(TaskCreationOptions.RunContinuationsAsynchronously);
 
     private void DetachPublisherConfirmHandlers()

--- a/src/Paramore.Brighter.MessagingGateway.RMQ.Async/RmqMessageProducer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ.Async/RmqMessageProducer.cs
@@ -51,6 +51,11 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
     private readonly InstrumentationOptions _instrumentationOptions;
     private static readonly ILogger s_logger = ApplicationLogging.CreateLogger<RmqMessageProducer>();
 
+    // Used to bound the active-send wait when the user opts out of confirms (timeout=0).
+    // Active sends in flight at dispose time should not be aborted: outbox would mark them Dispatched
+    // while the broker may not yet have accepted the frame, producing duplicates on the next sweep.
+    private const int DefaultActiveSendsShutdownTimeoutMs = 5000;
+
     private RmqPublication _publication;
     private readonly Dictionary<ulong, string> _pendingConfirmations = new();
     private readonly object _stateLock = new();
@@ -196,9 +201,15 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
         {
             Log.ErrorTalkingToSocketAsync(s_logger, io, Connection.AmpqUri!.GetSanitizedUri());
             ClearPendingConfirmations();
+            // Capture the failed channel before reset; otherwise the detach fires on the recovered channel
+            // and the next send loses confirm tracking.
+            var failedChannel = Channel;
             await ResetConnectionToBrokerAsync(cancellationToken);
-            Channel?.BasicAcksAsync -= OnPublishSucceeded;
-            Channel?.BasicNacksAsync -= OnPublishFailed;
+            if (failedChannel is not null)
+            {
+                failedChannel.BasicAcksAsync -= OnPublishSucceeded;
+                failedChannel.BasicNacksAsync -= OnPublishFailed;
+            }
             throw new ChannelFailureException("Error talking to the broker, see inner exception for details", io);
         }
         finally
@@ -295,11 +306,14 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
             activeSendsCompleted = _activeSendsCompleted.Task;
         }
 
-        if (_waitForConfirmsTimeOutInMilliseconds == 0)
-            return;
+        // Always wait for in-flight sends, even when the user opted out of confirm waits (timeout=0).
+        // See DefaultActiveSendsShutdownTimeoutMs comment for rationale.
+        var waitMilliseconds = _waitForConfirmsTimeOutInMilliseconds > 0
+            ? _waitForConfirmsTimeOutInMilliseconds
+            : DefaultActiveSendsShutdownTimeoutMs;
 
         using var timeoutCancellation = new CancellationTokenSource();
-        var timeout = Task.Delay(TimeSpan.FromMilliseconds(_waitForConfirmsTimeOutInMilliseconds), timeoutCancellation.Token);
+        var timeout = Task.Delay(TimeSpan.FromMilliseconds(waitMilliseconds), timeoutCancellation.Token);
         var completed = await Task.WhenAny(activeSendsCompleted, timeout);
 
         if (completed == activeSendsCompleted)
@@ -390,8 +404,12 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
 
         foreach (var pendingDeliveryTag in deliveryTagsToRemove)
         {
-            if (_pendingConfirmations.Remove(pendingDeliveryTag, out var messageId))
+            // Dictionary.Remove(key, out value) is unavailable on netstandard2.0; use the lookup-then-remove pattern.
+            if (_pendingConfirmations.TryGetValue(pendingDeliveryTag, out var messageId))
+            {
+                _pendingConfirmations.Remove(pendingDeliveryTag);
                 messageIds.Add(messageId);
+            }
         }
 
         return messageIds;

--- a/src/Paramore.Brighter.MessagingGateway.RMQ.Async/RmqMessageProducer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ.Async/RmqMessageProducer.cs
@@ -57,7 +57,8 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
     private readonly int _waitForConfirmsTimeOutInMilliseconds;
     private TaskCompletionSource<bool> _activeSendsCompleted = CompletedTask();
     private TaskCompletionSource<bool> _publisherConfirmationsCompleted = CompletedTask();
-    // Producer disposal has confirmation-specific work; the base guard separately protects channel and pool cleanup.
+    // Producer disposal has confirmation-specific work, so it has its own guard.
+    // The base guard separately protects channel and pool cleanup after producer shutdown.
     private int _activeSends;
     private int _disposed;
 
@@ -193,6 +194,7 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
         catch (IOException io)
         {
             Log.ErrorTalkingToSocketAsync(s_logger, io, Connection.AmpqUri!.GetSanitizedUri());
+            ClearPendingConfirmations();
             await ResetConnectionToBrokerAsync(cancellationToken);
             Channel?.BasicAcksAsync -= OnPublishSucceeded;
             Channel?.BasicNacksAsync -= OnPublishFailed;
@@ -335,6 +337,15 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
                 _publisherConfirmationsCompleted = PendingTask();
 
             _pendingConfirmations.Add(deliveryTag, messageId);
+        }
+    }
+
+    private void ClearPendingConfirmations()
+    {
+        lock (_stateLock)
+        {
+            _pendingConfirmations.Clear();
+            _publisherConfirmationsCompleted.TrySetResult(true);
         }
     }
 

--- a/src/Paramore.Brighter.MessagingGateway.RMQ.Async/RmqMessageProducer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ.Async/RmqMessageProducer.cs
@@ -36,6 +36,7 @@ using Paramore.Brighter.JsonConverters;
 using Paramore.Brighter.Logging;
 using Paramore.Brighter.Observability;
 using Paramore.Brighter.Tasks;
+using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
 
 namespace Paramore.Brighter.MessagingGateway.RMQ.Async;
@@ -49,11 +50,10 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
 {
     private readonly InstrumentationOptions _instrumentationOptions;
     private static readonly ILogger s_logger = ApplicationLogging.CreateLogger<RmqMessageProducer>();
-    private static readonly SemaphoreSlim s_lock = new(1, 1);
 
     private RmqPublication _publication;
     private readonly ConcurrentDictionary<ulong, string> _pendingConfirmations = new();
-    private readonly int _waitForConfirmsTimeOutInMilliseconds;
+    private bool _disposed;
 
     /// <summary>
     /// Action taken when a message is published, following receipt of a confirmation from the broker
@@ -103,7 +103,6 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
         : base(connection)
     {
         _publication = publication ?? new RmqPublication { MakeChannels = OnMissingChannel.Create };
-        _waitForConfirmsTimeOutInMilliseconds = _publication.WaitForConfirmsTimeOutInMilliseconds;
     }
 
     /// <summary>
@@ -196,9 +195,38 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
 
     public sealed override void Dispose()
     {
+        if (_disposed) return;
+        _disposed = true;
+
+        DetachPublisherConfirmHandlers();
+        Channel?.AbortAsync().Wait();
+        Channel?.Dispose();
+        Channel = null;
+
+        GC.SuppressFinalize(this);
+    }
+
+    public sealed override async ValueTask DisposeAsync()
+    {
+        if (_disposed) return;
+        _disposed = true;
+
+        DetachPublisherConfirmHandlers();
+
+        if (Channel is not null)
+        {
+            await Channel.AbortAsync();
+            await Channel.DisposeAsync();
+            Channel = null;
+        }
+
+        GC.SuppressFinalize(this);
+    }
+
+    private void DetachPublisherConfirmHandlers()
+    {
         Channel?.BasicAcksAsync -= OnPublishSucceeded;
         Channel?.BasicNacksAsync -= OnPublishFailed;
-        GC.SuppressFinalize(this);
     }
 
     private Task OnPublishFailed(object sender, BasicNackEventArgs e)

--- a/src/Paramore.Brighter.MessagingGateway.RMQ.Async/RmqMessageProducer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ.Async/RmqMessageProducer.cs
@@ -340,7 +340,16 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
             return;
         }
 
-        Log.FailedToAwaitActiveSends(s_logger);
+        int activeSends;
+        lock (_stateLock)
+        {
+            activeSends = _activeSends;
+        }
+
+        if (activeSends == 0)
+            return;
+
+        Log.FailedToAwaitActiveSends(s_logger, activeSends, waitMilliseconds);
     }
 
     private void WaitForPendingPublisherConfirmations() => BrighterAsyncContext.Run(WaitForPendingPublisherConfirmationsAsync);
@@ -348,20 +357,23 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
     private async Task WaitForPendingPublisherConfirmationsAsync()
     {
         Task publisherConfirmationsCompleted;
+        var waitMilliseconds = _waitForConfirmsTimeOutInMilliseconds;
 
+        // _stateLock protects pending confirmations, not Channel. Disposal has already blocked new sends
+        // and drained active sends, so the producer send path cannot replace Channel while this snapshot is taken.
         lock (_stateLock)
         {
             if (Channel is not { IsOpen: true } || _pendingConfirmations.Count == 0)
                 return;
 
-            if (_waitForConfirmsTimeOutInMilliseconds == 0)
+            if (waitMilliseconds == 0)
                 return;
 
             publisherConfirmationsCompleted = _publisherConfirmationsCompleted.Task;
         }
 
         using var timeoutCancellation = new CancellationTokenSource();
-        var timeout = Task.Delay(TimeSpan.FromMilliseconds(_waitForConfirmsTimeOutInMilliseconds), timeoutCancellation.Token);
+        var timeout = Task.Delay(TimeSpan.FromMilliseconds(waitMilliseconds), timeoutCancellation.Token);
         var completed = await Task.WhenAny(publisherConfirmationsCompleted, timeout);
 
         if (completed == publisherConfirmationsCompleted)
@@ -370,7 +382,16 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
             return;
         }
 
-        Log.FailedToAwaitPublisherConfirms(s_logger);
+        int pendingConfirmations;
+        lock (_stateLock)
+        {
+            pendingConfirmations = _pendingConfirmations.Count;
+        }
+
+        if (pendingConfirmations == 0)
+            return;
+
+        Log.FailedToAwaitPublisherConfirms(s_logger, pendingConfirmations, waitMilliseconds);
     }
 
     private void AddPendingConfirmation(ulong deliveryTag, string messageId)
@@ -491,11 +512,11 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
         [LoggerMessage(LogLevel.Debug, "Failed to publish message: {MessageId}")]
         public static partial void FailedToPublishMessageAsync(ILogger logger, string messageId);
 
-        [LoggerMessage(LogLevel.Warning, "Failed to await publisher confirms when shutting down")]
-        public static partial void FailedToAwaitPublisherConfirms(ILogger logger);
+        [LoggerMessage(LogLevel.Warning, "Failed to await {PendingCount} publisher confirms after {TimeoutMs}ms when shutting down")]
+        public static partial void FailedToAwaitPublisherConfirms(ILogger logger, int pendingCount, int timeoutMs);
 
-        [LoggerMessage(LogLevel.Warning, "Failed to await active sends when shutting down")]
-        public static partial void FailedToAwaitActiveSends(ILogger logger);
+        [LoggerMessage(LogLevel.Warning, "Failed to await {ActiveSendCount} active sends after {TimeoutMs}ms when shutting down")]
+        public static partial void FailedToAwaitActiveSends(ILogger logger, int activeSendCount, int timeoutMs);
 
         [LoggerMessage(LogLevel.Information, "Published message: {MessageId}")]
         public static partial void PublishedMessage(ILogger logger, string messageId);

--- a/src/Paramore.Brighter.MessagingGateway.RMQ.Async/RmqMessageProducer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ.Async/RmqMessageProducer.cs
@@ -227,7 +227,6 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
         }
 
         base.Dispose();
-        GC.SuppressFinalize(this);
     }
 
     public sealed override async ValueTask DisposeAsync()
@@ -300,7 +299,7 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
 
     private void WaitForPendingPublisherConfirmations() => BrighterAsyncContext.Run(() => WaitForPendingPublisherConfirmationsAsync());
 
-    private async Task WaitForPendingPublisherConfirmationsAsync(CancellationToken cancellationToken = default)
+    private async Task WaitForPendingPublisherConfirmationsAsync()
     {
         Task publisherConfirmationsCompleted;
 
@@ -315,14 +314,13 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
             publisherConfirmationsCompleted = _publisherConfirmationsCompleted.Task;
         }
 
-        using var timeoutCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        using var timeoutCancellation = new CancellationTokenSource();
         var timeout = Task.Delay(TimeSpan.FromMilliseconds(_waitForConfirmsTimeOutInMilliseconds), timeoutCancellation.Token);
         var completed = await Task.WhenAny(publisherConfirmationsCompleted, timeout);
 
         if (completed == publisherConfirmationsCompleted)
         {
             timeoutCancellation.Cancel();
-            await publisherConfirmationsCompleted;
             return;
         }
 

--- a/src/Paramore.Brighter.MessagingGateway.RMQ.Async/RmqMessageProducer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ.Async/RmqMessageProducer.cs
@@ -53,7 +53,8 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
 
     private RmqPublication _publication;
     private readonly ConcurrentDictionary<ulong, string> _pendingConfirmations = new();
-    private bool _disposed;
+    private readonly int _waitForConfirmsTimeOutInMilliseconds;
+    private int _disposed;
 
     /// <summary>
     /// Action taken when a message is published, following receipt of a confirmation from the broker
@@ -103,6 +104,7 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
         : base(connection)
     {
         _publication = publication ?? new RmqPublication { MakeChannels = OnMissingChannel.Create };
+        _waitForConfirmsTimeOutInMilliseconds = _publication.WaitForConfirmsTimeOutInMilliseconds;
     }
 
     /// <summary>
@@ -195,22 +197,23 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
 
     public sealed override void Dispose()
     {
-        if (_disposed) return;
-        _disposed = true;
+        if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
 
+        WaitForPendingPublisherConfirmations();
         DetachPublisherConfirmHandlers();
         Channel?.AbortAsync().Wait();
         Channel?.Dispose();
         Channel = null;
 
+        // Producer-owned channel disposal only. Connection pool lifetime is tracked separately in #4102.
         GC.SuppressFinalize(this);
     }
 
     public sealed override async ValueTask DisposeAsync()
     {
-        if (_disposed) return;
-        _disposed = true;
+        if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
 
+        await WaitForPendingPublisherConfirmationsAsync();
         DetachPublisherConfirmHandlers();
 
         if (Channel is not null)
@@ -220,7 +223,30 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
             Channel = null;
         }
 
+        // Producer-owned channel disposal only. Connection pool lifetime is tracked separately in #4102.
         GC.SuppressFinalize(this);
+    }
+
+    private void WaitForPendingPublisherConfirmations() => BrighterAsyncContext.Run(WaitForPendingPublisherConfirmationsAsync);
+
+    private async Task WaitForPendingPublisherConfirmationsAsync()
+    {
+        if (Channel is not { IsOpen: true } || _pendingConfirmations.IsEmpty)
+            return;
+
+        using var timeout = new CancellationTokenSource(_waitForConfirmsTimeOutInMilliseconds);
+
+        try
+        {
+            while (!_pendingConfirmations.IsEmpty)
+            {
+                await Task.Delay(10, timeout.Token);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            Log.FailedToAwaitPublisherConfirms(s_logger);
+        }
     }
 
     private void DetachPublisherConfirmHandlers()
@@ -269,6 +295,9 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
         
         [LoggerMessage(LogLevel.Debug, "Failed to publish message: {MessageId}")]
         public static partial void FailedToPublishMessageAsync(ILogger logger, string messageId);
+
+        [LoggerMessage(LogLevel.Warning, "Failed to await publisher confirms when shutting down!")]
+        public static partial void FailedToAwaitPublisherConfirms(ILogger logger);
 
         [LoggerMessage(LogLevel.Information, "Published message: {MessageId}")]
         public static partial void PublishedMessage(ILogger logger, string messageId);

--- a/src/Paramore.Brighter.MessagingGateway.RMQ.Async/RmqMessageProducer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ.Async/RmqMessageProducer.cs
@@ -150,6 +150,10 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
         // BeginSend is intentionally outside the try block; if it rejects a disposed producer, CompleteSend must not run.
         BeginSend();
 
+        // Tracks the publish sequence we have registered for confirmation. Cleared once the publish succeeds
+        // (broker takes ownership of the ack) or once we have explicitly removed the orphan in the catch path.
+        ulong? pendingDeliveryTag = null;
+
         try
         {
             if (Connection.Exchange is null) throw new ConfigurationException("RmqMessageProducer: Exchange is not set");
@@ -158,10 +162,10 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
             delay ??= TimeSpan.Zero;
 
             Log.PreparingToSendAsync(s_logger, Connection.Exchange.Name);
-            
-            var channelInitialized = Channel is not null;   
+
+            var channelInitialized = Channel is not null;
             await EnsureBrokerAsync(makeExchange: _publication.MakeChannels, cancellationToken: cancellationToken);
-            
+
             if (Channel is null) throw new ChannelFailureException($"RmqMessageProducer: Channel is not set for {_publication.Topic}");
             if (!channelInitialized)
             {
@@ -170,7 +174,7 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
             }
 
             message.Persist = Connection.PersistMessages;
-            
+
             BrighterTracer.WriteProducerEvent(Span, MessagingSystem.RabbitMQ, message, _instrumentationOptions);
 
             Log.PublishingMessageAsync(s_logger, Connection.Exchange.Name, Connection.AmpqUri.GetSanitizedUri(), delay.Value.TotalMilliseconds,
@@ -179,8 +183,12 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
             if (PublishesOnChannel(delay.Value))
             {
                 var rmqMessagePublisher = new RmqMessagePublisher(Channel, Connection);
-                AddPendingConfirmation(await Channel.GetNextPublishSequenceNumberAsync(cancellationToken), message.Id);
+                var deliveryTag = await Channel.GetNextPublishSequenceNumberAsync(cancellationToken);
+                AddPendingConfirmation(deliveryTag, message.Id);
+                pendingDeliveryTag = deliveryTag;
                 await rmqMessagePublisher.PublishMessageAsync(message, delay.Value, cancellationToken);
+                // Publish succeeded; the broker now owns the confirmation and will ack/nack via the handler.
+                pendingDeliveryTag = null;
             }
             else if (useSchedulerAsync)
             {
@@ -201,6 +209,8 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
         {
             Log.ErrorTalkingToSocketAsync(s_logger, io, Connection.AmpqUri!.GetSanitizedUri());
             ClearPendingConfirmations();
+            // ClearPendingConfirmations removed the orphan; suppress the per-tag cleanup in finally.
+            pendingDeliveryTag = null;
             // Capture the failed channel before reset; otherwise the detach fires on the recovered channel
             // and the next send loses confirm tracking.
             var failedChannel = Channel;
@@ -214,6 +224,12 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
         }
         finally
         {
+            // Non-IOException failures (broker timeouts, OperationInterruptedException, cancellation) leave
+            // the registered tag in flight without a corresponding broker ack — remove it so disposal does
+            // not block waiting on a confirmation that will never arrive.
+            if (pendingDeliveryTag.HasValue)
+                RemovePendingConfirmations(pendingDeliveryTag.Value, multiple: false);
+
             CompleteSend();
         }
     }
@@ -325,7 +341,7 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
         Log.FailedToAwaitActiveSends(s_logger);
     }
 
-    private void WaitForPendingPublisherConfirmations() => BrighterAsyncContext.Run(() => WaitForPendingPublisherConfirmationsAsync());
+    private void WaitForPendingPublisherConfirmations() => BrighterAsyncContext.Run(WaitForPendingPublisherConfirmationsAsync);
 
     private async Task WaitForPendingPublisherConfirmationsAsync()
     {

--- a/src/Paramore.Brighter.MessagingGateway.RMQ.Async/RmqMessageProducer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ.Async/RmqMessageProducer.cs
@@ -26,6 +26,7 @@ THE SOFTWARE. */
 #nullable enable
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Text.Json;
@@ -53,7 +54,9 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
 
     private RmqPublication _publication;
     private readonly ConcurrentDictionary<ulong, string> _pendingConfirmations = new();
+    private readonly object _pendingConfirmationsLock = new();
     private readonly int _waitForConfirmsTimeOutInMilliseconds;
+    private TaskCompletionSource<bool> _publisherConfirmationsCompleted = CompletedPublisherConfirmationsTask();
     private int _disposed;
 
     /// <summary>
@@ -164,7 +167,7 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
             Log.PublishingMessageAsync(s_logger, Connection.Exchange.Name, Connection.AmpqUri.GetSanitizedUri(), delay.Value.TotalMilliseconds,
                 message.Header.Topic, message.Persist, message.Id, message.Body.Value);
 
-            _pendingConfirmations.TryAdd(await Channel.GetNextPublishSequenceNumberAsync(cancellationToken), message.Id);
+            AddPendingConfirmation(await Channel.GetNextPublishSequenceNumberAsync(cancellationToken), message.Id);
 
             if (delay == TimeSpan.Zero || DelaySupported || Scheduler == null)
             {
@@ -201,12 +204,15 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
 
         WaitForPendingPublisherConfirmations();
         DetachPublisherConfirmHandlers();
-        Channel?.AbortAsync().Wait();
-        Channel?.Dispose();
-        Channel = null;
 
-        // Producer-owned channel disposal only. Connection pool lifetime is tracked separately in #4102.
-        GC.SuppressFinalize(this);
+        if (Channel is not null)
+        {
+            BrighterAsyncContext.Run(() => Channel.AbortAsync());
+            Channel.Dispose();
+            Channel = null;
+        }
+
+        base.Dispose();
     }
 
     public sealed override async ValueTask DisposeAsync()
@@ -223,7 +229,7 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
             Channel = null;
         }
 
-        // Producer-owned channel disposal only. Connection pool lifetime is tracked separately in #4102.
+        await base.DisposeAsync();
         GC.SuppressFinalize(this);
     }
 
@@ -231,23 +237,73 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
 
     private async Task WaitForPendingPublisherConfirmationsAsync()
     {
-        if (Channel is not { IsOpen: true } || _pendingConfirmations.IsEmpty)
-            return;
+        Task publisherConfirmationsCompleted;
 
-        using var timeout = new CancellationTokenSource(_waitForConfirmsTimeOutInMilliseconds);
-
-        try
+        lock (_pendingConfirmationsLock)
         {
-            while (!_pendingConfirmations.IsEmpty)
-            {
-                await Task.Delay(10, timeout.Token);
-            }
+            if (Channel is not { IsOpen: true } || _pendingConfirmations.IsEmpty)
+                return;
+
+            publisherConfirmationsCompleted = _publisherConfirmationsCompleted.Task;
         }
-        catch (OperationCanceledException)
+
+        var timeout = Task.Delay(TimeSpan.FromMilliseconds(_waitForConfirmsTimeOutInMilliseconds));
+        var completed = await Task.WhenAny(publisherConfirmationsCompleted, timeout);
+
+        if (completed == publisherConfirmationsCompleted)
         {
-            Log.FailedToAwaitPublisherConfirms(s_logger);
+            await publisherConfirmationsCompleted;
+            return;
+        }
+
+        Log.FailedToAwaitPublisherConfirms(s_logger);
+    }
+
+    private void AddPendingConfirmation(ulong deliveryTag, string messageId)
+    {
+        lock (_pendingConfirmationsLock)
+        {
+            if (_pendingConfirmations.IsEmpty)
+                _publisherConfirmationsCompleted = PendingPublisherConfirmationsTask();
+
+            _pendingConfirmations.TryAdd(deliveryTag, messageId);
         }
     }
+
+    private IReadOnlyCollection<string> RemovePendingConfirmations(ulong deliveryTag, bool multiple)
+    {
+        var messageIds = new List<string>();
+
+        lock (_pendingConfirmationsLock)
+        {
+            foreach (var pendingConfirmation in _pendingConfirmations)
+            {
+                if (multiple && pendingConfirmation.Key > deliveryTag)
+                    continue;
+
+                if (!multiple && pendingConfirmation.Key != deliveryTag)
+                    continue;
+
+                if (_pendingConfirmations.TryRemove(pendingConfirmation.Key, out var messageId))
+                    messageIds.Add(messageId);
+            }
+
+            if (_pendingConfirmations.IsEmpty)
+                _publisherConfirmationsCompleted.TrySetResult(true);
+        }
+
+        return messageIds;
+    }
+
+    private static TaskCompletionSource<bool> CompletedPublisherConfirmationsTask()
+    {
+        var publisherConfirmationsCompleted = PendingPublisherConfirmationsTask();
+        publisherConfirmationsCompleted.SetResult(true);
+        return publisherConfirmationsCompleted;
+    }
+
+    private static TaskCompletionSource<bool> PendingPublisherConfirmationsTask()
+        => new(TaskCreationOptions.RunContinuationsAsynchronously);
 
     private void DetachPublisherConfirmHandlers()
     {
@@ -257,10 +313,9 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
 
     private Task OnPublishFailed(object sender, BasicNackEventArgs e)
     {
-        if (_pendingConfirmations.TryGetValue(e.DeliveryTag, out var messageId))
+        foreach (var messageId in RemovePendingConfirmations(e.DeliveryTag, e.Multiple))
         {
             OnMessagePublished?.Invoke(false, messageId);
-            _pendingConfirmations.TryRemove(e.DeliveryTag, out _);
             Log.FailedToPublishMessageAsync(s_logger, messageId);
         }
 
@@ -269,10 +324,9 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
 
     private Task OnPublishSucceeded(object sender, BasicAckEventArgs e)
     {
-        if (_pendingConfirmations.TryGetValue(e.DeliveryTag, out var messageId))
+        foreach (var messageId in RemovePendingConfirmations(e.DeliveryTag, e.Multiple))
         {
             OnMessagePublished?.Invoke(true, messageId);
-            _pendingConfirmations.TryRemove(e.DeliveryTag, out _);
             Log.PublishedMessage(s_logger, messageId);
         }
 
@@ -296,7 +350,7 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
         [LoggerMessage(LogLevel.Debug, "Failed to publish message: {MessageId}")]
         public static partial void FailedToPublishMessageAsync(ILogger logger, string messageId);
 
-        [LoggerMessage(LogLevel.Warning, "Failed to await publisher confirms when shutting down!")]
+        [LoggerMessage(LogLevel.Warning, "Failed to await publisher confirms when shutting down")]
         public static partial void FailedToAwaitPublisherConfirms(ILogger logger);
 
         [LoggerMessage(LogLevel.Information, "Published message: {MessageId}")]

--- a/src/Paramore.Brighter.MessagingGateway.RMQ.Async/RmqMessageProducer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ.Async/RmqMessageProducer.cs
@@ -142,6 +142,7 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
     
     private async Task SendWithDelayAsync(Message message, TimeSpan? delay, bool useSchedulerAsync, CancellationToken cancellationToken = default)
     {
+        // BeginSend is intentionally outside the try block; if it rejects a disposed producer, CompleteSend must not run.
         BeginSend();
 
         try
@@ -294,7 +295,20 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
             activeSendsCompleted = _activeSendsCompleted.Task;
         }
 
-        await activeSendsCompleted;
+        if (_waitForConfirmsTimeOutInMilliseconds == 0)
+            return;
+
+        using var timeoutCancellation = new CancellationTokenSource();
+        var timeout = Task.Delay(TimeSpan.FromMilliseconds(_waitForConfirmsTimeOutInMilliseconds), timeoutCancellation.Token);
+        var completed = await Task.WhenAny(activeSendsCompleted, timeout);
+
+        if (completed == activeSendsCompleted)
+        {
+            timeoutCancellation.Cancel();
+            return;
+        }
+
+        Log.FailedToAwaitActiveSends(s_logger);
     }
 
     private void WaitForPendingPublisherConfirmations() => BrighterAsyncContext.Run(() => WaitForPendingPublisherConfirmationsAsync());
@@ -361,7 +375,7 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
                     deliveryTagsToRemove.Add(pendingDeliveryTag);
             }
 
-            var messageIds = RemovePendingConfirmations(deliveryTagsToRemove);
+            var messageIds = RemoveConfirmationsLocked(deliveryTagsToRemove);
 
             if (_pendingConfirmations.Count == 0)
                 _publisherConfirmationsCompleted.TrySetResult(true);
@@ -370,7 +384,7 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
         }
     }
 
-    private List<string> RemovePendingConfirmations(IEnumerable<ulong> deliveryTagsToRemove)
+    private List<string> RemoveConfirmationsLocked(IEnumerable<ulong> deliveryTagsToRemove)
     {
         var messageIds = new List<string>();
 
@@ -443,6 +457,9 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
 
         [LoggerMessage(LogLevel.Warning, "Failed to await publisher confirms when shutting down")]
         public static partial void FailedToAwaitPublisherConfirms(ILogger logger);
+
+        [LoggerMessage(LogLevel.Warning, "Failed to await active sends when shutting down")]
+        public static partial void FailedToAwaitActiveSends(ILogger logger);
 
         [LoggerMessage(LogLevel.Information, "Published message: {MessageId}")]
         public static partial void PublishedMessage(ILogger logger, string messageId);

--- a/src/Paramore.Brighter.MessagingGateway.RMQ.Async/RmqMessageProducer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ.Async/RmqMessageProducer.cs
@@ -25,7 +25,6 @@ THE SOFTWARE. */
 
 #nullable enable
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -53,11 +52,13 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
     private static readonly ILogger s_logger = ApplicationLogging.CreateLogger<RmqMessageProducer>();
 
     private RmqPublication _publication;
-    private readonly ConcurrentDictionary<ulong, string> _pendingConfirmations = new();
-    private readonly object _pendingConfirmationsLock = new();
+    private readonly Dictionary<ulong, string> _pendingConfirmations = new();
+    private readonly object _stateLock = new();
     private readonly int _waitForConfirmsTimeOutInMilliseconds;
-    private TaskCompletionSource<bool> _publisherConfirmationsCompleted = CompletedPublisherConfirmationsTask();
+    private TaskCompletionSource<bool> _activeSendsCompleted = CompletedTask();
+    private TaskCompletionSource<bool> _publisherConfirmationsCompleted = CompletedTask();
     // Producer disposal has confirmation-specific work; the base guard separately protects channel and pool cleanup.
+    private int _activeSends;
     private int _disposed;
 
     /// <summary>
@@ -140,13 +141,15 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
     
     private async Task SendWithDelayAsync(Message message, TimeSpan? delay, bool useSchedulerAsync, CancellationToken cancellationToken = default)
     {
-        if (Connection.Exchange is null) throw new ConfigurationException("RmqMessageProducer: Exchange is not set");
-        if (Connection.AmpqUri is null) throw new ConfigurationException("RmqMessageProducer: Broker URL is not set");
-        
-        delay ??= TimeSpan.Zero;
+        BeginSend();
 
         try
         {
+            if (Connection.Exchange is null) throw new ConfigurationException("RmqMessageProducer: Exchange is not set");
+            if (Connection.AmpqUri is null) throw new ConfigurationException("RmqMessageProducer: Broker URL is not set");
+
+            delay ??= TimeSpan.Zero;
+
             Log.PreparingToSendAsync(s_logger, Connection.Exchange.Name);
             
             var channelInitialized = Channel is not null;   
@@ -191,11 +194,15 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
         }
         catch (IOException io)
         {
-            Log.ErrorTalkingToSocketAsync(s_logger, io, Connection.AmpqUri.GetSanitizedUri());
+            Log.ErrorTalkingToSocketAsync(s_logger, io, Connection.AmpqUri!.GetSanitizedUri());
             await ResetConnectionToBrokerAsync(cancellationToken);
             Channel?.BasicAcksAsync -= OnPublishSucceeded;
             Channel?.BasicNacksAsync -= OnPublishFailed;
             throw new ChannelFailureException("Error talking to the broker, see inner exception for details", io);
+        }
+        finally
+        {
+            CompleteSend();
         }
     }
 
@@ -203,13 +210,18 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
     {
         if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
 
+        WaitForActiveSends();
         WaitForPendingPublisherConfirmations();
         DetachPublisherConfirmHandlers();
 
-        if (Channel is not null)
+        var channel = Channel;
+        if (channel is not null)
         {
-            BrighterAsyncContext.Run(() => Channel.AbortAsync());
-            Channel.Dispose();
+            BrighterAsyncContext.Run(async () =>
+            {
+                await channel.AbortAsync();
+                await channel.DisposeAsync();
+            });
             Channel = null;
         }
 
@@ -221,13 +233,15 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
     {
         if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
 
+        await WaitForActiveSendsAsync();
         await WaitForPendingPublisherConfirmationsAsync();
         DetachPublisherConfirmHandlers();
 
-        if (Channel is not null)
+        var channel = Channel;
+        if (channel is not null)
         {
-            await Channel.AbortAsync();
-            await Channel.DisposeAsync();
+            await channel.AbortAsync();
+            await channel.DisposeAsync();
             Channel = null;
         }
 
@@ -235,38 +249,91 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
         GC.SuppressFinalize(this);
     }
 
-    private void WaitForPendingPublisherConfirmations() => BrighterAsyncContext.Run(WaitForPendingPublisherConfirmationsAsync);
+    private void BeginSend()
+    {
+        lock (_stateLock)
+        {
+            ThrowIfDisposed();
 
-    private async Task WaitForPendingPublisherConfirmationsAsync()
+            if (_activeSends == 0)
+                _activeSendsCompleted = PendingTask();
+
+            _activeSends++;
+        }
+    }
+
+    private void CompleteSend()
+    {
+        lock (_stateLock)
+        {
+            _activeSends--;
+
+            if (_activeSends == 0)
+                _activeSendsCompleted.TrySetResult(true);
+        }
+    }
+
+    private void ThrowIfDisposed()
+    {
+        if (Volatile.Read(ref _disposed) != 0)
+            throw new ObjectDisposedException(nameof(RmqMessageProducer));
+    }
+
+    private void WaitForActiveSends() => BrighterAsyncContext.Run(WaitForActiveSendsAsync);
+
+    private async Task WaitForActiveSendsAsync()
+    {
+        Task activeSendsCompleted;
+
+        lock (_stateLock)
+        {
+            if (_activeSends == 0)
+                return;
+
+            activeSendsCompleted = _activeSendsCompleted.Task;
+        }
+
+        await activeSendsCompleted;
+    }
+
+    private void WaitForPendingPublisherConfirmations() => BrighterAsyncContext.Run(() => WaitForPendingPublisherConfirmationsAsync());
+
+    private async Task WaitForPendingPublisherConfirmationsAsync(CancellationToken cancellationToken = default)
     {
         Task publisherConfirmationsCompleted;
 
-        lock (_pendingConfirmationsLock)
+        lock (_stateLock)
         {
-            if (Channel is not { IsOpen: true } || _pendingConfirmations.IsEmpty)
+            if (Channel is not { IsOpen: true } || _pendingConfirmations.Count == 0)
+                return;
+
+            if (_waitForConfirmsTimeOutInMilliseconds == 0)
                 return;
 
             publisherConfirmationsCompleted = _publisherConfirmationsCompleted.Task;
         }
 
-        var timeout = Task.Delay(TimeSpan.FromMilliseconds(_waitForConfirmsTimeOutInMilliseconds));
+        using var timeoutCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        var timeout = Task.Delay(TimeSpan.FromMilliseconds(_waitForConfirmsTimeOutInMilliseconds), timeoutCancellation.Token);
         var completed = await Task.WhenAny(publisherConfirmationsCompleted, timeout);
 
         if (completed == publisherConfirmationsCompleted)
         {
+            timeoutCancellation.Cancel();
             await publisherConfirmationsCompleted;
             return;
         }
 
+        await timeout;
         Log.FailedToAwaitPublisherConfirms(s_logger);
     }
 
     private void AddPendingConfirmation(ulong deliveryTag, string messageId)
     {
-        lock (_pendingConfirmationsLock)
+        lock (_stateLock)
         {
-            if (_pendingConfirmations.IsEmpty)
-                _publisherConfirmationsCompleted = PendingPublisherConfirmationsTask();
+            if (_pendingConfirmations.Count == 0)
+                _publisherConfirmationsCompleted = PendingTask();
 
             _pendingConfirmations.TryAdd(deliveryTag, messageId);
         }
@@ -274,39 +341,49 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
 
     private IReadOnlyCollection<string> RemovePendingConfirmations(ulong deliveryTag, bool multiple)
     {
-        var messageIds = new List<string>();
-
-        lock (_pendingConfirmationsLock)
+        lock (_stateLock)
         {
             var deliveryTagsToRemove = new List<ulong>();
 
             foreach (var pendingDeliveryTag in _pendingConfirmations.Keys)
             {
-                if (multiple ? pendingDeliveryTag <= deliveryTag : pendingDeliveryTag == deliveryTag)
+                if (IsConfirmedBy(pendingDeliveryTag, deliveryTag, multiple))
                     deliveryTagsToRemove.Add(pendingDeliveryTag);
             }
 
-            foreach (var pendingDeliveryTag in deliveryTagsToRemove)
-            {
-                if (_pendingConfirmations.TryRemove(pendingDeliveryTag, out var messageId))
-                    messageIds.Add(messageId);
-            }
+            var messageIds = RemovePendingConfirmations(deliveryTagsToRemove);
 
-            if (_pendingConfirmations.IsEmpty)
+            if (_pendingConfirmations.Count == 0)
                 _publisherConfirmationsCompleted.TrySetResult(true);
+
+            return messageIds;
+        }
+    }
+
+    private List<string> RemovePendingConfirmations(IEnumerable<ulong> deliveryTagsToRemove)
+    {
+        var messageIds = new List<string>();
+
+        foreach (var pendingDeliveryTag in deliveryTagsToRemove)
+        {
+            if (_pendingConfirmations.Remove(pendingDeliveryTag, out var messageId))
+                messageIds.Add(messageId);
         }
 
         return messageIds;
     }
 
-    private static TaskCompletionSource<bool> CompletedPublisherConfirmationsTask()
+    private static bool IsConfirmedBy(ulong pendingDeliveryTag, ulong deliveryTag, bool multiple)
+        => multiple ? pendingDeliveryTag <= deliveryTag : pendingDeliveryTag == deliveryTag;
+
+    private static TaskCompletionSource<bool> CompletedTask()
     {
-        var publisherConfirmationsCompleted = PendingPublisherConfirmationsTask();
-        publisherConfirmationsCompleted.SetResult(true);
-        return publisherConfirmationsCompleted;
+        var taskCompletionSource = PendingTask();
+        taskCompletionSource.SetResult(true);
+        return taskCompletionSource;
     }
 
-    private static TaskCompletionSource<bool> PendingPublisherConfirmationsTask()
+    private static TaskCompletionSource<bool> PendingTask()
         => new(TaskCreationOptions.RunContinuationsAsynchronously);
 
     private void DetachPublisherConfirmHandlers()

--- a/src/Paramore.Brighter.MessagingGateway.RMQ.Async/RmqMessageProducer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ.Async/RmqMessageProducer.cs
@@ -255,6 +255,8 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
         }
 
         base.Dispose();
+        // Explicit for symmetry with DisposeAsync; base.Dispose() also suppresses, so this is defensive.
+        GC.SuppressFinalize(this);
     }
 
     public sealed override async ValueTask DisposeAsync()

--- a/src/Paramore.Brighter.MessagingGateway.RMQ.Async/RmqPublication.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ.Async/RmqPublication.cs
@@ -10,8 +10,9 @@ namespace Paramore.Brighter.MessagingGateway.RMQ.Async
         /// and any sweeper will resend.
         /// When non-zero, this value also bounds the wait for in-flight sends to complete on shutdown.
         /// Use 0 to skip waiting for publisher confirmations; in-flight sends are still awaited with an
-        /// internal default timeout to avoid aborting partially-sent messages (which would otherwise be
-        /// marked Dispatched in the Outbox and re-sent as duplicates).
+        /// internal 5-second fallback to avoid aborting partially-sent messages (which would otherwise
+        /// be marked Dispatched in the Outbox and re-sent as duplicates), so disposal can block for up
+        /// to that fallback when sends are in flight.
         /// </summary>
         public int WaitForConfirmsTimeOutInMilliseconds { get; set; } = 500;
     }

--- a/src/Paramore.Brighter.MessagingGateway.RMQ.Async/RmqPublication.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ.Async/RmqPublication.cs
@@ -5,10 +5,13 @@ namespace Paramore.Brighter.MessagingGateway.RMQ.Async
     public class RmqPublication : Publication
     {
         /// <summary>
-        /// How long should we wait on shutdown for the broker to finish confirming delivery of messages
+        /// How long should we wait on shutdown for the broker to finish confirming delivery of messages.
         /// If we shut down without confirmation then messages will not be marked as sent in the Outbox
-        /// Any sweeper will then resend.
-        /// Use 0 to skip waiting for publisher confirmations on shutdown.
+        /// and any sweeper will resend.
+        /// When non-zero, this value also bounds the wait for in-flight sends to complete on shutdown.
+        /// Use 0 to skip waiting for publisher confirmations; in-flight sends are still awaited with an
+        /// internal default timeout to avoid aborting partially-sent messages (which would otherwise be
+        /// marked Dispatched in the Outbox and re-sent as duplicates).
         /// </summary>
         public int WaitForConfirmsTimeOutInMilliseconds { get; set; } = 500;
     }

--- a/src/Paramore.Brighter.MessagingGateway.RMQ.Async/RmqPublication.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ.Async/RmqPublication.cs
@@ -8,6 +8,7 @@ namespace Paramore.Brighter.MessagingGateway.RMQ.Async
         /// How long should we wait on shutdown for the broker to finish confirming delivery of messages
         /// If we shut down without confirmation then messages will not be marked as sent in the Outbox
         /// Any sweeper will then resend.
+        /// Use 0 to skip waiting for publisher confirmations on shutdown.
         /// </summary>
         public int WaitForConfirmsTimeOutInMilliseconds { get; set; } = 500;
     }

--- a/tests/Paramore.Brighter.RMQ.Async.Tests/MessagingGateway/Proactor/When_disposing_after_sending_should_publish_confirmation.cs
+++ b/tests/Paramore.Brighter.RMQ.Async.Tests/MessagingGateway/Proactor/When_disposing_after_sending_should_publish_confirmation.cs
@@ -81,6 +81,7 @@ public class RmqMessageProducerDisposeConfirmationTests : IDisposable
         _messageProducer.Dispose();
 
         // Assert
+        // Dispose waits for confirms; the timeout keeps failures bounded if that contract regresses.
         Assert.True(await _published.Task.WaitAsync(TimeSpan.FromSeconds(10)));
     }
 

--- a/tests/Paramore.Brighter.RMQ.Async.Tests/MessagingGateway/Proactor/When_disposing_after_sending_should_publish_confirmation.cs
+++ b/tests/Paramore.Brighter.RMQ.Async.Tests/MessagingGateway/Proactor/When_disposing_after_sending_should_publish_confirmation.cs
@@ -31,10 +31,13 @@ using Xunit;
 namespace Paramore.Brighter.RMQ.Async.Tests.MessagingGateway.Proactor;
 
 [Trait("Category", "RMQ")]
-public class RmqMessageProducerDisposeConfirmationTests : IDisposable
+public class RmqMessageProducerDisposeConfirmationTests : IDisposable, IAsyncLifetime
 {
     private readonly Message _message;
     private readonly RmqMessageProducer _messageProducer;
+    private readonly RmqMessagingGatewayConnection _rmqConnection;
+    private readonly ChannelName _channelName;
+    private readonly RoutingKeys _routingKeys;
     private readonly TaskCompletionSource<bool> _published = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
     public RmqMessageProducerDisposeConfirmationTests()
@@ -45,14 +48,16 @@ public class RmqMessageProducerDisposeConfirmationTests : IDisposable
             new MessageHeader(Guid.NewGuid().ToString(), routingKey, MessageType.MT_COMMAND),
             new MessageBody("test content"));
 
-        var rmqConnection = new RmqMessagingGatewayConnection
+        _rmqConnection = new RmqMessagingGatewayConnection
         {
             AmpqUri = new AmqpUriSpecification(new Uri("amqp://guest:guest@localhost:5672/%2f")),
             Exchange = new Exchange("paramore.brighter.exchange")
         };
+        _channelName = new ChannelName(Guid.NewGuid().ToString());
+        _routingKeys = new RoutingKeys(routingKey);
 
         _messageProducer = new RmqMessageProducer(
-            rmqConnection,
+            _rmqConnection,
             new RmqPublication
             {
                 MakeChannels = OnMissingChannel.Create,
@@ -64,17 +69,12 @@ public class RmqMessageProducerDisposeConfirmationTests : IDisposable
             if (messageId == _message.Id)
                 _published.TrySetResult(success);
         };
-
-        new QueueFactory(rmqConnection, new ChannelName(Guid.NewGuid().ToString()), new RoutingKeys(routingKey))
-            .CreateAsync()
-            .GetAwaiter()
-            .GetResult();
     }
 
     [Fact]
     public async Task When_disposing_after_sending_should_publish_confirmation()
     {
-        // Arrange handled by the constructor.
+        // Arrange handled by fixture setup.
 
         // Act
         _messageProducer.Send(_message);
@@ -90,4 +90,11 @@ public class RmqMessageProducerDisposeConfirmationTests : IDisposable
         // The test disposes explicitly; teardown keeps cleanup idempotent if the test fails first.
         _messageProducer.Dispose();
     }
+
+    public async Task InitializeAsync()
+    {
+        await new QueueFactory(_rmqConnection, _channelName, _routingKeys).CreateAsync();
+    }
+
+    Task IAsyncLifetime.DisposeAsync() => Task.CompletedTask;
 }

--- a/tests/Paramore.Brighter.RMQ.Async.Tests/MessagingGateway/Proactor/When_disposing_after_sending_should_publish_confirmation.cs
+++ b/tests/Paramore.Brighter.RMQ.Async.Tests/MessagingGateway/Proactor/When_disposing_after_sending_should_publish_confirmation.cs
@@ -31,13 +31,13 @@ using Xunit;
 namespace Paramore.Brighter.RMQ.Async.Tests.MessagingGateway.Proactor;
 
 [Trait("Category", "RMQ")]
-public class RmqMessageProducerDisposeAsyncConfirmationTests : IDisposable
+public class RmqMessageProducerDisposeConfirmationTests : IDisposable
 {
     private readonly Message _message;
     private readonly RmqMessageProducer _messageProducer;
     private readonly TaskCompletionSource<bool> _published = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-    public RmqMessageProducerDisposeAsyncConfirmationTests()
+    public RmqMessageProducerDisposeConfirmationTests()
     {
         var routingKey = new RoutingKey(Guid.NewGuid().ToString());
 
@@ -72,13 +72,13 @@ public class RmqMessageProducerDisposeAsyncConfirmationTests : IDisposable
     }
 
     [Fact]
-    public async Task When_disposing_async_after_sending_should_publish_confirmation()
+    public async Task When_disposing_after_sending_should_publish_confirmation()
     {
         // Arrange handled by the constructor.
 
         // Act
-        await _messageProducer.SendAsync(_message);
-        await _messageProducer.DisposeAsync();
+        _messageProducer.Send(_message);
+        _messageProducer.Dispose();
 
         // Assert
         Assert.True(_published.Task.IsCompletedSuccessfully);

--- a/tests/Paramore.Brighter.RMQ.Async.Tests/MessagingGateway/Proactor/When_disposing_after_sending_should_publish_confirmation.cs
+++ b/tests/Paramore.Brighter.RMQ.Async.Tests/MessagingGateway/Proactor/When_disposing_after_sending_should_publish_confirmation.cs
@@ -81,8 +81,7 @@ public class RmqMessageProducerDisposeConfirmationTests : IDisposable
         _messageProducer.Dispose();
 
         // Assert
-        Assert.True(_published.Task.IsCompletedSuccessfully);
-        Assert.True(await _published.Task);
+        Assert.True(await _published.Task.WaitAsync(TimeSpan.FromSeconds(5)));
     }
 
     public void Dispose()

--- a/tests/Paramore.Brighter.RMQ.Async.Tests/MessagingGateway/Proactor/When_disposing_after_sending_should_publish_confirmation.cs
+++ b/tests/Paramore.Brighter.RMQ.Async.Tests/MessagingGateway/Proactor/When_disposing_after_sending_should_publish_confirmation.cs
@@ -81,11 +81,12 @@ public class RmqMessageProducerDisposeConfirmationTests : IDisposable
         _messageProducer.Dispose();
 
         // Assert
-        Assert.True(await _published.Task.WaitAsync(TimeSpan.FromSeconds(5)));
+        Assert.True(await _published.Task.WaitAsync(TimeSpan.FromSeconds(10)));
     }
 
     public void Dispose()
     {
+        // The test disposes explicitly; teardown keeps cleanup idempotent if the test fails first.
         _messageProducer.Dispose();
     }
 }

--- a/tests/Paramore.Brighter.RMQ.Async.Tests/MessagingGateway/Proactor/When_disposing_async_after_sending_should_publish_confirmation.cs
+++ b/tests/Paramore.Brighter.RMQ.Async.Tests/MessagingGateway/Proactor/When_disposing_async_after_sending_should_publish_confirmation.cs
@@ -31,7 +31,7 @@ using Xunit;
 namespace Paramore.Brighter.RMQ.Async.Tests.MessagingGateway.Proactor;
 
 [Trait("Category", "RMQ")]
-public class RmqMessageProducerDisposeAsyncConfirmationTests : IDisposable
+public class RmqMessageProducerDisposeAsyncConfirmationTests : IDisposable, IAsyncDisposable
 {
     private readonly Message _message;
     private readonly RmqMessageProducer _messageProducer;
@@ -87,5 +87,10 @@ public class RmqMessageProducerDisposeAsyncConfirmationTests : IDisposable
     public void Dispose()
     {
         _messageProducer.Dispose();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _messageProducer.DisposeAsync();
     }
 }

--- a/tests/Paramore.Brighter.RMQ.Async.Tests/MessagingGateway/Proactor/When_disposing_async_after_sending_should_publish_confirmation.cs
+++ b/tests/Paramore.Brighter.RMQ.Async.Tests/MessagingGateway/Proactor/When_disposing_async_after_sending_should_publish_confirmation.cs
@@ -81,6 +81,7 @@ public class RmqMessageProducerDisposeAsyncConfirmationTests : IDisposable, IAsy
         await _messageProducer.DisposeAsync();
 
         // Assert
+        // DisposeAsync waits for confirms; the timeout keeps failures bounded if that contract regresses.
         Assert.True(await _published.Task.WaitAsync(TimeSpan.FromSeconds(10)));
     }
 

--- a/tests/Paramore.Brighter.RMQ.Async.Tests/MessagingGateway/Proactor/When_disposing_async_after_sending_should_publish_confirmation.cs
+++ b/tests/Paramore.Brighter.RMQ.Async.Tests/MessagingGateway/Proactor/When_disposing_async_after_sending_should_publish_confirmation.cs
@@ -31,10 +31,13 @@ using Xunit;
 namespace Paramore.Brighter.RMQ.Async.Tests.MessagingGateway.Proactor;
 
 [Trait("Category", "RMQ")]
-public class RmqMessageProducerDisposeAsyncConfirmationTests : IDisposable, IAsyncDisposable
+public class RmqMessageProducerDisposeAsyncConfirmationTests : IDisposable, IAsyncLifetime, IAsyncDisposable
 {
     private readonly Message _message;
     private readonly RmqMessageProducer _messageProducer;
+    private readonly RmqMessagingGatewayConnection _rmqConnection;
+    private readonly ChannelName _channelName;
+    private readonly RoutingKeys _routingKeys;
     private readonly TaskCompletionSource<bool> _published = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
     public RmqMessageProducerDisposeAsyncConfirmationTests()
@@ -45,14 +48,16 @@ public class RmqMessageProducerDisposeAsyncConfirmationTests : IDisposable, IAsy
             new MessageHeader(Guid.NewGuid().ToString(), routingKey, MessageType.MT_COMMAND),
             new MessageBody("test content"));
 
-        var rmqConnection = new RmqMessagingGatewayConnection
+        _rmqConnection = new RmqMessagingGatewayConnection
         {
             AmpqUri = new AmqpUriSpecification(new Uri("amqp://guest:guest@localhost:5672/%2f")),
             Exchange = new Exchange("paramore.brighter.exchange")
         };
+        _channelName = new ChannelName(Guid.NewGuid().ToString());
+        _routingKeys = new RoutingKeys(routingKey);
 
         _messageProducer = new RmqMessageProducer(
-            rmqConnection,
+            _rmqConnection,
             new RmqPublication
             {
                 MakeChannels = OnMissingChannel.Create,
@@ -64,17 +69,12 @@ public class RmqMessageProducerDisposeAsyncConfirmationTests : IDisposable, IAsy
             if (messageId == _message.Id)
                 _published.TrySetResult(success);
         };
-
-        new QueueFactory(rmqConnection, new ChannelName(Guid.NewGuid().ToString()), new RoutingKeys(routingKey))
-            .CreateAsync()
-            .GetAwaiter()
-            .GetResult();
     }
 
     [Fact]
     public async Task When_disposing_async_after_sending_should_publish_confirmation()
     {
-        // Arrange handled by the constructor.
+        // Arrange handled by fixture setup.
 
         // Act
         await _messageProducer.SendAsync(_message);
@@ -96,4 +96,11 @@ public class RmqMessageProducerDisposeAsyncConfirmationTests : IDisposable, IAsy
         // The test disposes explicitly; teardown keeps cleanup idempotent if the test fails first.
         await _messageProducer.DisposeAsync();
     }
+
+    public async Task InitializeAsync()
+    {
+        await new QueueFactory(_rmqConnection, _channelName, _routingKeys).CreateAsync();
+    }
+
+    Task IAsyncLifetime.DisposeAsync() => DisposeAsync().AsTask();
 }

--- a/tests/Paramore.Brighter.RMQ.Async.Tests/MessagingGateway/Proactor/When_disposing_async_after_sending_should_publish_confirmation.cs
+++ b/tests/Paramore.Brighter.RMQ.Async.Tests/MessagingGateway/Proactor/When_disposing_async_after_sending_should_publish_confirmation.cs
@@ -81,16 +81,18 @@ public class RmqMessageProducerDisposeAsyncConfirmationTests : IDisposable, IAsy
         await _messageProducer.DisposeAsync();
 
         // Assert
-        Assert.True(await _published.Task.WaitAsync(TimeSpan.FromSeconds(5)));
+        Assert.True(await _published.Task.WaitAsync(TimeSpan.FromSeconds(10)));
     }
 
     public void Dispose()
     {
+        // The test disposes explicitly; teardown keeps cleanup idempotent if the test fails first.
         _messageProducer.Dispose();
     }
 
     public async ValueTask DisposeAsync()
     {
+        // The test disposes explicitly; teardown keeps cleanup idempotent if the test fails first.
         await _messageProducer.DisposeAsync();
     }
 }

--- a/tests/Paramore.Brighter.RMQ.Async.Tests/MessagingGateway/Proactor/When_disposing_async_after_sending_should_publish_confirmation.cs
+++ b/tests/Paramore.Brighter.RMQ.Async.Tests/MessagingGateway/Proactor/When_disposing_async_after_sending_should_publish_confirmation.cs
@@ -1,0 +1,91 @@
+#region Licence
+
+/* The MIT License (MIT)
+Copyright © 2026 Tom Longhurst <30480171+thomhurst@users.noreply.github.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+using System;
+using System.Threading.Tasks;
+using Paramore.Brighter.MessagingGateway.RMQ.Async;
+using Xunit;
+
+namespace Paramore.Brighter.RMQ.Async.Tests.MessagingGateway.Proactor;
+
+[Trait("Category", "RMQ")]
+public class RmqMessageProducerDisposeAsyncConfirmationTests : IDisposable
+{
+    private readonly Message _message;
+    private readonly RmqMessageProducer _messageProducer;
+    private readonly TaskCompletionSource<bool> _published = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public RmqMessageProducerDisposeAsyncConfirmationTests()
+    {
+        var routingKey = new RoutingKey(Guid.NewGuid().ToString());
+
+        _message = new Message(
+            new MessageHeader(Guid.NewGuid().ToString(), routingKey, MessageType.MT_COMMAND),
+            new MessageBody("test content"));
+
+        var rmqConnection = new RmqMessagingGatewayConnection
+        {
+            AmpqUri = new AmqpUriSpecification(new Uri("amqp://guest:guest@localhost:5672/%2f")),
+            Exchange = new Exchange("paramore.brighter.exchange")
+        };
+
+        _messageProducer = new RmqMessageProducer(
+            rmqConnection,
+            new RmqPublication
+            {
+                MakeChannels = OnMissingChannel.Create,
+                WaitForConfirmsTimeOutInMilliseconds = 2000
+            });
+
+        _messageProducer.OnMessagePublished += (success, messageId) =>
+        {
+            if (messageId == _message.Id)
+                _published.TrySetResult(success);
+        };
+
+        new QueueFactory(rmqConnection, new ChannelName(Guid.NewGuid().ToString()), new RoutingKeys(routingKey))
+            .CreateAsync()
+            .GetAwaiter()
+            .GetResult();
+    }
+
+    [Fact]
+    public async Task When_disposing_async_after_sending_should_publish_confirmation()
+    {
+        // Arrange handled by the constructor.
+
+        // Act
+        await _messageProducer.SendAsync(_message);
+        await _messageProducer.DisposeAsync();
+
+        // Assert
+        Assert.True(await _published.Task.WaitAsync(TimeSpan.FromSeconds(2)));
+    }
+
+    public void Dispose()
+    {
+        _messageProducer.Dispose();
+    }
+}

--- a/tests/Paramore.Brighter.RMQ.Async.Tests/MessagingGateway/Proactor/When_disposing_async_after_sending_should_publish_confirmation.cs
+++ b/tests/Paramore.Brighter.RMQ.Async.Tests/MessagingGateway/Proactor/When_disposing_async_after_sending_should_publish_confirmation.cs
@@ -81,8 +81,7 @@ public class RmqMessageProducerDisposeAsyncConfirmationTests : IDisposable
         await _messageProducer.DisposeAsync();
 
         // Assert
-        Assert.True(_published.Task.IsCompletedSuccessfully);
-        Assert.True(await _published.Task);
+        Assert.True(await _published.Task.WaitAsync(TimeSpan.FromSeconds(5)));
     }
 
     public void Dispose()

--- a/tests/Paramore.Brighter.RMQ.Async.Tests/MessagingGateway/Proactor/When_disposing_async_after_sending_should_publish_confirmation.cs
+++ b/tests/Paramore.Brighter.RMQ.Async.Tests/MessagingGateway/Proactor/When_disposing_async_after_sending_should_publish_confirmation.cs
@@ -31,7 +31,7 @@ using Xunit;
 namespace Paramore.Brighter.RMQ.Async.Tests.MessagingGateway.Proactor;
 
 [Trait("Category", "RMQ")]
-public class RmqMessageProducerDisposeAsyncConfirmationTests : IDisposable, IAsyncLifetime, IAsyncDisposable
+public class RmqMessageProducerDisposeAsyncConfirmationTests : IDisposable, IAsyncLifetime
 {
     private readonly Message _message;
     private readonly RmqMessageProducer _messageProducer;
@@ -91,16 +91,14 @@ public class RmqMessageProducerDisposeAsyncConfirmationTests : IDisposable, IAsy
         _messageProducer.Dispose();
     }
 
-    public async ValueTask DisposeAsync()
-    {
-        // The test disposes explicitly; teardown keeps cleanup idempotent if the test fails first.
-        await _messageProducer.DisposeAsync();
-    }
-
     public async Task InitializeAsync()
     {
         await new QueueFactory(_rmqConnection, _channelName, _routingKeys).CreateAsync();
     }
 
-    Task IAsyncLifetime.DisposeAsync() => DisposeAsync().AsTask();
+    public async Task DisposeAsync()
+    {
+        // The test disposes explicitly; teardown keeps cleanup idempotent if the test fails first.
+        await _messageProducer.DisposeAsync();
+    }
 }

--- a/tests/Paramore.Brighter.RMQ.Async.Tests/MessagingGateway/Proactor/When_sending_after_dispose_should_throw_object_disposed_exception.cs
+++ b/tests/Paramore.Brighter.RMQ.Async.Tests/MessagingGateway/Proactor/When_sending_after_dispose_should_throw_object_disposed_exception.cs
@@ -1,0 +1,82 @@
+#region Licence
+
+/* The MIT License (MIT)
+Copyright © 2026 Tom Longhurst <30480171+thomhurst@users.noreply.github.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+using System;
+using System.Threading.Tasks;
+using Paramore.Brighter.MessagingGateway.RMQ.Async;
+using Xunit;
+
+namespace Paramore.Brighter.RMQ.Async.Tests.MessagingGateway.Proactor;
+
+public class RmqMessageProducerDisposedSendTests
+{
+    [Fact]
+    public void When_sending_after_dispose_should_throw_object_disposed_exception()
+    {
+        // Arrange
+        var messageProducer = CreateMessageProducer();
+        messageProducer.Dispose();
+
+        // Act
+        var exception = Record.Exception(() => messageProducer.Send(CreateMessage()));
+
+        // Assert
+        Assert.IsType<ObjectDisposedException>(exception);
+    }
+
+    [Fact]
+    public async Task When_sending_async_after_dispose_should_throw_object_disposed_exception()
+    {
+        // Arrange
+        var messageProducer = CreateMessageProducer();
+        await messageProducer.DisposeAsync();
+
+        // Act
+        var exception = await Record.ExceptionAsync(async () => await messageProducer.SendAsync(CreateMessage()));
+
+        // Assert
+        Assert.IsType<ObjectDisposedException>(exception);
+    }
+
+    private static RmqMessageProducer CreateMessageProducer()
+    {
+        var rmqConnection = new RmqMessagingGatewayConnection
+        {
+            AmpqUri = new AmqpUriSpecification(new Uri("amqp://guest:guest@localhost:5672/%2f")),
+            Exchange = new Exchange("paramore.brighter.exchange")
+        };
+
+        return new RmqMessageProducer(rmqConnection);
+    }
+
+    private static Message CreateMessage()
+    {
+        var routingKey = new RoutingKey(Guid.NewGuid().ToString());
+
+        return new Message(
+            new MessageHeader(Guid.NewGuid().ToString(), routingKey, MessageType.MT_COMMAND),
+            new MessageBody("test content"));
+    }
+}


### PR DESCRIPTION
## Summary

Fix RMQ async producer shutdown so producer-owned channels are disposed in both sync and async dispose paths. Shutdown now drains active sends, waits for pending publisher confirmations, detaches confirm handlers before channel teardown, disposes the producer channel, and then delegates to the base gateway cleanup so pooled connection lifetime is still handled by the base class.

Additional correctness fixes included in this PR:

- Handle RabbitMQ publisher confirms with `multiple=true`, resolving all pending delivery tags up to the broker-confirmed tag instead of leaving earlier confirmations stuck indefinitely.
- Capture the failed channel before `ResetConnectionToBrokerAsync` on `IOException`, so confirm handlers are detached from the failed channel rather than accidentally detached from a newly recovered channel.
- Harden producer disposal with atomic guards and explicit `ObjectDisposedException` behavior for sends after disposal.
- Preserve the `BeginSend` / `CompleteSend` invariant so rejected sends after disposal do not decrement active-send tracking.

## Verification

- RMQ async Release build passed.
- `Paramore.Brighter.RMQ.Async.Tests` builds for `net10.0`.
- Targeted `RmqMessageProducerDisposedSendTests` passed: 2/2.

Fixes #4109.