### PR TITLE
chore(aws-tests): swap Moto for Floci as the AWS mock for integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -450,14 +450,12 @@ jobs:
       AWS_SERVICE_URL: http://localhost:4566
 
     services:
-      moto:
-        image: motoserver/moto:5.1.22
+      floci:
+        image: floci/floci:latest
         ports:
           - 4566:4566
-        env:
-          MOTO_PORT: "4566"
         options: >-
-          --health-cmd "curl -sf http://localhost:4566/moto-api/"
+          --health-cmd "curl -sf http://localhost:4566/_localstack/health"
           --health-interval 5s
           --health-timeout 3s
           --health-retries 10

--- a/docker-compose-aws.yaml
+++ b/docker-compose-aws.yaml
@@ -1,12 +1,10 @@
 services:
-  moto:
-    image: motoserver/moto:5.1.22
+  floci:
+    image: floci/floci:latest
     ports:
-      - "4566:4566" # Moto Gateway (same port as former LocalStack for compatibility)
-    environment:
-      - "MOTO_PORT=4566"
+      - "4566:4566" # Floci AWS emulator (same port as Moto/LocalStack for compatibility)
     healthcheck:
-      test: ["CMD", "curl", "-sf", "http://localhost:4566/moto-api/"]
+      test: ["CMD-SHELL", "curl -sf http://localhost:4566/_localstack/health || curl -sf http://localhost:4566/"]
       interval: 5s
       timeout: 3s
       retries: 10

--- a/tests/Paramore.Brighter.AWS.Tests/Helpers/CredentialsChain.cs
+++ b/tests/Paramore.Brighter.AWS.Tests/Helpers/CredentialsChain.cs
@@ -33,7 +33,9 @@ public static class CredentialsChain
         var serviceUrl = Environment.GetEnvironmentVariable("AWS_SERVICE_URL");
         if (!string.IsNullOrEmpty(serviceUrl) && Uri.TryCreate(serviceUrl, UriKind.Absolute, out var uri))
         {
-            return $"http://{{BucketName}}.s3.{{BucketRegion}}.{uri.Authority}";
+            // Short vhost form ({bucket}.{authority}) works on Floci where the full
+            // region-qualified form ({bucket}.s3.{region}.{authority}) does not — see floci-io/floci#977.
+            return $"{uri.Scheme}://{{BucketName}}.{uri.Authority}";
         }
 
         return S3LuggageOptions.DefaultBucketAddressTemplate;

--- a/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sqs/Standard/Proactor/When_infrastructure_exists_can_verify_by_url.cs
+++ b/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sqs/Standard/Proactor/When_infrastructure_exists_can_verify_by_url.cs
@@ -55,7 +55,7 @@ public class AWSValidateInfrastructureByUrlTests : IDisposable, IAsyncDisposable
         //Now change the subscription to validate, just check what we made
         subscription = new SqsSubscription<MyCommand>(
             subscriptionName: new SubscriptionName(subscriptionName),
-            channelName: channel.Name,
+            channelName: new ChannelName(queueUrl),
             routingKey: routingKey,
             findQueueBy: QueueFindBy.Url,
             messagePumpType: MessagePumpType.Reactor,

--- a/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sqs/Standard/Proactor/When_posting_a_message_resources_are_tagged_async.cs
+++ b/tests/Paramore.Brighter.AWS.Tests/MessagingGateway/Sqs/Standard/Proactor/When_posting_a_message_resources_are_tagged_async.cs
@@ -59,13 +59,9 @@ public class SqsMessageProducerResourcesAreTaggedAsyncTests : IAsyncDisposable, 
             });
     }
 
-    [SkippableFact]
+    [Fact]
     public async Task When_posting_a_message_resources_are_tagged_async()
     {
-        Skip.If(
-            !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("AWS_SERVICE_URL")),
-            "SQS tag verification fails against Moto; runs against real AWS.");
-
         // arrange
         await _messageProducer.SendAsync(_message);
 

--- a/tests/Paramore.Brighter.AWS.Tests/Transformers/When_creating_luggagestore_missing_parameters.cs
+++ b/tests/Paramore.Brighter.AWS.Tests/Transformers/When_creating_luggagestore_missing_parameters.cs
@@ -71,7 +71,7 @@ public class S3LuggageUploadMissingParametersTests
     }
     
     [Fact]
