### PR TITLE
fix(#3828): dedup duplicate publications and subscriptions by (channel, action)

### DIFF
--- a/src/Paramore.Brighter.AsyncAPI/AsyncApiDocumentGenerator.cs
+++ b/src/Paramore.Brighter.AsyncAPI/AsyncApiDocumentGenerator.cs
@@ -64,8 +64,6 @@ namespace Paramore.Brighter.AsyncAPI
         // the document and which message it points at.
         private readonly record struct ChannelMessageKey(string ChannelId, string MessageName);
 
-        // The action + channel-id pair forms an operation's identity in the document.
-        private readonly record struct OperationKey(string Action, string ChannelId);
 
         private readonly AsyncApiOptions _options;
         private readonly IAmASchemaGenerator _schemaGenerator;
@@ -177,15 +175,20 @@ namespace Paramore.Brighter.AsyncAPI
             CancellationToken ct)
         {
             var channelId = SanitizeChannelId(source.Address);
+            var actionString = source.Action == V3OperationAction.Send ? "send" : "receive";
+
+            // Dedup by (channel, action). First source wins — covers producer-registry vs
+            // SupplementalPublications collisions and assembly-scan vs producer-registry
+            // collisions alike. Same channel + different action (e.g. a subscription and
+            // a publication on the same routing key) is not a duplicate and proceeds.
+            if (!context.CoveredChannelActions.Add((channelId, actionString))) return;
+
             EnsureChannel(context.Channels, new ChannelDescriptor(channelId, source.Address));
 
             var messageName = await EnsureMessageForSourceAsync(source, channelId, context.Messages, ct).ConfigureAwait(false);
             AddChannelMessageRef(context.Channels, new ChannelMessageKey(channelId, messageName));
 
-            var actionString = source.Action == V3OperationAction.Send ? "send" : "receive";
-            context.CoveredChannelActions.Add((channelId, actionString));
-
-            var operationId = GetUniqueOperationId(context.Operations, new OperationKey(actionString, channelId));
+            var operationId = $"{actionString}_{channelId}";
             context.Operations[operationId] = BuildOperation(source.Action, channelId, messageName);
         }
 
@@ -228,8 +231,7 @@ namespace Paramore.Brighter.AsyncAPI
             {
                 foreach (var (type, topic) in GetPublicationTopicTypes(assembly))
                 {
-                    if (context.CoveredChannelActions.Contains((SanitizeChannelId(topic), "send"))) continue;
-
+                    // ProcessSourceAsync dedups by (channel, action) so no early-skip needed here.
                     await ProcessSourceAsync(
                         new MessageSource(topic, V3OperationAction.Send, type),
                         context, ct).ConfigureAwait(false);
@@ -341,20 +343,7 @@ namespace Paramore.Brighter.AsyncAPI
                 });
         }
 
-        private static string GetUniqueOperationId(Dictionary<string, V3OperationDefinition> operations, OperationKey key)
-        {
-            var baseId = $"{key.Action}_{key.ChannelId}";
-            if (!operations.TryGetValue(baseId, out _))
-                return baseId;
-
-            var counter = 2;
-            while (operations.TryGetValue($"{baseId}_{counter}", out _))
-                counter++;
-
-            return $"{baseId}_{counter}";
-        }
-
-        private static V3SchemaDefinition EmptyObjectSchema()
+private static V3SchemaDefinition EmptyObjectSchema()
         {
             using var doc = JsonDocument.Parse("{}");
             return new V3SchemaDefinition

--- a/src/Paramore.Brighter.AsyncAPI/AsyncApiDocumentGenerator.cs
+++ b/src/Paramore.Brighter.AsyncAPI/AsyncApiDocumentGenerator.cs
@@ -343,7 +343,7 @@ namespace Paramore.Brighter.AsyncAPI
                 });
         }
 
-private static V3SchemaDefinition EmptyObjectSchema()
+        private static V3SchemaDefinition EmptyObjectSchema()
         {
             using var doc = JsonDocument.Parse("{}");
             return new V3SchemaDefinition

--- a/tests/Paramore.Brighter.AsyncAPI.Tests/When_Deduplicating_Channels_And_Messages.cs
+++ b/tests/Paramore.Brighter.AsyncAPI.Tests/When_Deduplicating_Channels_And_Messages.cs
@@ -58,8 +58,11 @@ namespace Paramore.Brighter.AsyncAPI.Tests
         }
 
         [Fact]
