### PR TITLE
fix(aws): surface unknown SNS/SQS message attributes into MessageHeader.Bag

### DIFF
--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS.V4/HeaderNames.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS.V4/HeaderNames.cs
@@ -23,6 +23,8 @@ THE SOFTWARE. */
 
 #endregion
 
+using System.Collections.Generic;
+
 namespace Paramore.Brighter.MessagingGateway.AWSSQS.V4;
 
 /// <summary>
@@ -51,11 +53,33 @@ public static class HeaderNames
     public const string TraceState = "tracestate";
     public const string TraceParent = "traceparent";
     public const string Baggage = "baggage";
-    
+
     /// <summary>
     /// Use this because we cannot set cloud events as individual headers, SNS/SQS can only have 10 headers in raw message delivery
-    /// and instead need a single header with all cloud events for example, 
+    /// and instead need a single header with all cloud events for example,
     /// </summary>
     public const string CloudEventHeaders = "cloudeventheaders";
 
+    /// <summary>
+    /// SNS/SQS MessageAttribute names that Brighter reads into typed
+    /// <see cref="MessageHeader"/> fields (or its own JSON-serialised bag). Inbound
+    /// attributes whose names are <em>not</em> in this set are surfaced into
+    /// <see cref="MessageHeader.Bag"/> under their raw name so interop with foreign
+    /// producers is preserved instead of silently discarding their metadata.
+    /// Comparison is ordinal — AWS message attribute names are case-sensitive.
+    /// </summary>
+    private static readonly HashSet<string> s_knownNames = new(System.StringComparer.Ordinal)
+    {
+        Id, Topic, ContentType, CorrelationId, HandledCount, MessageType, Timestamp,
+        ReplyTo, Subject, Bag, DeduplicationId, Type, SpecVersion, Source, Time,
+        DataContentType, DataSchema, DataRef, TraceState, TraceParent, Baggage,
+        CloudEventHeaders
+    };
+
+    /// <summary>
+    /// Returns <c>true</c> when <paramref name="name"/> is one of the SNS/SQS
+    /// MessageAttribute names Brighter consumes directly into a typed
+    /// <see cref="MessageHeader"/> field or its JSON-serialised bag.
+    /// </summary>
+    public static bool IsKnown(string name) => s_knownNames.Contains(name);
 }

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS.V4/SqsInlineMessageCreator.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS.V4/SqsInlineMessageCreator.cs
@@ -162,20 +162,20 @@ internal sealed partial class SqsInlineMessageCreator : SqsMessageCreatorBase, I
 
     private Dictionary<string, object> ReadMessageBag()
     {
+        var bag = new Dictionary<string, object>();
+
         if (_messageAttributes.TryGetValue(HeaderNames.Bag, out var headerBag))
         {
             try
             {
                 var json = headerBag.GetValueInString();
-                if (string.IsNullOrEmpty(json))
+                if (!string.IsNullOrEmpty(json))
                 {
-                    return new Dictionary<string, object>();
+                    var parsed = JsonSerializer.Deserialize<Dictionary<string, object>>(json!,
+                        JsonSerialisationOptions.Options);
+                    if (parsed != null)
+                        bag = parsed;
                 }
-
-                var bag = JsonSerializer.Deserialize<Dictionary<string, object>>(json!,
-                    JsonSerialisationOptions.Options);
-
-                return bag ?? new Dictionary<string, object>();
             }
             catch (Exception)
             {
@@ -183,7 +183,19 @@ internal sealed partial class SqsInlineMessageCreator : SqsMessageCreatorBase, I
             }
         }
 
-        return new Dictionary<string, object>();
+        // Surface inbound MessageAttributes Brighter doesn't already consume so foreign producers'
+        // metadata can flow through to consumers via the bag. Entries already present in Brighter's
+        // own JSON bag attribute take precedence.
+        foreach (var attribute in _messageAttributes)
+        {
+            if (HeaderNames.IsKnown(attribute.Key) || bag.ContainsKey(attribute.Key))
+                continue;
+            var raw = attribute.Value.GetValueInString();
+            if (raw != null)
+                bag[attribute.Key] = raw;
+        }
+
+        return bag;
     }
 
     private HeaderResult<RoutingKey?> ReadReplyTo()

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS.V4/SqsMessageCreator.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS.V4/SqsMessageCreator.cs
@@ -263,7 +263,9 @@ internal sealed partial class SqsMessageCreator : SqsMessageCreatorBase, ISqsMes
         {
             if (HeaderNames.IsKnown(attribute.Key) || bag.ContainsKey(attribute.Key))
                 continue;
-            bag[attribute.Key] = attribute.Value.StringValue;
+            var raw = attribute.Value.StringValue;
+            if (raw != null)
+                bag[attribute.Key] = raw;
         }
 
         return bag;

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS.V4/SqsMessageCreator.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS.V4/SqsMessageCreator.cs
@@ -258,6 +258,9 @@ internal sealed partial class SqsMessageCreator : SqsMessageCreatorBase, ISqsMes
             }
         }
 