-    public async Task When_creating_luggagestore_missing_ACL() 
+    public async Task When_creating_luggagestore_missing_ACL()
     {
         //arrange
         var exception = await Catch.ExceptionAsync(async () =>

--- a/tests/Paramore.Brighter.AWS.V4.Tests/Helpers/CredentialsChain.cs
+++ b/tests/Paramore.Brighter.AWS.V4.Tests/Helpers/CredentialsChain.cs
@@ -32,7 +32,9 @@ public static class CredentialsChain
         var serviceUrl = Environment.GetEnvironmentVariable("AWS_SERVICE_URL");
         if (!string.IsNullOrEmpty(serviceUrl) && Uri.TryCreate(serviceUrl, UriKind.Absolute, out var uri))
         {
-            return $"http://{{BucketName}}.s3.{{BucketRegion}}.{uri.Authority}";
+            // Short vhost form ({bucket}.{authority}) works on Floci where the full
+            // region-qualified form ({bucket}.s3.{region}.{authority}) does not — see floci-io/floci#977.
+            return $"{uri.Scheme}://{{BucketName}}.{uri.Authority}";
         }
 
         return S3LuggageOptions.DefaultBucketAddressTemplate;

--- a/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Standard/Proactor/When_a_message_consumer_reads_multiple_messages_async.cs
+++ b/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Standard/Proactor/When_a_message_consumer_reads_multiple_messages_async.cs
@@ -50,15 +50,11 @@ public class SqsBufferedConsumerTestsAsync : IDisposable, IAsyncDisposable
             new SnsPublication { MakeChannels = OnMissingChannel.Create });
     }
 
-    [SkippableTheory]
+    [Theory]
     [InlineData(true)]
     [InlineData(false)]
     public async Task When_a_message_consumer_reads_multiple_messages_async(bool fairQueue)
     {
-        // TODO: remove once Moto pin in #4096 is bumped to 5.1.23+
-        Skip.If(fairQueue && !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("AWS_SERVICE_URL")),
-            "SQS fair queues require Moto >= 5.1.23; pinned image is 5.1.22. Runs against real AWS.");
-
         var partitionOne = fairQueue ? new PartitionKey(Uuid.NewAsString()) : PartitionKey.Empty;
         var partitionTwo = fairQueue ? new PartitionKey(Uuid.NewAsString()) : PartitionKey.Empty;
         var routingKey = new RoutingKey(_topicName);

--- a/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Standard/Proactor/When_posting_a_message_via_the_messaging_gateway_async.cs
+++ b/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Standard/Proactor/When_posting_a_message_via_the_messaging_gateway_async.cs
@@ -64,15 +64,11 @@ public class SqsMessageProducerSendAsyncTests : IAsyncDisposable, IDisposable
             });
     }
 
-    [SkippableTheory]
+    [Theory]
     [InlineData(true)]
     [InlineData(false)]
     public async Task When_posting_a_message_via_the_producer_async(bool fairQueue)
     {
-        // TODO: remove once Moto pin in #4096 is bumped to 5.1.23+
-        Skip.If(fairQueue && !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("AWS_SERVICE_URL")),
-            "SQS fair queues require Moto >= 5.1.23; pinned image is 5.1.22. Runs against real AWS.");
-
         // arrange
         _message.Header.Subject = "test subject";
         _message.Header.PartitionKey = fairQueue ? new PartitionKey(Uuid.NewAsString()) : PartitionKey.Empty;

--- a/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Standard/Reactor/When_a_message_consumer_reads_multiple_messages.cs
+++ b/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Standard/Reactor/When_a_message_consumer_reads_multiple_messages.cs
@@ -54,15 +54,11 @@ public class SqsBufferedConsumerTests : IDisposable, IAsyncDisposable
             });
     }
             
-    [SkippableTheory]
+    [Theory]
     [InlineData(true)]
     [InlineData(false)]
     public async Task When_a_message_consumer_reads_multiple_messages(bool fairQueue)
     {
-        // TODO: remove once Moto pin in #4096 is bumped to 5.1.23+
-        Skip.If(fairQueue && !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("AWS_SERVICE_URL")),
-            "SQS fair queues require Moto >= 5.1.23; pinned image is 5.1.22. Runs against real AWS.");
-
         var partitionOne = fairQueue ? new PartitionKey(Uuid.NewAsString()) : PartitionKey.Empty;
         var partitionTwo = fairQueue ? new PartitionKey(Uuid.NewAsString()) : PartitionKey.Empty;
         

--- a/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Standard/Reactor/When_posting_a_message_via_the_messaging_gateway.cs
+++ b/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sns/Standard/Reactor/When_posting_a_message_via_the_messaging_gateway.cs
@@ -62,15 +62,11 @@ public class SqsMessageProducerSendTests : IDisposable, IAsyncDisposable
             new SnsPublication{Topic = new RoutingKey(_topicName), MakeChannels = OnMissingChannel.Create});
     }
 