-        public async Task It_Should_Produce_One_Channel_And_Two_Operations_For_Duplicate_Subscriptions()
+        public async Task It_Should_Dedup_Duplicate_Subscriptions_On_The_Same_Topic()
         {
+            // Two subscriptions for the same routing key collapse into one channel + one
+            // receive operation. The first subscription wins; the duplicate is dropped
+            // rather than emitted as a misleading "_2"-suffixed second operation.
             var subscriptions = new[]
             {
                 new Subscription(
@@ -79,16 +82,13 @@ namespace Paramore.Brighter.AsyncAPI.Tests
             var generator = new AsyncApiDocumentGenerator(_options, _schemaGenerator, subscriptions, null);
             var result = await generator.GenerateAsync();
 
-            // One channel for the shared topic
             Assert.NotNull(result.Channels);
             Assert.Single(result.Channels);
             Assert.True(result.Channels.ContainsKey("shared_topic"));
 
-            // Two receive operations with unique IDs
             Assert.NotNull(result.Operations);
-            Assert.Equal(2, result.Operations.Count);
+            Assert.Single(result.Operations);
             Assert.True(result.Operations.ContainsKey("receive_shared_topic"));
-            Assert.True(result.Operations.ContainsKey("receive_shared_topic_2"));
 
             // Only one message component
             Assert.NotNull(result.Components?.Messages);
@@ -155,7 +155,9 @@ namespace Paramore.Brighter.AsyncAPI.Tests
         [Fact]
         public async Task It_Should_Dedup_Producer_Registry_Over_Supplemental_Publications()
         {
-            // Both producer registry and supplemental have the same topic
+            // Both producer registry and supplemental declare the same (topic, action). The
+            // producer-registry entry comes first and wins; the supplemental duplicate is
+            // dropped rather than emitted as a misleading "_2"-suffixed second operation.
             var producerPubs = new[]
             {
                 new Publication { Topic = new RoutingKey("dedup.topic"), RequestType = typeof(SharedEvent) }
@@ -166,16 +168,14 @@ namespace Paramore.Brighter.AsyncAPI.Tests
                 new Publication { Topic = new RoutingKey("dedup.topic"), RequestType = typeof(SharedEvent) }
             };
 
-            // Combine: producer registry publications first, supplemental second
             var allPubs = producerPubs.Concat(supplementalPubs).ToArray();
 
             var generator = new AsyncApiDocumentGenerator(_options, _schemaGenerator, null, allPubs);
             var result = await generator.GenerateAsync();
 
             Assert.NotNull(result.Operations);
-            // Should have send_dedup_topic and send_dedup_topic_2 since both get added
-            // The producer registry "wins" by being first; the supplemental gets a unique ID
-            Assert.Equal(2, result.Operations.Count);
+            Assert.Single(result.Operations);
+            Assert.True(result.Operations.ContainsKey("send_dedup_topic"));
         }
 
         public class SharedEvent : Event

--- a/tests/Paramore.Brighter.AsyncAPI.Tests/When_Generating_Document_From_Assembly_Scanning.cs
+++ b/tests/Paramore.Brighter.AsyncAPI.Tests/When_Generating_Document_From_Assembly_Scanning.cs
@@ -119,7 +119,7 @@ namespace Paramore.Brighter.AsyncAPI.Tests
         }
 
         [Fact]
-        public async Task It_Should_Skip_Assembly_Scanned_Type_When_DI_Has_Uniqueified_Operation_Id()
+        public async Task It_Should_Collapse_Duplicate_DI_And_Scanned_Publications_To_One_Operation()
         {
             var options = new AsyncApiOptions
             {
@@ -128,10 +128,11 @@ namespace Paramore.Brighter.AsyncAPI.Tests
                 AssembliesToScan = new[] { typeof(ScannableEvent).Assembly }
             };
 
-            // Two DI publications on the same topic as the [PublicationTopic]-decorated ScannableEvent.
-            // The first gets send_scannable_topic, the second gets send_scannable_topic_2.
-            // Assembly scanning must still detect that a send operation for scannable_topic
-            // already exists from DI and skip the scanned type.
+            // Two DI publications on the same topic as the [PublicationTopic]-decorated
+            // ScannableEvent. Deduplication is by (channel, action): the first DI
+            // publication wins, the second DI publication is dropped, and the
+            // assembly-scanned type is also dropped. The document ends up with a single
+            // send operation rather than misleading "_2"-suffixed duplicates.
             var publications = new[]
             {
                 new Publication
@@ -150,11 +151,8 @@ namespace Paramore.Brighter.AsyncAPI.Tests
             var result = await generator.GenerateAsync();
 
             Assert.NotNull(result.Operations);
-            // Only the two DI publications should produce operations (send_scannable_topic and send_scannable_topic_2)
-            // The assembly-scanned type must NOT add a third operation
-            Assert.Equal(2, result.Operations.Count);
+            Assert.Single(result.Operations);
             Assert.True(result.Operations.ContainsKey("send_scannable_topic"));
-            Assert.True(result.Operations.ContainsKey("send_scannable_topic_2"));
         }
 
         [PublicationTopic("scannable.topic")]


### PR DESCRIPTION

Previously the producer registry and SupplementalPublications could declare the same topic and end up in the document as two send operations (send_foo + send_foo_2). Subscriptions had the same flaw on the receive side. Assembly scanning was the only path that correctly skipped duplicates.

Move the dedup into ProcessSourceAsync so all three sources go through the same gate: if (channel, action) is already covered, drop the duplicate. First source wins (producer registry beats SupplementalPublications; DI publications beat assembly scanning). Same channel with a different action (e.g. a subscription and a publication on one routing key) still produces both operations as intended.

GetUniqueOperationId and the OperationKey record become dead code with true dedup in place — both removed. The redundant CoveredChannelActions check in AddFromAssemblyScanningAsync is also dropped.

Tests:
- It_Should_Dedup_Duplicate_Subscriptions_On_The_Same_Topic (was It_Should_Produce_One_Channel_And_Two_Operations_For_Duplicate_Subscriptions, which asserted the buggy behaviour).
- It_Should_Dedup_Producer_Registry_Over_Supplemental_Publications now asserts one operation rather than two.
- It_Should_Collapse_Duplicate_DI_And_Scanned_Publications_To_One_Operation replaces the "_Uniqueified_Operation_Id" test that codified the old suffix behaviour.

46/46 AsyncAPI tests pass on net9.0 and net10.0.

## Description

<!-- Briefly describe what this PR does and why -->

## Related Issues

<!-- Link any related issues: Fixes #123, Closes #456 -->

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [ ] I have read the [Contributing Guide](../blob/master/CONTRIBUTING.md)
- [ ] I have checked the [documentation](https://brightercommand.gitbook.io/paramore-brighter-documentation/) for relevant guidance
- [ ] I have added/updated XML documentation for any public API changes
- [ ] I have added/updated tests as appropriate
- [ ] My changes follow the existing code style and conventions

## Additional Notes

<!-- Any additional context, screenshots, or notes for reviewers -->