+        if (sqsMessage.MessageAttributes is null)
+            return bag;
+
         // Surface inbound MessageAttributes Brighter doesn't already consume so foreign producers'
         // metadata can flow through to consumers via the bag. Entries already present in Brighter's
         // own JSON bag attribute take precedence.

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS.V4/SqsMessageCreator.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS.V4/SqsMessageCreator.cs
@@ -239,14 +239,16 @@ internal sealed partial class SqsMessageCreator : SqsMessageCreatorBase, ISqsMes
 
     private static Dictionary<string, object> ReadMessageBag(Amazon.SQS.Model.Message sqsMessage)
     {
+        var bag = new Dictionary<string, object>();
+
         if (sqsMessage.MessageAttributes.TryGetValue(HeaderNames.Bag, out MessageAttributeValue? value))
         {
             try
             {
-                var bag = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object>>(value.StringValue,
+                var parsed = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object>>(value.StringValue,
                     JsonSerialisationOptions.Options);
-                if (bag != null)
-                    return bag;
+                if (parsed != null)
+                    bag = parsed;
             }
             catch (Exception)
             {
@@ -254,7 +256,17 @@ internal sealed partial class SqsMessageCreator : SqsMessageCreatorBase, ISqsMes
             }
         }
 
-        return new Dictionary<string, object>();
+        // Surface inbound MessageAttributes Brighter doesn't already consume so foreign producers'
+        // metadata can flow through to consumers via the bag. Entries already present in Brighter's
+        // own JSON bag attribute take precedence.
+        foreach (var attribute in sqsMessage.MessageAttributes)
+        {
+            if (HeaderNames.IsKnown(attribute.Key) || bag.ContainsKey(attribute.Key))
+                continue;
+            bag[attribute.Key] = attribute.Value.StringValue;
+        }
+
+        return bag;
     }
 
     private static HeaderResult<RoutingKey> ReadReplyTo(Amazon.SQS.Model.Message sqsMessage)

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS/HeaderNames.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS/HeaderNames.cs
@@ -23,6 +23,8 @@ THE SOFTWARE. */
 
 #endregion
 
+using System.Collections.Generic;
+
 namespace Paramore.Brighter.MessagingGateway.AWSSQS;
 
 /// <summary>
@@ -51,11 +53,33 @@ public static class HeaderNames
     public const string TraceState = "tracestate";
     public const string TraceParent = "traceparent";
     public const string Baggage = "baggage";
-    
+
     /// <summary>
     /// Use this because we cannot set cloud events as individual headers, SNS/SQS can only have 10 headers in raw message delivery
-    /// and instead need a single header with all cloud events for example, 
+    /// and instead need a single header with all cloud events for example,
     /// </summary>
     public const string CloudEventHeaders = "cloudeventheaders";
 
+    /// <summary>
+    /// SNS/SQS MessageAttribute names that Brighter reads into typed
+    /// <see cref="MessageHeader"/> fields (or its own JSON-serialised bag). Inbound
+    /// attributes whose names are <em>not</em> in this set are surfaced into
+    /// <see cref="MessageHeader.Bag"/> under their raw name so interop with foreign
+    /// producers is preserved instead of silently discarding their metadata.
+    /// Comparison is ordinal — AWS message attribute names are case-sensitive.
+    /// </summary>
+    private static readonly HashSet<string> s_knownNames = new(System.StringComparer.Ordinal)
+    {
+        Id, Topic, ContentType, CorrelationId, HandledCount, MessageType, Timestamp,
+        ReplyTo, Subject, Bag, DeduplicationId, Type, SpecVersion, Source, Time,
+        DataContentType, DataSchema, DataRef, TraceState, TraceParent, Baggage,
+        CloudEventHeaders
+    };
+
+    /// <summary>
+    /// Returns <c>true</c> when <paramref name="name"/> is one of the SNS/SQS
+    /// MessageAttribute names Brighter consumes directly into a typed
+    /// <see cref="MessageHeader"/> field or its JSON-serialised bag.
+    /// </summary>
+    public static bool IsKnown(string name) => s_knownNames.Contains(name);
 }

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS/SqsInlineMessageCreator.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS/SqsInlineMessageCreator.cs
@@ -168,20 +168,20 @@ internal sealed partial class SqsInlineMessageCreator : SqsMessageCreatorBase, I
 
     private Dictionary<string, object> ReadMessageBag()
     {
+        var bag = new Dictionary<string, object>();
+
         if (_messageAttributes.TryGetValue(HeaderNames.Bag, out var headerBag))
         {
             try
             {
                 var json = headerBag.GetValueInString();
-                if (string.IsNullOrEmpty(json))
+                if (!string.IsNullOrEmpty(json))
                 {
-                    return new Dictionary<string, object>();
+                    var parsed = JsonSerializer.Deserialize<Dictionary<string, object>>(json!,
+                        JsonSerialisationOptions.Options);
+                    if (parsed != null)
+                        bag = parsed;
                 }
-
-                var bag = JsonSerializer.Deserialize<Dictionary<string, object>>(json!,
-                    JsonSerialisationOptions.Options);
-
-                return bag ?? new Dictionary<string, object>();
             }
             catch (Exception)
             {
@@ -189,7 +189,19 @@ internal sealed partial class SqsInlineMessageCreator : SqsMessageCreatorBase, I
             }
         }
 
-        return new Dictionary<string, object>();
+        // Surface inbound MessageAttributes Brighter doesn't already consume so foreign producers'
+        // metadata can flow through to consumers via the bag. Entries already present in Brighter's
+        // own JSON bag attribute take precedence.
+        foreach (var attribute in _messageAttributes)
+        {
+            if (HeaderNames.IsKnown(attribute.Key) || bag.ContainsKey(attribute.Key))
+                continue;
+            var raw = attribute.Value.GetValueInString();
+            if (raw != null)
+                bag[attribute.Key] = raw;
+        }
+
+        return bag;
     }
     
     private Dictionary<string, string> ReadMessageCloudEvents()

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS/SqsMessageCreator.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS/SqsMessageCreator.cs
@@ -266,7 +266,9 @@ internal sealed partial class SqsMessageCreator : SqsMessageCreatorBase, ISqsMes
         {
             if (HeaderNames.IsKnown(attribute.Key) || bag.ContainsKey(attribute.Key))
                 continue;
-            bag[attribute.Key] = attribute.Value.StringValue;
+            var raw = attribute.Value.StringValue;
+            if (raw != null)
+                bag[attribute.Key] = raw;
         }
 
         return bag;