-    [SkippableTheory]
+    [Theory]
     [InlineData(true)]
     [InlineData(false)]
     public async Task When_posting_a_message_via_the_producer(bool fairQueue)
     {
-        // TODO: remove once Moto pin in #4096 is bumped to 5.1.23+
-        Skip.If(fairQueue && !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("AWS_SERVICE_URL")),
-            "SQS fair queues require Moto >= 5.1.23; pinned image is 5.1.22. Runs against real AWS.");
-
         //arrange
         _message.Header.Subject = "test subject";
         _message.Header.PartitionKey = fairQueue ? new PartitionKey(Uuid.NewAsString()) : PartitionKey.Empty;

--- a/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sqs/Standard/Proactor/When_a_message_consumer_reads_multiple_messages_async.cs
+++ b/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sqs/Standard/Proactor/When_a_message_consumer_reads_multiple_messages_async.cs
@@ -52,15 +52,11 @@ public class SQSBufferedConsumerTestsAsync : IDisposable, IAsyncDisposable
             );
     }
 
-    [SkippableTheory]
+    [Theory]
     [InlineData(true)]
     [InlineData(false)]
     public async Task When_a_message_consumer_reads_multiple_messages_async(bool fairQueue)
     {
-        // TODO: remove once Moto pin in #4096 is bumped to 5.1.23+
-        Skip.If(fairQueue && !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("AWS_SERVICE_URL")),
-            "SQS fair queues require Moto >= 5.1.23; pinned image is 5.1.22. Runs against real AWS.");
-
         var partitionOne = fairQueue ? new PartitionKey(Uuid.NewAsString()) : PartitionKey.Empty;
         var partitionTwo = fairQueue ? new PartitionKey(Uuid.NewAsString()) : PartitionKey.Empty;
         

--- a/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sqs/Standard/Proactor/When_infastructure_exists_can_verify_by_url.cs
+++ b/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sqs/Standard/Proactor/When_infastructure_exists_can_verify_by_url.cs
@@ -55,7 +55,7 @@ public class AWSValidateInfrastructureByUrlTests : IDisposable, IAsyncDisposable
         //Now change the subscription to validate, just check what we made
         subscription = new SqsSubscription<MyCommand>(
             subscriptionName: new SubscriptionName(subscriptionName),
-            channelName: channel.Name,
+            channelName: new ChannelName(queueUrl),
             routingKey: routingKey,
             findQueueBy: QueueFindBy.Url,
             messagePumpType: MessagePumpType.Reactor,

--- a/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sqs/Standard/Proactor/When_posting_a_message_via_the_messaging_gateway_async.cs
+++ b/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sqs/Standard/Proactor/When_posting_a_message_via_the_messaging_gateway_async.cs
@@ -63,15 +63,11 @@ public class SqsMessageProducerSendAsyncTests : IAsyncDisposable, IDisposable
         });
     }
 
-    [SkippableTheory]
+    [Theory]
     [InlineData(true)]
     [InlineData(false)]
     public async Task When_posting_a_message_via_the_producer_async(bool fairQueue)
     {
-        // TODO: remove once Moto pin in #4096 is bumped to 5.1.23+
-        Skip.If(fairQueue && !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("AWS_SERVICE_URL")),
-            "SQS fair queues require Moto >= 5.1.23; pinned image is 5.1.22. Runs against real AWS.");
-
         // arrange
         _message.Header.Subject = "test subject";
         _message.Header.PartitionKey = fairQueue ? new PartitionKey(Uuid.NewAsString()) : PartitionKey.Empty;

--- a/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sqs/Standard/Reactor/When_a_message_consumer_reads_multiple_messages.cs
+++ b/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sqs/Standard/Reactor/When_a_message_consumer_reads_multiple_messages.cs
@@ -52,15 +52,11 @@ public class SQSBufferedConsumerTests : IDisposable, IAsyncDisposable
             new SqsPublication(channelName:  channelName, makeChannels: OnMissingChannel.Create));
     }
             
-    [SkippableTheory]
+    [Theory]
     [InlineData(true)]
     [InlineData(false)]
     public async Task When_a_message_consumer_reads_multiple_messages(bool fairQueue)
     {
-        // TODO: remove once Moto pin in #4096 is bumped to 5.1.23+
-        Skip.If(fairQueue && !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("AWS_SERVICE_URL")),
-            "SQS fair queues require Moto >= 5.1.23; pinned image is 5.1.22. Runs against real AWS.");
-
         var partitionOne = fairQueue ? new PartitionKey(Uuid.NewAsString()) : PartitionKey.Empty;
         var partitionTwo = fairQueue ? new PartitionKey(Uuid.NewAsString()) : PartitionKey.Empty;
         

