### PR TITLE
fix(aws): add Environment=Test tag to FIFO SNS topics so cleanup scri…

### DIFF
--- a/.github/workflows/aws-cleanup.yml
+++ b/.github/workflows/aws-cleanup.yml
@@ -19,7 +19,7 @@ jobs:
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AWS_REGION: us-west-2
+      AWS_REGION: eu-west-1
       AWS_DEFAULT_OUTPUT: json
 
     steps:

--- a/clean_failed_tests_aws_assets.sh
+++ b/clean_failed_tests_aws_assets.sh
@@ -214,7 +214,7 @@ fi
 # Some test fixtures (particularly FIFO tests) were not tagged with Environment=Test.
 # These are identified by their naming pattern: <TestPrefix>-<GUID> (truncated to 45 chars).
 # This section lists all topics/queues and deletes those matching known test prefixes.
-TEST_PREFIXES="Producer-Send-Tests|Producer-Requeue-Tests|Producer-DLQ-Tests|Producer-Scheduler-Tests|Producer-Scheduler-Async-Tests|Producer-Fire-Scheduler-Tests|Producer-Fire-Scheduler-Async-Tests|Producer-Tag-Tests|Producer-FSR-Tests|Producer-FSRA-Tests|Consumer-Requeue-Tests|Consumer-DLQ-Tests|Consumer-Fallback-Tests|Consumer-Invalid-Tests|Consumer-NoChan-Tests|Buffered-Consumer-Tests|Buffered-Scheduler-Tests|Buffered-Scheduler-Async-Tests|Buffered-FSR-Tests|Redrive-Tests|Redrive-DLQ-Tests|Raw-Msg-Delivery-Tests"
+TEST_PREFIXES="Producer-Send-Tests|Producer-Requeue-Tests|Producer-DLQ-Tests|Producer-Scheduler-Tests|Producer-Scheduler-Async-Tests|Producer-Fire-Scheduler-Tests|Producer-Fire-Scheduler-Async-Tests|Producer-Tag-Tests|Producer-FSR-Tests|Producer-FSRA-Tests|Consumer-Requeue-Tests|Consumer-DLQ-Tests|Consumer-DLQ-Fifo|Consumer-Fallback-Tests|Consumer-Invalid-Tests|Consumer-NoChan-Tests|Buffered-Consumer-Tests|Buffered-Scheduler-Tests|Buffered-Scheduler-Async-Tests|Buffered-FSR-Tests|Redrive-Tests|Redrive-DLQ-Tests|Raw-Msg-Delivery-Tests|DLQ-Reader|Invalid-Reader"
 
 echo ""
 echo "Scanning for untagged test resources by naming convention ..."

--- a/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sns/Fifo/Proactor/When_a_message_consumer_reads_multiple_messages_async.cs
+++ b/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sns/Fifo/Proactor/When_a_message_consumer_reads_multiple_messages_async.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Amazon.SimpleNotificationService.Model;
 using System.Linq;
 using System.Net.Mime;
 using System.Threading.Tasks;
@@ -28,7 +29,7 @@ public class SqsBufferedConsumerTestsAsync : IDisposable, IAsyncDisposable
         _channelFactory = new ChannelFactory(awsConnection);
         var channelName = $"Buffered-Consumer-Tests-{Guid.NewGuid().ToString()}".Truncate(45);
         _topicName = $"Buffered-Consumer-Tests-{Guid.NewGuid().ToString()}".Truncate(45);
-        var topicAttributes = new SnsAttributes { Type = SqsType.Fifo };
+        var topicAttributes = new SnsAttributes(type: SqsType.Fifo, tags: [new Tag { Key = "Environment", Value = "Test" }]);
 
         //we need the channel to create the queues and notifications
         var routingKey = new RoutingKey(_topicName);

--- a/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sns/Fifo/Proactor/When_infastructure_exists_can_assume_async.cs
+++ b/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sns/Fifo/Proactor/When_infastructure_exists_can_assume_async.cs
@@ -9,6 +9,7 @@ using Paramore.Brighter.JsonConverters;
 using Paramore.Brighter.MessagingGateway.AWSSQS;
 using Xunit;
 using System.Collections.Generic;
+using Amazon.SimpleNotificationService.Model;
 
 namespace Paramore.Brighter.AWS.Tests.MessagingGateway.Sns.Fifo.Proactor;
 
@@ -31,7 +32,7 @@ public class AwsAssumeInfrastructureTestsAsync : IDisposable, IAsyncDisposable
         var topicName = $"Producer-Send-Tests-{Guid.NewGuid().ToString()}".Truncate(45);
         var messageGroupId = $"MessageGroup{Guid.NewGuid():N}";
         var routingKey = new RoutingKey(topicName);
