### PR TITLE
feat(sqs.v4): bypass string Body via raw bytes receive path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -344,3 +344,5 @@ ralph.log
 
 # AI agent session state
 PROMPT.md
+
+*.lscache

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS.V4/AWSClientFactory.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS.V4/AWSClientFactory.cs
@@ -29,6 +29,7 @@ using Amazon.Runtime;
 using Amazon.SecurityToken;
 using Amazon.SimpleNotificationService;
 using Amazon.SQS;
+using Paramore.Brighter.MessagingGateway.AWSSQS.V4.Internal;
 
 namespace Paramore.Brighter.MessagingGateway.AWSSQS.V4;
 
@@ -77,6 +78,22 @@ public class AWSClientFactory(
         ClientConfigAction?.Invoke(config);
 
         return new AmazonSQSClient(Credentials, config);
+    }
+
+    /// <summary>
+    /// Create an internal SQS client that supports the bytes-based receive path
+    /// used by <see cref="SqsMessageConsumer"/>. Constructed from the same
+    /// credentials and config as <see cref="CreateSqsClient"/>; not exposed on
+    /// the public factory contract so that a future user-supplied factory only
+    /// needs to produce a plain <see cref="AmazonSQSClient"/>.
+    /// </summary>
+    internal RawAmazonSQSClient CreateRawSqsClient()
+    {
+        var config = new AmazonSQSConfig { RegionEndpoint = RegionEndpoint };
+
+        ClientConfigAction?.Invoke(config);
+
+        return new RawAmazonSQSClient(Credentials, config);
     }
 
     /// <summary>

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS.V4/ISqsMessageCreator.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS.V4/ISqsMessageCreator.cs
@@ -1,9 +1,9 @@
-﻿#region Licence
+#region Licence
 /* The MIT License (MIT)
 Copyright © 2022 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the “Software”), to deal
+of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights
 to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
@@ -12,7 +12,7 @@ furnished to do so, subject to the following conditions:
 The above copyright notice and this permission notice shall be included in
 all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
@@ -21,16 +21,18 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE. */
 #endregion
 