--- a/src/Paramore.Brighter.MessagingGateway.AWSSQS/SqsMessageCreator.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AWSSQS/SqsMessageCreator.cs
@@ -242,14 +242,16 @@ internal sealed partial class SqsMessageCreator : SqsMessageCreatorBase, ISqsMes
 
     private static Dictionary<string, object> ReadMessageBag(Amazon.SQS.Model.Message sqsMessage)
     {
+        var bag = new Dictionary<string, object>();
+
         if (sqsMessage.MessageAttributes.TryGetValue(HeaderNames.Bag, out MessageAttributeValue? value))
         {
             try
             {
-                var bag = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object>>(value.StringValue,
+                var parsed = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object>>(value.StringValue,
                     JsonSerialisationOptions.Options);
-                if (bag != null)
-                    return bag;
+                if (parsed != null)
+                    bag = parsed;
             }
             catch (Exception)
             {
@@ -257,7 +259,17 @@ internal sealed partial class SqsMessageCreator : SqsMessageCreatorBase, ISqsMes
             }
         }
 
-        return new Dictionary<string, object>();
+        // Surface inbound MessageAttributes Brighter doesn't already consume so foreign producers'
+        // metadata can flow through to consumers via the bag. Entries already present in Brighter's
+        // own JSON bag attribute take precedence.
+        foreach (var attribute in sqsMessage.MessageAttributes)
+        {
+            if (HeaderNames.IsKnown(attribute.Key) || bag.ContainsKey(attribute.Key))
+                continue;
+            bag[attribute.Key] = attribute.Value.StringValue;
+        }
+
+        return bag;
     }
 
     private static HeaderResult<RoutingKey> ReadReplyTo(Amazon.SQS.Model.Message sqsMessage)

--- a/src/Paramore.Brighter.Transformers.JustSaying/JustSayingAttributesName.cs
+++ b/src/Paramore.Brighter.Transformers.JustSaying/JustSayingAttributesName.cs
@@ -41,4 +41,17 @@ public static class JustSayingAttributesName
     /// Format: "{HeaderPrefix}-Raising-Component"
     /// </summary>
     public const string Conversation = $"{HeaderPrefix}-Conversation";
+
+    /// <summary>
+    /// Identifies the body encoding applied by JustSaying when publish-side compression is enabled.
+    /// JustSaying sets this as an SNS/SQS message attribute (key: <c>"Content-Encoding"</c>) with a value
+    /// of <see cref="GzipBase64ContentEncoding"/> when the payload exceeds the configured threshold.
+    /// </summary>
+    public const string ContentEncoding = "Content-Encoding";
+
+    /// <summary>
+    /// JustSaying's gzip + base64 content-encoding marker. Matches
+    /// <c>JustSaying.Messaging.Compression.ContentEncodings.GzipBase64</c>.
+    /// </summary>
+    public const string GzipBase64ContentEncoding = "gzip,base64";
 }