--- a/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sqs/Standard/Reactor/When_posting_a_message_via_the_messaging_gateway.cs
+++ b/tests/Paramore.Brighter.AWS.V4.Tests/MessagingGateway/Sqs/Standard/Reactor/When_posting_a_message_via_the_messaging_gateway.cs
@@ -63,15 +63,11 @@ public class SqsMessageProducerSendTests : IDisposable, IAsyncDisposable
         );
     }
 
-    [SkippableTheory]
+    [Theory]
     [InlineData(true)]
     [InlineData(false)]
     public async Task When_posting_a_message_via_the_producer(bool fairQueue)
     {
-        // TODO: remove once Moto pin in #4096 is bumped to 5.1.23+
-        Skip.If(fairQueue && !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("AWS_SERVICE_URL")),
-            "SQS fair queues require Moto >= 5.1.23; pinned image is 5.1.22. Runs against real AWS.");
-
         //arrange
         _message.Header.Subject = "test subject";
         _message.Header.PartitionKey = fairQueue ? new PartitionKey(Uuid.NewAsString()) : PartitionKey.Empty;

--- a/tests/Paramore.Brighter.AWS.V4.Tests/Transformers/When_creating_luggagestore_missing_parameters.cs
+++ b/tests/Paramore.Brighter.AWS.V4.Tests/Transformers/When_creating_luggagestore_missing_parameters.cs
@@ -71,7 +71,7 @@ public class S3LuggageUploadMissingParametersTests
     }
     
     [Fact]
-    public async Task When_creating_luggagestore_missing_ACL() 
+    public async Task When_creating_luggagestore_missing_ACL()
     {
         //arrange
         var exception = await Catch.ExceptionAsync(async () =>


### PR DESCRIPTION
## Description

Swaps `motoserver/moto:5.1.22` for `floci/floci:latest` in `docker-compose-aws.yaml` and the `aws-mock-ci` workflow. Same port (4566), same `AWS_SERVICE_URL` contract, no production code touched.

### Why

A few `Skip.If(AWS_SERVICE_URL is set, ...)` guards in the AWS tests existed because Moto either didn't implement a thing or had it gated behind a newer version than we pin. Floci handles them, so the guards come off:

- 1× SQS tag verification (V3).
- 4× SQS fair-queue parameterisations (V4 Standard, producer + multi-message consumer, Reactor + Proactor).
- 4× SNS fair-queue parameterisations (V4 Standard, same shape).

Counts: V3 `aws-mock-ci` 136 → 137 passing, V4 `aws-mock-ci` 130 → 138 passing. No new skips.

Cold start is noticeably quicker too — `docker run` to health-endpoint-responding goes from ~2.7s on Moto to ~0.7s on Floci on my machine. Worth a few seconds per CI run.

Floci is also under active development and explicitly aims to be a drop-in LocalStack-Community replacement — [Why Floci](https://github.com/floci-io/floci#why-floci) covers the project's goals.

### Bonus fix exposed by stricter behaviour

`When_infastructure_exists_can_verify_by_url` (V3 + V4 Reactor) was passing the queue **name** as `channelName` while declaring `FindQueueBy.Url`. Moto tolerated the mismatch; Floci (and real AWS) don't. The Async sibling already passed the URL, so this just makes the Reactor variant consistent.

### One Floci quirk worked around

Floci returns `200` for `HEAD` on `{bucket}.s3.{region}.localhost:4566` regardless of whether the bucket exists. Path-style and short-vhost (`{bucket}.localhost:4566`) both behave correctly. The S3 luggage-store existence probe is vhost-style, so the test helper now emits the short-vhost form when `AWS_SERVICE_URL` is set. The full template is still the default for real-AWS runs. Filed upstream as [floci-io/floci#977](https://github.com/floci-io/floci/issues/977).

## Related Issues

Upstream: floci-io/floci#977

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [Contributing Guide](CONTRIBUTING.md)
- [x] I have checked the [documentation](https://brightercommand.gitbook.io/paramore-brighter-documentation/) for relevant guidance
- [x] I have added/updated XML documentation for any public API changes
- [x] I have added/updated tests as appropriate
- [x] My changes follow the existing code style and conventions

## Additional Notes

Tests verified locally against Floci with `AWS_SERVICE_URL=http://localhost:4566`: V3 137/137 and V4 138/138 passing, no skips.