-        var topicAttributes = new SnsAttributes { Type = SqsType.Fifo };
+        var topicAttributes = new SnsAttributes(type: SqsType.Fifo, tags: [new Tag { Key = "Environment", Value = "Test" }]);
 
         var subscription = new SqsSubscription<MyCommand>(
             subscriptionName: new SubscriptionName(channelName),

--- a/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sns/Fifo/Proactor/When_infrastructure_exists_can_verify_async.cs
+++ b/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sns/Fifo/Proactor/When_infrastructure_exists_can_verify_async.cs
@@ -9,6 +9,7 @@ using Paramore.Brighter.JsonConverters;
 using Paramore.Brighter.MessagingGateway.AWSSQS;
 using Xunit;
 using System.Collections.Generic;
+using Amazon.SimpleNotificationService.Model;
 
 namespace Paramore.Brighter.AWS.Tests.MessagingGateway.Sns.Fifo.Proactor;
 
@@ -31,7 +32,7 @@ public class AwsValidateInfrastructureTestsAsync : IDisposable, IAsyncDisposable
         var topicName = $"Producer-Send-Tests-{Guid.NewGuid().ToString()}".Truncate(45);
         var messageGroupId = $"MessageGroup{Guid.NewGuid():N}";
         var routingKey = new RoutingKey(topicName);
-        var topicAttributes = new SnsAttributes { Type = SqsType.Fifo };
+        var topicAttributes = new SnsAttributes(type: SqsType.Fifo, tags: [new Tag { Key = "Environment", Value = "Test" }]);
 
         var subscription = new SqsSubscription<MyCommand>(
             subscriptionName: new SubscriptionName(channelName),

--- a/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sns/Fifo/Proactor/When_infrastructure_exists_can_verify_by_arn_async.cs
+++ b/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sns/Fifo/Proactor/When_infrastructure_exists_can_verify_by_arn_async.cs
@@ -9,6 +9,7 @@ using Paramore.Brighter.JsonConverters;
 using Paramore.Brighter.MessagingGateway.AWSSQS;
 using Xunit;
 using System.Collections.Generic;
+using Amazon.SimpleNotificationService.Model;
 
 namespace Paramore.Brighter.AWS.Tests.MessagingGateway.Sns.Fifo.Proactor;
 
@@ -30,7 +31,7 @@ public class AwsValidateInfrastructureByArnTestsAsync : IAsyncDisposable, IDispo
         var channelName = $"Producer-Send-Tests-{Guid.NewGuid().ToString()}".Truncate(45);
         var messageGroupId = $"MessageGroup{Guid.NewGuid():N}";
         var routingKey = new RoutingKey($"Producer-Send-Tests-{Guid.NewGuid().ToString()}".Truncate(45));
-        var topicAttributes = new SnsAttributes { Type = SqsType.Fifo };
+        var topicAttributes = new SnsAttributes(type: SqsType.Fifo, tags: [new Tag { Key = "Environment", Value = "Test" }]);
 
         var subscription = new SqsSubscription<MyCommand>(
             subscriptionName: new SubscriptionName(channelName),

--- a/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sns/Fifo/Proactor/When_posting_a_message_via_the_messaging_gateway_async.cs
+++ b/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sns/Fifo/Proactor/When_posting_a_message_via_the_messaging_gateway_async.cs
@@ -8,6 +8,7 @@ using Paramore.Brighter.JsonConverters;
 using Paramore.Brighter.MessagingGateway.AWSSQS;
 using Xunit;
 using System.Collections.Generic;
+using Amazon.SimpleNotificationService.Model;
 
 namespace Paramore.Brighter.AWS.Tests.MessagingGateway.Sns.Fifo.Proactor;
 
@@ -37,7 +38,7 @@ public class SqsMessageProducerSendAsyncTests : IAsyncDisposable, IDisposable
         _topicName = $"Producer-Send-Tests-{Guid.NewGuid().ToString()}".Truncate(45);
         var channelName = $"Producer-Send-Tests-{Guid.NewGuid().ToString()}".Truncate(45);
         var routingKey = new RoutingKey(_topicName);
-        var topicAttributes = new SnsAttributes { Type = SqsType.Fifo };
+        var topicAttributes = new SnsAttributes(type: SqsType.Fifo, tags: [new Tag { Key = "Environment", Value = "Test" }]);
 
         var subscription = new SqsSubscription<MyCommand>(
             subscriptionName: new SubscriptionName(channelName),

--- a/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sns/Fifo/Proactor/When_queues_missing_assume_throws_async.cs
+++ b/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sns/Fifo/Proactor/When_queues_missing_assume_throws_async.cs
@@ -6,6 +6,7 @@ using Paramore.Brighter.AWS.Tests.TestDoubles;
 using Paramore.Brighter.MessagingGateway.AWSSQS;
 using Xunit;
 using System.Collections.Generic;
+using Amazon.SimpleNotificationService.Model;
 
 namespace Paramore.Brighter.AWS.Tests.MessagingGateway.Sns.Fifo.Proactor;
 
@@ -20,7 +21,7 @@ public class AwsAssumeQueuesTestsAsync : IAsyncDisposable, IDisposable
         var channelName = $"Producer-Send-Tests-{Guid.NewGuid().ToString()}".Truncate(45);
         string topicName = $"Producer-Send-Tests-{Guid.NewGuid().ToString()}".Truncate(45);
         var routingKey = new RoutingKey(topicName);
-        var topicAttributes = new SnsAttributes { Type = SqsType.Fifo };
+        var topicAttributes = new SnsAttributes(type: SqsType.Fifo, tags: [new Tag { Key = "Environment", Value = "Test" }]);
 
         var subscription = new SqsSubscription<MyCommand>(
             subscriptionName: new SubscriptionName(channelName),

--- a/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sns/Fifo/Proactor/When_queues_missing_verify_throws_async.cs
+++ b/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sns/Fifo/Proactor/When_queues_missing_verify_throws_async.cs
@@ -6,6 +6,7 @@ using Paramore.Brighter.AWS.Tests.TestDoubles;
 using Paramore.Brighter.MessagingGateway.AWSSQS;
 using Xunit;
 using System.Collections.Generic;
+using Amazon.SimpleNotificationService.Model;
 
 namespace Paramore.Brighter.AWS.Tests.MessagingGateway.Sns.Fifo.Proactor;
 
@@ -21,7 +22,7 @@ public class AwsValidateQueuesTestsAsync : IAsyncDisposable
         var channelName = $"Producer-Send-Tests-{Guid.NewGuid().ToString()}".Truncate(45);
         string topicName = $"Producer-Send-Tests-{Guid.NewGuid().ToString()}".Truncate(45);
         var routingKey = new RoutingKey(topicName);
-        var topicAttributes = new SnsAttributes { Type = SqsType.Fifo };
+        var topicAttributes = new SnsAttributes(type: SqsType.Fifo, tags: [new Tag { Key = "Environment", Value = "Test" }]);
 
         _subscription = new SqsSubscription<MyCommand>(
             subscriptionName: new SubscriptionName(channelName),

--- a/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sns/Fifo/Proactor/When_raw_message_delivery_disabled_async.cs
+++ b/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sns/Fifo/Proactor/When_raw_message_delivery_disabled_async.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Amazon.SimpleNotificationService.Model;
 using System.Net.Mime;
 using System.Threading.Tasks;
 using Paramore.Brighter.AWS.Tests.Helpers;
@@ -24,7 +25,7 @@ public class SqsRawMessageDeliveryTestsAsync : IAsyncDisposable, IDisposable
         _channelFactory = new ChannelFactory(awsConnection);
         var channelName = $"Raw-Msg-Delivery-Tests-{Guid.NewGuid().ToString()}".Truncate(45);
         _routingKey = new RoutingKey($"Raw-Msg-Delivery-Tests-{Guid.NewGuid().ToString()}".Truncate(45));
-        var topicAttributes = new SnsAttributes { Type = SqsType.Fifo };
+        var topicAttributes = new SnsAttributes(type: SqsType.Fifo, tags: [new Tag { Key = "Environment", Value = "Test" }]);
 
         const int bufferSize = 10;
 

--- a/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sns/Fifo/Proactor/When_rejecting_a_message_should_delete_from_queue_async.cs
+++ b/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sns/Fifo/Proactor/When_rejecting_a_message_should_delete_from_queue_async.cs
@@ -8,6 +8,7 @@ using Paramore.Brighter.JsonConverters;
 using Paramore.Brighter.MessagingGateway.AWSSQS;
 using Xunit;
 using System.Collections.Generic;
+using Amazon.SimpleNotificationService.Model;
 
 namespace Paramore.Brighter.AWS.Tests.MessagingGateway.Sns.Fifo.Proactor;
 
@@ -30,7 +31,7 @@ public class SqsMessageConsumerRejectTestsAsync : IDisposable, IAsyncDisposable
         var messageGroupId = $"MessageGroup{Guid.NewGuid():N}";
         var topicName = $"Consumer-Requeue-Tests-{Guid.NewGuid().ToString()}".Truncate(45);
         var routingKey = new RoutingKey(topicName);
-        var topicAttributes = new SnsAttributes { Type = SqsType.Fifo };
+        var topicAttributes = new SnsAttributes(type: SqsType.Fifo, tags: [new Tag { Key = "Environment", Value = "Test" }]);
 
         var subscription = new SqsSubscription<MyCommand>(
             subscriptionName: new SubscriptionName(channelName),

--- a/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sns/Fifo/Proactor/When_requeueing_redrives_to_the_dlq_async.cs
+++ b/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sns/Fifo/Proactor/When_requeueing_redrives_to_the_dlq_async.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Amazon.SimpleNotificationService.Model;
 using System.Net;
 using System.Net.Mime;
 using System.Text.Json;
@@ -36,7 +37,7 @@ public class SqsMessageProducerDlqTestsAsync : IDisposable, IAsyncDisposable
         var messageGroupId = $"MessageGroup{Guid.NewGuid():N}";
         var routingKey = new RoutingKey(topicName);
         _deadLetterChannel = new ChannelName(dlQueue);
-        var topicAttributes = new SnsAttributes { Type = SqsType.Fifo };
+        var topicAttributes = new SnsAttributes(type: SqsType.Fifo, tags: [new Tag { Key = "Environment", Value = "Test" }]);
 
         var subscription = new SqsSubscription<MyCommand>(
             subscriptionName: new SubscriptionName(channelName),

--- a/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sns/Fifo/Proactor/When_throwing_defer_action_respect_redrive_async.cs
+++ b/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sns/Fifo/Proactor/When_throwing_defer_action_respect_redrive_async.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Amazon.SimpleNotificationService.Model;
 using System.Net;
 using System.Net.Mime;
 using System.Text.Json;
@@ -38,7 +39,7 @@ public class SnsReDrivePolicySDlqTestsAsync : IDisposable, IAsyncDisposable
         var topicName = $"Redrive-Tests-{Guid.NewGuid().ToString()}".Truncate(45);
         var messageGroupId = $"MessageGroup{Guid.NewGuid():N}";
         var routingKey = new RoutingKey(topicName);
-        var topicAttributes = new SnsAttributes { Type = SqsType.Fifo };
+        var topicAttributes = new SnsAttributes(type: SqsType.Fifo, tags: [new Tag { Key = "Environment", Value = "Test" }]);
 
         _subscription = new SqsSubscription<MyCommand>(
             subscriptionName: new SubscriptionName(channelName),

--- a/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sns/Fifo/Proactor/When_topic_missing_verify_throws_async.cs
+++ b/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sns/Fifo/Proactor/When_topic_missing_verify_throws_async.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Paramore.Brighter.AWS.Tests.Helpers;
 using Paramore.Brighter.MessagingGateway.AWSSQS;
 using Xunit;
+using Amazon.SimpleNotificationService.Model;
 
 namespace Paramore.Brighter.AWS.Tests.MessagingGateway.Sns.Fifo.Proactor;
 
@@ -31,7 +32,7 @@ public class AwsValidateMissingTopicTestsAsync
             new SnsPublication
             {
                 MakeChannels = OnMissingChannel.Validate,
-                TopicAttributes = new SnsAttributes { Type = SqsType.Fifo }
+                TopicAttributes = new SnsAttributes(type: SqsType.Fifo, tags: [new Tag { Key = "Environment", Value = "Test" }])
             });
 
         var messageGroupId = $"MessageGroup{Guid.NewGuid():N}";

--- a/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sns/Fifo/Reactor/When_a_message_consumer_reads_multiple_messages.cs
+++ b/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sns/Fifo/Reactor/When_a_message_consumer_reads_multiple_messages.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Amazon.SimpleNotificationService.Model;
 using System.Linq;
 using System.Net.Mime;
 using System.Threading.Tasks;
@@ -31,7 +32,7 @@ public class SqsBufferedConsumerTests : IDisposable, IAsyncDisposable
 
         //we need the channel to create the queues and notifications
         var routingKey = new RoutingKey(_topicName);
-        var topicAttributes = new SnsAttributes { Type = SqsType.Fifo };
+        var topicAttributes = new SnsAttributes(type: SqsType.Fifo, tags: [new Tag { Key = "Environment", Value = "Test" }]);
 
         var subscription = new SqsSubscription<MyCommand>(
             subscriptionName: new SubscriptionName(channelName),

--- a/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sns/Fifo/Reactor/When_infastructure_exists_can_assume.cs
+++ b/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sns/Fifo/Reactor/When_infastructure_exists_can_assume.cs
@@ -9,6 +9,7 @@ using Paramore.Brighter.JsonConverters;
 using Paramore.Brighter.MessagingGateway.AWSSQS;
 using Xunit;
 using System.Collections.Generic;
+using Amazon.SimpleNotificationService.Model;
 
 namespace Paramore.Brighter.AWS.Tests.MessagingGateway.Sns.Fifo.Reactor;
 
@@ -34,7 +35,7 @@ public class AwsAssumeInfrastructureTests : IDisposable, IAsyncDisposable
 
         var channelName = new ChannelName(queueName);
         var queueAttributes = new SqsAttributes(type: SqsType.Fifo, tags: new Dictionary<string, string> { { "Environment", "Test" } });
-        var topicAttributes = new SnsAttributes { Type = SqsType.Fifo };
+        var topicAttributes = new SnsAttributes(type: SqsType.Fifo, tags: [new Tag { Key = "Environment", Value = "Test" }]);
         
         var subscription = new SqsSubscription<MyCommand>(
             subscriptionName: new SubscriptionName(queueName),

--- a/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sns/Fifo/Reactor/When_infastructure_exists_can_verify.cs
+++ b/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sns/Fifo/Reactor/When_infastructure_exists_can_verify.cs
@@ -9,6 +9,7 @@ using Paramore.Brighter.JsonConverters;
 using Paramore.Brighter.MessagingGateway.AWSSQS;
 using Xunit;
 using System.Collections.Generic;
+using Amazon.SimpleNotificationService.Model;
 
 namespace Paramore.Brighter.AWS.Tests.MessagingGateway.Sns.Fifo.Reactor;
 
@@ -34,7 +35,7 @@ public class AwsValidateInfrastructureTests : IDisposable, IAsyncDisposable
 
         var channelName = new ChannelName(queueName);
         var queueAttributes = new SqsAttributes(type: SqsType.Fifo, tags: new Dictionary<string, string> { { "Environment", "Test" } });
-        var topicAttributes = new SnsAttributes { Type = SqsType.Fifo };
+        var topicAttributes = new SnsAttributes(type: SqsType.Fifo, tags: [new Tag { Key = "Environment", Value = "Test" }]);
         
         var subscription = new SqsSubscription<MyCommand>(
             subscriptionName: new SubscriptionName(queueName),

--- a/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sns/Fifo/Reactor/When_infastructure_exists_can_verify_by_arn.cs
+++ b/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sns/Fifo/Reactor/When_infastructure_exists_can_verify_by_arn.cs
@@ -9,6 +9,7 @@ using Paramore.Brighter.JsonConverters;
 using Paramore.Brighter.MessagingGateway.AWSSQS;
 using Xunit;
 using System.Collections.Generic;
+using Amazon.SimpleNotificationService.Model;
 
 namespace Paramore.Brighter.AWS.Tests.MessagingGateway.Sns.Fifo.Reactor;
 
@@ -31,7 +32,7 @@ public class AwsValidateInfrastructureByArnTests : IDisposable, IAsyncDisposable
         var channelName = $"Producer-Send-Tests-{Guid.NewGuid().ToString()}".Truncate(45);
         var messageGroupId = $"MessageGroup{Guid.NewGuid():N}";
         var routingKey = new RoutingKey($"Producer-Send-Tests-{Guid.NewGuid().ToString()}".Truncate(45));
-        var topicAttributes = new SnsAttributes { Type = SqsType.Fifo };
+        var topicAttributes = new SnsAttributes(type: SqsType.Fifo, tags: [new Tag { Key = "Environment", Value = "Test" }]);
 
         var subscription = new SqsSubscription<MyCommand>(
             subscriptionName: new SubscriptionName(channelName),

--- a/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sns/Fifo/Reactor/When_infastructure_exists_can_verify_by_convention.cs
+++ b/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sns/Fifo/Reactor/When_infastructure_exists_can_verify_by_convention.cs
@@ -9,6 +9,7 @@ using Paramore.Brighter.JsonConverters;
 using Paramore.Brighter.MessagingGateway.AWSSQS;
 using Xunit;
 using System.Collections.Generic;
+using Amazon.SimpleNotificationService.Model;
 
 namespace Paramore.Brighter.AWS.Tests.MessagingGateway.Sns.Fifo.Reactor;
 
@@ -30,7 +31,7 @@ public class AwsValidateInfrastructureByConventionTests : IDisposable, IAsyncDis
         var topicName = $"Producer-Send-Tests-{Guid.NewGuid().ToString()}".Truncate(45);
         var messageGroupId = $"MessageGroup{Guid.NewGuid():N}";
         var routingKey = new RoutingKey(topicName);
-        var topicAttributes = new SnsAttributes { Type = SqsType.Fifo };
+        var topicAttributes = new SnsAttributes(type: SqsType.Fifo, tags: [new Tag { Key = "Environment", Value = "Test" }]);
 
         var channelName = new ChannelName($"Producer-Send-Tests-{Guid.NewGuid().ToString()}".Truncate(45));
 

--- a/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sns/Fifo/Reactor/When_infrastructure_exists_can_verify_by_convention.cs
+++ b/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sns/Fifo/Reactor/When_infrastructure_exists_can_verify_by_convention.cs
@@ -9,6 +9,7 @@ using Paramore.Brighter.JsonConverters;
 using Paramore.Brighter.MessagingGateway.AWSSQS;
 using Xunit;
 using System.Collections.Generic;
+using Amazon.SimpleNotificationService.Model;
 
 namespace Paramore.Brighter.AWS.Tests.MessagingGateway.Sns.Fifo.Reactor;
 
@@ -31,7 +32,7 @@ public class AwsValidateInfrastructureByConventionTestsAsync : IAsyncDisposable,
         var topicName = $"Producer-Send-Tests-{Guid.NewGuid().ToString()}".Truncate(45);
         var messageGroupId = $"MessageGroup{Guid.NewGuid():N}";
         var routingKey = new RoutingKey(topicName);
-        var topicAttributes = new SnsAttributes { Type = SqsType.Fifo };
+        var topicAttributes = new SnsAttributes(type: SqsType.Fifo, tags: [new Tag { Key = "Environment", Value = "Test" }]);
 
         var subscription = new SqsSubscription<MyCommand>(
             subscriptionName: new SubscriptionName(channelName),

--- a/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sns/Fifo/Reactor/When_posting_a_message_via_the_messaging_gateway.cs
+++ b/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sns/Fifo/Reactor/When_posting_a_message_via_the_messaging_gateway.cs
@@ -8,6 +8,7 @@ using Paramore.Brighter.JsonConverters;
 using Paramore.Brighter.MessagingGateway.AWSSQS;
 using Xunit;
 using System.Collections.Generic;
+using Amazon.SimpleNotificationService.Model;
 
 namespace Paramore.Brighter.AWS.Tests.MessagingGateway.Sns.Fifo.Reactor;
 
@@ -37,7 +38,7 @@ public class SqsMessageProducerSendTests : IDisposable, IAsyncDisposable
         _deduplicationId = $"DeduplicationId{Guid.NewGuid():N}";
         var channelName = $"Producer-Send-Tests-{Guid.NewGuid().ToString()}".Truncate(45);
         var routingKey = new RoutingKey(_topicName);
-        var topicAttributes = new SnsAttributes { Type = SqsType.Fifo };
+        var topicAttributes = new SnsAttributes(type: SqsType.Fifo, tags: [new Tag { Key = "Environment", Value = "Test" }]);
 
         var subscription = new SqsSubscription<MyCommand>(
             subscriptionName: new SubscriptionName(channelName),

--- a/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sns/Fifo/Reactor/When_queues_missing_assume_throws.cs
+++ b/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sns/Fifo/Reactor/When_queues_missing_assume_throws.cs
@@ -6,6 +6,7 @@ using Paramore.Brighter.AWS.Tests.TestDoubles;
 using Paramore.Brighter.MessagingGateway.AWSSQS;
 using Xunit;
 using System.Collections.Generic;
+using Amazon.SimpleNotificationService.Model;
 
 namespace Paramore.Brighter.AWS.Tests.MessagingGateway.Sns.Fifo.Reactor;
 
@@ -20,7 +21,7 @@ public class AwsAssumeQueuesTests : IDisposable, IAsyncDisposable
         var channelName = $"Producer-Send-Tests-{Guid.NewGuid().ToString()}".Truncate(45);
         string topicName = $"Producer-Send-Tests-{Guid.NewGuid().ToString()}".Truncate(45);
         var routingKey = new RoutingKey(topicName);
-        var topicAttributes = new SnsAttributes { Type = SqsType.Fifo };
+        var topicAttributes = new SnsAttributes(type: SqsType.Fifo, tags: [new Tag { Key = "Environment", Value = "Test" }]);
 
         var subscription = new SqsSubscription<MyCommand>(
             subscriptionName: new SubscriptionName(channelName),

--- a/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sns/Fifo/Reactor/When_queues_missing_verify_throws.cs
+++ b/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sns/Fifo/Reactor/When_queues_missing_verify_throws.cs
@@ -6,6 +6,7 @@ using Paramore.Brighter.AWS.Tests.TestDoubles;
 using Paramore.Brighter.MessagingGateway.AWSSQS;
 using Xunit;
 using System.Collections.Generic;
+using Amazon.SimpleNotificationService.Model;
 
 namespace Paramore.Brighter.AWS.Tests.MessagingGateway.Sns.Fifo.Reactor;
 
@@ -21,7 +22,7 @@ public class AwsValidateQueuesTests : IDisposable, IAsyncDisposable
         var channelName = $"Producer-Send-Tests-{Guid.NewGuid().ToString()}".Truncate(45);
         string topicName = $"Producer-Send-Tests-{Guid.NewGuid().ToString()}".Truncate(45);
         var routingKey = new RoutingKey(topicName);
-        var topicAttributes = new SnsAttributes { Type = SqsType.Fifo };
+        var topicAttributes = new SnsAttributes(type: SqsType.Fifo, tags: [new Tag { Key = "Environment", Value = "Test" }]);
 
         _subscription = new SqsSubscription<MyCommand>(
             subscriptionName: new SubscriptionName(channelName),

--- a/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sns/Fifo/Reactor/When_raw_message_delivery_disabled.cs
+++ b/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sns/Fifo/Reactor/When_raw_message_delivery_disabled.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Amazon.SimpleNotificationService.Model;
 using System.Net.Mime;
 using System.Threading.Tasks;
 using Paramore.Brighter.AWS.Tests.Helpers;
@@ -24,7 +25,7 @@ public class SqsRawMessageDeliveryTests : IDisposable, IAsyncDisposable
         _channelFactory = new ChannelFactory(awsConnection);
         var channelName = $"Raw-Msg-Delivery-Tests-{Guid.NewGuid().ToString()}".Truncate(45);
         _routingKey = new RoutingKey($"Raw-Msg-Delivery-Tests-{Guid.NewGuid().ToString()}".Truncate(45));
-        var topicAttributes = new SnsAttributes { Type = SqsType.Fifo };
+        var topicAttributes = new SnsAttributes(type: SqsType.Fifo, tags: [new Tag { Key = "Environment", Value = "Test" }]);
 
         var bufferSize = 10;
 

--- a/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sns/Fifo/Reactor/When_rejecting_a_message_should_delete_from_queue.cs
+++ b/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sns/Fifo/Reactor/When_rejecting_a_message_should_delete_from_queue.cs
@@ -8,6 +8,7 @@ using Paramore.Brighter.JsonConverters;
 using Paramore.Brighter.MessagingGateway.AWSSQS;
 using Xunit;
 using System.Collections.Generic;
+using Amazon.SimpleNotificationService.Model;
 
 namespace Paramore.Brighter.AWS.Tests.MessagingGateway.Sns.Fifo.Reactor;
 
@@ -30,7 +31,7 @@ public class SqsMessageConsumerRejectTests : IDisposable
         var messageGroupId = $"MessageGroup{Guid.NewGuid():N}";
         var topicName = $"Consumer-Requeue-Tests-{Guid.NewGuid().ToString()}".Truncate(45);
         var routingKey = new RoutingKey(topicName);
-        var topicAttributes = new SnsAttributes { Type = SqsType.Fifo };
+        var topicAttributes = new SnsAttributes(type: SqsType.Fifo, tags: [new Tag { Key = "Environment", Value = "Test" }]);
 
         SqsSubscription<MyCommand> subscription = new(
             subscriptionName: new SubscriptionName(channelName),

--- a/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sns/Fifo/Reactor/When_requeueing_a_message.cs
+++ b/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sns/Fifo/Reactor/When_requeueing_a_message.cs
@@ -8,6 +8,7 @@ using Paramore.Brighter.JsonConverters;
 using Paramore.Brighter.MessagingGateway.AWSSQS;
 using Xunit;
 using System.Collections.Generic;
+using Amazon.SimpleNotificationService.Model;
 
 namespace Paramore.Brighter.AWS.Tests.MessagingGateway.Sns.Fifo.Reactor;
 
@@ -31,7 +32,7 @@ public class SqsMessageProducerRequeueTests : IDisposable, IAsyncDisposable
         var topicName = $"Producer-Requeue-Tests-{Guid.NewGuid().ToString()}".Truncate(45);
         var messageGroupId = $"MessageGroup{Guid.NewGuid():N}";
         var routingKey = new RoutingKey(topicName);
-        var topicAttributes = new SnsAttributes { Type = SqsType.Fifo };
+        var topicAttributes = new SnsAttributes(type: SqsType.Fifo, tags: [new Tag { Key = "Environment", Value = "Test" }]);
 
         var subscription = new SqsSubscription<MyCommand>(
             subscriptionName: new SubscriptionName(channelName),

--- a/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sns/Fifo/Reactor/When_requeueing_redrives_to_the_dlq.cs
+++ b/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sns/Fifo/Reactor/When_requeueing_redrives_to_the_dlq.cs
@@ -11,6 +11,7 @@ using Paramore.Brighter.JsonConverters;
 using Paramore.Brighter.MessagingGateway.AWSSQS;
 using Xunit;
 using System.Collections.Generic;
+using Amazon.SimpleNotificationService.Model;
 
 namespace Paramore.Brighter.AWS.Tests.MessagingGateway.Sns.Fifo.Reactor;
 
@@ -35,7 +36,7 @@ public class SqsMessageProducerDlqTests : IDisposable, IAsyncDisposable
         var topicName = $"Producer-DLQ-Tests-{Guid.NewGuid().ToString()}".Truncate(45);
         var messageGroupId = $"MessageGroup{Guid.NewGuid():N}";
         var routingKey = new RoutingKey(topicName);
-        var topicAttributes = new SnsAttributes { Type = SqsType.Fifo };
+        var topicAttributes = new SnsAttributes(type: SqsType.Fifo, tags: [new Tag { Key = "Environment", Value = "Test" }]);
 
         var queueAttributes = new SqsAttributes(
             redrivePolicy: new RedrivePolicy(new ChannelName(_dlqChannelName), 2),

--- a/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sns/Fifo/Reactor/When_throwing_defer_action_respect_redrive.cs
+++ b/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sns/Fifo/Reactor/When_throwing_defer_action_respect_redrive.cs
@@ -13,6 +13,7 @@ using Paramore.Brighter.ServiceActivator;
 using Polly.Registry;
 using Xunit;
 using System.Collections.Generic;
+using Amazon.SimpleNotificationService.Model;
 
 namespace Paramore.Brighter.AWS.Tests.MessagingGateway.Sns.Fifo.Reactor;
 
@@ -38,7 +39,7 @@ public class SnsReDrivePolicySDlqTests : IDisposable, IAsyncDisposable
         var topicName = $"Redrive-Tests-{Guid.NewGuid().ToString()}".Truncate(45);
         var messageGroupId = $"MessageGroup{Guid.NewGuid():N}";
         var routingKey = new RoutingKey(topicName);
-        var topicAttributes = new SnsAttributes { Type = SqsType.Fifo };
+        var topicAttributes = new SnsAttributes(type: SqsType.Fifo, tags: [new Tag { Key = "Environment", Value = "Test" }]);
 
         //how are we consuming
         _subscription = new SqsSubscription<MyCommand>(

--- a/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sns/Fifo/Reactor/When_topic_missing_verify_throws.cs
+++ b/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sns/Fifo/Reactor/When_topic_missing_verify_throws.cs
@@ -2,6 +2,7 @@
 using Paramore.Brighter.AWS.Tests.Helpers;
 using Paramore.Brighter.MessagingGateway.AWSSQS;
 using Xunit;
+using Amazon.SimpleNotificationService.Model;
 
 namespace Paramore.Brighter.AWS.Tests.MessagingGateway.Sns.Fifo.Reactor;
 
@@ -29,7 +30,7 @@ public class AwsValidateMissingTopicTests
             new SnsPublication
             {
                 MakeChannels = OnMissingChannel.Validate,
-                TopicAttributes = new SnsAttributes { Type = SqsType.Fifo }
+                TopicAttributes = new SnsAttributes(type: SqsType.Fifo, tags: [new Tag { Key = "Environment", Value = "Test" }])
             });
 
         var messageGroupId = $"MessageGroup{Guid.NewGuid():N}";

--- a/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Fifo/Proactor/When_a_message_consumer_reads_multiple_messages_async.cs
+++ b/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Fifo/Proactor/When_a_message_consumer_reads_multiple_messages_async.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Amazon.SimpleNotificationService.Model;
 using System.Linq;
 using System.Net.Mime;
 using System.Threading.Tasks;
@@ -28,7 +29,7 @@ public class SqsBufferedConsumerTestsAsync : IDisposable, IAsyncDisposable
         _channelFactory = new ChannelFactory(awsConnection);
         var channelName = $"Buffered-Consumer-Tests-{Guid.NewGuid().ToString()}".Truncate(45);
         _topicName = $"Buffered-Consumer-Tests-{Guid.NewGuid().ToString()}".Truncate(45);
-        var topicAttributes = new SnsAttributes { Type = SqsType.Fifo };
+        var topicAttributes = new SnsAttributes(type: SqsType.Fifo, tags: [new Tag { Key = "Environment", Value = "Test" }]);
 
         //we need the channel to create the queues and notifications
         var routingKey = new RoutingKey(_topicName);

--- a/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Fifo/Proactor/When_infastructure_exists_can_assume_async.cs
+++ b/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Fifo/Proactor/When_infastructure_exists_can_assume_async.cs
@@ -9,6 +9,7 @@ using Paramore.Brighter.JsonConverters;
 using Paramore.Brighter.MessagingGateway.AWSSQS.V4;
 using Xunit;
 using System.Collections.Generic;
+using Amazon.SimpleNotificationService.Model;
 
 namespace Paramore.Brighter.AWS.V4.Tests.MessagingGateway.Sns.Fifo.Proactor;
 
@@ -31,7 +32,7 @@ public class AwsAssumeInfrastructureTestsAsync : IDisposable, IAsyncDisposable
         var topicName = $"Producer-Send-Tests-{Guid.NewGuid().ToString()}".Truncate(45);
         var messageGroupId = $"MessageGroup{Guid.NewGuid():N}";
         var routingKey = new RoutingKey(topicName);
-        var topicAttributes = new SnsAttributes { Type = SqsType.Fifo };
+        var topicAttributes = new SnsAttributes(type: SqsType.Fifo, tags: [new Tag { Key = "Environment", Value = "Test" }]);
 
         var subscription = new SqsSubscription<MyCommand>(
             subscriptionName: new SubscriptionName(channelName),

--- a/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Fifo/Proactor/When_infrastructure_exists_can_verify_async.cs
+++ b/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Fifo/Proactor/When_infrastructure_exists_can_verify_async.cs
@@ -9,6 +9,7 @@ using Paramore.Brighter.JsonConverters;
 using Paramore.Brighter.MessagingGateway.AWSSQS.V4;
 using Xunit;
 using System.Collections.Generic;
+using Amazon.SimpleNotificationService.Model;
 
 namespace Paramore.Brighter.AWS.V4.Tests.MessagingGateway.Sns.Fifo.Proactor;
 
@@ -31,7 +32,7 @@ public class AwsValidateInfrastructureTestsAsync : IDisposable, IAsyncDisposable
         var topicName = $"Producer-Send-Tests-{Guid.NewGuid().ToString()}".Truncate(45);
         var messageGroupId = $"MessageGroup{Guid.NewGuid():N}";
         var routingKey = new RoutingKey(topicName);
-        var topicAttributes = new SnsAttributes { Type = SqsType.Fifo };
+        var topicAttributes = new SnsAttributes(type: SqsType.Fifo, tags: [new Tag { Key = "Environment", Value = "Test" }]);
 
         var subscription = new SqsSubscription<MyCommand>(
             subscriptionName: new SubscriptionName(channelName),

--- a/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Fifo/Proactor/When_infrastructure_exists_can_verify_by_arn_async.cs
+++ b/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Fifo/Proactor/When_infrastructure_exists_can_verify_by_arn_async.cs
@@ -9,6 +9,7 @@ using Paramore.Brighter.JsonConverters;
 using Paramore.Brighter.MessagingGateway.AWSSQS.V4;
 using Xunit;
 using System.Collections.Generic;
+using Amazon.SimpleNotificationService.Model;
 
 namespace Paramore.Brighter.AWS.V4.Tests.MessagingGateway.Sns.Fifo.Proactor;
 
@@ -30,7 +31,7 @@ public class AwsValidateInfrastructureByArnTestsAsync : IAsyncDisposable, IDispo
         var channelName = $"Producer-Send-Tests-{Guid.NewGuid().ToString()}".Truncate(45);
         var messageGroupId = $"MessageGroup{Guid.NewGuid():N}";
         var routingKey = new RoutingKey($"Producer-Send-Tests-{Guid.NewGuid().ToString()}".Truncate(45));
-        var topicAttributes = new SnsAttributes { Type = SqsType.Fifo };
+        var topicAttributes = new SnsAttributes(type: SqsType.Fifo, tags: [new Tag { Key = "Environment", Value = "Test" }]);
 
         var subscription = new SqsSubscription<MyCommand>(
             subscriptionName: new SubscriptionName(channelName),

--- a/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Fifo/Proactor/When_posting_a_message_via_the_messaging_gateway_async.cs
+++ b/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Fifo/Proactor/When_posting_a_message_via_the_messaging_gateway_async.cs
@@ -8,6 +8,7 @@ using Paramore.Brighter.JsonConverters;
 using Paramore.Brighter.MessagingGateway.AWSSQS.V4;
 using Xunit;
 using System.Collections.Generic;
+using Amazon.SimpleNotificationService.Model;
 
 namespace Paramore.Brighter.AWS.V4.Tests.MessagingGateway.Sns.Fifo.Proactor;
 
@@ -37,7 +38,7 @@ public class SqsMessageProducerSendAsyncTests : IAsyncDisposable, IDisposable
         _topicName = $"Producer-Send-Tests-{Guid.NewGuid().ToString()}".Truncate(45);
         var channelName = $"Producer-Send-Tests-{Guid.NewGuid().ToString()}".Truncate(45);
         var routingKey = new RoutingKey(_topicName);
-        var topicAttributes = new SnsAttributes { Type = SqsType.Fifo };
+        var topicAttributes = new SnsAttributes(type: SqsType.Fifo, tags: [new Tag { Key = "Environment", Value = "Test" }]);
 
         var subscription = new SqsSubscription<MyCommand>(
             subscriptionName: new SubscriptionName(channelName),

--- a/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Fifo/Proactor/When_queues_missing_assume_throws_async.cs
+++ b/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Fifo/Proactor/When_queues_missing_assume_throws_async.cs
@@ -6,6 +6,7 @@ using Paramore.Brighter.AWS.V4.Tests.TestDoubles;
 using Paramore.Brighter.MessagingGateway.AWSSQS.V4;
 using Xunit;
 using System.Collections.Generic;
+using Amazon.SimpleNotificationService.Model;
 
 namespace Paramore.Brighter.AWS.V4.Tests.MessagingGateway.Sns.Fifo.Proactor;
 
@@ -20,7 +21,7 @@ public class AwsAssumeQueuesTestsAsync : IAsyncDisposable, IDisposable
         var channelName = $"Producer-Send-Tests-{Guid.NewGuid().ToString()}".Truncate(45);
         string topicName = $"Producer-Send-Tests-{Guid.NewGuid().ToString()}".Truncate(45);
         var routingKey = new RoutingKey(topicName);
-        var topicAttributes = new SnsAttributes { Type = SqsType.Fifo };
+        var topicAttributes = new SnsAttributes(type: SqsType.Fifo, tags: [new Tag { Key = "Environment", Value = "Test" }]);
 
         var subscription = new SqsSubscription<MyCommand>(
             subscriptionName: new SubscriptionName(channelName),

--- a/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Fifo/Proactor/When_queues_missing_verify_throws_async.cs
+++ b/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Fifo/Proactor/When_queues_missing_verify_throws_async.cs
@@ -6,6 +6,7 @@ using Paramore.Brighter.AWS.V4.Tests.TestDoubles;
 using Paramore.Brighter.MessagingGateway.AWSSQS.V4;
 using Xunit;
 using System.Collections.Generic;
+using Amazon.SimpleNotificationService.Model;
 
 namespace Paramore.Brighter.AWS.V4.Tests.MessagingGateway.Sns.Fifo.Proactor;
 
@@ -21,7 +22,7 @@ public class AwsValidateQueuesTestsAsync : IAsyncDisposable
         var channelName = $"Producer-Send-Tests-{Guid.NewGuid().ToString()}".Truncate(45);
         string topicName = $"Producer-Send-Tests-{Guid.NewGuid().ToString()}".Truncate(45);
         var routingKey = new RoutingKey(topicName);
-        var topicAttributes = new SnsAttributes { Type = SqsType.Fifo };
+        var topicAttributes = new SnsAttributes(type: SqsType.Fifo, tags: [new Tag { Key = "Environment", Value = "Test" }]);
 
         _subscription = new SqsSubscription<MyCommand>(
             subscriptionName: new SubscriptionName(channelName),

--- a/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Fifo/Proactor/When_raw_message_delivery_disabled_async.cs
+++ b/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Fifo/Proactor/When_raw_message_delivery_disabled_async.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Amazon.SimpleNotificationService.Model;
 using System.Net.Mime;
 using System.Threading.Tasks;
 using Paramore.Brighter.AWS.V4.Tests.Helpers;
@@ -24,7 +25,7 @@ public class SqsRawMessageDeliveryTestsAsync : IAsyncDisposable, IDisposable
         _channelFactory = new ChannelFactory(awsConnection);
         var channelName = $"Raw-Msg-Delivery-Tests-{Guid.NewGuid().ToString()}".Truncate(45);
         _routingKey = new RoutingKey($"Raw-Msg-Delivery-Tests-{Guid.NewGuid().ToString()}".Truncate(45));
-        var topicAttributes = new SnsAttributes { Type = SqsType.Fifo };
+        var topicAttributes = new SnsAttributes(type: SqsType.Fifo, tags: [new Tag { Key = "Environment", Value = "Test" }]);
 
         const int bufferSize = 10;
 

--- a/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Fifo/Proactor/When_rejecting_a_message_should_delete_from_queue_async.cs
+++ b/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Fifo/Proactor/When_rejecting_a_message_should_delete_from_queue_async.cs
@@ -8,6 +8,7 @@ using Paramore.Brighter.JsonConverters;
 using Paramore.Brighter.MessagingGateway.AWSSQS.V4;
 using Xunit;
 using System.Collections.Generic;
+using Amazon.SimpleNotificationService.Model;
 
 namespace Paramore.Brighter.AWS.V4.Tests.MessagingGateway.Sns.Fifo.Proactor;
 
@@ -30,7 +31,7 @@ public class SqsMessageConsumerRejectTestsAsync : IDisposable, IAsyncDisposable
         var messageGroupId = $"MessageGroup{Guid.NewGuid():N}";
         var topicName = $"Consumer-Requeue-Tests-{Guid.NewGuid().ToString()}".Truncate(45);
         var routingKey = new RoutingKey(topicName);
-        var topicAttributes = new SnsAttributes { Type = SqsType.Fifo };
+        var topicAttributes = new SnsAttributes(type: SqsType.Fifo, tags: [new Tag { Key = "Environment", Value = "Test" }]);
 
         var subscription = new SqsSubscription<MyCommand>(
             subscriptionName: new SubscriptionName(channelName),

--- a/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Fifo/Proactor/When_requeueing_redrives_to_the_dlq_async.cs
+++ b/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Fifo/Proactor/When_requeueing_redrives_to_the_dlq_async.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Amazon.SimpleNotificationService.Model;
 using System.Net;
 using System.Net.Mime;
 using System.Text.Json;
@@ -36,7 +37,7 @@ public class SqsMessageProducerDlqTestsAsync : IDisposable, IAsyncDisposable
         var messageGroupId = $"MessageGroup{Guid.NewGuid():N}";
         var routingKey = new RoutingKey(topicName);
         _deadLetterChannel = new ChannelName(dlQueue);
-        var topicAttributes = new SnsAttributes { Type = SqsType.Fifo };
+        var topicAttributes = new SnsAttributes(type: SqsType.Fifo, tags: [new Tag { Key = "Environment", Value = "Test" }]);
 
         var subscription = new SqsSubscription<MyCommand>(
             subscriptionName: new SubscriptionName(channelName),

--- a/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Fifo/Proactor/When_throwing_defer_action_respect_redrive_async.cs
+++ b/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Fifo/Proactor/When_throwing_defer_action_respect_redrive_async.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Amazon.SimpleNotificationService.Model;
 using System.Net;
 using System.Net.Mime;
 using System.Text.Json;
@@ -38,7 +39,7 @@ public class SnsReDrivePolicySDlqTestsAsync : IDisposable, IAsyncDisposable
         var topicName = $"Redrive-Tests-{Guid.NewGuid().ToString()}".Truncate(45);
         var messageGroupId = $"MessageGroup{Guid.NewGuid():N}";
         var routingKey = new RoutingKey(topicName);
-        var topicAttributes = new SnsAttributes { Type = SqsType.Fifo };
+        var topicAttributes = new SnsAttributes(type: SqsType.Fifo, tags: [new Tag { Key = "Environment", Value = "Test" }]);
 
         _subscription = new SqsSubscription<MyCommand>(
             subscriptionName: new SubscriptionName(channelName),

--- a/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Fifo/Proactor/When_topic_missing_verify_throws_async.cs
+++ b/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Fifo/Proactor/When_topic_missing_verify_throws_async.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Paramore.Brighter.AWS.V4.Tests.Helpers;
 using Paramore.Brighter.MessagingGateway.AWSSQS.V4;
 using Xunit;
+using Amazon.SimpleNotificationService.Model;
 
 namespace Paramore.Brighter.AWS.V4.Tests.MessagingGateway.Sns.Fifo.Proactor;
 
@@ -31,7 +32,7 @@ public class AwsValidateMissingTopicTestsAsync
             new SnsPublication
             {
                 MakeChannels = OnMissingChannel.Validate,
-                TopicAttributes = new SnsAttributes { Type = SqsType.Fifo }
+                TopicAttributes = new SnsAttributes(type: SqsType.Fifo, tags: [new Tag { Key = "Environment", Value = "Test" }])
             });
 
         var messageGroupId = $"MessageGroup{Guid.NewGuid():N}";

--- a/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Fifo/Reactor/When_a_message_consumer_reads_multiple_messages.cs
+++ b/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Fifo/Reactor/When_a_message_consumer_reads_multiple_messages.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Amazon.SimpleNotificationService.Model;
 using System.Linq;
 using System.Net.Mime;
 using System.Threading.Tasks;
@@ -31,7 +32,7 @@ public class SqsBufferedConsumerTests : IDisposable, IAsyncDisposable
 
         //we need the channel to create the queues and notifications
         var routingKey = new RoutingKey(_topicName);
-        var topicAttributes = new SnsAttributes { Type = SqsType.Fifo };
+        var topicAttributes = new SnsAttributes(type: SqsType.Fifo, tags: [new Tag { Key = "Environment", Value = "Test" }]);
 
         var subscription = new SqsSubscription<MyCommand>(
             subscriptionName: new SubscriptionName(channelName),

--- a/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Fifo/Reactor/When_infastructure_exists_can_assume.cs
+++ b/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Fifo/Reactor/When_infastructure_exists_can_assume.cs
@@ -9,6 +9,7 @@ using Paramore.Brighter.JsonConverters;
 using Paramore.Brighter.MessagingGateway.AWSSQS.V4;
 using Xunit;
 using System.Collections.Generic;
+using Amazon.SimpleNotificationService.Model;
 
 namespace Paramore.Brighter.AWS.V4.Tests.MessagingGateway.Sns.Fifo.Reactor;
 
@@ -34,7 +35,7 @@ public class AwsAssumeInfrastructureTests : IDisposable, IAsyncDisposable
 
         var channelName = new ChannelName(queueName);
         var queueAttributes = new SqsAttributes(type: SqsType.Fifo, tags: new Dictionary<string, string> { { "Environment", "Test" } });
-        var topicAttributes = new SnsAttributes { Type = SqsType.Fifo };
+        var topicAttributes = new SnsAttributes(type: SqsType.Fifo, tags: [new Tag { Key = "Environment", Value = "Test" }]);
         
         var subscription = new SqsSubscription<MyCommand>(
             subscriptionName: new SubscriptionName(queueName),

--- a/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Fifo/Reactor/When_infastructure_exists_can_verify.cs
+++ b/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Fifo/Reactor/When_infastructure_exists_can_verify.cs
@@ -9,6 +9,7 @@ using Paramore.Brighter.JsonConverters;
 using Paramore.Brighter.MessagingGateway.AWSSQS.V4;
 using Xunit;
 using System.Collections.Generic;
+using Amazon.SimpleNotificationService.Model;
 
 namespace Paramore.Brighter.AWS.V4.Tests.MessagingGateway.Sns.Fifo.Reactor;
 
@@ -34,7 +35,7 @@ public class AwsValidateInfrastructureTests : IDisposable, IAsyncDisposable
 
         var channelName = new ChannelName(queueName);
         var queueAttributes = new SqsAttributes(type: SqsType.Fifo, tags: new Dictionary<string, string> { { "Environment", "Test" } });
-        var topicAttributes = new SnsAttributes { Type = SqsType.Fifo };
+        var topicAttributes = new SnsAttributes(type: SqsType.Fifo, tags: [new Tag { Key = "Environment", Value = "Test" }]);
         
         var subscription = new SqsSubscription<MyCommand>(
             subscriptionName: new SubscriptionName(queueName),

--- a/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Fifo/Reactor/When_infastructure_exists_can_verify_by_arn.cs
+++ b/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Fifo/Reactor/When_infastructure_exists_can_verify_by_arn.cs
@@ -9,6 +9,7 @@ using Paramore.Brighter.JsonConverters;
 using Paramore.Brighter.MessagingGateway.AWSSQS.V4;
 using Xunit;
 using System.Collections.Generic;
+using Amazon.SimpleNotificationService.Model;
 
 namespace Paramore.Brighter.AWS.V4.Tests.MessagingGateway.Sns.Fifo.Reactor;
 
@@ -31,7 +32,7 @@ public class AwsValidateInfrastructureByArnTests : IDisposable, IAsyncDisposable
         var channelName = $"Producer-Send-Tests-{Guid.NewGuid().ToString()}".Truncate(45);
         var messageGroupId = $"MessageGroup{Guid.NewGuid():N}";
         var routingKey = new RoutingKey($"Producer-Send-Tests-{Guid.NewGuid().ToString()}".Truncate(45));
-        var topicAttributes = new SnsAttributes { Type = SqsType.Fifo };
+        var topicAttributes = new SnsAttributes(type: SqsType.Fifo, tags: [new Tag { Key = "Environment", Value = "Test" }]);
 
         var subscription = new SqsSubscription<MyCommand>(
             subscriptionName: new SubscriptionName(channelName),

--- a/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Fifo/Reactor/When_infastructure_exists_can_verify_by_convention.cs
+++ b/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Fifo/Reactor/When_infastructure_exists_can_verify_by_convention.cs
@@ -9,6 +9,7 @@ using Paramore.Brighter.JsonConverters;
 using Paramore.Brighter.MessagingGateway.AWSSQS.V4;
 using Xunit;
 using System.Collections.Generic;
+using Amazon.SimpleNotificationService.Model;
 
 namespace Paramore.Brighter.AWS.V4.Tests.MessagingGateway.Sns.Fifo.Reactor;
 
@@ -30,7 +31,7 @@ public class AwsValidateInfrastructureByConventionTests : IDisposable, IAsyncDis
         var topicName = $"Producer-Send-Tests-{Guid.NewGuid().ToString()}".Truncate(45);
         var messageGroupId = $"MessageGroup{Guid.NewGuid():N}";
         var routingKey = new RoutingKey(topicName);
-        var topicAttributes = new SnsAttributes { Type = SqsType.Fifo };
+        var topicAttributes = new SnsAttributes(type: SqsType.Fifo, tags: [new Tag { Key = "Environment", Value = "Test" }]);
 
         var channelName = new ChannelName($"Producer-Send-Tests-{Guid.NewGuid().ToString()}".Truncate(45));
 

--- a/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Fifo/Reactor/When_infrastructure_exists_can_verify_by_convention.cs
+++ b/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Fifo/Reactor/When_infrastructure_exists_can_verify_by_convention.cs
@@ -9,6 +9,7 @@ using Paramore.Brighter.JsonConverters;
 using Paramore.Brighter.MessagingGateway.AWSSQS.V4;
 using Xunit;
 using System.Collections.Generic;
+using Amazon.SimpleNotificationService.Model;
 
 namespace Paramore.Brighter.AWS.V4.Tests.MessagingGateway.Sns.Fifo.Reactor;
 
@@ -31,7 +32,7 @@ public class AwsValidateInfrastructureByConventionTestsAsync : IAsyncDisposable,
         var topicName = $"Producer-Send-Tests-{Guid.NewGuid().ToString()}".Truncate(45);
         var messageGroupId = $"MessageGroup{Guid.NewGuid():N}";
         var routingKey = new RoutingKey(topicName);
-        var topicAttributes = new SnsAttributes { Type = SqsType.Fifo };
+        var topicAttributes = new SnsAttributes(type: SqsType.Fifo, tags: [new Tag { Key = "Environment", Value = "Test" }]);
 
         var subscription = new SqsSubscription<MyCommand>(
             subscriptionName: new SubscriptionName(channelName),

--- a/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Fifo/Reactor/When_posting_a_message_via_the_messaging_gateway.cs
+++ b/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Fifo/Reactor/When_posting_a_message_via_the_messaging_gateway.cs
@@ -8,6 +8,7 @@ using Paramore.Brighter.JsonConverters;
 using Paramore.Brighter.MessagingGateway.AWSSQS.V4;
 using Xunit;
 using System.Collections.Generic;
+using Amazon.SimpleNotificationService.Model;
 
 namespace Paramore.Brighter.AWS.V4.Tests.MessagingGateway.Sns.Fifo.Reactor;
 
@@ -37,7 +38,7 @@ public class SqsMessageProducerSendTests : IDisposable, IAsyncDisposable
         _deduplicationId = $"DeduplicationId{Guid.NewGuid():N}";
         var channelName = $"Producer-Send-Tests-{Guid.NewGuid().ToString()}".Truncate(45);
         var routingKey = new RoutingKey(_topicName);
-        var topicAttributes = new SnsAttributes { Type = SqsType.Fifo };
+        var topicAttributes = new SnsAttributes(type: SqsType.Fifo, tags: [new Tag { Key = "Environment", Value = "Test" }]);
 
         var subscription = new SqsSubscription<MyCommand>(
             subscriptionName: new SubscriptionName(channelName),

--- a/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Fifo/Reactor/When_queues_missing_assume_throws.cs
+++ b/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Fifo/Reactor/When_queues_missing_assume_throws.cs
@@ -6,6 +6,7 @@ using Paramore.Brighter.AWS.V4.Tests.TestDoubles;
 using Paramore.Brighter.MessagingGateway.AWSSQS.V4;
 using Xunit;
 using System.Collections.Generic;
+using Amazon.SimpleNotificationService.Model;
 
 namespace Paramore.Brighter.AWS.V4.Tests.MessagingGateway.Sns.Fifo.Reactor;
 
@@ -20,7 +21,7 @@ public class AwsAssumeQueuesTests : IDisposable, IAsyncDisposable
         var channelName = $"Producer-Send-Tests-{Guid.NewGuid().ToString()}".Truncate(45);
         string topicName = $"Producer-Send-Tests-{Guid.NewGuid().ToString()}".Truncate(45);
         var routingKey = new RoutingKey(topicName);
-        var topicAttributes = new SnsAttributes { Type = SqsType.Fifo };
+        var topicAttributes = new SnsAttributes(type: SqsType.Fifo, tags: [new Tag { Key = "Environment", Value = "Test" }]);
 
         var subscription = new SqsSubscription<MyCommand>(
             subscriptionName: new SubscriptionName(channelName),

--- a/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Fifo/Reactor/When_queues_missing_verify_throws.cs
+++ b/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Fifo/Reactor/When_queues_missing_verify_throws.cs
@@ -6,6 +6,7 @@ using Paramore.Brighter.AWS.V4.Tests.TestDoubles;
 using Paramore.Brighter.MessagingGateway.AWSSQS.V4;
 using Xunit;
 using System.Collections.Generic;
+using Amazon.SimpleNotificationService.Model;
 
 namespace Paramore.Brighter.AWS.V4.Tests.MessagingGateway.Sns.Fifo.Reactor;
 
@@ -21,7 +22,7 @@ public class AwsValidateQueuesTests : IDisposable, IAsyncDisposable
         var channelName = $"Producer-Send-Tests-{Guid.NewGuid().ToString()}".Truncate(45);
         string topicName = $"Producer-Send-Tests-{Guid.NewGuid().ToString()}".Truncate(45);
         var routingKey = new RoutingKey(topicName);
-        var topicAttributes = new SnsAttributes { Type = SqsType.Fifo };
+        var topicAttributes = new SnsAttributes(type: SqsType.Fifo, tags: [new Tag { Key = "Environment", Value = "Test" }]);
 
         _subscription = new SqsSubscription<MyCommand>(
             subscriptionName: new SubscriptionName(channelName),

--- a/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Fifo/Reactor/When_raw_message_delivery_disabled.cs
+++ b/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Fifo/Reactor/When_raw_message_delivery_disabled.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Amazon.SimpleNotificationService.Model;
 using System.Net.Mime;
 using System.Threading.Tasks;
 using Paramore.Brighter.AWS.V4.Tests.Helpers;
@@ -24,7 +25,7 @@ public class SqsRawMessageDeliveryTests : IDisposable, IAsyncDisposable
         _channelFactory = new ChannelFactory(awsConnection);
         var channelName = $"Raw-Msg-Delivery-Tests-{Guid.NewGuid().ToString()}".Truncate(45);
         _routingKey = new RoutingKey($"Raw-Msg-Delivery-Tests-{Guid.NewGuid().ToString()}".Truncate(45));
-        var topicAttributes = new SnsAttributes { Type = SqsType.Fifo };
+        var topicAttributes = new SnsAttributes(type: SqsType.Fifo, tags: [new Tag { Key = "Environment", Value = "Test" }]);
 
         var bufferSize = 10;
 

--- a/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Fifo/Reactor/When_rejecting_a_message_should_delete_from_queue.cs
+++ b/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Fifo/Reactor/When_rejecting_a_message_should_delete_from_queue.cs
@@ -8,6 +8,7 @@ using Paramore.Brighter.JsonConverters;
 using Paramore.Brighter.MessagingGateway.AWSSQS.V4;
 using Xunit;
 using System.Collections.Generic;
+using Amazon.SimpleNotificationService.Model;
 
 namespace Paramore.Brighter.AWS.V4.Tests.MessagingGateway.Sns.Fifo.Reactor;
 
@@ -30,7 +31,7 @@ public class SqsMessageConsumerRejectTests : IDisposable
         var messageGroupId = $"MessageGroup{Guid.NewGuid():N}";
         var topicName = $"Consumer-Requeue-Tests-{Guid.NewGuid().ToString()}".Truncate(45);
         var routingKey = new RoutingKey(topicName);
-        var topicAttributes = new SnsAttributes { Type = SqsType.Fifo };
+        var topicAttributes = new SnsAttributes(type: SqsType.Fifo, tags: [new Tag { Key = "Environment", Value = "Test" }]);
 
         SqsSubscription<MyCommand> subscription = new(
             subscriptionName: new SubscriptionName(channelName),

--- a/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Fifo/Reactor/When_requeueing_a_message.cs
+++ b/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Fifo/Reactor/When_requeueing_a_message.cs
@@ -8,6 +8,7 @@ using Paramore.Brighter.JsonConverters;
 using Paramore.Brighter.MessagingGateway.AWSSQS.V4;
 using Xunit;
 using System.Collections.Generic;
+using Amazon.SimpleNotificationService.Model;
 
 namespace Paramore.Brighter.AWS.V4.Tests.MessagingGateway.Sns.Fifo.Reactor;
 
@@ -31,7 +32,7 @@ public class SqsMessageProducerRequeueTests : IDisposable, IAsyncDisposable
         var topicName = $"Producer-Requeue-Tests-{Guid.NewGuid().ToString()}".Truncate(45);
         var messageGroupId = $"MessageGroup{Guid.NewGuid():N}";
         var routingKey = new RoutingKey(topicName);
-        var topicAttributes = new SnsAttributes { Type = SqsType.Fifo };
+        var topicAttributes = new SnsAttributes(type: SqsType.Fifo, tags: [new Tag { Key = "Environment", Value = "Test" }]);
 
         var subscription = new SqsSubscription<MyCommand>(
             subscriptionName: new SubscriptionName(channelName),

--- a/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Fifo/Reactor/When_requeueing_redrives_to_the_dlq.cs
+++ b/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Fifo/Reactor/When_requeueing_redrives_to_the_dlq.cs
@@ -11,6 +11,7 @@ using Paramore.Brighter.JsonConverters;
 using Paramore.Brighter.MessagingGateway.AWSSQS.V4;
 using Xunit;
 using System.Collections.Generic;
+using Amazon.SimpleNotificationService.Model;
 
 namespace Paramore.Brighter.AWS.V4.Tests.MessagingGateway.Sns.Fifo.Reactor;
 
@@ -35,7 +36,7 @@ public class SqsMessageProducerDlqTests : IDisposable, IAsyncDisposable
         var topicName = $"Producer-DLQ-Tests-{Guid.NewGuid().ToString()}".Truncate(45);
         var messageGroupId = $"MessageGroup{Guid.NewGuid():N}";
         var routingKey = new RoutingKey(topicName);
-        var topicAttributes = new SnsAttributes { Type = SqsType.Fifo };
+        var topicAttributes = new SnsAttributes(type: SqsType.Fifo, tags: [new Tag { Key = "Environment", Value = "Test" }]);
 
         var queueAttributes = new SqsAttributes(
             redrivePolicy: new RedrivePolicy(new ChannelName(_dlqChannelName), 2),

--- a/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Fifo/Reactor/When_throwing_defer_action_respect_redrive.cs
+++ b/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Fifo/Reactor/When_throwing_defer_action_respect_redrive.cs
@@ -13,6 +13,7 @@ using Paramore.Brighter.ServiceActivator;
 using Polly.Registry;
 using Xunit;
 using System.Collections.Generic;
+using Amazon.SimpleNotificationService.Model;
 
 namespace Paramore.Brighter.AWS.V4.Tests.MessagingGateway.Sns.Fifo.Reactor;
 
@@ -38,7 +39,7 @@ public class SnsReDrivePolicySDlqTests : IDisposable, IAsyncDisposable
         var topicName = $"Redrive-Tests-{Guid.NewGuid().ToString()}".Truncate(45);
         var messageGroupId = $"MessageGroup{Guid.NewGuid():N}";
         var routingKey = new RoutingKey(topicName);
-        var topicAttributes = new SnsAttributes { Type = SqsType.Fifo };
+        var topicAttributes = new SnsAttributes(type: SqsType.Fifo, tags: [new Tag { Key = "Environment", Value = "Test" }]);
 
         //how are we consuming
         _subscription = new SqsSubscription<MyCommand>(

--- a/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Fifo/Reactor/When_topic_missing_verify_throws.cs
+++ b/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Fifo/Reactor/When_topic_missing_verify_throws.cs
@@ -2,6 +2,7 @@
 using Paramore.Brighter.AWS.V4.Tests.Helpers;
 using Paramore.Brighter.MessagingGateway.AWSSQS.V4;
 using Xunit;
+using Amazon.SimpleNotificationService.Model;
 
 namespace Paramore.Brighter.AWS.V4.Tests.MessagingGateway.Sns.Fifo.Reactor;
 
@@ -29,7 +30,7 @@ public class AwsValidateMissingTopicTests
             new SnsPublication
             {
                 MakeChannels = OnMissingChannel.Validate,
-                TopicAttributes = new SnsAttributes { Type = SqsType.Fifo }
+                TopicAttributes = new SnsAttributes(type: SqsType.Fifo, tags: [new Tag { Key = "Environment", Value = "Test" }])
             });
 
         var messageGroupId = $"MessageGroup{Guid.NewGuid():N}";


### PR DESCRIPTION
…pt can find orphaned resources

FIFO test fixtures were creating SNS topics without the Environment=Test tag, causing orphaned FIFO topics to accumulate and hit the SNS topic quota. Also updates cleanup script with missing test prefixes and corrects the target region to eu-west-1.

## Description

<!-- Briefly describe what this PR does and why -->

## Related Issues

<!-- Link any related issues: Fixes #123, Closes #456 -->

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [X] I have read the [Contributing Guide](CONTRIBUTING.md)
- [X] I have checked the [documentation](https://brightercommand.gitbook.io/paramore-brighter-documentation/) for relevant guidance
- [X] I have added/updated XML documentation for any public API changes
- [X] I have added/updated tests as appropriate
- [X] My changes follow the existing code style and conventions

## Additional Notes

<!-- Any additional context, screenshots, or notes for reviewers -->