--- a/src/Paramore.Brighter.Transformers.JustSaying/JustSayingCompressionTransform.cs
+++ b/src/Paramore.Brighter.Transformers.JustSaying/JustSayingCompressionTransform.cs
@@ -1,0 +1,94 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Paramore.Brighter.Transformers.JustSaying;
+
+/// <summary>
+/// Decompresses message bodies produced by JustSaying's publish-side compression.
+/// </summary>
+/// <remarks>
+/// JustSaying signals compression with an SNS/SQS MessageAttribute named
+/// <see cref="JustSayingAttributesName.ContentEncoding"/> set to
+/// <see cref="JustSayingAttributesName.GzipBase64ContentEncoding"/>. When that
+/// marker is present in <see cref="MessageHeader.Bag"/>, the body is
+/// <c>base64(gzip(json))</c>; this transform reverses both layers so the
+/// downstream mapper sees plain JSON.
+/// <para>
+/// Wired up via <see cref="JustSayingDecompressAttribute"/> on the mapper's
+/// <c>MapToRequest</c> method, mirroring how
+/// <see cref="Paramore.Brighter.Transforms.Attributes.DecompressAttribute"/>
+/// pairs with <see cref="Paramore.Brighter.Transforms.Transformers.CompressPayloadTransformer"/>.
+/// </para>
+/// <para>
+/// The wrap (publish-side) path is currently a no-op: round-tripping a
+/// <see cref="JustSayingAttributesName.ContentEncoding"/> header onto the wire
+/// as a native SNS message attribute requires a gateway-publisher change that
+/// is out of scope here. See issue #4129 for the follow-up.
+/// </para>
+/// </remarks>
+public class JustSayingCompressionTransform : IAmAMessageTransform, IAmAMessageTransformAsync
+{
+    /// <inheritdoc cref="IAmAMessageTransform.Context"/>
+    public IRequestContext? Context { get; set; }
+
+    /// <inheritdoc cref="IAmAMessageTransform.InitializeWrapFromAttributeParams"/>
+    public void InitializeWrapFromAttributeParams(params object?[] initializerList)
+    {
+    }
+
+    /// <inheritdoc cref="IAmAMessageTransform.InitializeUnwrapFromAttributeParams"/>
+    public void InitializeUnwrapFromAttributeParams(params object?[] initializerList)
+    {
+    }
+
+    /// <inheritdoc />
+    public Message Wrap(Message message, Publication publication) => message;
+
+    /// <inheritdoc />
+    public Task<Message> WrapAsync(Message message, Publication publication, CancellationToken cancellationToken = default)
+        => Task.FromResult(message);
+
+    /// <inheritdoc />
+    public Message Unwrap(Message message)
+    {
+        if (!IsGzipBase64(message))
+        {
+            return message;
+        }
+
+        var decompressed = DecodeGzipBase64(message.Body.Memory);
+        message.Body = new MessageBody(decompressed, message.Header.ContentType);
+        return message;
+    }
+
+    /// <inheritdoc />
+    public Task<Message> UnwrapAsync(Message message, CancellationToken cancellationToken = default)
+        => Task.FromResult(Unwrap(message));
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+    }
+
+    private static bool IsGzipBase64(Message message)
+    {
+        return message.Header.Bag.TryGetValue(JustSayingAttributesName.ContentEncoding, out var encoding)
+               && encoding is string s
+               && string.Equals(s, JustSayingAttributesName.GzipBase64ContentEncoding, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static byte[] DecodeGzipBase64(ReadOnlyMemory<byte> body)
+    {
+        var base64 = System.Text.Encoding.ASCII.GetString(body.ToArray());
+        var gzipped = Convert.FromBase64String(base64);
+
+        using var input = new MemoryStream(gzipped, writable: false);
+        using var gz = new GZipStream(input, CompressionMode.Decompress);
+        using var output = new MemoryStream();
+        gz.CopyTo(output);
+        return output.ToArray();
+    }
+}

--- a/src/Paramore.Brighter.Transformers.JustSaying/JustSayingCompressionTransform.cs
+++ b/src/Paramore.Brighter.Transformers.JustSaying/JustSayingCompressionTransform.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Buffers;
+using System.Buffers.Text;
 using System.IO;
 using System.IO.Compression;
 using System.Threading;
@@ -59,8 +61,7 @@ public class JustSayingCompressionTransform : IAmAMessageTransform, IAmAMessageT
             return message;
         }
 
-        var decompressed = DecodeGzipBase64(message.Body.Memory);
-        message.Body = new MessageBody(decompressed, message.Header.ContentType);
+        message.Body = new MessageBody(DecodeGzipBase64(message.Body.Memory.Span), message.Header.ContentType);
         return message;
     }
 
@@ -80,15 +81,35 @@ public class JustSayingCompressionTransform : IAmAMessageTransform, IAmAMessageT
                && string.Equals(s, JustSayingAttributesName.GzipBase64ContentEncoding, StringComparison.OrdinalIgnoreCase);
     }
 
-    private static byte[] DecodeGzipBase64(ReadOnlyMemory<byte> body)
+    private static ReadOnlyMemory<byte> DecodeGzipBase64(ReadOnlySpan<byte> body)
     {
-        var base64 = System.Text.Encoding.ASCII.GetString(body.ToArray());
-        var gzipped = Convert.FromBase64String(base64);
+        // body is the UTF-8/ASCII base64 representation; Base64.DecodeFromUtf8 reads it
+        // directly so we don't materialise a string or a Convert.FromBase64String buffer.
+        var decoded = ArrayPool<byte>.Shared.Rent(Base64.GetMaxDecodedFromUtf8Length(body.Length));
+        try
+        {
+            var status = Base64.DecodeFromUtf8(body, decoded, out _, out var decodedLength);
+            if (status != OperationStatus.Done)
+            {
+                throw new InvalidOperationException(
+                    $"Message body marked as {JustSayingAttributesName.GzipBase64ContentEncoding} contained invalid base64 (status: {status}).");
+            }
 
-        using var input = new MemoryStream(gzipped, writable: false);
-        using var gz = new GZipStream(input, CompressionMode.Decompress);
-        using var output = new MemoryStream();
-        gz.CopyTo(output);
-        return output.ToArray();
+            using var input = new MemoryStream(decoded, 0, decodedLength, writable: false);
+            using var gz = new GZipStream(input, CompressionMode.Decompress);
+            // Typical JSON payloads compress ~3-5x; seed the output buffer to skip an early grow.
+            using var output = new MemoryStream(capacity: decodedLength * 4);
+            gz.CopyTo(output);
+
+            // MemoryStream.Dispose does not free the internal byte[]; TryGetBuffer hands us a
+            // segment we can wrap and return without an extra copy.
+            return output.TryGetBuffer(out var buffer)
+                ? new ReadOnlyMemory<byte>(buffer.Array!, buffer.Offset, buffer.Count)
+                : output.ToArray();
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(decoded);
+        }
     }
 }

