### PR TITLE
fix(cloud-events): preserve message header values in CloudEventsTransformer

### DIFF
--- a/src/Paramore.Brighter/Transforms/Attributes/CloudEventsAttribute.cs
+++ b/src/Paramore.Brighter/Transforms/Attributes/CloudEventsAttribute.cs
@@ -5,12 +5,14 @@ namespace Paramore.Brighter.Transforms.Attributes;
 
 /// <summary>
 /// Support the usage of CloudEvents in the message.
-/// We can take the metadata for a CloudEvent from different sources, and they are handled in this order:
-/// 1. The <see cref="Publication"/> parameter in the Message Mapper; use this if you want to map them by hand
-/// 2. The <see cref="Publication"/> parameter in the CloudEvents transformer; use this if you just want mapping by convention
-///     via the <see cref="CloudEventsTransformer"/>
-/// 2. The parameters provided to the <see cref="CloudEventsAttribute"/> attribute; use this if you want to hardcode these via the
-///     attribute over the <see cref="Publication"/>
+/// We can take the metadata for a CloudEvent from different sources, and they are handled in this order
+/// (highest priority first):
+/// 1. The parameters provided to the <see cref="CloudEventsAttribute"/> attribute; use this if you want to hardcode values
+///     that override everything else
+/// 2. The message header values set by the Message Mapper; these are preserved if already set (e.g. by a custom mapper
+///     or <c>JustSayingMessageMapper</c>), so the mapper's values take priority over the <see cref="Publication"/> defaults
+/// 3. The <see cref="Publication"/> parameter passed to the <see cref="CloudEventsTransformer"/>; use this as a fallback
+///     when neither the attribute nor the mapper provides a value
 /// </summary>
 public class CloudEventsAttribute : WrapWithAttribute
 {

--- a/src/Paramore.Brighter/Transforms/Attributes/CloudEventsAttribute.cs
+++ b/src/Paramore.Brighter/Transforms/Attributes/CloudEventsAttribute.cs
@@ -66,7 +66,7 @@ public class CloudEventsAttribute : WrapWithAttribute
     /// When translating an event message with no "datacontenttype" attribute to a different format or protocol binding,
     /// the target datacontenttype SHOULD be set explicitly to the implied datacontenttype of the source. 
     /// </summary>
-    public string DataContentType { get; set; } = "application/json";
+    public string? DataContentType { get; set; }
     
     /// <summary>
     /// Identifies the schema that data adheres to. Incompatible changes to the schema SHOULD be reflected by a different URI.

--- a/src/Paramore.Brighter/Transforms/Transformers/CloudEventsTransformer.cs
+++ b/src/Paramore.Brighter/Transforms/Transformers/CloudEventsTransformer.cs
@@ -26,7 +26,7 @@ namespace Paramore.Brighter.Transforms.Transformers;
 /// REQUIRED
 ///     id => the message id from <see cref="MessageHeader"/>; you don't set this here, as we use the id from the <see cref="Request"/>
 ///     source => attribute > mapper > publication
-///     specversion => attribute > mapper; defaults to 1.0
+///     specversion => attribute > mapper; defaults to 1.0 (no publication fallback — <see cref="Publication"/> has no SpecVersion property)
 ///     type => attribute > mapper > publication
 /// OPTIONAL
 ///     datacontenttype => attribute > mapper (no publication fallback)
@@ -132,7 +132,7 @@ public partial class CloudEventsTransformer : IAmAMessageTransform, IAmAMessageT
     /// <inheritdoc />
     public Message Wrap(Message message, Publication publication)
     {
-        var msg =  WritePublicationHeaders(message,  publication);
+        var msg =  ApplyCloudEventsPrecedence(message,  publication);
         return _format == CloudEventFormat.Binary ? msg : WriteJsonMessage(msg, publication);
     }
 
@@ -219,7 +219,7 @@ public partial class CloudEventsTransformer : IAmAMessageTransform, IAmAMessageT
         }
     }
 