+using Paramore.Brighter.MessagingGateway.AWSSQS.V4.Internal;
+
 namespace Paramore.Brighter.MessagingGateway.AWSSQS.V4;
 
 internal interface ISqsMessageCreator
 {
-    Message CreateMessage(Amazon.SQS.Model.Message sqsMessage);
+    Message CreateMessage(RawMessage sqsMessage);
 }
 
 internal class SqsMessageCreatorBase
 {
-    protected static HeaderResult<string> ReadReceiptHandle(Amazon.SQS.Model.Message sqsMessage)
+    protected static HeaderResult<string> ReadReceiptHandle(RawMessage sqsMessage)
     {
         if (sqsMessage.ReceiptHandle != null)
         {

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS.V4/Internal/RawAmazonSQSClient.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS.V4/Internal/RawAmazonSQSClient.cs
@@ -1,0 +1,68 @@
+#region Licence
+/* The MIT License (MIT)
+Copyright © 2026 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+#endregion
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon.Runtime;
+using Amazon.Runtime.Internal;
+using Amazon.SQS;
+using Amazon.SQS.Model;
+using Amazon.SQS.Model.Internal.MarshallTransformations;
+
+namespace Paramore.Brighter.MessagingGateway.AWSSQS.V4.Internal;
+
+/// <summary>
+/// An <see cref="AmazonSQSClient"/> subclass that adds <see cref="ReceiveMessageRawAsync"/>:
+/// a ReceiveMessage variant whose response carries the message body as raw UTF-8
+/// bytes (<see cref="ReadOnlyMemory{Byte}"/>) rather than a <see cref="string"/>.
+/// All other operations behave identically to <see cref="AmazonSQSClient"/>.
+/// </summary>
+internal sealed class RawAmazonSQSClient : AmazonSQSClient
+{
+    public RawAmazonSQSClient(AWSCredentials credentials, AmazonSQSConfig config)
+        : base(credentials, config)
+    {
+    }
+
+    /// <summary>
+    /// Issues a ReceiveMessage call and returns the response with each message body
+    /// captured as raw UTF-8 bytes, avoiding the string allocation that the standard
+    /// <see cref="AmazonSQSClient.ReceiveMessageAsync(ReceiveMessageRequest, CancellationToken)"/>
+    /// performs for <see cref="Amazon.SQS.Model.Message.Body"/>.
+    /// </summary>
+    public Task<ReceiveMessageRawResponse> ReceiveMessageRawAsync(
+        ReceiveMessageRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        if (request is null) throw new ArgumentNullException(nameof(request));
+
+        var options = new InvokeOptions
+        {
+            RequestMarshaller = ReceiveMessageRequestMarshaller.Instance,
+            ResponseUnmarshaller = ReceiveMessageRawResponseUnmarshaller.Instance,
+        };
+
+        return InvokeAsync<ReceiveMessageRawResponse>(request, options, cancellationToken);
+    }
+}

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS.V4/Internal/RawMessage.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS.V4/Internal/RawMessage.cs
@@ -1,0 +1,59 @@
+#region Licence
+/* The MIT License (MIT)
+Copyright © 2026 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using Amazon.Runtime;
+using Amazon.SQS.Model;
+
+namespace Paramore.Brighter.MessagingGateway.AWSSQS.V4.Internal;
+
+/// <summary>
+/// Mirrors <see cref="Amazon.SQS.Model.Message"/> but exposes the body as the raw
+/// UTF-8 bytes that came off the wire, rather than as a <see cref="string"/>. The
+/// Brighter pipeline takes <see cref="ReadOnlyMemory{Byte}"/> directly, so this
+/// avoids the SDK's per-message string allocation and the round-trip back to bytes
+/// that <see cref="MessageBody"/> would otherwise perform.
+/// </summary>
+internal sealed class RawMessage
+{
+    public string? MessageId { get; set; }
+    public string? ReceiptHandle { get; set; }
+    public string? MD5OfBody { get; set; }
+    public string? MD5OfMessageAttributes { get; set; }
+
+    /// <summary>
+    /// The message body as UTF-8 bytes. Backed by an array allocated for this
+    /// message; safe to retain past the receive call.
+    /// </summary>
+    public ReadOnlyMemory<byte> BodyBytes { get; set; }
+
+    public Dictionary<string, string> Attributes { get; set; } = new();
+
+    public Dictionary<string, MessageAttributeValue> MessageAttributes { get; set; } = new();
+}
+
+internal sealed class ReceiveMessageRawResponse : AmazonWebServiceResponse
+{
+    public List<RawMessage> Messages { get; set; } = new();
+}

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS.V4/Internal/RawMessageUnmarshaller.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS.V4/Internal/RawMessageUnmarshaller.cs
@@ -21,7 +21,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE. */
 #endregion
 
+using System;
 using System.Buffers;
+using System.Collections.Generic;
 using System.Text.Json;
 using Amazon.Runtime.Internal.Transform;
 using Amazon.Runtime.Internal.Util;
@@ -50,104 +52,109 @@ internal sealed class RawMessageUnmarshaller
         if (!context.IsEmptyResponse)
         {
             context.Read(ref reader);
-            if (context.CurrentTokenType == JsonTokenType.Null)
-            {
-                return null!;
-            }
+            if (context.CurrentTokenType == JsonTokenType.Null) return null!;
         }
 
         var depth = context.CurrentDepth;
         while (context.ReadAtDepth(depth, ref reader))
         {
-            if (context.TestExpression("Body", depth))
-            {
-                message.BodyBytes = ReadBodyBytes(context, ref reader);
-                continue;
-            }
-            if (context.TestExpression("MessageId", depth))
-            {
-                message.MessageId = StringUnmarshaller.Instance.Unmarshall(context, ref reader);
-                continue;
-            }
-            if (context.TestExpression("ReceiptHandle", depth))
-            {
-                message.ReceiptHandle = StringUnmarshaller.Instance.Unmarshall(context, ref reader);
-                continue;
-            }
-            if (context.TestExpression("MD5OfBody", depth))
-            {
-                message.MD5OfBody = StringUnmarshaller.Instance.Unmarshall(context, ref reader);
-                continue;
-            }
-            if (context.TestExpression("MD5OfMessageAttributes", depth))
-            {
-                message.MD5OfMessageAttributes = StringUnmarshaller.Instance.Unmarshall(context, ref reader);
-                continue;
-            }
-            if (context.TestExpression("Attributes", depth))
-            {
-                var dict = new JsonDictionaryUnmarshaller<string, string, StringUnmarshaller, StringUnmarshaller>(
-                    StringUnmarshaller.Instance, StringUnmarshaller.Instance);
-                message.Attributes = dict.Unmarshall(context, ref reader) ?? new();
-                continue;
-            }
-            if (context.TestExpression("MessageAttributes", depth))
-            {
-                var dict = new JsonDictionaryUnmarshaller<string, MessageAttributeValue, StringUnmarshaller, MessageAttributeValueUnmarshaller>(
-                    StringUnmarshaller.Instance, MessageAttributeValueUnmarshaller.Instance);
-                message.MessageAttributes = dict.Unmarshall(context, ref reader) ?? new();
-                continue;
-            }
+            ReadField(message, context, ref reader, depth);
         }
 
         return message;
     }
 
-    private static System.ReadOnlyMemory<byte> ReadBodyBytes(JsonUnmarshallerContext context, ref StreamingUtf8JsonReader reader)
+    private static void ReadField(RawMessage message, JsonUnmarshallerContext context, ref StreamingUtf8JsonReader reader, int depth)
+    {
+        if (context.TestExpression("Body", depth))
+        {
+            message.BodyBytes = ReadBodyBytes(context, ref reader);
+            return;
+        }
+        if (context.TestExpression("MessageId", depth))
+        {
+            message.MessageId = StringUnmarshaller.Instance.Unmarshall(context, ref reader);
+            return;
+        }
+        if (context.TestExpression("ReceiptHandle", depth))
+        {
+            message.ReceiptHandle = StringUnmarshaller.Instance.Unmarshall(context, ref reader);
+            return;
+        }
+        if (context.TestExpression("MD5OfBody", depth))
+        {
+            message.MD5OfBody = StringUnmarshaller.Instance.Unmarshall(context, ref reader);
+            return;
+        }
+        if (context.TestExpression("MD5OfMessageAttributes", depth))
+        {
+            message.MD5OfMessageAttributes = StringUnmarshaller.Instance.Unmarshall(context, ref reader);
+            return;
+        }
+        if (context.TestExpression("Attributes", depth))
+        {
+            message.Attributes = ReadAttributes(context, ref reader);
+            return;
+        }
+        if (context.TestExpression("MessageAttributes", depth))
+        {
+            message.MessageAttributes = ReadMessageAttributes(context, ref reader);
+        }
+    }
+
+    private static Dictionary<string, string> ReadAttributes(JsonUnmarshallerContext context, ref StreamingUtf8JsonReader reader)
+    {
+        var dict = new JsonDictionaryUnmarshaller<string, string, StringUnmarshaller, StringUnmarshaller>(
+            StringUnmarshaller.Instance, StringUnmarshaller.Instance);
+        return dict.Unmarshall(context, ref reader) ?? new();
+    }
+
+    private static Dictionary<string, MessageAttributeValue> ReadMessageAttributes(JsonUnmarshallerContext context, ref StreamingUtf8JsonReader reader)
+    {
+        var dict = new JsonDictionaryUnmarshaller<string, MessageAttributeValue, StringUnmarshaller, MessageAttributeValueUnmarshaller>(
+            StringUnmarshaller.Instance, MessageAttributeValueUnmarshaller.Instance);
+        return dict.Unmarshall(context, ref reader) ?? new();
+    }
+
+    private static ReadOnlyMemory<byte> ReadBodyBytes(JsonUnmarshallerContext context, ref StreamingUtf8JsonReader reader)
     {
         // Advance to the value token for the current "Body" property.
         context.Read(ref reader);
 
         var jsonReader = reader.Reader;
-        if (jsonReader.TokenType == JsonTokenType.Null)
-        {
-            return System.ReadOnlyMemory<byte>.Empty;
-        }
+        if (jsonReader.TokenType == JsonTokenType.Null) return ReadOnlyMemory<byte>.Empty;
 
-        // Body is a JSON string in the SQS protocol. Copy the unescaped UTF-8 bytes
-        // (the user's payload) into a freshly-allocated array so the buffer is safe
-        // to retain past the SDK's response-stream lifetime.
+        // Body is a JSON string in the SQS protocol; an unexpected token type is a
+        // protocol violation we surface loudly rather than silently dropping data.
         if (jsonReader.TokenType != JsonTokenType.String)
         {
-            // SQS Body is always a JSON string; an unexpected token type is a
-            // protocol violation. Surface it loudly rather than silently dropping
-            // data.
-            throw new System.Text.Json.JsonException(
-                $"Expected JSON string for SQS Message.Body but found {jsonReader.TokenType}.");
+            throw new JsonException($"Expected JSON string for SQS Message.Body but found {jsonReader.TokenType}.");
         }
 
-        if (!jsonReader.ValueIsEscaped)
+        // Copy the unescaped UTF-8 bytes (the user's payload) into a freshly-allocated
+        // array so the buffer is safe to retain past the SDK's response-stream lifetime.
+        return jsonReader.ValueIsEscaped
+            ? CopyEscaped(ref jsonReader)
+            : CopyUnescaped(ref jsonReader);
+    }
+
+    private static byte[] CopyUnescaped(ref Utf8JsonReader jsonReader)
+    {
+        if (!jsonReader.HasValueSequence)
         {
-            if (jsonReader.HasValueSequence)
-            {
-                var seq = jsonReader.ValueSequence;
-                var len = checked((int)seq.Length);
-                var copy = new byte[len];
-                seq.CopyTo(copy);
-                return copy;
-            }
-            else
-            {
-                var span = jsonReader.ValueSpan;
-                var copy = new byte[span.Length];
-                span.CopyTo(copy);
-                return copy;
-            }
+            return jsonReader.ValueSpan.ToArray();
         }
 
-        // Escaped path: copy the unescaped value into a pooled scratch buffer to
-        // determine the actual length, then trim into a right-sized array. The
-        // pooled buffer is returned before we leave the method.
+        var seq = jsonReader.ValueSequence;
+        var copy = new byte[checked((int)seq.Length)];
+        seq.CopyTo(copy);
+        return copy;
+    }
+
+    private static byte[] CopyEscaped(ref Utf8JsonReader jsonReader)
+    {
+        // The unescaped value can only shrink, so the source length is a safe upper
+        // bound for the scratch buffer.
         var maxLen = jsonReader.HasValueSequence
             ? checked((int)jsonReader.ValueSequence.Length)
             : jsonReader.ValueSpan.Length;
@@ -156,7 +163,7 @@ internal sealed class RawMessageUnmarshaller
         {
             var written = jsonReader.CopyString(scratch);
             var copy = new byte[written];
-            System.Buffer.BlockCopy(scratch, 0, copy, 0, written);
+            Buffer.BlockCopy(scratch, 0, copy, 0, written);
             return copy;
         }
         finally
@@ -164,5 +171,4 @@ internal sealed class RawMessageUnmarshaller
             ArrayPool<byte>.Shared.Return(scratch);
         }
     }
-
 }

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS.V4/Internal/RawMessageUnmarshaller.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS.V4/Internal/RawMessageUnmarshaller.cs
@@ -1,0 +1,168 @@
+#region Licence
+/* The MIT License (MIT)
+Copyright © 2026 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+#endregion
+
+using System.Buffers;
+using System.Text.Json;
+using Amazon.Runtime.Internal.Transform;
+using Amazon.Runtime.Internal.Util;
+using Amazon.SQS.Model;
+using Amazon.SQS.Model.Internal.MarshallTransformations;
+
+namespace Paramore.Brighter.MessagingGateway.AWSSQS.V4.Internal;
+
+/// <summary>
+/// Reads a single SQS Message JSON object into a <see cref="RawMessage"/>,
+/// capturing the Body field as raw UTF-8 bytes (copied into a fresh array) instead
+/// of decoding it to a <see cref="string"/>. Mirrors the field walk in the SDK's
+/// <c>MessageUnmarshaller</c> for everything else.
+/// </summary>
+internal sealed class RawMessageUnmarshaller
+    : IJsonUnmarshaller<RawMessage, JsonUnmarshallerContext>
+{
+    public static RawMessageUnmarshaller Instance { get; } = new();
+
+    private RawMessageUnmarshaller() { }
+
+    public RawMessage Unmarshall(JsonUnmarshallerContext context, ref StreamingUtf8JsonReader reader)
+    {
+        var message = new RawMessage();
+
+        if (!context.IsEmptyResponse)
+        {
+            context.Read(ref reader);
+            if (context.CurrentTokenType == JsonTokenType.Null)
+            {
+                return null!;
+            }
+        }
+
+        var depth = context.CurrentDepth;
+        while (context.ReadAtDepth(depth, ref reader))
+        {
+            if (context.TestExpression("Body", depth))
+            {
+                message.BodyBytes = ReadBodyBytes(context, ref reader);
+                continue;
+            }
+            if (context.TestExpression("MessageId", depth))
+            {
+                message.MessageId = StringUnmarshaller.Instance.Unmarshall(context, ref reader);
+                continue;
+            }
+            if (context.TestExpression("ReceiptHandle", depth))
+            {
+                message.ReceiptHandle = StringUnmarshaller.Instance.Unmarshall(context, ref reader);
+                continue;
+            }
+            if (context.TestExpression("MD5OfBody", depth))
+            {
+                message.MD5OfBody = StringUnmarshaller.Instance.Unmarshall(context, ref reader);
+                continue;
+            }
+            if (context.TestExpression("MD5OfMessageAttributes", depth))
+            {
+                message.MD5OfMessageAttributes = StringUnmarshaller.Instance.Unmarshall(context, ref reader);
+                continue;
+            }
+            if (context.TestExpression("Attributes", depth))
+            {
+                var dict = new JsonDictionaryUnmarshaller<string, string, StringUnmarshaller, StringUnmarshaller>(
+                    StringUnmarshaller.Instance, StringUnmarshaller.Instance);
+                message.Attributes = dict.Unmarshall(context, ref reader) ?? new();
+                continue;
+            }
+            if (context.TestExpression("MessageAttributes", depth))
+            {
+                var dict = new JsonDictionaryUnmarshaller<string, MessageAttributeValue, StringUnmarshaller, MessageAttributeValueUnmarshaller>(
+                    StringUnmarshaller.Instance, MessageAttributeValueUnmarshaller.Instance);
+                message.MessageAttributes = dict.Unmarshall(context, ref reader) ?? new();
+                continue;
+            }
+        }
+
+        return message;
+    }
+
+    private static System.ReadOnlyMemory<byte> ReadBodyBytes(JsonUnmarshallerContext context, ref StreamingUtf8JsonReader reader)
+    {
+        // Advance to the value token for the current "Body" property.
+        context.Read(ref reader);
+
+        var jsonReader = reader.Reader;
+        if (jsonReader.TokenType == JsonTokenType.Null)
+        {
+            return System.ReadOnlyMemory<byte>.Empty;
+        }
+
+        // Body is a JSON string in the SQS protocol. Copy the unescaped UTF-8 bytes
+        // (the user's payload) into a freshly-allocated array so the buffer is safe
+        // to retain past the SDK's response-stream lifetime.
+        if (jsonReader.TokenType != JsonTokenType.String)
+        {
+            // SQS Body is always a JSON string; an unexpected token type is a
+            // protocol violation. Surface it loudly rather than silently dropping
+            // data.
+            throw new System.Text.Json.JsonException(
+                $"Expected JSON string for SQS Message.Body but found {jsonReader.TokenType}.");
+        }
+
+        if (!jsonReader.ValueIsEscaped)
+        {
+            if (jsonReader.HasValueSequence)
+            {
+                var seq = jsonReader.ValueSequence;
+                var len = checked((int)seq.Length);
+                var copy = new byte[len];
+                seq.CopyTo(copy);
+                return copy;
+            }
+            else
+            {
+                var span = jsonReader.ValueSpan;
+                var copy = new byte[span.Length];
+                span.CopyTo(copy);
+                return copy;
+            }
+        }
+
+        // Escaped path: copy the unescaped value into a pooled scratch buffer to
+        // determine the actual length, then trim into a right-sized array. The
+        // pooled buffer is returned before we leave the method.
+        var maxLen = jsonReader.HasValueSequence
+            ? checked((int)jsonReader.ValueSequence.Length)
+            : jsonReader.ValueSpan.Length;
+        var scratch = ArrayPool<byte>.Shared.Rent(maxLen);
+        try
+        {
+            var written = jsonReader.CopyString(scratch);
+            var copy = new byte[written];
+            System.Buffer.BlockCopy(scratch, 0, copy, 0, written);
+            return copy;
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(scratch);
+        }
+    }
+
+}

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS.V4/Internal/ReceiveMessageRawResponseUnmarshaller.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS.V4/Internal/ReceiveMessageRawResponseUnmarshaller.cs
@@ -1,0 +1,73 @@
+#region Licence
+/* The MIT License (MIT)
+Copyright © 2026 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+#endregion
+
+using System.Net;
+using Amazon.Runtime;
+using Amazon.Runtime.Internal.Transform;
+using Amazon.Runtime.Internal.Util;
+using Amazon.SQS.Model.Internal.MarshallTransformations;
+
+namespace Paramore.Brighter.MessagingGateway.AWSSQS.V4.Internal;
+
+/// <summary>
+/// Mirrors the SDK's <c>ReceiveMessageResponseUnmarshaller</c> but produces a
+/// <see cref="ReceiveMessageRawResponse"/> by routing each message through
+/// <see cref="RawMessageUnmarshaller"/>.
+/// </summary>
+internal sealed class ReceiveMessageRawResponseUnmarshaller : JsonResponseUnmarshaller
+{
+    public static ReceiveMessageRawResponseUnmarshaller Instance { get; } = new();
+
+    private ReceiveMessageRawResponseUnmarshaller() { }
+
+    public override AmazonWebServiceResponse Unmarshall(JsonUnmarshallerContext context)
+    {
+        var response = new ReceiveMessageRawResponse();
+        var reader = new StreamingUtf8JsonReader(context.Stream);
+        context.Read(ref reader);
+
+        var depth = context.CurrentDepth;
+        while (context.ReadAtDepth(depth, ref reader))
+        {
+            if (context.TestExpression("Messages", depth))
+            {
+                var listUnmarshaller = new JsonListUnmarshaller<RawMessage, RawMessageUnmarshaller>(
+                    RawMessageUnmarshaller.Instance);
+                response.Messages = listUnmarshaller.Unmarshall(context, ref reader) ?? new();
+            }
+        }
+
+        return response;
+    }
+
+    public override AmazonServiceException UnmarshallException(
+        JsonUnmarshallerContext context,
+        System.Exception innerException,
+        HttpStatusCode statusCode)
+    {
+        // Delegate to the SDK-supplied unmarshaller so that service-specific error
+        // types (QueueDoesNotExist, etc.) are produced exactly as they would be for
+        // the standard ReceiveMessage call.
+        return ReceiveMessageResponseUnmarshaller.Instance.UnmarshallException(context, innerException, statusCode);
+    }
+}

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS.V4/SqsInlineMessageCreator.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS.V4/SqsInlineMessageCreator.cs
@@ -32,6 +32,7 @@ using Amazon.SQS;
 using Microsoft.Extensions.Logging;
 using Paramore.Brighter.JsonConverters;
 using Paramore.Brighter.Logging;
+using Paramore.Brighter.MessagingGateway.AWSSQS.V4.Internal;
 using Paramore.Brighter.Observability;
 
 namespace Paramore.Brighter.MessagingGateway.AWSSQS.V4;
@@ -42,14 +43,16 @@ internal sealed partial class SqsInlineMessageCreator : SqsMessageCreatorBase, I
 
     private Dictionary<string, JsonElement> _messageAttributes = new();
 
-    public Message CreateMessage(Amazon.SQS.Model.Message sqsMessage)
+    public Message CreateMessage(RawMessage sqsMessage)
     {
         var topic = HeaderResult<RoutingKey>.Empty();
         var messageId = HeaderResult<Id?>.Empty();
 
         try
         {
-            var jsonDocument = JsonDocument.Parse(sqsMessage.Body);
+            // Parse the SNS-wrapped envelope directly from the UTF-8 byte buffer,
+            // skipping the string materialization the SDK would otherwise perform.
+            var jsonDocument = JsonDocument.Parse(sqsMessage.BodyBytes);
             _messageAttributes = ReadMessageAttributes(jsonDocument);
 
             topic = ReadTopic();
@@ -81,7 +84,7 @@ internal sealed partial class SqsInlineMessageCreator : SqsMessageCreatorBase, I
 
             if (receiptHandle.Success)
             {
-                bag["ReceiptHandle"] = sqsMessage.ReceiptHandle;
+                bag["ReceiptHandle"] = sqsMessage.ReceiptHandle!;
             }
 
             var messageHeader = new MessageHeader(
@@ -404,7 +407,7 @@ internal sealed partial class SqsInlineMessageCreator : SqsMessageCreatorBase, I
         return new MessageBody(string.Empty);
     }
 
-    private static HeaderResult<PartitionKey> ReadPartitionKey(Amazon.SQS.Model.Message sqsMessage)
+    private static HeaderResult<PartitionKey> ReadPartitionKey(RawMessage sqsMessage)
     {
         if (sqsMessage.Attributes.TryGetValue(MessageSystemAttributeName.MessageGroupId, out var value))
         {
@@ -415,7 +418,7 @@ internal sealed partial class SqsInlineMessageCreator : SqsMessageCreatorBase, I
         return new HeaderResult<PartitionKey>(string.Empty, false);
     }
 
-    private static HeaderResult<string> ReadDeduplicationId(Amazon.SQS.Model.Message sqsMessage)
+    private static HeaderResult<string> ReadDeduplicationId(RawMessage sqsMessage)
     {
         if (sqsMessage.Attributes.TryGetValue(MessageSystemAttributeName.MessageDeduplicationId, out var value))
         {

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS.V4/SqsMessageConsumer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS.V4/SqsMessageConsumer.cs
@@ -32,6 +32,7 @@ using Amazon.SQS.Model;
 using Microsoft.Extensions.Logging;
 using Paramore.Brighter.JsonConverters;
 using Paramore.Brighter.Logging;
+using Paramore.Brighter.MessagingGateway.AWSSQS.V4.Internal;
 using Paramore.Brighter.Tasks;
 
 namespace Paramore.Brighter.MessagingGateway.AWSSQS.V4;
@@ -257,11 +258,15 @@ public partial class SqsMessageConsumer : IAmAMessageConsumerSync, IAmAMessageCo
     public async Task<Message[]> ReceiveAsync(TimeSpan? timeOut = null,
         CancellationToken cancellationToken = default(CancellationToken))
     {
-        AmazonSQSClient? client = null;
-        Amazon.SQS.Model.Message[] sqsMessages;
+        RawAmazonSQSClient? client = null;
+        RawMessage[] sqsMessages;
         try
         {
-            client = _clientFactory.CreateSqsClient();
+            // The receive path uses an internal RawAmazonSQSClient that hands back
+            // the message body as UTF-8 bytes. It is constructed from the same
+            // credentials and config as CreateSqsClient, so a future custom factory
+            // (which only needs to produce a plain AmazonSQSClient) is unaffected.
+            client = _clientFactory.CreateRawSqsClient();
 
             await EnsureChannelUrl(client, cancellationToken);
             timeOut ??= TimeSpan.Zero;
@@ -276,9 +281,9 @@ public partial class SqsMessageConsumer : IAmAMessageConsumerSync, IAmAMessageCo
                 MessageSystemAttributeNames = ["All"]
             };
 
-            var receiveResponse = await client.ReceiveMessageAsync(request, cancellationToken);
+            var receiveResponse = await client.ReceiveMessageRawAsync(request, cancellationToken);
 
-            sqsMessages = receiveResponse.Messages?.ToArray() ?? [];
+            sqsMessages = receiveResponse.Messages.ToArray();
         }
         catch (InvalidOperationException ioe)
         {

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS.V4/SqsMessageCreator.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS.V4/SqsMessageCreator.cs
@@ -24,14 +24,18 @@ THE SOFTWARE. */
 #endregion
 
 using System;