--- a/src/Paramore.Brighter.Transformers.JustSaying/JustSayingDecompressAttribute.cs
+++ b/src/Paramore.Brighter.Transformers.JustSaying/JustSayingDecompressAttribute.cs
@@ -1,0 +1,30 @@
+using System;
+
+namespace Paramore.Brighter.Transformers.JustSaying;
+
+/// <summary>
+/// Decompresses inbound messages produced by JustSaying's publish-side compression
+/// (<c>Content-Encoding: gzip,base64</c>). Apply to a mapper's <c>MapToRequest</c>
+/// method on the unwrap pipeline. Mirrors
+/// <see cref="Paramore.Brighter.Transforms.Attributes.DecompressAttribute"/>.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method, Inherited = false)]
+public class JustSayingDecompressAttribute : UnwrapWithAttribute
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="JustSayingDecompressAttribute"/> class.
+    /// </summary>
+    /// <param name="step">
+    /// The step order in the unwrap pipeline. Lower numbers execute earlier; pick a step
+    /// that runs before any transform that needs to read the decompressed JSON body.
+    /// </param>
+    public JustSayingDecompressAttribute(int step) : base(step)
+    {
+    }
+
+    /// <inheritdoc />
+    public override object?[] InitializerParams() => Array.Empty<object?>();
+
+    /// <inheritdoc />
+    public override Type GetHandlerType() => typeof(JustSayingCompressionTransform);
+}

--- a/src/Paramore.Brighter.Transformers.JustSaying/JustSayingMessageMapper.cs
+++ b/src/Paramore.Brighter.Transformers.JustSaying/JustSayingMessageMapper.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
-using System.IO.Compression;
 using System.Net.Mime;
 using System.Text.Json;
 using System.Threading;
@@ -50,6 +48,7 @@ public class JustSayingMessageMapper<TMessage> : IAmAMessageMapper<TMessage>, IA
     }
 
     /// <inheritdoc />
+    [JustSayingDecompress(0)]
     public Task<TMessage> MapToRequestAsync(Message message, CancellationToken cancellationToken = default)
     {
         return Task.FromResult(MapToRequest(message));
@@ -220,48 +219,12 @@ public class JustSayingMessageMapper<TMessage> : IAmAMessageMapper<TMessage>, IA
     }
 
     /// <inheritdoc />
+    [JustSayingDecompress(0)]
     public TMessage MapToRequest(Message message)
-    {
-        var body = message.Body.Memory;
-        if (IsJustSayingGzipBase64(message))
-        {
-            return DeserializeCompressed(body);
-        }
-
 #if NETSTANDARD2_0
-        return JsonSerializer.Deserialize<TMessage>(body.ToArray(), JsonSerialisationOptions.Options)!;
+        => JsonSerializer.Deserialize<TMessage>(message.Body.Memory.ToArray(), JsonSerialisationOptions.Options)!;
 #else
-        return JsonSerializer.Deserialize<TMessage>(body.Span, JsonSerialisationOptions.Options)!;
+        => JsonSerializer.Deserialize<TMessage>(message.Body.Memory.Span, JsonSerialisationOptions.Options)!;
 #endif
-    }
-
-    private static bool IsJustSayingGzipBase64(Message message)
-    {
-        // JustSaying signals compression via a "Content-Encoding" SNS message attribute. The AWS
-        // SQS gateway surfaces foreign message attributes into MessageHeader.Bag under their raw
-        // name, so we look it up there.
-        return message.Header.Bag.TryGetValue(JustSayingAttributesName.ContentEncoding, out var encoding)
-               && encoding is string s
-               && string.Equals(s, JustSayingAttributesName.GzipBase64ContentEncoding, StringComparison.OrdinalIgnoreCase);
-    }
-
-    private static TMessage DeserializeCompressed(ReadOnlyMemory<byte> body)
-    {
-        // Body is base64(gzip(json)); base64-decode then gunzip before deserializing.
-        var base64 = System.Text.Encoding.ASCII.GetString(body.ToArray());
-        var gzipped = Convert.FromBase64String(base64);
-
-        using var input = new MemoryStream(gzipped, writable: false);
-        using var gz = new GZipStream(input, CompressionMode.Decompress);
-        using var output = new MemoryStream();
-        gz.CopyTo(output);
-
-        if (output.TryGetBuffer(out var buffer))
-        {
-            return JsonSerializer.Deserialize<TMessage>(buffer.AsSpan(), JsonSerialisationOptions.Options)!;
-        }
-
-        return JsonSerializer.Deserialize<TMessage>(output.ToArray(), JsonSerialisationOptions.Options)!;
-    }
 }
 

