### PR TITLE
task: surface broker SequenceNumber in message header bag

### DIFF
--- a/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/ASBConstants.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/ASBConstants.cs
@@ -3,6 +3,7 @@
     internal static class ASBConstants
     {
         public const string LockTokenHeaderBagKey = "LockToken";
+        public const string SequenceNumberBagKey = "SequenceNumber";
         public const string MessageTypeHeaderBagKey = "MessageType";
         public const string HandledCountHeaderBagKey = "HandledCount";
         public const string ReplyToHeaderBagKey = "ReplyTo";

--- a/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusMesssageCreator.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusMesssageCreator.cs
@@ -107,6 +107,7 @@ public partial class AzureServiceBusMesssageCreator(AzureServiceBusSubscription 
         );
 
         headers.Bag.Add(ASBConstants.LockTokenHeaderBagKey, azureServiceBusMessage.LockToken);
+        headers.Bag.Add(ASBConstants.SequenceNumberBagKey, azureServiceBusMessage.SequenceNumber);
             
         foreach (var property in azureServiceBusMessage.ApplicationProperties)
         {

--- a/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusWrappers/BrokeredMessageWrapper.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusWrappers/BrokeredMessageWrapper.cs
@@ -21,6 +21,8 @@ namespace Paramore.Brighter.MessagingGateway.AzureServiceBus.AzureServiceBusWrap
 
         public string LockToken => _brokeredMessage.LockToken;
 
+        public long SequenceNumber => _brokeredMessage.SequenceNumber;
+
         public string Id => _brokeredMessage.MessageId;
 
         public string CorrelationId

--- a/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusWrappers/IBrokeredMessageWrapper.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/AzureServiceBusWrappers/IBrokeredMessageWrapper.cs
@@ -29,6 +29,11 @@ namespace Paramore.Brighter.MessagingGateway.AzureServiceBus.AzureServiceBusWrap
         string LockToken { get; }
 
         /// <summary>
+        /// The broker-assigned sequence number. Uniquely identifies a message within a Service Bus entity.
+        /// </summary>
+        long SequenceNumber { get; }
+
+        /// <summary>
         /// The message Id.
         /// </summary>
         string Id { get; }

--- a/tests/Paramore.Brighter.AzureServiceBus.Tests/MessagingGateway/When_Mapping_Message_SequenceNumber_Is_Added_To_Bag.cs
+++ b/tests/Paramore.Brighter.AzureServiceBus.Tests/MessagingGateway/When_Mapping_Message_SequenceNumber_Is_Added_To_Bag.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Paramore.Brighter.AzureServiceBus.Tests.TestDoubles;
+using Paramore.Brighter.MessagingGateway.AzureServiceBus;
+using Xunit;
+
+// ASBConstants is internal to the gateway assembly; tests use the agreed
+// public contract string directly so they act as a stability guard too.
+
+namespace Paramore.Brighter.AzureServiceBus.Tests.MessagingGateway;
+
+[Trait("Category", "ASB")]
+public class AzureServiceBusMessageSequenceNumberTests
+{
+    private readonly AzureServiceBusMesssageCreator _creator;
+
+    public AzureServiceBusMessageSequenceNumberTests()
+    {
+        var subscription = new AzureServiceBusSubscription<ASBTestCommand>(
+            subscriptionName: new SubscriptionName("test-sub"),
+            channelName: new ChannelName("test-channel"),
+            routingKey: new RoutingKey("test-topic"),
+            messagePumpType: MessagePumpType.Reactor);
+
+        _creator = new AzureServiceBusMesssageCreator(subscription);
+    }
+
+    [Fact]
+    public void When_mapping_a_message_the_sequence_number_is_added_to_the_header_bag()
+    {
+        // Arrange
+        const long expectedSequenceNumber = 12345678L;
+
+        var brokeredMessage = new BrokeredMessage
+        {
+            MessageBodyValue = Encoding.UTF8.GetBytes("{\"key\":\"value\"}"),
+            ApplicationProperties = new Dictionary<string, object>
+            {
+                { "MessageType", "MT_EVENT" }
+            },
+            LockToken = Guid.NewGuid().ToString(),
+            SequenceNumber = expectedSequenceNumber,
+            Id = Guid.NewGuid().ToString(),
+            CorrelationId = Guid.NewGuid().ToString(),
+            ContentType = "application/json"
+        };
+
+        // Act
+        var message = _creator.MapToBrighterMessage(brokeredMessage);
+
+        // Assert
+        Assert.True(message.Header.Bag.ContainsKey("SequenceNumber"));
+        Assert.Equal(expectedSequenceNumber, message.Header.Bag["SequenceNumber"]);
+    }
+
+    [Fact]
+    public void When_mapping_a_message_with_a_zero_sequence_number_it_is_still_present_in_the_bag()
+    {
+        // Arrange
+        var brokeredMessage = new BrokeredMessage
+        {
+            MessageBodyValue = Encoding.UTF8.GetBytes("{}"),
+            ApplicationProperties = new Dictionary<string, object>
+            {
+                { "MessageType", "MT_EVENT" }
+            },
+            LockToken = Guid.NewGuid().ToString(),
+            SequenceNumber = 0L,
+            Id = Guid.NewGuid().ToString(),
+            CorrelationId = Guid.NewGuid().ToString(),
+            ContentType = "application/json"
+        };
+
+        // Act
+        var message = _creator.MapToBrighterMessage(brokeredMessage);
+
+        // Assert
+        Assert.True(message.Header.Bag.ContainsKey("SequenceNumber"));
+        Assert.Equal(0L, message.Header.Bag["SequenceNumber"]);
+    }
+}

--- a/tests/Paramore.Brighter.AzureServiceBus.Tests/TestDoubles/BrokeredMessage.cs
+++ b/tests/Paramore.Brighter.AzureServiceBus.Tests/TestDoubles/BrokeredMessage.cs
@@ -10,6 +10,7 @@ public class BrokeredMessage : IBrokeredMessageWrapper
     public ReadOnlyMemory<byte> MessageBodyMemory => (MessageBodyValue ?? Array.Empty<byte>()).AsMemory();
     public IReadOnlyDictionary<string, object> ApplicationProperties { get; init; }
     public string LockToken { get;  init;}
+    public long SequenceNumber { get; init; }
     public string Id { get;  init;}
     public string CorrelationId { get;  init;}
     public string ContentType { get;  init;}


### PR DESCRIPTION
This pull request adds support for handling the Azure Service Bus message `SequenceNumber` throughout the message mapping process, ensuring it is available in the header bag for downstream consumers. It also introduces comprehensive tests to verify this behavior.

**Support for Azure Service Bus Sequence Number**

* Added a new constant `SequenceNumberBagKey` to `ASBConstants` for consistent header bag key usage.
* Modified `AzureServiceBusMesssageCreator.MapToBrighterMessage` to include the `SequenceNumber` from the incoming message in the header bag.
* Extended the `IBrokeredMessageWrapper` interface and its implementations (`BrokeredMessageWrapper` and test double `BrokeredMessage`) to expose the `SequenceNumber` property. [[1]](diffhunk://#diff-ec32312cf3a661114af000df1616867d2f57955dd43976e972b10c8b86f10a79R31-R35) [[2]](diffhunk://#diff-5b73c6c6d46cc92fc88a10c3ba2083c93f25d550207e3c45b7581aec7ad50b1cR24-R25) [[3]](diffhunk://#diff-df3b595943277101a68d90d010609884609acdfe42562b5a928eacb324fbbfe7R13)

**Testing and Validation**

* Added a new test class `AzureServiceBusMessageSequenceNumberTests` to verify that the `SequenceNumber` is correctly added to the header bag, including edge cases such as a sequence number of zero.