-    private Message WritePublicationHeaders(Message message, Publication publication)
+    private Message ApplyCloudEventsPrecedence(Message message, Publication publication)
     {
         // Precedence for all attributes: attribute params > message header (set by mapper) > publication (fallback)
         // Source and Type use sentinel checks (s_defaultSource / CloudEventsType.Empty) because their defaults
@@ -230,7 +230,8 @@ public partial class CloudEventsTransformer : IAmAMessageTransform, IAmAMessageT
         message.Header.Type = _type is not null
             ? new CloudEventsType(_type)
             : (message.Header.Type != CloudEventsType.Empty ? message.Header.Type : publication.Type);
-        message.Header.ContentType = _dataContentType ?? message.Header.ContentType;
+        if (_dataContentType is not null)
+            message.Header.ContentType = _dataContentType;
         message.Header.DataSchema = _dataSchema ?? message.Header.DataSchema ?? publication.DataSchema;
         message.Header.Subject = _subject ?? message.Header.Subject ?? publication.Subject;
         message.Header.SpecVersion = _specVersion ?? message.Header.SpecVersion;

--- a/src/Paramore.Brighter/Transforms/Transformers/CloudEventsTransformer.cs
+++ b/src/Paramore.Brighter/Transforms/Transformers/CloudEventsTransformer.cs
@@ -24,7 +24,7 @@ namespace Paramore.Brighter.Transforms.Transformers;
 ///     type => uses the type <see cref="MessageHeader"/>; as we used type based routing, we recommend using the hostname
 ///         scoped name of the request class you are sending
 /// OPTIONAL
-///      datacontenttype => sets the content type for <see cref="MessageBody"/> and <see cref="MessageHeader"/>
+///      datacontenttype => uses the content type from the <see cref="CloudEventsAttribute"/>, or preserves the existing <see cref="MessageHeader"/> value
 ///      dataschema => sets the schema for <see cref="MessageBody"/> and <see cref="MessageHeader"/>
 ///      subject => sets the subject for <see cref="MessageHeader"/>
 ///      time => sets the timestamp for <see cref="MessageHeader"/>
@@ -37,6 +37,7 @@ public partial class CloudEventsTransformer : IAmAMessageTransform, IAmAMessageT
     private Uri? _source;
     private string? _type;
     private string? _specVersion;
+    private ContentType? _dataContentType;
     private Uri? _dataSchema;
     private string? _subject;
     private CloudEventFormat _format;
@@ -60,9 +61,10 @@ public partial class CloudEventsTransformer : IAmAMessageTransform, IAmAMessageT
     /// 0 - <see cref="CloudEventsAttribute.Source"/> as a string, which will be converted to a <see cref="Uri"/>.
     /// 1 - <see cref="CloudEventsAttribute.Type"/> as a string.
     /// 2 - <see cref="CloudEventsAttribute.SpecVersion"/> as a string, defaults to "1.0".
-    /// 3 - <see cref="CloudEventsAttribute.DataSchema"/> as a string, which will be converted to a <see cref="Uri"/>.
-    /// 4- <see cref="CloudEventsAttribute.Subject"/> as a string.
-    /// 5 - <see cref="CloudEventsAttribute.Format"/> as a <see cref="CloudEventFormat"/>.
+    /// 3 - <see cref="CloudEventsAttribute.DataContentType"/> as a string, which will be converted to a <see cref="ContentType"/>.
+    /// 4 - <see cref="CloudEventsAttribute.DataSchema"/> as a string, which will be converted to a <see cref="Uri"/>.
+    /// 5 - <see cref="CloudEventsAttribute.Subject"/> as a string.
+    /// 6 - <see cref="CloudEventsAttribute.Format"/> as a <see cref="CloudEventFormat"/>.
     /// </param>
     public void InitializeWrapFromAttributeParams(params object?[] initializerList)
     {
@@ -81,17 +83,22 @@ public partial class CloudEventsTransformer : IAmAMessageTransform, IAmAMessageT
             _specVersion = specVersion;
         }
 
-        if (initializerList[3] is string dataSchema)
+        if (initializerList[3] is string dataContentType)
+        {
+            _dataContentType = new ContentType(dataContentType);
+        }
+
+        if (initializerList[4] is string dataSchema)
         {
             _dataSchema = new Uri(dataSchema, UriKind.RelativeOrAbsolute);
         }
 
-        if (initializerList[4] is string subject)
+        if (initializerList[5] is string subject)
         {
             _subject = subject;
         }
 
-        if (initializerList[5] is CloudEventFormat format)
+        if (initializerList[6] is CloudEventFormat format)
         {
             _format = format;
         }
@@ -215,6 +222,7 @@ public partial class CloudEventsTransformer : IAmAMessageTransform, IAmAMessageT
         message.Header.Type = _type is not null
             ? new CloudEventsType(_type)
             : (message.Header.Type != CloudEventsType.Empty ? message.Header.Type : publication.Type);
+        message.Header.ContentType = _dataContentType ?? message.Header.ContentType;
         message.Header.DataSchema = _dataSchema ?? message.Header.DataSchema ?? publication.DataSchema;
         message.Header.Subject = _subject ?? message.Header.Subject ?? publication.Subject;
         message.Header.SpecVersion = _specVersion ?? message.Header.SpecVersion;

--- a/src/Paramore.Brighter/Transforms/Transformers/CloudEventsTransformer.cs
+++ b/src/Paramore.Brighter/Transforms/Transformers/CloudEventsTransformer.cs
@@ -15,19 +15,24 @@ namespace Paramore.Brighter.Transforms.Transformers;
 
 /// <summary>
 /// Provides support for the <see href="https://github.com/cloudevents/spec?tab=readme-ov-file">Cloud Events specification</see>
-/// by ensuring that our message has the required metadata to support Cloud Events
+/// by ensuring that our message has the required metadata to support Cloud Events.
+///
+/// All settable attributes follow the same precedence (highest priority first):
+///   1. <see cref="CloudEventsAttribute"/> parameters (hardcoded on the attribute)
+///   2. Message header values already set by the message mapper
+///   3. <see cref="Publication"/> properties (fallback defaults)
+///
 /// The following Cloud Events attributes are supported:
 /// REQUIRED
-///     id => the message id <see cref="MessageHeader"/>; you don't set this here, as we use the id from the <see cref="Request"/>
-///     source => uses the source Uri from the <see cref="CloudEventsAttribute"/>, or preserves the existing <see cref="MessageHeader"/> value, falling back to <see cref="Publication"/>
-///     specversion => uses the spec version <see cref="MessageHeader"/>; you don't set this and it defaults to 1.0
-///     type => uses the type <see cref="MessageHeader"/>; as we used type based routing, we recommend using the hostname
-///         scoped name of the request class you are sending
+///     id => the message id from <see cref="MessageHeader"/>; you don't set this here, as we use the id from the <see cref="Request"/>
+///     source => attribute > mapper > publication
+///     specversion => attribute > mapper; defaults to 1.0
+///     type => attribute > mapper > publication
 /// OPTIONAL
-///      datacontenttype => uses the content type from the <see cref="CloudEventsAttribute"/>, or preserves the existing <see cref="MessageHeader"/> value
-///      dataschema => sets the schema for <see cref="MessageBody"/> and <see cref="MessageHeader"/>
-///      subject => sets the subject for <see cref="MessageHeader"/>
-///      time => sets the timestamp for <see cref="MessageHeader"/>
+///     datacontenttype => attribute > mapper (no publication fallback)
+///     dataschema => attribute > mapper > publication
+///     subject => attribute > mapper > publication
+///     time => sets the timestamp for <see cref="MessageHeader"/>
 /// </summary>
 public partial class CloudEventsTransformer : IAmAMessageTransform, IAmAMessageTransformAsync
 {
@@ -216,7 +221,10 @@ public partial class CloudEventsTransformer : IAmAMessageTransform, IAmAMessageT
 
     private Message WritePublicationHeaders(Message message, Publication publication)
     {
-        // Precedence: attribute params > message header (set by mapper) > publication (fallback)
+        // Precedence for all attributes: attribute params > message header (set by mapper) > publication (fallback)
+        // Source and Type use sentinel checks (s_defaultSource / CloudEventsType.Empty) because their defaults
+        // are non-null, so we need a way to distinguish "mapper didn't set it" from "mapper set it explicitly."
+        // DataSchema, Subject, and DataContentType default to null, so plain null-coalescing suffices.
         message.Header.Source = _source
             ?? (!Equals(message.Header.Source, s_defaultSource) ? message.Header.Source : publication.Source);
         message.Header.Type = _type is not null

--- a/src/Paramore.Brighter/Transforms/Transformers/CloudEventsTransformer.cs
+++ b/src/Paramore.Brighter/Transforms/Transformers/CloudEventsTransformer.cs
@@ -222,20 +222,30 @@ public partial class CloudEventsTransformer : IAmAMessageTransform, IAmAMessageT
     private Message ApplyCloudEventsPrecedence(Message message, Publication publication)
     {
         // Precedence for all attributes: attribute params > message header (set by mapper) > publication (fallback)
-        // Source and Type use sentinel checks (s_defaultSource / CloudEventsType.Empty) because their defaults
-        // are non-null, so we need a way to distinguish "mapper didn't set it" from "mapper set it explicitly."
-        // DataSchema, Subject, and DataContentType default to null, so plain null-coalescing suffices.
-        message.Header.Source = _source
-            ?? (!Equals(message.Header.Source, s_defaultSource) ? message.Header.Source : publication.Source);
-        message.Header.Type = _type is not null
-            ? new CloudEventsType(_type)
-            : (message.Header.Type != CloudEventsType.Empty ? message.Header.Type : publication.Type);
+        message.Header.Source = ResolveWithSentinel(_source, message.Header.Source, s_defaultSource, publication.Source)!;
+        message.Header.Type = ResolveWithSentinel(
+            _type is not null ? new CloudEventsType(_type) : null,
+            message.Header.Type, CloudEventsType.Empty, publication.Type)!;
         if (_dataContentType is not null)
             message.Header.ContentType = _dataContentType;
         message.Header.DataSchema = _dataSchema ?? message.Header.DataSchema ?? publication.DataSchema;
         message.Header.Subject = _subject ?? message.Header.Subject ?? publication.Subject;
         message.Header.SpecVersion = _specVersion ?? message.Header.SpecVersion;
         return message;
+    }
+
+    /// <summary>
+    /// Resolves a CloudEvents attribute value using 3-way precedence: attribute > mapper > publication.
+    /// Used for fields whose defaults are non-null (e.g. Source, Type), where we need a sentinel to
+    /// distinguish "mapper didn't set it" from "mapper set it explicitly." For nullable fields
+    /// (DataSchema, Subject, DataContentType), plain null-coalescing suffices instead.
+    /// </summary>
+    private static T? ResolveWithSentinel<T>(T? attrValue, T? headerValue, T sentinel, T? publicationValue)
+        where T : class
+    {
+        if (attrValue is not null) return attrValue;
+        if (!Equals(headerValue, sentinel)) return headerValue;
+        return publicationValue;
     }
     
     private Message WriteJsonMessage(Message message, Publication publication)

--- a/src/Paramore.Brighter/Transforms/Transformers/CloudEventsTransformer.cs
+++ b/src/Paramore.Brighter/Transforms/Transformers/CloudEventsTransformer.cs
@@ -208,10 +208,13 @@ public partial class CloudEventsTransformer : IAmAMessageTransform, IAmAMessageT
 
     private Message WritePublicationHeaders(Message message, Publication publication)
     {
-        message.Header.Source = _source ?? publication.Source;
-        message.Header.Type = _type is not null ? new CloudEventsType(_type) : publication.Type;
-        message.Header.DataSchema = _dataSchema ?? publication.DataSchema;
-        message.Header.Subject = _subject ?? publication.Subject;
+        message.Header.Source = _source
+            ?? (message.Header.Source.AbsoluteUri != MessageHeader.DefaultSource ? message.Header.Source : publication.Source);
+        message.Header.Type = _type is not null
+            ? new CloudEventsType(_type)
+            : (message.Header.Type != CloudEventsType.Empty ? message.Header.Type : publication.Type);
+        message.Header.DataSchema = _dataSchema ?? message.Header.DataSchema ?? publication.DataSchema;
+        message.Header.Subject = _subject ?? message.Header.Subject ?? publication.Subject;
         message.Header.SpecVersion = _specVersion ?? message.Header.SpecVersion;
         return message;
     }

--- a/src/Paramore.Brighter/Transforms/Transformers/CloudEventsTransformer.cs
+++ b/src/Paramore.Brighter/Transforms/Transformers/CloudEventsTransformer.cs
@@ -19,7 +19,7 @@ namespace Paramore.Brighter.Transforms.Transformers;
 /// The following Cloud Events attributes are supported:
 /// REQUIRED
 ///     id => the message id <see cref="MessageHeader"/>; you don't set this here, as we use the id from the <see cref="Request"/>
-///     source => uses the source Uri from the <see cref="Publication"/> or <see cref="CloudEventsAttribute"/> and assigns to the message source <see cref="MessageHeader"/>
+///     source => uses the source Uri from the <see cref="CloudEventsAttribute"/>, or preserves the existing <see cref="MessageHeader"/> value, falling back to <see cref="Publication"/>
 ///     specversion => uses the spec version <see cref="MessageHeader"/>; you don't set this and it defaults to 1.0
 ///     type => uses the type <see cref="MessageHeader"/>; as we used type based routing, we recommend using the hostname
 ///         scoped name of the request class you are sending
@@ -32,6 +32,7 @@ namespace Paramore.Brighter.Transforms.Transformers;
 public partial class CloudEventsTransformer : IAmAMessageTransform, IAmAMessageTransformAsync
 {
     private static readonly ILogger s_logger = ApplicationLogging.CreateLogger<CloudEventsTransformer>();
+    private static readonly Uri s_defaultSource = new(MessageHeader.DefaultSource);
 
     private Uri? _source;
     private string? _type;
@@ -208,8 +209,9 @@ public partial class CloudEventsTransformer : IAmAMessageTransform, IAmAMessageT
 
     private Message WritePublicationHeaders(Message message, Publication publication)
     {
+        // Precedence: attribute params > message header (set by mapper) > publication (fallback)
         message.Header.Source = _source
-            ?? (message.Header.Source.AbsoluteUri != MessageHeader.DefaultSource ? message.Header.Source : publication.Source);
+            ?? (!Equals(message.Header.Source, s_defaultSource) ? message.Header.Source : publication.Source);
         message.Header.Type = _type is not null
             ? new CloudEventsType(_type)
             : (message.Header.Type != CloudEventsType.Empty ? message.Header.Type : publication.Type);

--- a/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sns/Standard/Proactor/When_queues_missing_assume_throws_async.cs
+++ b/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sns/Standard/Proactor/When_queues_missing_assume_throws_async.cs
@@ -39,7 +39,8 @@ public class AwsAssumeQueuesTestsAsync : IAsyncDisposable, IDisposable
         var producer = new SnsMessageProducer(awsConnection,
             new SnsPublication
             {
-                MakeChannels = OnMissingChannel.Create
+                MakeChannels = OnMissingChannel.Create,
+                TopicAttributes = new SnsAttributes(tags: [new Tag { Key = "Environment", Value = "Test" }])
             });
 
         producer.ConfirmTopicExistsAsync(topicName).Wait();

--- a/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sns/Standard/Proactor/When_queues_missing_verify_throws_async.cs
+++ b/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sns/Standard/Proactor/When_queues_missing_verify_throws_async.cs
@@ -39,7 +39,8 @@ public class AwsValidateQueuesTestsAsync : IAsyncDisposable
         var producer = new SnsMessageProducer(_awsConnection,
             new SnsPublication
             {
-                MakeChannels = OnMissingChannel.Create
+                MakeChannels = OnMissingChannel.Create,
+                TopicAttributes = new SnsAttributes(tags: [new Tag { Key = "Environment", Value = "Test" }])
             });
         producer.ConfirmTopicExistsAsync(topicName).Wait();
     }

--- a/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sns/Standard/Proactor/When_requeueing_redrives_to_the_dlq_async.cs
+++ b/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sns/Standard/Proactor/When_requeueing_redrives_to_the_dlq_async.cs
@@ -58,7 +58,12 @@ public class SqsMessageProducerDlqTestsAsync : IDisposable, IAsyncDisposable
 
         _awsConnection = GatewayFactory.CreateFactory();
 
-        _sender = new SnsMessageProducer(_awsConnection,  new SnsPublication { Topic = routingKey, MakeChannels = OnMissingChannel.Create });
+        _sender = new SnsMessageProducer(_awsConnection, new SnsPublication
+        {
+            Topic = routingKey,
+            MakeChannels = OnMissingChannel.Create,
+            TopicAttributes = new SnsAttributes(tags: [new Tag { Key = "Environment", Value = "Test" }])
+        });
 
         _sender.ConfirmTopicExistsAsync(topicName).Wait();
 

--- a/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sns/Standard/Reactor/When_queues_missing_assume_throws.cs
+++ b/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sns/Standard/Reactor/When_queues_missing_assume_throws.cs
@@ -36,10 +36,11 @@ public class AwsAssumeQueuesTests  : IDisposable, IAsyncDisposable
             
         //create the topic, we want the queue to be the issue
         //We need to create the topic at least, to check the queues
-        var producer = new SnsMessageProducer(awsConnection, 
+        var producer = new SnsMessageProducer(awsConnection,
             new SnsPublication
             {
-                MakeChannels = OnMissingChannel.Create 
+                MakeChannels = OnMissingChannel.Create,
+                TopicAttributes = new SnsAttributes(tags: [new Tag { Key = "Environment", Value = "Test" }])
             });
             
         producer.ConfirmTopicExistsAsync(topicName).Wait(); 

--- a/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sns/Standard/Reactor/When_queues_missing_verify_throws.cs
+++ b/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sns/Standard/Reactor/When_queues_missing_verify_throws.cs
@@ -36,10 +36,11 @@ public class AwsValidateQueuesTests  : IDisposable, IAsyncDisposable
         _awsConnection = GatewayFactory.CreateFactory();
             
         //We need to create the topic at least, to check the queues
-        var producer = new SnsMessageProducer(_awsConnection, 
+        var producer = new SnsMessageProducer(_awsConnection,
             new SnsPublication
             {
-                MakeChannels = OnMissingChannel.Create 
+                MakeChannels = OnMissingChannel.Create,
+                TopicAttributes = new SnsAttributes(tags: [new Tag { Key = "Environment", Value = "Test" }])
             });
         producer.ConfirmTopicExistsAsync(topicName).Wait(); 
             

--- a/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sns/Standard/Reactor/When_requeueing_redrives_to_the_dlq.cs
+++ b/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sns/Standard/Reactor/When_requeueing_redrives_to_the_dlq.cs
@@ -57,7 +57,11 @@ public class SqsMessageProducerDlqTests : IDisposable, IAsyncDisposable
         //Must have credentials stored in the SDK Credentials store or shared credentials file
         _awsConnection = GatewayFactory.CreateFactory();
 
-        _sender = new SnsMessageProducer(_awsConnection,  new SnsPublication { MakeChannels = OnMissingChannel.Create });
+        _sender = new SnsMessageProducer(_awsConnection, new SnsPublication
+        {
+            MakeChannels = OnMissingChannel.Create,
+            TopicAttributes = new SnsAttributes(tags: [new Tag { Key = "Environment", Value = "Test" }])
+        });
 
         _sender.ConfirmTopicExistsAsync(topicName).Wait();
 

--- a/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Standard/Proactor/When_queues_missing_assume_throws_async.cs
+++ b/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Standard/Proactor/When_queues_missing_assume_throws_async.cs
@@ -39,7 +39,8 @@ public class AwsAssumeQueuesTestsAsync : IAsyncDisposable, IDisposable
         var producer = new SnsMessageProducer(awsConnection,
             new SnsPublication
             {
-                MakeChannels = OnMissingChannel.Create
+                MakeChannels = OnMissingChannel.Create,
+                TopicAttributes = new SnsAttributes(tags: [new Tag { Key = "Environment", Value = "Test" }])
             });
 
         producer.ConfirmTopicExistsAsync(topicName).Wait();

--- a/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Standard/Proactor/When_queues_missing_verify_throws_async.cs
+++ b/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Standard/Proactor/When_queues_missing_verify_throws_async.cs
@@ -39,7 +39,8 @@ public class AwsValidateQueuesTestsAsync : IAsyncDisposable
         var producer = new SnsMessageProducer(_awsConnection,
             new SnsPublication
             {
-                MakeChannels = OnMissingChannel.Create
+                MakeChannels = OnMissingChannel.Create,
+                TopicAttributes = new SnsAttributes(tags: [new Tag { Key = "Environment", Value = "Test" }])
             });
         producer.ConfirmTopicExistsAsync(topicName).Wait();
     }

--- a/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Standard/Proactor/When_requeueing_redrives_to_the_dlq_async.cs
+++ b/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Standard/Proactor/When_requeueing_redrives_to_the_dlq_async.cs
@@ -58,7 +58,12 @@ public class SqsMessageProducerDlqTestsAsync : IDisposable, IAsyncDisposable
 
         _awsConnection = GatewayFactory.CreateFactory();
 
-        _sender = new SnsMessageProducer(_awsConnection,  new SnsPublication { Topic = routingKey, MakeChannels = OnMissingChannel.Create });
+        _sender = new SnsMessageProducer(_awsConnection, new SnsPublication
+        {
+            Topic = routingKey,
+            MakeChannels = OnMissingChannel.Create,
+            TopicAttributes = new SnsAttributes(tags: [new Tag { Key = "Environment", Value = "Test" }])
+        });
 
         _sender.ConfirmTopicExistsAsync(topicName).Wait();
 

--- a/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Standard/Reactor/When_queues_missing_assume_throws.cs
+++ b/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Standard/Reactor/When_queues_missing_assume_throws.cs
@@ -36,10 +36,11 @@ public class AwsAssumeQueuesTests  : IDisposable, IAsyncDisposable
             
         //create the topic, we want the queue to be the issue
         //We need to create the topic at least, to check the queues
-        var producer = new SnsMessageProducer(awsConnection, 
+        var producer = new SnsMessageProducer(awsConnection,
             new SnsPublication
             {
-                MakeChannels = OnMissingChannel.Create 
+                MakeChannels = OnMissingChannel.Create,
+                TopicAttributes = new SnsAttributes(tags: [new Tag { Key = "Environment", Value = "Test" }])
             });
             
         producer.ConfirmTopicExistsAsync(topicName).Wait(); 

--- a/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Standard/Reactor/When_queues_missing_verify_throws.cs
+++ b/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Standard/Reactor/When_queues_missing_verify_throws.cs
@@ -36,10 +36,11 @@ public class AwsValidateQueuesTests  : IDisposable, IAsyncDisposable
         _awsConnection = GatewayFactory.CreateFactory();
             
         //We need to create the topic at least, to check the queues
-        var producer = new SnsMessageProducer(_awsConnection, 
+        var producer = new SnsMessageProducer(_awsConnection,
             new SnsPublication
             {
-                MakeChannels = OnMissingChannel.Create 
+                MakeChannels = OnMissingChannel.Create,
+                TopicAttributes = new SnsAttributes(tags: [new Tag { Key = "Environment", Value = "Test" }])
             });
         producer.ConfirmTopicExistsAsync(topicName).Wait(); 
             

--- a/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Standard/Reactor/When_requeueing_redrives_to_the_dlq.cs
+++ b/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Standard/Reactor/When_requeueing_redrives_to_the_dlq.cs
@@ -57,7 +57,11 @@ public class SqsMessageProducerDlqTests : IDisposable, IAsyncDisposable
         //Must have credentials stored in the SDK Credentials store or shared credentials file
         _awsConnection = GatewayFactory.CreateFactory();
 
-        _sender = new SnsMessageProducer(_awsConnection,  new SnsPublication { MakeChannels = OnMissingChannel.Create });
+        _sender = new SnsMessageProducer(_awsConnection, new SnsPublication
+        {
+            MakeChannels = OnMissingChannel.Create,
+            TopicAttributes = new SnsAttributes(tags: [new Tag { Key = "Environment", Value = "Test" }])
+        });
 
         _sender.ConfirmTopicExistsAsync(topicName).Wait();
 

--- a/tests/Paramore.Brighter.Core.Tests/CloudEvents/When_a_message_uses_cloud_events.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CloudEvents/When_a_message_uses_cloud_events.cs
@@ -258,12 +258,12 @@ public class CloudEventsTransformerTests
         //act
         var cloudEvents = _transformer.Wrap(_message, publication);
         
-        //assert
-        Assert.Equal(new Uri("http://goparamore.io"), cloudEvents.Header.Source);
-        Assert.Equal( CloudEventsType.Empty, cloudEvents.Header.Type);
+        //assert - message header values should be preserved when publication has no explicit cloud event properties
+        Assert.Equal(_source, cloudEvents.Header.Source);
+        Assert.Equal(_type, cloudEvents.Header.Type);
         Assert.Equal(new ContentType(MediaTypeNames.Text.Plain), cloudEvents.Header.ContentType);
-        Assert.Null(cloudEvents.Header.DataSchema);
-        Assert.Null(cloudEvents.Header.Subject);
+        Assert.Equal(_dataSchema, cloudEvents.Header.DataSchema);
+        Assert.Equal(_subject, cloudEvents.Header.Subject);
     }
     
     [Fact]
@@ -299,7 +299,7 @@ public class CloudEventsTransformerTests
        var message = _transformer.Unwrap(cloudEvents);
        
        Assert.Equal(_source, message.Header.Source);
-       Assert.Equal(CloudEventsType.Empty, message.Header.Type);
+       Assert.Equal(_type, message.Header.Type);
        Assert.Equal(_dataSchema, message.Header.DataSchema);
        Assert.Equal(_subject, message.Header.Subject);
        Assert.Equal(_message.Body.Bytes, message.Body.Bytes);

--- a/tests/Paramore.Brighter.Core.Tests/CloudEvents/When_a_message_uses_cloud_events.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CloudEvents/When_a_message_uses_cloud_events.cs
@@ -32,7 +32,7 @@ public class CloudEventsTransformerTests
     {
         //act
         var body = _message.Body;
-        _transformer.InitializeWrapFromAttributeParams(_source.ToString(), _type, null, _dataSchema.ToString(), _subject, CloudEventFormat.Binary);
+        _transformer.InitializeWrapFromAttributeParams(_source.ToString(), _type, null, null, _dataSchema.ToString(), _subject, CloudEventFormat.Binary);
         var cloudEvents = _transformer.Wrap(_message, new Publication
         {
             DataSchema = _dataSchema,
@@ -55,7 +55,7 @@ public class CloudEventsTransformerTests
     {
         //act
         var body = _message.Body;
-        _transformer.InitializeWrapFromAttributeParams(_source.AbsoluteUri, _type, null, _dataSchema.ToString(), _subject, CloudEventFormat.Json);
+        _transformer.InitializeWrapFromAttributeParams(_source.AbsoluteUri, _type, null, null, _dataSchema.ToString(), _subject, CloudEventFormat.Json);
         var cloudEvents = _transformer.Wrap(_message, new Publication
         {
             DataSchema = _dataSchema,
@@ -91,7 +91,7 @@ public class CloudEventsTransformerTests
             new MessageBody([]) );
         
         var body = _message.Body;
-        _transformer.InitializeWrapFromAttributeParams(_source.AbsoluteUri, _type, null,  _dataSchema.ToString(), _subject, CloudEventFormat.Json);
+        _transformer.InitializeWrapFromAttributeParams(_source.AbsoluteUri, _type, null, null, _dataSchema.ToString(), _subject, CloudEventFormat.Json);
         var cloudEvents = _transformer.Wrap(_message, new Publication
         {
             DataSchema = _dataSchema,
@@ -127,7 +127,7 @@ public class CloudEventsTransformerTests
             new MessageBody("teste"));
         
         var body = _message.Body;
-        _transformer.InitializeWrapFromAttributeParams(_source.AbsoluteUri, _type, null, _dataSchema.ToString(), _subject, CloudEventFormat.Json);
+        _transformer.InitializeWrapFromAttributeParams(_source.AbsoluteUri, _type, null, null, _dataSchema.ToString(), _subject, CloudEventFormat.Json);
         var cloudEvents = _transformer.Wrap(_message, new Publication
         {
             DataSchema = _dataSchema,
@@ -185,7 +185,7 @@ public class CloudEventsTransformerTests
         const string subject = "CloudEventsTransformerAlternative"; 
 
         //act
-        _transformer.InitializeWrapFromAttributeParams(source, type, null,  dataSchema, subject, CloudEventFormat.Binary);
+        _transformer.InitializeWrapFromAttributeParams(source, type, null, null, dataSchema, subject, CloudEventFormat.Binary);
 
         var cloudEvents = _transformer.Wrap(_message, publication);
         
@@ -222,7 +222,7 @@ public class CloudEventsTransformerTests
         var body = _message.Body;
 
         //act
-        _transformer.InitializeWrapFromAttributeParams(source, type, null,  dataSchema, subject, CloudEventFormat.Json);
+        _transformer.InitializeWrapFromAttributeParams(source, type, null, null, dataSchema, subject, CloudEventFormat.Json);
 
         var cloudEvents = _transformer.Wrap(_message, publication);
         
@@ -270,7 +270,7 @@ public class CloudEventsTransformerTests
     public void When_unwrap_a_message_with_binary_format()
     {
         //arrange
-        _transformer.InitializeWrapFromAttributeParams(_source.AbsoluteUri, _type, null,  _dataSchema.ToString(), _subject, CloudEventFormat.Binary);
+        _transformer.InitializeWrapFromAttributeParams(_source.AbsoluteUri, _type, null, null, _dataSchema.ToString(), _subject, CloudEventFormat.Binary);
        
         // act
         var message = _transformer.Unwrap(_message);
@@ -292,7 +292,7 @@ public class CloudEventsTransformerTests
             //no cloud events properties set
         };
         
-       _transformer.InitializeWrapFromAttributeParams(_source.AbsoluteUri, _type, null, _dataSchema.ToString(), _subject, CloudEventFormat.Binary);
+       _transformer.InitializeWrapFromAttributeParams(_source.AbsoluteUri, _type, null, null, _dataSchema.ToString(), _subject, CloudEventFormat.Binary);
        var cloudEvents = _transformer.Wrap(_message, publication);
        
        // act
@@ -309,7 +309,7 @@ public class CloudEventsTransformerTests
     public void When_unwrap_a_message_with_json_format_and_provided_message_is_not_json()
     {
         //arrange
-        _transformer.InitializeWrapFromAttributeParams(_source.AbsoluteUri, _type, null,  _dataSchema.ToString(), _subject, CloudEventFormat.Json);
+        _transformer.InitializeWrapFromAttributeParams(_source.AbsoluteUri, _type, null, null, _dataSchema.ToString(), _subject, CloudEventFormat.Json);
         _message = new Message(
             new MessageHeader(Guid.NewGuid().ToString(), new RoutingKey("Test Topic"), MessageType.MT_COMMAND), 
             new MessageBody("teste"));
@@ -329,7 +329,7 @@ public class CloudEventsTransformerTests
     public void When_unwrap_a_message_with_json_format_and_provided_message_is_not_cloud_event_json()
     {
         //arrange
-        _transformer.InitializeWrapFromAttributeParams(_source.AbsoluteUri, _type, null, _dataSchema.ToString(), _subject, CloudEventFormat.Json);
+        _transformer.InitializeWrapFromAttributeParams(_source.AbsoluteUri, _type, null, null, _dataSchema.ToString(), _subject, CloudEventFormat.Json);
        
         // act
         var message = _transformer.Unwrap(_message);
@@ -346,7 +346,7 @@ public class CloudEventsTransformerTests
     public void When_unwrap_a_message_with_json_format_and_provided_message_has_no_body()
     {
         //arrange
-        _transformer.InitializeWrapFromAttributeParams(_source.AbsoluteUri, _type, null,  _dataSchema.ToString(), _subject, CloudEventFormat.Json);
+        _transformer.InitializeWrapFromAttributeParams(_source.AbsoluteUri, _type, null, null, _dataSchema.ToString(), _subject, CloudEventFormat.Json);
         _message = new Message(
             new MessageHeader(Guid.NewGuid().ToString(), new RoutingKey("Test Topic"), MessageType.MT_COMMAND), 
             new MessageBody([]) );
@@ -374,7 +374,7 @@ public class CloudEventsTransformerTests
     public void When_unwrap_a_message_with_json_format()
     {
         //arrange
-        _transformer.InitializeWrapFromAttributeParams(_source.AbsoluteUri, _type, null, _dataSchema.ToString(), _subject, CloudEventFormat.Json);
+        _transformer.InitializeWrapFromAttributeParams(_source.AbsoluteUri, _type, null, null, _dataSchema.ToString(), _subject, CloudEventFormat.Json);
         var body = _message.Body;
         var cloudEventsMessage = _transformer.Wrap(_message, new Publication
         {

--- a/tests/Paramore.Brighter.Core.Tests/CloudEvents/When_migrating_subject_from_bag_to_header.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CloudEvents/When_migrating_subject_from_bag_to_header.cs
@@ -8,12 +8,13 @@ using Xunit;
 namespace Paramore.Brighter.Core.Tests.CloudEvents;
 
 /// <summary>
-/// Demonstrates the V9 → V10 migration issue for Subject.
+/// Demonstrates the V9 → V10 migration issue for Subject (PR #4132).
 /// In V9, users put Subject in the Bag and the Bag preserved PascalCase keys.
-/// In V10, the Bag serialization applies camelCase to dictionary keys, so "Subject" becomes "subject".
+/// In V10, the Bag serialization applies camelCase to dictionary keys, so "Subject" becomes "subject",
+/// causing downstream consumers (e.g. Python Lambdas reading SNS notifications) to fail with KeyError.
 /// The fix is to use MessageHeader.Subject instead of the Bag, which feeds the native SNS Subject field.
 /// </summary>
-public class CloudEventsBagSubjectMigrationTests
+public class When_migrating_subject_from_bag_to_header
 {
     [Fact]
     public void When_subject_is_in_bag_serialization_converts_to_camelCase()

--- a/tests/Paramore.Brighter.Core.Tests/CloudEvents/When_migrating_subject_from_bag_to_header.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CloudEvents/When_migrating_subject_from_bag_to_header.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Net.Mime;
+using System.Text.Json;
+using Paramore.Brighter.JsonConverters;
+using Paramore.Brighter.Transforms.Transformers;
+using Xunit;
+
+namespace Paramore.Brighter.Core.Tests.CloudEvents;
+
+/// <summary>
+/// Demonstrates the V9 → V10 migration issue for Subject.
+/// In V9, users put Subject in the Bag and the Bag preserved PascalCase keys.
+/// In V10, the Bag serialization applies camelCase to dictionary keys, so "Subject" becomes "subject".
+/// The fix is to use MessageHeader.Subject instead of the Bag, which feeds the native SNS Subject field.
+/// </summary>
+public class CloudEventsBagSubjectMigrationTests
+{
+    [Fact]
+    public void When_subject_is_in_bag_serialization_converts_to_camelCase()
+    {
+        //Arrange - V9 pattern: user puts Subject in the Bag with PascalCase key
+        var message = new Message(
+            new MessageHeader(Id.Random(), new RoutingKey("Test.Topic"), MessageType.MT_EVENT),
+            new MessageBody("{\"orderId\": 123}"));
+
+        message.Header.Bag.Add("Subject", "OrderAccepted");
+
+        //Act - serialize the Bag as V10 does (using JsonSerialisationOptions with CamelCase policy)
+        var bagJson = JsonSerializer.Serialize(message.Header.Bag, JsonSerialisationOptions.Options);
+
+        //Assert - the key is now camelCase, so a consumer looking for "Subject" won't find it
+        using var doc = JsonDocument.Parse(bagJson);
+        Assert.True(doc.RootElement.TryGetProperty("subject", out _), "Bag key should be serialized as camelCase 'subject'");
+        Assert.False(doc.RootElement.TryGetProperty("Subject", out _), "Bag key 'Subject' should not survive serialization as PascalCase");
+    }
+
+    [Fact]
+    public void When_subject_is_set_on_header_it_is_available_for_sns_publish_request()
+    {
+        //Arrange - V10 pattern: user sets Subject on the MessageHeader directly
+        const string expectedSubject = "OrderAccepted";
+        var message = new Message(
+            new MessageHeader(
+                Id.Random(),
+                new RoutingKey("Test.Topic"),
+                MessageType.MT_EVENT,
+                subject: expectedSubject),
+            new MessageBody("{\"orderId\": 123}"));
+
+        //Assert - Header.Subject is the value the SNS publisher uses for the native SNS Subject field
+        // (PublishRequest constructor third argument), which AWS serializes as PascalCase "Subject" in the
+        // SNS notification envelope that downstream consumers (e.g. Python Lambdas) read
+        Assert.Equal(expectedSubject, message.Header.Subject);
+    }
+
+    [Fact]
+    public void When_subject_is_set_on_header_cloud_events_transformer_preserves_it()
+    {
+        //Arrange - V10 pattern: mapper sets Subject on header, publication has no Subject
+        const string expectedSubject = "OrderAccepted";
+        var message = new Message(
+            new MessageHeader(
+                Id.Random(),
+                new RoutingKey("Test.Topic"),
+                MessageType.MT_EVENT,
+                subject: expectedSubject),
+            new MessageBody("{\"orderId\": 123}"));
+
+        var transformer = new CloudEventsTransformer();
+        var publication = new Publication(); // empty, no subject
+
+        //Act - CloudEventsTransformer wraps the message
+        var wrapped = transformer.Wrap(message, publication);
+
+        //Assert - Subject survives the transformer and is available for the SNS publisher
+        Assert.Equal(expectedSubject, wrapped.Header.Subject);
+    }
+}

--- a/tests/Paramore.Brighter.Core.Tests/CloudEvents/When_wrapping_a_message_that_already_has_cloud_event_headers_should_preserve_them.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CloudEvents/When_wrapping_a_message_that_already_has_cloud_event_headers_should_preserve_them.cs
@@ -2,6 +2,7 @@ using System;
 using System.Net.Mime;
 using System.Text.Json;
 using Paramore.Brighter.JsonConverters;
+using Paramore.Brighter.Transforms.Attributes;
 using Paramore.Brighter.Transforms.Transformers;
 using Xunit;
 
@@ -179,5 +180,36 @@ public class CloudEventsPreservesExistingHeadersTests
         Assert.Equal(_mapperType, json.Type);
         Assert.Equal(_mapperDataSchema, json.DataSchema);
         Assert.Equal(_mapperSubject, json.Subject);
+    }
+
+    [Fact]
+    public void When_attribute_has_default_data_content_type_should_not_override_mapper_content_type()
+    {
+        //Arrange - mapper sets XML content type; attribute uses [CloudEvents(0)] with no explicit DataContentType
+        var xmlContentType = new ContentType(MediaTypeNames.Text.Xml);
+        var message = new Message(
+            new MessageHeader(
+                Id.Random(),
+                new RoutingKey("Test.Topic"),
+                MessageType.MT_EVENT,
+                contentType: xmlContentType,
+                source: _mapperSource,
+                subject: _mapperSubject,
+                type: _mapperType,
+                dataSchema: _mapperDataSchema),
+            new MessageBody("<order><id>123</id></order>"));
+
+        // Simulate the real attribute pipeline: CloudEventsAttribute with no explicit DataContentType
+        var attribute = new CloudEventsAttribute(0);
+        var initParams = attribute.InitializerParams();
+        _transformer.InitializeWrapFromAttributeParams(initParams);
+
+        var publication = new Publication();
+
+        //Act
+        var wrapped = _transformer.Wrap(message, publication);
+
+        //Assert - mapper's XML content type should be preserved, not overwritten with application/json
+        Assert.Equal(xmlContentType, wrapped.Header.ContentType);
     }
 }

--- a/tests/Paramore.Brighter.Core.Tests/CloudEvents/When_wrapping_a_message_that_already_has_cloud_event_headers_should_preserve_them.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CloudEvents/When_wrapping_a_message_that_already_has_cloud_event_headers_should_preserve_them.cs
@@ -178,6 +178,7 @@ public class When_wrapping_a_message_that_already_has_cloud_event_headers_should
         Assert.NotNull(json);
         Assert.Equal(_mapperSource, json.Source);
         Assert.Equal(_mapperType, json.Type);
+        Assert.Equal(MediaTypeNames.Application.Json, json.DataContentType);
         Assert.Equal(_mapperDataSchema, json.DataSchema);
         Assert.Equal(_mapperSubject, json.Subject);
     }
@@ -211,6 +212,33 @@ public class When_wrapping_a_message_that_already_has_cloud_event_headers_should
 
         //Assert - mapper's XML content type should be preserved, not overwritten with application/json
         Assert.Equal(xmlContentType, wrapped.Header.ContentType);
+    }
+
+    [Fact]
+    public void When_attribute_sets_data_content_type_should_override_mapper_content_type()
+    {
+        //Arrange - mapper sets XML, attribute explicitly sets JSON → attribute wins
+        var mapperContentType = new ContentType(MediaTypeNames.Text.Xml);
+        var message = new Message(
+            new MessageHeader(
+                Id.Random(),
+                new RoutingKey("Test.Topic"),
+                MessageType.MT_EVENT,
+                contentType: mapperContentType,
+                source: _mapperSource,
+                type: _mapperType),
+            new MessageBody("<order/>"));
+
+        const string attrDataContentType = MediaTypeNames.Application.Json;
+        _transformer.InitializeWrapFromAttributeParams(null, null, null, attrDataContentType, null, null, CloudEventFormat.Binary);
+
+        var publication = new Publication();
+
+        //Act
+        var wrapped = _transformer.Wrap(message, publication);
+
+        //Assert - attribute's DataContentType wins over mapper's XML
+        Assert.Equal(new ContentType(attrDataContentType), wrapped.Header.ContentType);
     }
 
     [Fact]

--- a/tests/Paramore.Brighter.Core.Tests/CloudEvents/When_wrapping_a_message_that_already_has_cloud_event_headers_should_preserve_them.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CloudEvents/When_wrapping_a_message_that_already_has_cloud_event_headers_should_preserve_them.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Net.Mime;
+using Paramore.Brighter.Transforms.Transformers;
+using Xunit;
+
+namespace Paramore.Brighter.Core.Tests.CloudEvents;
+
+public class CloudEventsPreservesExistingHeadersTests
+{
+    private readonly CloudEventsTransformer _transformer = new();
+    private readonly Uri _source = new("http://goparamore.io/MyMapper");
+    private readonly CloudEventsType _type = new("MyApp.OrderAccepted");
+    private readonly Uri _dataSchema = new("http://goparamore.io/MyMapper/schema");
+    private readonly string _subject = "OrderAccepted";
+
+    [Fact]
+    public void When_wrapping_a_message_that_already_has_cloud_event_headers_should_preserve_them()
+    {
+        //Arrange - a message with cloud event headers already set (e.g. by a message mapper)
+        var message = new Message(
+            new MessageHeader(
+                Id.Random(),
+                new RoutingKey("Test.Topic"),
+                MessageType.MT_EVENT,
+                contentType: new ContentType(MediaTypeNames.Application.Json),
+                source: _source,
+                subject: _subject,
+                type: _type,
+                dataSchema: _dataSchema),
+            new MessageBody("{\"orderId\": 123}"));
+
+        // Publication has no cloud event properties set — the mapper already handled them
+        var publication = new Publication();
+
+        //Act - CloudEventsTransformer wraps after the mapper
+        var wrapped = _transformer.Wrap(message, publication);
+
+        //Assert - existing header values should be preserved, not overwritten
+        Assert.Equal(_source, wrapped.Header.Source);
+        Assert.Equal(_type, wrapped.Header.Type);
+        Assert.Equal(_dataSchema, wrapped.Header.DataSchema);
+        Assert.Equal(_subject, wrapped.Header.Subject);
+    }
+}

--- a/tests/Paramore.Brighter.Core.Tests/CloudEvents/When_wrapping_a_message_that_already_has_cloud_event_headers_should_preserve_them.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CloudEvents/When_wrapping_a_message_that_already_has_cloud_event_headers_should_preserve_them.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Paramore.Brighter.Core.Tests.CloudEvents;
 
-public class CloudEventsPreservesExistingHeadersTests
+public class When_wrapping_a_message_that_already_has_cloud_event_headers_should_preserve_them
 {
     private readonly CloudEventsTransformer _transformer = new();
     private readonly Uri _mapperSource = new("http://goparamore.io/MyMapper");
@@ -32,7 +32,7 @@ public class CloudEventsPreservesExistingHeadersTests
     }
 
     [Fact]
-    public void When_wrapping_a_message_that_already_has_cloud_event_headers_should_preserve_them()
+    public void When_no_attribute_and_no_publication_should_preserve_mapper_headers()
     {
         //Arrange - a message with cloud event headers already set (e.g. by a message mapper)
         var message = CreateMessageWithMapperHeaders();
@@ -211,5 +211,34 @@ public class CloudEventsPreservesExistingHeadersTests
 
         //Assert - mapper's XML content type should be preserved, not overwritten with application/json
         Assert.Equal(xmlContentType, wrapped.Header.ContentType);
+    }
+
+    [Fact]
+    public void When_mapper_sets_source_to_default_uri_publication_wins_sentinel_collision()
+    {
+        //Arrange - mapper explicitly sets Source to the same URI as DefaultSource (http://goparamore.io).
+        // This is a known trade-off: we use the default URI as a sentinel for "mapper didn't set it,"
+        // so a mapper that intentionally picks the default URI will have its value replaced by publication.
+        var defaultSource = new Uri(MessageHeader.DefaultSource);
+        var publicationSource = new Uri("http://goparamore.io/FromPublication");
+
+        var message = new Message(
+            new MessageHeader(
+                Id.Random(),
+                new RoutingKey("Test.Topic"),
+                MessageType.MT_EVENT,
+                source: defaultSource),
+            new MessageBody("{\"orderId\": 123}"));
+
+        var publication = new Publication
+        {
+            Source = publicationSource
+        };
+
+        //Act
+        var wrapped = _transformer.Wrap(message, publication);
+
+        //Assert - publication wins because the mapper's value matches the sentinel
+        Assert.Equal(publicationSource, wrapped.Header.Source);
     }
 }

--- a/tests/Paramore.Brighter.Core.Tests/CloudEvents/When_wrapping_a_message_that_already_has_cloud_event_headers_should_preserve_them.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CloudEvents/When_wrapping_a_message_that_already_has_cloud_event_headers_should_preserve_them.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Net.Mime;
+using System.Text.Json;
+using Paramore.Brighter.JsonConverters;
 using Paramore.Brighter.Transforms.Transformers;
 using Xunit;
 
@@ -8,37 +10,172 @@ namespace Paramore.Brighter.Core.Tests.CloudEvents;
 public class CloudEventsPreservesExistingHeadersTests
 {
     private readonly CloudEventsTransformer _transformer = new();
-    private readonly Uri _source = new("http://goparamore.io/MyMapper");
-    private readonly CloudEventsType _type = new("MyApp.OrderAccepted");
-    private readonly Uri _dataSchema = new("http://goparamore.io/MyMapper/schema");
-    private readonly string _subject = "OrderAccepted";
+    private readonly Uri _mapperSource = new("http://goparamore.io/MyMapper");
+    private readonly CloudEventsType _mapperType = new("MyApp.OrderAccepted");
+    private readonly Uri _mapperDataSchema = new("http://goparamore.io/MyMapper/schema");
+    private readonly string _mapperSubject = "OrderAccepted";
 
-    [Fact]
-    public void When_wrapping_a_message_that_already_has_cloud_event_headers_should_preserve_them()
+    private Message CreateMessageWithMapperHeaders()
     {
-        //Arrange - a message with cloud event headers already set (e.g. by a message mapper)
-        var message = new Message(
+        return new Message(
             new MessageHeader(
                 Id.Random(),
                 new RoutingKey("Test.Topic"),
                 MessageType.MT_EVENT,
                 contentType: new ContentType(MediaTypeNames.Application.Json),
-                source: _source,
-                subject: _subject,
-                type: _type,
-                dataSchema: _dataSchema),
+                source: _mapperSource,
+                subject: _mapperSubject,
+                type: _mapperType,
+                dataSchema: _mapperDataSchema),
             new MessageBody("{\"orderId\": 123}"));
+    }
 
-        // Publication has no cloud event properties set — the mapper already handled them
+    [Fact]
+    public void When_wrapping_a_message_that_already_has_cloud_event_headers_should_preserve_them()
+    {
+        //Arrange - a message with cloud event headers already set (e.g. by a message mapper)
+        var message = CreateMessageWithMapperHeaders();
+
+        // Publication has no cloud event properties set - the mapper already handled them
         var publication = new Publication();
 
         //Act - CloudEventsTransformer wraps after the mapper
         var wrapped = _transformer.Wrap(message, publication);
 
         //Assert - existing header values should be preserved, not overwritten
-        Assert.Equal(_source, wrapped.Header.Source);
-        Assert.Equal(_type, wrapped.Header.Type);
-        Assert.Equal(_dataSchema, wrapped.Header.DataSchema);
-        Assert.Equal(_subject, wrapped.Header.Subject);
+        Assert.Equal(_mapperSource, wrapped.Header.Source);
+        Assert.Equal(_mapperType, wrapped.Header.Type);
+        Assert.Equal(_mapperDataSchema, wrapped.Header.DataSchema);
+        Assert.Equal(_mapperSubject, wrapped.Header.Subject);
+    }
+
+    [Fact]
+    public void When_attribute_is_set_should_override_mapper_headers()
+    {
+        //Arrange
+        var message = CreateMessageWithMapperHeaders();
+        const string attrSource = "http://goparamore.io/FromAttribute";
+        const string attrType = "MyApp.FromAttribute";
+        const string attrDataSchema = "http://goparamore.io/FromAttribute/schema";
+        const string attrSubject = "FromAttribute";
+
+        _transformer.InitializeWrapFromAttributeParams(attrSource, attrType, null, attrDataSchema, attrSubject, CloudEventFormat.Binary);
+
+        var publication = new Publication
+        {
+            Source = new Uri("http://goparamore.io/FromPublication"),
+            Type = new CloudEventsType("MyApp.FromPublication"),
+            DataSchema = new Uri("http://goparamore.io/FromPublication/schema"),
+            Subject = "FromPublication"
+        };
+
+        //Act
+        var wrapped = _transformer.Wrap(message, publication);
+
+        //Assert - attribute wins over both mapper and publication
+        Assert.Equal(attrSource, wrapped.Header.Source.ToString());
+        Assert.Equal(attrType, wrapped.Header.Type);
+        Assert.Equal(attrDataSchema, wrapped.Header.DataSchema!.ToString());
+        Assert.Equal(attrSubject, wrapped.Header.Subject);
+    }
+
+    [Fact]
+    public void When_mapper_sets_headers_and_publication_also_sets_them_mapper_should_win()
+    {
+        //Arrange - mapper set headers, publication has different values
+        var message = CreateMessageWithMapperHeaders();
+
+        var publication = new Publication
+        {
+            Source = new Uri("http://goparamore.io/FromPublication"),
+            Type = new CloudEventsType("MyApp.FromPublication"),
+            DataSchema = new Uri("http://goparamore.io/FromPublication/schema"),
+            Subject = "FromPublication"
+        };
+
+        //Act - no attribute params, so precedence is mapper > publication
+        var wrapped = _transformer.Wrap(message, publication);
+
+        //Assert - mapper values win over publication
+        Assert.Equal(_mapperSource, wrapped.Header.Source);
+        Assert.Equal(_mapperType, wrapped.Header.Type);
+        Assert.Equal(_mapperDataSchema, wrapped.Header.DataSchema);
+        Assert.Equal(_mapperSubject, wrapped.Header.Subject);
+    }
+
+    [Fact]
+    public void When_mapper_leaves_defaults_publication_should_provide_values()
+    {
+        //Arrange - message with default headers (mapper did not set cloud event properties)
+        var message = new Message(
+            new MessageHeader(Id.Random(), new RoutingKey("Test.Topic"), MessageType.MT_EVENT),
+            new MessageBody("{\"orderId\": 123}"));
+
+        var publicationSource = new Uri("http://goparamore.io/FromPublication");
+        var publicationType = new CloudEventsType("MyApp.FromPublication");
+        var publicationDataSchema = new Uri("http://goparamore.io/FromPublication/schema");
+        const string publicationSubject = "FromPublication";
+
+        var publication = new Publication
+        {
+            Source = publicationSource,
+            Type = publicationType,
+            DataSchema = publicationDataSchema,
+            Subject = publicationSubject
+        };
+
+        //Act
+        var wrapped = _transformer.Wrap(message, publication);
+
+        //Assert - publication values are used as fallback when message has defaults
+        Assert.Equal(publicationSource, wrapped.Header.Source);
+        Assert.Equal(publicationType, wrapped.Header.Type);
+        Assert.Equal(publicationDataSchema, wrapped.Header.DataSchema);
+        Assert.Equal(publicationSubject, wrapped.Header.Subject);
+    }
+
+    [Fact]
+    public void When_mapper_sets_relative_uri_source_should_preserve_it()
+    {
+        //Arrange - CloudEvents spec allows relative URI-references for source
+        var relativeSource = new Uri("/my-service/orders", UriKind.Relative);
+        var message = new Message(
+            new MessageHeader(
+                Id.Random(),
+                new RoutingKey("Test.Topic"),
+                MessageType.MT_EVENT,
+                source: relativeSource),
+            new MessageBody("{\"orderId\": 123}"));
+
+        var publication = new Publication();
+
+        //Act - should not throw, and should preserve the relative URI
+        var wrapped = _transformer.Wrap(message, publication);
+
+        //Assert
+        Assert.Equal(relativeSource, wrapped.Header.Source);
+    }
+
+    [Fact]
+    public void When_wrapping_as_json_format_should_preserve_mapper_headers_in_body()
+    {
+        //Arrange
+        var message = CreateMessageWithMapperHeaders();
+        message.Header.ContentType = new ContentType(MediaTypeNames.Application.Json);
+
+        _transformer.InitializeWrapFromAttributeParams(null, null, null, null, null, CloudEventFormat.Json);
+
+        var publication = new Publication();
+
+        //Act
+        var wrapped = _transformer.Wrap(message, publication);
+
+        //Assert - the CloudEvent JSON body should contain the mapper's values
+        var json = JsonSerializer.Deserialize<CloudEventsTransformer.JsonEvent>(wrapped.Body.Bytes, JsonSerialisationOptions.Options);
+        Assert.NotNull(json);
+        Assert.Equal(_mapperSource, json.Source);
+        Assert.Equal(_mapperType, json.Type);
+        Assert.Equal(_mapperDataSchema, json.DataSchema);
+        Assert.Equal(_mapperSubject, json.Subject);
     }
 }

--- a/tests/Paramore.Brighter.Core.Tests/CloudEvents/When_wrapping_a_message_that_already_has_cloud_event_headers_should_preserve_them.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CloudEvents/When_wrapping_a_message_that_already_has_cloud_event_headers_should_preserve_them.cs
@@ -56,10 +56,11 @@ public class CloudEventsPreservesExistingHeadersTests
         var message = CreateMessageWithMapperHeaders();
         const string attrSource = "http://goparamore.io/FromAttribute";
         const string attrType = "MyApp.FromAttribute";
+        const string attrDataContentType = MediaTypeNames.Text.Xml;
         const string attrDataSchema = "http://goparamore.io/FromAttribute/schema";
         const string attrSubject = "FromAttribute";
 
-        _transformer.InitializeWrapFromAttributeParams(attrSource, attrType, null, attrDataSchema, attrSubject, CloudEventFormat.Binary);
+        _transformer.InitializeWrapFromAttributeParams(attrSource, attrType, null, attrDataContentType, attrDataSchema, attrSubject, CloudEventFormat.Binary);
 
         var publication = new Publication
         {
@@ -75,6 +76,7 @@ public class CloudEventsPreservesExistingHeadersTests
         //Assert - attribute wins over both mapper and publication
         Assert.Equal(attrSource, wrapped.Header.Source.ToString());
         Assert.Equal(attrType, wrapped.Header.Type);
+        Assert.Equal(new ContentType(attrDataContentType), wrapped.Header.ContentType);
         Assert.Equal(attrDataSchema, wrapped.Header.DataSchema!.ToString());
         Assert.Equal(attrSubject, wrapped.Header.Subject);
     }
@@ -163,7 +165,7 @@ public class CloudEventsPreservesExistingHeadersTests
         var message = CreateMessageWithMapperHeaders();
         message.Header.ContentType = new ContentType(MediaTypeNames.Application.Json);
 
-        _transformer.InitializeWrapFromAttributeParams(null, null, null, null, null, CloudEventFormat.Json);
+        _transformer.InitializeWrapFromAttributeParams(null, null, null, null, null, null, CloudEventFormat.Json);
 
         var publication = new Publication();
 


### PR DESCRIPTION
## Summary

- **Fix**: `CloudEventsTransformer` was overwriting `Source`, `Type`, `DataSchema`, `Subject`, and `DataContentType` values already set by upstream message mappers (e.g. `JustSayingMessageMapper`). When neither the `[CloudEvents]` attribute nor the `Publication` provided explicit values, properties were nulled out or reset to defaults.
- **Impact**: This caused the SNS `PublishRequest.Subject` to be null, so AWS omitted the `"Subject"` field from the SNS notification envelope — breaking downstream consumers (e.g. Python Lambda) expecting `record.json_body["Subject"]`.
- **Fix approach**: Changed precedence to: attribute params > message header (if explicitly set) > publication value, matching the existing `SpecVersion` pattern on the same method.

## ⚠️ Behavior changes

### 1. Precedence flip (attribute > mapper > publication)

This changes the precedence of CloudEvent header resolution from `attribute > publication` to `attribute > message header (mapper) > publication`. Previously, `Publication.Source/Type/Subject/DataSchema` would always overwrite values that a custom message mapper had set. After this change, **mapper-set values take priority over Publication defaults**, and Publication values serve as a fallback.

**Who is affected**: Users with custom message mappers that set CloudEvent header values AND also set explicit (non-default) values on `Publication` for the same properties, expecting Publication to override the mapper. This is unlikely in practice since the mapper and transformer receive the same Publication object.

### 2. `CloudEventsAttribute.DataContentType` default removed

Previously `CloudEventsAttribute.DataContentType` defaulted to `"application/json"`, meaning `[CloudEvents(0)]` always stamped `application/json` as the content type — silently overriding any mapper-set content type (e.g. `text/xml`, `application/protobuf`). It is now nullable with no default, so the attribute only sets `datacontenttype` when explicitly provided. The mapper's content type is preserved by default.

**Wire format note**: Messages that previously had bare `application/json` as `datacontenttype` may now show `application/json; charset=utf-8` (the `MessageHeader.ContentType` default). Consumers using strict `==` comparison against `application/json` should update to a prefix/contains check.

### 3. `InitializeWrapFromAttributeParams` signature change

A new positional slot was inserted at index 3 (`DataContentType`), shifting `DataSchema` (→4), `Subject` (→5), and `Format` (→6). Internal callers all go through `attribute.InitializerParams()` so in-tree wiring is consistent. Third-party code calling `InitializeWrapFromAttributeParams` directly with a hand-rolled `object?[]` will need to update their call sites.

## Changes

### Production code
- `CloudEventsTransformer.cs` — Renamed `WritePublicationHeaders` → `ApplyCloudEventsPrecedence`; extracted `ResolveWithSentinel<T>` helper for sentinel-based precedence; added `_dataContentType` field with explicit `if`-guard assignment
- `CloudEventsAttribute.cs` — Made `DataContentType` nullable (`string?`) with no default
- Updated class-level XML docs on both classes to document precedence consistently for all 5 settable attributes

### Tests
- Precedence matrix tests: no-attribute/no-publication preserves mapper; attribute wins over mapper+publication; mapper wins over publication; publication used as fallback
- DataContentType tests: default attribute doesn't override mapper (via real `InitializerParams()` pipeline); explicit attribute overrides mapper
- Sentinel collision test: documents that mapper Source == DefaultSource → publication wins (known trade-off)
- JSON format test: verifies `datacontenttype` in CloudEvent envelope body reflects mapper's original content type
- Relative URI source test (CloudEvents spec compliance)
- V9→V10 Bag camelCase migration tests (PR #4132 context)
- Aligned test class names to match file names per project convention

## Test plan

- [x] All 39 CloudEvents tests pass on both net9.0 and net10.0
- [x] Precedence matrix fully covered (attribute > mapper > publication > defaults)
- [x] DataContentType nullable change tested via real attribute pipeline
- [x] Sentinel collision behavior documented and tested
- [x] JSON envelope body content type verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)