--- a/src/Paramore.Brighter.Transformers.JustSaying/JustSayingMessageMapper.cs
+++ b/src/Paramore.Brighter.Transformers.JustSaying/JustSayingMessageMapper.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
 using System.Net.Mime;
 using System.Text.Json;
 using System.Threading;
@@ -218,11 +220,48 @@ public class JustSayingMessageMapper<TMessage> : IAmAMessageMapper<TMessage>, IA
     }
 
     /// <inheritdoc />
-    public TMessage MapToRequest(Message message) 
+    public TMessage MapToRequest(Message message)
+    {
+        var body = message.Body.Memory;
+        if (IsJustSayingGzipBase64(message))
+        {
+            return DeserializeCompressed(body);
+        }
+
 #if NETSTANDARD2_0
-        => JsonSerializer.Deserialize<TMessage>(message.Body.Memory.ToArray(), JsonSerialisationOptions.Options)!;
+        return JsonSerializer.Deserialize<TMessage>(body.ToArray(), JsonSerialisationOptions.Options)!;
 #else
-        => JsonSerializer.Deserialize<TMessage>(message.Body.Memory.Span, JsonSerialisationOptions.Options)!;
+        return JsonSerializer.Deserialize<TMessage>(body.Span, JsonSerialisationOptions.Options)!;
 #endif
+    }
+
+    private static bool IsJustSayingGzipBase64(Message message)
+    {
+        // JustSaying signals compression via a "Content-Encoding" SNS message attribute. The AWS
+        // SQS gateway surfaces foreign message attributes into MessageHeader.Bag under their raw
+        // name, so we look it up there.
+        return message.Header.Bag.TryGetValue(JustSayingAttributesName.ContentEncoding, out var encoding)
+               && encoding is string s
+               && string.Equals(s, JustSayingAttributesName.GzipBase64ContentEncoding, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static TMessage DeserializeCompressed(ReadOnlyMemory<byte> body)
+    {
+        // Body is base64(gzip(json)); base64-decode then gunzip before deserializing.
+        var base64 = System.Text.Encoding.ASCII.GetString(body.ToArray());
+        var gzipped = Convert.FromBase64String(base64);
+
+        using var input = new MemoryStream(gzipped, writable: false);
+        using var gz = new GZipStream(input, CompressionMode.Decompress);
+        using var output = new MemoryStream();
+        gz.CopyTo(output);
+
+        if (output.TryGetBuffer(out var buffer))
+        {
+            return JsonSerializer.Deserialize<TMessage>(buffer.AsSpan(), JsonSerialisationOptions.Options)!;
+        }
+
+        return JsonSerializer.Deserialize<TMessage>(output.ToArray(), JsonSerialisationOptions.Options)!;
+    }
 }
 

--- a/tests/Paramore.Brighter.Transforms.Adaptors.Tests/JustSaying/JustSayingCompressionTransformTest.cs
+++ b/tests/Paramore.Brighter.Transforms.Adaptors.Tests/JustSaying/JustSayingCompressionTransformTest.cs
@@ -1,0 +1,87 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Net.Mime;
+using System.Text;
+using System.Text.Json;
+using Paramore.Brighter.JsonConverters;
+using Paramore.Brighter.Transformers.JustSaying;
+using Xunit;
+
+namespace Paramore.Brighter.Transforms.Adaptors.Tests.JustSaying;
+
+public class JustSayingCompressionTransformTest
+{
+    [Fact]
+    public void Unwrap_when_content_encoding_marks_gzip_base64_should_decompress_body()
+    {
+        var command = new Payload { Name = new string('x', 4096) };
+        var compressed = GzipBase64Encode(command);
+
+        var header = new MessageHeader { ContentType = new ContentType("application/json") };
+        header.Bag[JustSayingAttributesName.ContentEncoding] = JustSayingAttributesName.GzipBase64ContentEncoding;
+        var message = new Message(header, new MessageBody(Encoding.ASCII.GetBytes(compressed), new ContentType("application/json")));
+
+        using var transform = new JustSayingCompressionTransform();
+        var result = transform.Unwrap(message);
+
+        var decoded = JsonSerializer.Deserialize<Payload>(result.Body.Memory.Span, JsonSerialisationOptions.Options);
+        Assert.NotNull(decoded);
+        Assert.Equal(command.Name, decoded!.Name);
+    }
+
+    [Fact]
+    public void Unwrap_when_content_encoding_header_is_absent_should_leave_body_untouched()
+    {
+        var json = JsonSerializer.SerializeToUtf8Bytes(new Payload { Name = "plain" }, JsonSerialisationOptions.Options);
+        var message = new Message(new MessageHeader(), new MessageBody(json, new ContentType("application/json")));
+
+        using var transform = new JustSayingCompressionTransform();
+        var result = transform.Unwrap(message);
+
+        Assert.True(result.Body.Memory.Span.SequenceEqual(json));
+    }
+
+    [Fact]
+    public void Unwrap_when_content_encoding_is_some_other_value_should_leave_body_untouched()
+    {
+        var json = JsonSerializer.SerializeToUtf8Bytes(new Payload { Name = "plain" }, JsonSerialisationOptions.Options);
+        var header = new MessageHeader();
+        header.Bag[JustSayingAttributesName.ContentEncoding] = "br";
+        var message = new Message(header, new MessageBody(json, new ContentType("application/json")));
+
+        using var transform = new JustSayingCompressionTransform();
+        var result = transform.Unwrap(message);
+
+        Assert.True(result.Body.Memory.Span.SequenceEqual(json));
+    }
+
+    [Fact]
+    public void Wrap_is_a_no_op()
+    {
+        var json = JsonSerializer.SerializeToUtf8Bytes(new Payload { Name = "plain" }, JsonSerialisationOptions.Options);
+        var message = new Message(new MessageHeader(), new MessageBody(json, new ContentType("application/json")));
+
+        using var transform = new JustSayingCompressionTransform();
+        var result = transform.Wrap(message, new Publication());
+
+        Assert.True(result.Body.Memory.Span.SequenceEqual(json));
+    }
+
+    private static string GzipBase64Encode<T>(T value)
+    {
+        var json = JsonSerializer.SerializeToUtf8Bytes(value, JsonSerialisationOptions.Options);
+        using var output = new MemoryStream();
+        using (var gz = new GZipStream(output, CompressionLevel.Optimal, leaveOpen: true))
+        {
+            gz.Write(json, 0, json.Length);
+        }
+
+        return Convert.ToBase64String(output.ToArray());
+    }
+
+    private sealed class Payload
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+}

--- a/tests/Paramore.Brighter.Transforms.Adaptors.Tests/JustSaying/JustSayingMessageMapperTest.cs
+++ b/tests/Paramore.Brighter.Transforms.Adaptors.Tests/JustSaying/JustSayingMessageMapperTest.cs
@@ -1,5 +1,9 @@
 ﻿using System;
+using System.IO;
+using System.IO.Compression;
 using System.Net;
+using System.Net.Mime;
+using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Paramore.Brighter.JsonConverters;
@@ -326,6 +330,70 @@ public class JustSayingMessageMapperTest
         Assert.Equal(MessageType.MT_COMMAND, message.Header.MessageType);
     }
     