+using System.Buffers;
+using System.Buffers.Text;
 using System.Collections.Generic;
 using System.Net.Mime;
+using System.Runtime.InteropServices;
 using Amazon;
 using Amazon.SQS;
 using Amazon.SQS.Model;
 using Microsoft.Extensions.Logging;
 using Paramore.Brighter.JsonConverters;
 using Paramore.Brighter.Logging;
+using Paramore.Brighter.MessagingGateway.AWSSQS.V4.Internal;
 using Paramore.Brighter.Observability;
 using Paramore.Brighter.Transforms.Transformers;
 
@@ -54,7 +58,7 @@ internal sealed partial class SqsMessageCreator : SqsMessageCreatorBase, ISqsMes
 {
     private static readonly ILogger s_logger = ApplicationLogging.CreateLogger<SqsMessageCreator>();
 
-    public Message CreateMessage(Amazon.SQS.Model.Message sqsMessage)
+    public Message CreateMessage(RawMessage sqsMessage)
     {
         var topic = HeaderResult<RoutingKey>.Empty();
         var messageId = HeaderResult<Id?>.Empty();
@@ -145,7 +149,7 @@ internal sealed partial class SqsMessageCreator : SqsMessageCreatorBase, ISqsMes
         return new HeaderResult<Uri?>(null, false);
     }
     
-    private static Dictionary<string, string> ReadCloudEventHeaders(Amazon.SQS.Model.Message sqsMessage)
+    private static Dictionary<string, string> ReadCloudEventHeaders(RawMessage sqsMessage)
     {
         if (sqsMessage.MessageAttributes.TryGetValue(HeaderNames.CloudEventHeaders, out var value))
         {
@@ -227,17 +231,46 @@ internal sealed partial class SqsMessageCreator : SqsMessageCreatorBase, ISqsMes
     }
 
 
-    private static MessageBody ReadMessageBody(Amazon.SQS.Model.Message sqsMessage, ContentType contentType)
+    private static MessageBody ReadMessageBody(RawMessage sqsMessage, ContentType contentType)
     {
+        var bodyBytes = sqsMessage.BodyBytes;
+
         if (contentType.ToString() == CompressPayloadTransformer.GZIP
             || contentType.ToString() == CompressPayloadTransformer.DEFLATE
             || contentType.ToString() == CompressPayloadTransformer.BROTLI)
-            return new MessageBody(sqsMessage.Body, contentType, CharacterEncoding.Base64);
+        {
+            // The wire body is a Base64-encoded UTF-8 string. We allocated the
+            // backing array ourselves in RawMessageUnmarshaller, so decode in
+            // place and slice — no string materialization, no extra allocation.
+            return new MessageBody(DecodeBase64FromUtf8InPlace(bodyBytes), contentType);
+        }
 
-        return new MessageBody(sqsMessage.Body, contentType);
+        return new MessageBody(bodyBytes, contentType);
     }
 
-    private static Dictionary<string, object> ReadMessageBag(Amazon.SQS.Model.Message sqsMessage)
+    private static ReadOnlyMemory<byte> DecodeBase64FromUtf8InPlace(ReadOnlyMemory<byte> utf8)
+    {
+        // Base64 always shrinks (4 chars in, 3 bytes out), so we can decode the
+        // input buffer onto itself and return a slice. The buffer is the byte[]
+        // that RawMessageUnmarshaller allocated for this message.
+        if (MemoryMarshal.TryGetArray(utf8, out ArraySegment<byte> segment))
+        {
+            var span = segment.AsSpan();
+            var status = Base64.DecodeFromUtf8InPlace(span, out var written);
+            if (status == OperationStatus.Done)
+            {
+                return utf8.Slice(0, written);
+            }
+        }
+
+        // Fallback path: the memory wasn't array-backed (shouldn't happen) or the
+        // bytes weren't valid Base64. Preserve prior behaviour by going through
+        // System.Convert rather than throwing.
+        var ascii = utf8.ToArray();
+        return Convert.FromBase64String(System.Text.Encoding.UTF8.GetString(ascii, 0, ascii.Length));
+    }
+
+    private static Dictionary<string, object> ReadMessageBag(RawMessage sqsMessage)
     {
         if (sqsMessage.MessageAttributes.TryGetValue(HeaderNames.Bag, out MessageAttributeValue? value))
         {
@@ -257,7 +290,7 @@ internal sealed partial class SqsMessageCreator : SqsMessageCreatorBase, ISqsMes
         return new Dictionary<string, object>();
     }
 
-    private static HeaderResult<RoutingKey> ReadReplyTo(Amazon.SQS.Model.Message sqsMessage)
+    private static HeaderResult<RoutingKey> ReadReplyTo(RawMessage sqsMessage)
     {
         if (sqsMessage.MessageAttributes.TryGetValue(HeaderNames.ReplyTo, out MessageAttributeValue? value))
         {
@@ -267,7 +300,7 @@ internal sealed partial class SqsMessageCreator : SqsMessageCreatorBase, ISqsMes
         return new HeaderResult<RoutingKey>(RoutingKey.Empty, true);
     }
 
-    private static HeaderResult<DateTimeOffset> ReadTimestamp(Amazon.SQS.Model.Message sqsMessage, Dictionary<string, string> headers)
+    private static HeaderResult<DateTimeOffset> ReadTimestamp(RawMessage sqsMessage, Dictionary<string, string> headers)
     {
         if (headers.TryGetValue(HeaderNames.Timestamp, out var val) 
             && DateTimeOffset.TryParse(val, out var timestamp))
@@ -290,7 +323,7 @@ internal sealed partial class SqsMessageCreator : SqsMessageCreatorBase, ISqsMes
         return new HeaderResult<DateTimeOffset>(DateTimeOffset.UtcNow, true);
     }
 
-    private static HeaderResult<MessageType> ReadMessageType(Amazon.SQS.Model.Message sqsMessage)
+    private static HeaderResult<MessageType> ReadMessageType(RawMessage sqsMessage)
     {
         if (sqsMessage.MessageAttributes.TryGetValue(HeaderNames.MessageType, out MessageAttributeValue? value))
         {
@@ -314,7 +347,7 @@ internal sealed partial class SqsMessageCreator : SqsMessageCreatorBase, ISqsMes
         return new HeaderResult<int>(0, true);
     }
 
-    private static HeaderResult<Id> ReadCorrelationId(Amazon.SQS.Model.Message sqsMessage)
+    private static HeaderResult<Id> ReadCorrelationId(RawMessage sqsMessage)
     {
         if (sqsMessage.MessageAttributes.TryGetValue(HeaderNames.CorrelationId,
                 out MessageAttributeValue? correlationId))
@@ -325,7 +358,7 @@ internal sealed partial class SqsMessageCreator : SqsMessageCreatorBase, ISqsMes
         return new HeaderResult<Id>(Id.Empty, true);
     }
 
-    private static HeaderResult<ContentType> ReadContentType(Amazon.SQS.Model.Message sqsMessage, Dictionary<string, string> headers)
+    private static HeaderResult<ContentType> ReadContentType(RawMessage sqsMessage, Dictionary<string, string> headers)
     {
         if (sqsMessage.MessageAttributes.TryGetValue(HeaderNames.DataContentType, out var value)
             && !string.IsNullOrEmpty(value.StringValue))
@@ -347,7 +380,7 @@ internal sealed partial class SqsMessageCreator : SqsMessageCreatorBase, ISqsMes
         return new HeaderResult<ContentType>(new ContentType(MediaTypeNames.Text.Plain), true);
     }
 
-    private static HeaderResult<Id?> ReadMessageId(Amazon.SQS.Model.Message sqsMessage)
+    private static HeaderResult<Id?> ReadMessageId(RawMessage sqsMessage)
     {
         if (sqsMessage.MessageAttributes.TryGetValue(HeaderNames.Id, out MessageAttributeValue? messageId))
         {
@@ -358,7 +391,7 @@ internal sealed partial class SqsMessageCreator : SqsMessageCreatorBase, ISqsMes
         return new HeaderResult<Id?>(Id.Random(), true);
     }
 
-    private static HeaderResult<RoutingKey> ReadTopic(Amazon.SQS.Model.Message sqsMessage)
+    private static HeaderResult<RoutingKey> ReadTopic(RawMessage sqsMessage)
     {
         if (sqsMessage.MessageAttributes.TryGetValue(HeaderNames.Topic, out MessageAttributeValue? value))
         {
@@ -381,7 +414,7 @@ internal sealed partial class SqsMessageCreator : SqsMessageCreatorBase, ISqsMes
         return new HeaderResult<RoutingKey>(RoutingKey.Empty, true);
     }
 
-    private static HeaderResult<PartitionKey> ReadPartitionKey(Amazon.SQS.Model.Message sqsMessage)
+    private static HeaderResult<PartitionKey> ReadPartitionKey(RawMessage sqsMessage)
     {
         if (sqsMessage.Attributes.TryGetValue(MessageSystemAttributeName.MessageGroupId, out var value))
         {
@@ -393,7 +426,7 @@ internal sealed partial class SqsMessageCreator : SqsMessageCreatorBase, ISqsMes
         return new HeaderResult<PartitionKey>(null, false);
     }
 
-    private static HeaderResult<string> ReadDeduplicationId(Amazon.SQS.Model.Message sqsMessage)
+    private static HeaderResult<string> ReadDeduplicationId(RawMessage sqsMessage)
     {
         if (sqsMessage.Attributes.TryGetValue(MessageSystemAttributeName.MessageDeduplicationId, out var value))
         {
@@ -405,7 +438,7 @@ internal sealed partial class SqsMessageCreator : SqsMessageCreatorBase, ISqsMes
         return new HeaderResult<string>(null, false);
     }
     
-    private static HeaderResult<string> ReadSubject(Amazon.SQS.Model.Message sqsMessage, Dictionary<string, string> headers)
+    private static HeaderResult<string> ReadSubject(RawMessage sqsMessage, Dictionary<string, string> headers)
     {
         if (sqsMessage.MessageAttributes.TryGetValue(HeaderNames.Subject, out var value))
         {


### PR DESCRIPTION
## Description

The standard AWS SDK v4 `ReceiveMessageAsync` path materializes each message body as a `System.String`. Brighter then immediately re-encodes that string back to UTF-8 bytes inside `MessageBody`, so every received message pays for a string allocation plus an encoding round-trip — pure waste, since the bytes already came off the wire as UTF-8 and are about to be consumed as bytes by the rest of the pipeline (#4113).

This PR routes the SQS receive call through a custom unmarshaller that captures the body's UTF-8 bytes directly into a `ReadOnlyMemory<byte>` and feeds them straight to `MessageBody(in ReadOnlyMemory<byte>, …)`. The compressed-payload branch decodes Base64 in place over the same buffer (`Base64.DecodeFromUtf8InPlace` + slice), so a compressed message is allocation-free beyond the initial body buffer. The custom unmarshaller is reached via an internal `RawAmazonSQSClient` subclass (the only way to access the SDK's `protected InvokeAsync<T>`) constructed in parallel with `CreateSqsClient` from the same credentials and config — the public `AWSClientFactory.CreateSqsClient` contract stays as plain `AmazonSQSClient`, so a future user-supplied factory needs no awareness of the bypass.

Buffers are copied into fresh arrays rather than rented from `ArrayPool`: `MessageBody` has no `IDisposable` and `RequestContext.OriginatingMessage` exposes `Body.Memory` to handlers with no lifetime contract, so a pooled buffer would leak whenever a handler captured a reference past the pump iteration.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have read the [Contributing Guide](CONTRIBUTING.md)
- [ ] I have checked the [documentation](https://brightercommand.gitbook.io/paramore-brighter-documentation/) for relevant guidance
- [ ] I have added/updated XML documentation for any public API changes
- [ ] I have added/updated tests as appropriate
- [ ] My changes follow the existing code style and conventions

## Additional Notes

V4 unit tests build clean across netstandard2.0/net8/net9/net10. Integration tests need Moto/LocalStack and weren't run.