### PR TITLE
Clarify DontAckAction transport semantics

### DIFF
--- a/src/Paramore.Brighter/Actions/DontAckAction.cs
+++ b/src/Paramore.Brighter/Actions/DontAckAction.cs
@@ -27,16 +27,17 @@ using System;
 namespace Paramore.Brighter.Actions;
 
 /// <summary>
-/// Thrown to indicate that a message should not be acknowledged. The message remains on the channel and will be
-/// presented again on the next pump iteration. Call <c>throw new DontAckAction()</c> from within a
+/// Thrown to indicate that a message should not be acknowledged as successfully handled. A message pump translates
+/// this into the channel-specific not-acknowledged behavior. Call <c>throw new DontAckAction()</c> from within a
 /// <see cref="RequestHandler{TRequest}"/> or <see cref="RequestHandlerAsync{TRequest}"/> to prevent acknowledgment.
 /// </summary>
 /// <remarks>
-/// Unlike <see cref="DeferMessageAction"/> which requeues the message, and <see cref="RejectMessageAction"/> which
-/// moves the message to a dead letter queue, <see cref="DontAckAction"/> leaves the message completely unacknowledged
-/// on the channel. The message will be re-delivered by the transport after its visibility timeout expires.
-/// A configurable delay on the pump prevents tight-loop CPU burn. The unacceptable message count is incremented,
-/// allowing the pump to eventually stop if a limit is configured.
+/// Unlike <see cref="DeferMessageAction"/> which explicitly schedules a requeue, and <see cref="RejectMessageAction"/>
+/// which moves the message to a dead letter queue, <see cref="DontAckAction"/> asks the pump to use the transport's
+/// not-acknowledged disposition. For <see cref="InMemoryMessageConsumer"/> this nacks the message and immediately
+/// makes it available for redelivery; other transports may redeliver later or use their own offset or disposition
+/// semantics. A configurable delay on the pump prevents tight-loop CPU burn. The unacceptable message count is
+/// incremented, allowing the pump to eventually stop if a limit is configured.
 /// </remarks>
 public class DontAckAction : Exception
 {

--- a/src/Paramore.Brighter/DontAck/Attributes/DontAckOnErrorAsyncAttribute.cs
+++ b/src/Paramore.Brighter/DontAck/Attributes/DontAckOnErrorAsyncAttribute.cs
@@ -29,8 +29,8 @@ namespace Paramore.Brighter.DontAck.Attributes;
 
 /// <summary>
 /// Attribute that adds an async handler to catch unhandled exceptions and convert them to <see cref="Actions.DontAckAction"/>.
-/// When used with a message pump (Reactor or Proactor), this causes the message to remain unacknowledged on the channel,
-/// allowing the transport to re-deliver it after its visibility timeout expires.
+/// When used with a message pump (Reactor or Proactor), this asks the channel to apply its not-acknowledged
+/// disposition. The resulting redelivery behavior is transport-specific.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -47,7 +47,7 @@ namespace Paramore.Brighter.DontAck.Attributes;
 /// [UsePolicyAsync("RetryPolicy", step: 2)]        // Retries first
 /// public override async Task&lt;MyMessage&gt; HandleAsync(MyMessage message, CancellationToken cancellationToken)
 /// {
-///     // Business logic - if this fails after retries, message stays on the channel
+///     // Business logic - if this fails after retries, the transport's not-acknowledged behavior is used
 ///     return await base.HandleAsync(message, cancellationToken);
 /// }
 /// </code>

--- a/src/Paramore.Brighter/DontAck/Attributes/DontAckOnErrorAttribute.cs
+++ b/src/Paramore.Brighter/DontAck/Attributes/DontAckOnErrorAttribute.cs
@@ -29,8 +29,8 @@ namespace Paramore.Brighter.DontAck.Attributes;
 
 /// <summary>
 /// Attribute that adds a handler to catch unhandled exceptions and convert them to <see cref="Actions.DontAckAction"/>.
-/// When used with a message pump (Reactor or Proactor), this causes the message to remain unacknowledged on the channel,
-/// allowing the transport to re-deliver it after its visibility timeout expires.
+/// When used with a message pump (Reactor or Proactor), this asks the channel to apply its not-acknowledged
+/// disposition. The resulting redelivery behavior is transport-specific.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -44,7 +44,7 @@ namespace Paramore.Brighter.DontAck.Attributes;
 /// [UsePolicy("RetryPolicy", step: 2)]        // Retries first
 /// public override MyMessage Handle(MyMessage message)
 /// {
-///     // Business logic - if this fails after retries, message stays on the channel
+///     // Business logic - if this fails after retries, the transport's not-acknowledged behavior is used
 ///     return base.Handle(message);
 /// }
 /// </code>

--- a/src/Paramore.Brighter/DontAck/Handlers/DontAckOnErrorHandler.cs
+++ b/src/Paramore.Brighter/DontAck/Handlers/DontAckOnErrorHandler.cs
@@ -29,8 +29,8 @@ namespace Paramore.Brighter.DontAck.Handlers;
 
 /// <summary>
 /// Handler that catches unhandled exceptions and converts them to <see cref="DontAckAction"/>.
-/// When used with a message pump (Reactor or Proactor), this causes the message to remain unacknowledged
-/// on the channel, allowing the transport to re-deliver it after its visibility timeout expires.
+/// When used with a message pump (Reactor or Proactor), this asks the channel to apply its not-acknowledged
+/// disposition. The resulting redelivery behavior is transport-specific.
 /// </summary>
 /// <typeparam name="TRequest">The type of request being handled.</typeparam>
 /// <remarks>

--- a/src/Paramore.Brighter/DontAck/Handlers/DontAckOnErrorHandlerAsync.cs
+++ b/src/Paramore.Brighter/DontAck/Handlers/DontAckOnErrorHandlerAsync.cs
@@ -31,8 +31,8 @@ namespace Paramore.Brighter.DontAck.Handlers;
 
 /// <summary>
 /// Async handler that catches unhandled exceptions and converts them to <see cref="DontAckAction"/>.
-/// When used with a message pump (Reactor or Proactor), this causes the message to remain unacknowledged
-/// on the channel, allowing the transport to re-deliver it after its visibility timeout expires.
+/// When used with a message pump (Reactor or Proactor), this asks the channel to apply its not-acknowledged
+/// disposition. The resulting redelivery behavior is transport-specific.
 /// </summary>
 /// <typeparam name="TRequest">The type of request being handled.</typeparam>
 /// <remarks>

--- a/tests/Paramore.Brighter.Core.Tests/MessageDispatch/Proactor/When_a_handler_throws_dont_ack_action_should_not_acknowledge_async.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageDispatch/Proactor/When_a_handler_throws_dont_ack_action_should_not_acknowledge_async.cs
@@ -52,7 +52,7 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch.Proactor
 
             // Arrange: enqueue the message to the BUS (not the channel's internal queue)
             // so that InMemoryMessageConsumer.Receive locks it in _lockedMessages.
-            // This is essential for testing ack/no-ack behavior via the ack timeout mechanism.
+            // DontAckAction is translated to Nack for this channel, which unlocks and re-enqueues immediately.
             var message = new Message(
                 new MessageHeader(Guid.NewGuid().ToString(), _routingKey, MessageType.MT_COMMAND),
                 new MessageBody(JsonSerializer.Serialize(new MyCommand(), JsonSerialisationOptions.Options))
@@ -68,15 +68,11 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch.Proactor
 
             // Wait for the handler to be invoked (first delivery)
             Assert.True(_commandProcessor.WaitForHandle(), "Handler was not invoked within timeout");
-            Assert.Equal(1, _commandProcessor.SendCount);
+            Assert.True(_commandProcessor.SendCount >= 1,
+                $"Expected at least 1 send, but got {_commandProcessor.SendCount}");
 
-            // Advance time past the ack timeout to trigger requeue of unacknowledged messages.
-            // The message was received via InMemoryMessageConsumer.Receive which locks it in _lockedMessages.
-            // If the message was NOT acknowledged (DontAckAction handler with continue),
-            // the ack timeout timer requeues it and the pump re-delivers it.
-            // If the message WAS acknowledged (generic Exception handler without continue),
-            // it was removed from _lockedMessages and no requeue occurs.
-            _timeProvider.Advance(TimeSpan.FromSeconds(2));
+            // For InMemoryMessageConsumer, DontAckAction is translated to Nack. Nack removes the lock and
+            // re-enqueues the message immediately; the fake ack timeout is not part of this redelivery path.
 
             // Wait for the handler to be invoked again (re-delivery of unacknowledged message)
             Assert.True(_commandProcessor.WaitForHandle(), "Re-delivery did not occur - message may have been acknowledged");


### PR DESCRIPTION
## Summary
- Clarifies `DontAckAction` and `DontAckOnError` docs to describe transport-specific not-acknowledged behavior.
- Updates the Proactor DontAck test comments/assertion to reflect that `InMemoryMessageConsumer` nacks and re-enqueues immediately, rather than relying on the ack timeout.

Fixes #4097

## Test
- `dotnet test tests\Paramore.Brighter.Core.Tests\Paramore.Brighter.Core.Tests.csproj --filter "FullyQualifiedName~MessagePumpCommandDontAckActionTestsAsync"`