+    [Fact]
+    public void MapToRequest_when_body_is_uncompressed_should_deserialize_as_json()
+    {
+        var mapper = new JustSayingMessageMapper<SomeJustSayingCommand>();
+        var command = new SomeJustSayingCommand
+        {
+            Id = Guid.NewGuid().ToString(),
+            Conversation = $"Conversation{Guid.NewGuid()}",
+            RaisingComponent = $"Raising{Guid.NewGuid()}",
+            Tenant = $"Tenant{Guid.NewGuid()}",
+            Version = $"Version{Guid.NewGuid()}",
+            TimeStamp = DateTimeOffset.UtcNow,
+            Name = $"Name{Guid.NewGuid()}",
+        };
+
+        var json = JsonSerializer.SerializeToUtf8Bytes(command, JsonSerialisationOptions.Options);
+        var message = new Message(new MessageHeader(), new MessageBody(json, new ContentType("application/json")));
+
+        var result = mapper.MapToRequest(message);
+
+        Assert.Equal(command.Id, result.Id);
+        Assert.Equal(command.Name, result.Name);
+        Assert.Equal(command.Tenant, result.Tenant);
+    }
+
+    [Fact]
+    public void MapToRequest_when_body_is_justsaying_gzip_base64_should_decompress_before_deserializing()
+    {
+        var mapper = new JustSayingMessageMapper<SomeJustSayingCommand>();
+        var command = new SomeJustSayingCommand
+        {
+            Id = Guid.NewGuid().ToString(),
+            Conversation = $"Conversation{Guid.NewGuid()}",
+            RaisingComponent = $"Raising{Guid.NewGuid()}",
+            Tenant = $"Tenant{Guid.NewGuid()}",
+            Version = $"Version{Guid.NewGuid()}",
+            TimeStamp = DateTimeOffset.UtcNow,
+            Name = new string('x', 4096),
+        };
+
+        var compressedBody = GzipBase64Encode(command);
+        var header = new MessageHeader();
+        header.Bag[JustSayingAttributesName.ContentEncoding] = JustSayingAttributesName.GzipBase64ContentEncoding;
+        var message = new Message(header, new MessageBody(Encoding.ASCII.GetBytes(compressedBody), new ContentType("application/json")));
+
+        var result = mapper.MapToRequest(message);
+
+        Assert.Equal(command.Id, result.Id);
+        Assert.Equal(command.Name, result.Name);
+        Assert.Equal(command.Tenant, result.Tenant);
+    }
+
+    private static string GzipBase64Encode<T>(T value)
+    {
+        var json = JsonSerializer.SerializeToUtf8Bytes(value, JsonSerialisationOptions.Options);
+        using var output = new MemoryStream();
+        using (var gz = new GZipStream(output, CompressionLevel.Optimal, leaveOpen: true))
+        {
+            gz.Write(json, 0, json.Length);
+        }
+
+        return Convert.ToBase64String(output.ToArray());
+    }
+
     public class SomeJustSayingCommand : JustSayingCommand
     {
         public string Name { get; set; } = string.Empty;

--- a/tests/Paramore.Brighter.Transforms.Adaptors.Tests/JustSaying/JustSayingMessageMapperTest.cs
+++ b/tests/Paramore.Brighter.Transforms.Adaptors.Tests/JustSaying/JustSayingMessageMapperTest.cs
@@ -1,9 +1,5 @@
 ﻿using System;
-using System.IO;
-using System.IO.Compression;
 using System.Net;
-using System.Net.Mime;
-using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Paramore.Brighter.JsonConverters;
@@ -330,70 +326,6 @@ public class JustSayingMessageMapperTest
         Assert.Equal(MessageType.MT_COMMAND, message.Header.MessageType);
     }
     
