### PR TITLE
fix(aws): handle null MessageAttributes/Attributes in V4 SQS message creators

### DIFF
--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS.V4/SqsInlineMessageCreator.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS.V4/SqsInlineMessageCreator.cs
@@ -49,9 +49,6 @@ internal sealed partial class SqsInlineMessageCreator : SqsMessageCreatorBase, I
 
         try
         {
-            // AWS SDK v4 returns null (not an empty dictionary) when Attributes was never set on the wire.
-            sqsMessage.Attributes ??= new Dictionary<string, string>();
-
             var jsonDocument = JsonDocument.Parse(sqsMessage.Body);
             _messageAttributes = ReadMessageAttributes(jsonDocument);
 
@@ -409,7 +406,8 @@ internal sealed partial class SqsInlineMessageCreator : SqsMessageCreatorBase, I
 
     private static HeaderResult<PartitionKey> ReadPartitionKey(Amazon.SQS.Model.Message sqsMessage)
     {
-        if (sqsMessage.Attributes.TryGetValue(MessageSystemAttributeName.MessageGroupId, out var value))
+        if (sqsMessage.Attributes is not null
+            && sqsMessage.Attributes.TryGetValue(MessageSystemAttributeName.MessageGroupId, out var value))
         {
             //we have an arn, and we want the topic
             return new HeaderResult<PartitionKey>(value, true);
@@ -420,7 +418,8 @@ internal sealed partial class SqsInlineMessageCreator : SqsMessageCreatorBase, I
 
     private static HeaderResult<string> ReadDeduplicationId(Amazon.SQS.Model.Message sqsMessage)
     {
-        if (sqsMessage.Attributes.TryGetValue(MessageSystemAttributeName.MessageDeduplicationId, out var value))
+        if (sqsMessage.Attributes is not null
+            && sqsMessage.Attributes.TryGetValue(MessageSystemAttributeName.MessageDeduplicationId, out var value))
         {
             //we have an arn, and we want the topic
             return new HeaderResult<string>(value, true);

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS.V4/SqsInlineMessageCreator.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS.V4/SqsInlineMessageCreator.cs
@@ -49,6 +49,9 @@ internal sealed partial class SqsInlineMessageCreator : SqsMessageCreatorBase, I
 
         try
         {
+            // AWS SDK v4 returns null (not an empty dictionary) when Attributes was never set on the wire.
+            sqsMessage.Attributes ??= new Dictionary<string, string>();
+
             var jsonDocument = JsonDocument.Parse(sqsMessage.Body);
             _messageAttributes = ReadMessageAttributes(jsonDocument);
 

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS.V4/SqsMessageCreator.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS.V4/SqsMessageCreator.cs
@@ -61,11 +61,6 @@ internal sealed partial class SqsMessageCreator : SqsMessageCreatorBase, ISqsMes
 
         try
         {
-            // AWS SDK v4 returns null (not an empty dictionary) when these properties were never set on the wire.
-            // Normalise so the Read* helpers can use TryGetValue unconditionally.
-            sqsMessage.MessageAttributes ??= new Dictionary<string, MessageAttributeValue>();
-            sqsMessage.Attributes ??= new Dictionary<string, string>();
-
             topic = ReadTopic(sqsMessage);
             messageId = ReadMessageId(sqsMessage);
             var cloudEventHeaders = ReadCloudEventHeaders(sqsMessage);
@@ -152,7 +147,8 @@ internal sealed partial class SqsMessageCreator : SqsMessageCreatorBase, ISqsMes
     
     private static Dictionary<string, string> ReadCloudEventHeaders(Amazon.SQS.Model.Message sqsMessage)
     {
-        if (sqsMessage.MessageAttributes.TryGetValue(HeaderNames.CloudEventHeaders, out var value))
+        if (sqsMessage.MessageAttributes is not null
+            && sqsMessage.MessageAttributes.TryGetValue(HeaderNames.CloudEventHeaders, out var value))
         {
             try
             {
@@ -244,7 +240,8 @@ internal sealed partial class SqsMessageCreator : SqsMessageCreatorBase, ISqsMes
 
     private static Dictionary<string, object> ReadMessageBag(Amazon.SQS.Model.Message sqsMessage)
     {
-        if (sqsMessage.MessageAttributes.TryGetValue(HeaderNames.Bag, out MessageAttributeValue? value))
+        if (sqsMessage.MessageAttributes is not null
+            && sqsMessage.MessageAttributes.TryGetValue(HeaderNames.Bag, out MessageAttributeValue? value))
         {
             try
             {
@@ -264,7 +261,8 @@ internal sealed partial class SqsMessageCreator : SqsMessageCreatorBase, ISqsMes
 
     private static HeaderResult<RoutingKey> ReadReplyTo(Amazon.SQS.Model.Message sqsMessage)
     {
-        if (sqsMessage.MessageAttributes.TryGetValue(HeaderNames.ReplyTo, out MessageAttributeValue? value))
+        if (sqsMessage.MessageAttributes is not null
+            && sqsMessage.MessageAttributes.TryGetValue(HeaderNames.ReplyTo, out MessageAttributeValue? value))
         {
             return new HeaderResult<RoutingKey>(new RoutingKey(value.StringValue), true);
         }
@@ -274,19 +272,22 @@ internal sealed partial class SqsMessageCreator : SqsMessageCreatorBase, ISqsMes
 
     private static HeaderResult<DateTimeOffset> ReadTimestamp(Amazon.SQS.Model.Message sqsMessage, Dictionary<string, string> headers)
     {
-        if (headers.TryGetValue(HeaderNames.Timestamp, out var val) 
+        if (headers.TryGetValue(HeaderNames.Timestamp, out var val)
             && DateTimeOffset.TryParse(val, out var timestamp))
         {
             return new HeaderResult<DateTimeOffset>(timestamp, true);
         }
-        
-        if (sqsMessage.MessageAttributes.TryGetValue(HeaderNames.Time, out var value)
+
+        var attributes = sqsMessage.MessageAttributes;
+        if (attributes is not null
+            && attributes.TryGetValue(HeaderNames.Time, out var value)
             && DateTimeOffset.TryParse(value.StringValue, out timestamp))
         {
             return new HeaderResult<DateTimeOffset>(timestamp, true);
         }
-        
-        if (sqsMessage.MessageAttributes.TryGetValue(HeaderNames.Timestamp, out value)
+
+        if (attributes is not null
+            && attributes.TryGetValue(HeaderNames.Timestamp, out value)
             && DateTimeOffset.TryParse(value.StringValue, out timestamp))
         {
             return new HeaderResult<DateTimeOffset>(timestamp, true);
@@ -297,7 +298,8 @@ internal sealed partial class SqsMessageCreator : SqsMessageCreatorBase, ISqsMes
 
     private static HeaderResult<MessageType> ReadMessageType(Amazon.SQS.Model.Message sqsMessage)
     {
-        if (sqsMessage.MessageAttributes.TryGetValue(HeaderNames.MessageType, out MessageAttributeValue? value))
+        if (sqsMessage.MessageAttributes is not null
+            && sqsMessage.MessageAttributes.TryGetValue(HeaderNames.MessageType, out MessageAttributeValue? value))
         {
             if (Enum.TryParse(value.StringValue, out MessageType messageType))
             {
@@ -321,7 +323,8 @@ internal sealed partial class SqsMessageCreator : SqsMessageCreatorBase, ISqsMes
 
     private static HeaderResult<Id> ReadCorrelationId(Amazon.SQS.Model.Message sqsMessage)
     {
-        if (sqsMessage.MessageAttributes.TryGetValue(HeaderNames.CorrelationId,
+        if (sqsMessage.MessageAttributes is not null
+            && sqsMessage.MessageAttributes.TryGetValue(HeaderNames.CorrelationId,
                 out MessageAttributeValue? correlationId))
         {
             return new HeaderResult<Id>(new Id(correlationId.StringValue), true);
@@ -332,18 +335,21 @@ internal sealed partial class SqsMessageCreator : SqsMessageCreatorBase, ISqsMes
 
     private static HeaderResult<ContentType> ReadContentType(Amazon.SQS.Model.Message sqsMessage, Dictionary<string, string> headers)
     {
-        if (sqsMessage.MessageAttributes.TryGetValue(HeaderNames.DataContentType, out var value)
+        var attributes = sqsMessage.MessageAttributes;
+        if (attributes is not null
+            && attributes.TryGetValue(HeaderNames.DataContentType, out var value)
             && !string.IsNullOrEmpty(value.StringValue))
         {
             return new HeaderResult<ContentType>(new ContentType(value.StringValue), true);
         }
-        
-        if (sqsMessage.MessageAttributes.TryGetValue(HeaderNames.ContentType, out value) 
+
+        if (attributes is not null
+            && attributes.TryGetValue(HeaderNames.ContentType, out value)
             && !string.IsNullOrEmpty(value.StringValue))
         {
             return new HeaderResult<ContentType>(new ContentType(value.StringValue), true);
         }
-        
+
         if (headers.TryGetValue(HeaderNames.DataContentType, out var val))
         {
             return new HeaderResult<ContentType>(new ContentType(val), true);
@@ -354,7 +360,8 @@ internal sealed partial class SqsMessageCreator : SqsMessageCreatorBase, ISqsMes
 
     private static HeaderResult<Id?> ReadMessageId(Amazon.SQS.Model.Message sqsMessage)
     {
-        if (sqsMessage.MessageAttributes.TryGetValue(HeaderNames.Id, out MessageAttributeValue? messageId))
+        if (sqsMessage.MessageAttributes is not null
+            && sqsMessage.MessageAttributes.TryGetValue(HeaderNames.Id, out MessageAttributeValue? messageId))
         {
             var value = messageId.StringValue;
             return new HeaderResult<Id?>(string.IsNullOrEmpty(value) ? Id.Random() : Id.Create(value), true);
@@ -365,7 +372,8 @@ internal sealed partial class SqsMessageCreator : SqsMessageCreatorBase, ISqsMes
 
     private static HeaderResult<RoutingKey> ReadTopic(Amazon.SQS.Model.Message sqsMessage)
     {
-        if (sqsMessage.MessageAttributes.TryGetValue(HeaderNames.Topic, out MessageAttributeValue? value))
+        if (sqsMessage.MessageAttributes is not null
+            && sqsMessage.MessageAttributes.TryGetValue(HeaderNames.Topic, out MessageAttributeValue? value))
         {
             //we have an arn, and we want the topic
             var topic = value.StringValue ?? string.Empty;
@@ -388,7 +396,8 @@ internal sealed partial class SqsMessageCreator : SqsMessageCreatorBase, ISqsMes
 
     private static HeaderResult<PartitionKey> ReadPartitionKey(Amazon.SQS.Model.Message sqsMessage)
     {
-        if (sqsMessage.Attributes.TryGetValue(MessageSystemAttributeName.MessageGroupId, out var value))
+        if (sqsMessage.Attributes is not null
+            && sqsMessage.Attributes.TryGetValue(MessageSystemAttributeName.MessageGroupId, out var value))
         {
             //we have an arn, and we want the topic
             var messageGroupId = value;
@@ -400,7 +409,8 @@ internal sealed partial class SqsMessageCreator : SqsMessageCreatorBase, ISqsMes
 
     private static HeaderResult<string> ReadDeduplicationId(Amazon.SQS.Model.Message sqsMessage)
     {
-        if (sqsMessage.Attributes.TryGetValue(MessageSystemAttributeName.MessageDeduplicationId, out var value))
+        if (sqsMessage.Attributes is not null
+            && sqsMessage.Attributes.TryGetValue(MessageSystemAttributeName.MessageDeduplicationId, out var value))
         {
             //we have an arn, and we want the topic
             var messageGroupId = value;
@@ -412,7 +422,8 @@ internal sealed partial class SqsMessageCreator : SqsMessageCreatorBase, ISqsMes
     
     private static HeaderResult<string> ReadSubject(Amazon.SQS.Model.Message sqsMessage, Dictionary<string, string> headers)
     {
-        if (sqsMessage.MessageAttributes.TryGetValue(HeaderNames.Subject, out var value))
+        if (sqsMessage.MessageAttributes is not null
+            && sqsMessage.MessageAttributes.TryGetValue(HeaderNames.Subject, out var value))
         {
             return new HeaderResult<string>(value.StringValue, true);
         }

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS.V4/SqsMessageCreator.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS.V4/SqsMessageCreator.cs
@@ -61,6 +61,11 @@ internal sealed partial class SqsMessageCreator : SqsMessageCreatorBase, ISqsMes
 
         try
         {
+            // AWS SDK v4 returns null (not an empty dictionary) when these properties were never set on the wire.
+            // Normalise so the Read* helpers can use TryGetValue unconditionally.
+            sqsMessage.MessageAttributes ??= new Dictionary<string, MessageAttributeValue>();
+            sqsMessage.Attributes ??= new Dictionary<string, string>();
+
             topic = ReadTopic(sqsMessage);
             messageId = ReadMessageId(sqsMessage);
             var cloudEventHeaders = ReadCloudEventHeaders(sqsMessage);


### PR DESCRIPTION
## Description

AWS SDK for .NET v4 changed the default for unset collection properties: they are now `null` rather than empty collections. As a result, `SqsMessageCreator.CreateMessage` in the `AWSSQS.V4` gateway throws `NullReferenceException` for any inbound SQS message that has no `MessageAttributes` (e.g. messages from `aws sqs send-message`, EventBridge → SQS targets, or any non-Brighter producer). The exception was swallowed into a `Message.FailureMessage(...)`, so every such message was silently rejected and the handler never invoked. This PR normalises `MessageAttributes` and `Attributes` to an empty dictionary at the top of `CreateMessage` in both `SqsMessageCreator` and `SqsInlineMessageCreator`, restoring v3-equivalent behaviour. The `??=` only allocates on the bug path (when the property is null); the happy path is unchanged.

## Related Issues

Fixes #4126

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [Contributing Guide](CONTRIBUTING.md)
- [x] I have checked the [documentation](https://brightercommand.gitbook.io/paramore-brighter-documentation/) for relevant guidance
- [ ] I have added/updated XML documentation for any public API changes
- [ ] I have added/updated tests as appropriate
- [x] My changes follow the existing code style and conventions

## Additional Notes

There are no existing unit tests for `SqsMessageCreator`/`SqsInlineMessageCreator` (only AWS integration tests) — happy to add a regression test on request.