-    [Fact]
-    public void MapToRequest_when_body_is_uncompressed_should_deserialize_as_json()
-    {
-        var mapper = new JustSayingMessageMapper<SomeJustSayingCommand>();
-        var command = new SomeJustSayingCommand
-        {
-            Id = Guid.NewGuid().ToString(),
-            Conversation = $"Conversation{Guid.NewGuid()}",
-            RaisingComponent = $"Raising{Guid.NewGuid()}",
-            Tenant = $"Tenant{Guid.NewGuid()}",
-            Version = $"Version{Guid.NewGuid()}",
-            TimeStamp = DateTimeOffset.UtcNow,
-            Name = $"Name{Guid.NewGuid()}",
-        };
-
-        var json = JsonSerializer.SerializeToUtf8Bytes(command, JsonSerialisationOptions.Options);
-        var message = new Message(new MessageHeader(), new MessageBody(json, new ContentType("application/json")));
-
-        var result = mapper.MapToRequest(message);
-
-        Assert.Equal(command.Id, result.Id);
-        Assert.Equal(command.Name, result.Name);
-        Assert.Equal(command.Tenant, result.Tenant);
-    }
-
-    [Fact]
-    public void MapToRequest_when_body_is_justsaying_gzip_base64_should_decompress_before_deserializing()
-    {
-        var mapper = new JustSayingMessageMapper<SomeJustSayingCommand>();
-        var command = new SomeJustSayingCommand
-        {
-            Id = Guid.NewGuid().ToString(),
-            Conversation = $"Conversation{Guid.NewGuid()}",
-            RaisingComponent = $"Raising{Guid.NewGuid()}",
-            Tenant = $"Tenant{Guid.NewGuid()}",
-            Version = $"Version{Guid.NewGuid()}",
-            TimeStamp = DateTimeOffset.UtcNow,
-            Name = new string('x', 4096),
-        };
-
-        var compressedBody = GzipBase64Encode(command);
-        var header = new MessageHeader();
-        header.Bag[JustSayingAttributesName.ContentEncoding] = JustSayingAttributesName.GzipBase64ContentEncoding;
-        var message = new Message(header, new MessageBody(Encoding.ASCII.GetBytes(compressedBody), new ContentType("application/json")));
-
-        var result = mapper.MapToRequest(message);
-
-        Assert.Equal(command.Id, result.Id);
-        Assert.Equal(command.Name, result.Name);
-        Assert.Equal(command.Tenant, result.Tenant);
-    }
-
-    private static string GzipBase64Encode<T>(T value)
-    {
-        var json = JsonSerializer.SerializeToUtf8Bytes(value, JsonSerialisationOptions.Options);
-        using var output = new MemoryStream();
-        using (var gz = new GZipStream(output, CompressionLevel.Optimal, leaveOpen: true))
-        {
-            gz.Write(json, 0, json.Length);
-        }
-
-        return Convert.ToBase64String(output.ToArray());
-    }
-
     public class SomeJustSayingCommand : JustSayingCommand
     {
         public string Name { get; set; } = string.Empty;


### PR DESCRIPTION
## Description

The AWS SQS gateway previously read a fixed set of known SNS/SQS `MessageAttribute` names into typed `MessageHeader` fields (and Brighter's own JSON-serialised `bag` attribute), silently discarding every other inbound attribute. That made Brighter consumers blind to interop metadata sent by foreign producers — the JustSaying gzip+base64 compression flag (`Content-Encoding: gzip,base64`) being the motivating example. Both V3 and V4 message creators (raw + inline paths) now copy any inbound `MessageAttribute` not in `HeaderNames.IsKnown` into `MessageHeader.Bag` under its raw name, with Brighter's own JSON bag attribute taking precedence on key collision. On top of that, `JustSayingMessageMapper.MapToRequest` now reads `Content-Encoding` from the bag and decompresses `base64(gzip(json))` bodies before deserialising.

## Related Issues

Fixes #4129

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [Contributing Guide](CONTRIBUTING.md)
- [x] I have checked the [documentation](https://brightercommand.gitbook.io/paramore-brighter-documentation/) for relevant guidance
- [x] I have added/updated XML documentation for any public API changes
- [x] I have added/updated tests as appropriate
- [x] My changes follow the existing code style and conventions

## Additional Notes

The publish-side of JustSaying compression is intentionally not in scope — the gateway publisher emits Brighter's bag as a single JSON attribute rather than per-key attributes, so emitting a native `Content-Encoding` SNS attribute would need a separate publisher change. Worth a follow-up issue.

Unit-test coverage for the gateway attribute-surfacing change lives transitively in the JustSaying mapper tests (which exercise the bag-lookup contract). `SqsMessageCreator` is `internal sealed` with no `InternalsVisibleTo`, and the existing gateway test suite is integration-only (LocalStack); happy to add a LocalStack integration test if reviewers want belt-and-braces.