### PR TITLE
fix: Newtonsoft.Json compatibility on MessageHeader and Baggage (#4149)

### DIFF
--- a/src/Paramore.Brighter/MessageHeader.cs
+++ b/src/Paramore.Brighter/MessageHeader.cs
@@ -269,7 +269,7 @@ namespace Paramore.Brighter
         /// </summary>
         /// <value>The reply to.</value>
         [JsonConverter(typeof(RoutingKeyConvertor))]
-        [Newtonsoft.Json.JsonConverter(typeof(RoutingKeyConvertor))]
+        [Newtonsoft.Json.JsonConverter(typeof(NRoutingKeyConverter))]
         public RoutingKey? ReplyTo { get; set; }
         
         /// <summary>
@@ -308,7 +308,7 @@ namespace Paramore.Brighter
         /// </summary>
         /// <value>The topic.</value>
         [JsonConverter(typeof(RoutingKeyConvertor))]
-        [Newtonsoft.Json.JsonConverter(typeof(RoutingKeyConvertor))]
+        [Newtonsoft.Json.JsonConverter(typeof(NRoutingKeyConverter))]
         public RoutingKey Topic { get; set; } = RoutingKey.Empty;
 
         /// <summary>
@@ -332,7 +332,7 @@ namespace Paramore.Brighter
         /// </summary>
         /// <value>The traceparent.</value>
         [JsonConverter(typeof(TraceParentConverter))]
-        [Newtonsoft.Json.JsonConverter(typeof(TraceParentConverter))]
+        [Newtonsoft.Json.JsonConverter(typeof(NTraceParentConverter))]
         public TraceParent? TraceParent { get; set; }
 
         /// <summary>
@@ -346,7 +346,7 @@ namespace Paramore.Brighter
         /// </summary>
         /// <value>The tracestate.</value>
         [JsonConverter(typeof(TraceStateConverter))]
-        [Newtonsoft.Json.JsonConverter(typeof(TraceStateConverter))]
+        [Newtonsoft.Json.JsonConverter(typeof(NTraceStateConverter))]
         public TraceState? TraceState { get; set; }
 
         /// <summary>

--- a/src/Paramore.Brighter/NJsonConverters/NBaggageConverter.cs
+++ b/src/Paramore.Brighter/NJsonConverters/NBaggageConverter.cs
@@ -1,0 +1,123 @@
+#region Licence
+/* The MIT License (MIT)
+Copyright © 2026 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+using System;
+using Newtonsoft.Json;
+using Paramore.Brighter.Observability;
+
+namespace Paramore.Brighter.NJsonConverters;
+
+/// <summary>
+/// Newtonsoft.Json converter for <see cref="Baggage"/>. Mirrors the wire shape of the
+/// System.Text.Json sibling <see cref="BaggageConverter"/>: a JSON array of objects with
+/// <c>Key</c> and <c>Value</c> properties (e.g. <c>[{"Key":"user","Value":"alice"}]</c>),
+/// so the two stacks can round-trip the same persisted document.
+/// </summary>
+public class NBaggageConverter : JsonConverter<Baggage>
+{
+    public override Baggage ReadJson(
+        JsonReader reader,
+        Type objectType,
+        Baggage? existingValue,
+        bool hasExistingValue,
+        JsonSerializer serializer)
+    {
+        var baggage = existingValue ?? new Baggage();
+
+        if (reader.TokenType == JsonToken.Null)
+        {
+            return baggage;
+        }
+
+        if (reader.TokenType != JsonToken.StartArray)
+        {
+            throw new JsonSerializationException($"Expected StartArray for Baggage, got {reader.TokenType}");
+        }
+
+        while (reader.Read())
+        {
+            if (reader.TokenType == JsonToken.EndArray)
+            {
+                break;
+            }
+
+            if (reader.TokenType != JsonToken.StartObject)
+            {
+                throw new JsonSerializationException($"Expected StartObject for Baggage entry, got {reader.TokenType}");
+            }
+
+            string? key = null;
+            string? value = null;
+
+            while (reader.Read() && reader.TokenType != JsonToken.EndObject)
+            {
+                if (reader.TokenType != JsonToken.PropertyName)
+                {
+                    continue;
+                }
+
+                var propertyName = (string)reader.Value!;
+                reader.Read();
+
+                switch (propertyName)
+                {
+                    case "Key":
+                        key = reader.Value as string;
+                        break;
+                    case "Value":
+                        value = reader.Value as string;
+                        break;
+                }
+            }
+
+            if (key != null && value != null)
+            {
+                baggage.Add(key, value);
+            }
+        }
+
+        return baggage;
+    }
+
+    public override void WriteJson(JsonWriter writer, Baggage? value, JsonSerializer serializer)
+    {
+        if (value is null)
+        {
+            writer.WriteNull();
+            return;
+        }
+
+        writer.WriteStartArray();
+        foreach (var entry in value)
+        {
+            writer.WriteStartObject();
+            writer.WritePropertyName("Key");
+            writer.WriteValue(entry.Key);
+            writer.WritePropertyName("Value");
+            writer.WriteValue(entry.Value);
+            writer.WriteEndObject();
+        }
+        writer.WriteEndArray();
+    }
+}

--- a/src/Paramore.Brighter/NJsonConverters/NBaggageConverter.cs
+++ b/src/Paramore.Brighter/NJsonConverters/NBaggageConverter.cs
@@ -70,6 +70,16 @@ public class NBaggageConverter : JsonConverter<Baggage>
             throw new JsonSerializationException($"Expected StartObject for Baggage entry, got {reader.TokenType}");
         }
 
+        var (key, value) = ReadKeyValuePair(reader);
+
+        if (key != null && value != null)
+        {
+            baggage.Add(key, value);
+        }
+    }
+
+    private static (string? Key, string? Value) ReadKeyValuePair(JsonReader reader)
+    {
         string? key = null;
         string? value = null;
 
@@ -83,21 +93,17 @@ public class NBaggageConverter : JsonConverter<Baggage>
             var propertyName = (string)reader.Value!;
             reader.Read();
 
-            switch (propertyName)
+            if (propertyName == "Key")
             {
-                case "Key":
-                    key = reader.Value as string;
-                    break;
-                case "Value":
-                    value = reader.Value as string;
-                    break;
+                key = reader.Value as string;
+            }
+            else if (propertyName == "Value")
+            {
+                value = reader.Value as string;
             }
         }
 
-        if (key != null && value != null)
-        {
-            baggage.Add(key, value);
-        }
+        return (key, value);
     }
 
     public override void WriteJson(JsonWriter writer, Baggage? value, JsonSerializer serializer)

--- a/src/Paramore.Brighter/NJsonConverters/NBaggageConverter.cs
+++ b/src/Paramore.Brighter/NJsonConverters/NBaggageConverter.cs
@@ -55,49 +55,49 @@ public class NBaggageConverter : JsonConverter<Baggage>
             throw new JsonSerializationException($"Expected StartArray for Baggage, got {reader.TokenType}");
         }
 
-        while (reader.Read())
+        while (reader.Read() && reader.TokenType != JsonToken.EndArray)
         {
-            if (reader.TokenType == JsonToken.EndArray)
-            {
-                break;
-            }
-
-            if (reader.TokenType != JsonToken.StartObject)
-            {
-                throw new JsonSerializationException($"Expected StartObject for Baggage entry, got {reader.TokenType}");
-            }
-
-            string? key = null;
-            string? value = null;
-
-            while (reader.Read() && reader.TokenType != JsonToken.EndObject)
-            {
-                if (reader.TokenType != JsonToken.PropertyName)
-                {
-                    continue;
-                }
-
-                var propertyName = (string)reader.Value!;
-                reader.Read();
-
-                switch (propertyName)
-                {
-                    case "Key":
-                        key = reader.Value as string;
-                        break;
-                    case "Value":
-                        value = reader.Value as string;
-                        break;
-                }
-            }
-
-            if (key != null && value != null)
-            {
-                baggage.Add(key, value);
-            }
+            ReadEntry(reader, baggage);
         }
 
         return baggage;
+    }
+
+    private static void ReadEntry(JsonReader reader, Baggage baggage)
+    {
+        if (reader.TokenType != JsonToken.StartObject)
+        {
+            throw new JsonSerializationException($"Expected StartObject for Baggage entry, got {reader.TokenType}");
+        }
+
+        string? key = null;
+        string? value = null;
+
+        while (reader.Read() && reader.TokenType != JsonToken.EndObject)
+        {
+            if (reader.TokenType != JsonToken.PropertyName)
+            {
+                continue;
+            }
+
+            var propertyName = (string)reader.Value!;
+            reader.Read();
+
+            switch (propertyName)
+            {
+                case "Key":
+                    key = reader.Value as string;
+                    break;
+                case "Value":
+                    value = reader.Value as string;
+                    break;
+            }
+        }
+
+        if (key != null && value != null)
+        {
+            baggage.Add(key, value);
+        }
     }
 
     public override void WriteJson(JsonWriter writer, Baggage? value, JsonSerializer serializer)

--- a/src/Paramore.Brighter/Observability/Baggage.cs
+++ b/src/Paramore.Brighter/Observability/Baggage.cs
@@ -24,6 +24,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
+using Paramore.Brighter.NJsonConverters;
 
 namespace Paramore.Brighter.Observability;
 
@@ -35,6 +36,8 @@ namespace Paramore.Brighter.Observability;
 /// Each entry consists of a key-value pair where the key identifies the vendor and the value contains user-defined request or workflow data.
 /// Note that baggage entries are not intended for telemetry data, but rather for user-defined metadata about a trace.
 /// </remarks>
+[System.Text.Json.Serialization.JsonConverter(typeof(BaggageConverter))]
+[Newtonsoft.Json.JsonConverter(typeof(NBaggageConverter))]
 public class Baggage : IEnumerable<KeyValuePair<string, string?>>
 {
     private readonly Dictionary<string, string> _entries = new();

--- a/tests/Paramore.Brighter.Core.Tests/MessageSerialisation/When_Baggage_Crosses_Stj_And_Newtonsoft.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageSerialisation/When_Baggage_Crosses_Stj_And_Newtonsoft.cs
@@ -1,0 +1,46 @@
+using System.Linq;
+using System.Text.Json;
+using Newtonsoft.Json;
+using Paramore.Brighter.JsonConverters;
+using Paramore.Brighter.Observability;
+using Xunit;
+
+namespace Paramore.Brighter.Core.Tests.MessageSerialisation;
+
+// Pins the wire-format parity decision for issue #4149: a Baggage value written by one
+// JSON stack must read identically on the other. This is critical for persistence stacks
+// that write outbox/inbox rows on one stack and consume them on the other.
+public class BaggageStjNewtonsoftParityTests
+{
+    [Fact]
+    public void When_Baggage_Is_Serialised_On_Stj_It_Deserialises_Identically_On_Newtonsoft()
+    {
+        var original = new Baggage();
+        original.Add("user", "alice");
+        original.Add("tenant", "acme");
+
+        var stjJson = System.Text.Json.JsonSerializer.Serialize(original, JsonSerialisationOptions.Options);
+        var roundTripped = JsonConvert.DeserializeObject<Baggage>(stjJson);
+
+        Assert.NotNull(roundTripped);
+        var entries = roundTripped!.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+        Assert.Equal("alice", entries["user"]);
+        Assert.Equal("acme", entries["tenant"]);
+    }
+
+    [Fact]
+    public void When_Baggage_Is_Serialised_On_Newtonsoft_It_Deserialises_Identically_On_Stj()
+    {
+        var original = new Baggage();
+        original.Add("user", "alice");
+        original.Add("tenant", "acme");
+
+        var newtonsoftJson = JsonConvert.SerializeObject(original);
+        var roundTripped = System.Text.Json.JsonSerializer.Deserialize<Baggage>(newtonsoftJson, JsonSerialisationOptions.Options);
+
+        Assert.NotNull(roundTripped);
+        var entries = roundTripped!.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+        Assert.Equal("alice", entries["user"]);
+        Assert.Equal("acme", entries["tenant"]);
+    }
+}

--- a/tests/Paramore.Brighter.Core.Tests/MessageSerialisation/When_Baggage_Crosses_Stj_And_Newtonsoft.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageSerialisation/When_Baggage_Crosses_Stj_And_Newtonsoft.cs
@@ -43,4 +43,17 @@ public class BaggageStjNewtonsoftParityTests
         Assert.Equal("alice", entries["user"]);
         Assert.Equal("acme", entries["tenant"]);
     }
+
+    [Fact]
+    public void When_Baggage_Is_Serialised_The_Bytes_Are_Identical_On_Both_Stacks()
+    {
+        var original = new Baggage();
+        original.Add("user", "alice");
+        original.Add("tenant", "acme");
+
+        var stjJson = System.Text.Json.JsonSerializer.Serialize(original, JsonSerialisationOptions.Options);
+        var newtonsoftJson = JsonConvert.SerializeObject(original);
+
+        Assert.Equal(stjJson, newtonsoftJson);
+    }
 }

--- a/tests/Paramore.Brighter.Core.Tests/MessageSerialisation/When_Message_Header_Custom_Properties_Cross_Stj_And_Newtonsoft.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageSerialisation/When_Message_Header_Custom_Properties_Cross_Stj_And_Newtonsoft.cs
@@ -1,0 +1,56 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Paramore.Brighter.JsonConverters;
+using Xunit;
+
+namespace Paramore.Brighter.Core.Tests.MessageSerialisation;
+
+// Pins value-level parity for the four custom-converter properties on MessageHeader
+// (Topic, ReplyTo, TraceParent, TraceState). Property *names* differ across the two
+// stacks because Brighter's STJ options use camelCase while Newtonsoft default is
+// PascalCase, but both serializers tolerate either casing on read, so cross-stack
+// interop depends on the *values* matching, not byte-equal JSON. Full deserialisation
+// parity for the whole MessageHeader is blocked on the unrelated ContentType issue
+// (tracked separately) — this test stays on serialisation only.
+public class MessageHeaderCustomPropertyParityTests
+{
+    [Fact]
+    public void When_Message_Header_Is_Serialised_The_Custom_Properties_Are_Identical_On_Both_Stacks()
+    {
+        var header = new MessageHeader(
+            messageId: "id-1",
+            topic: new RoutingKey("the.topic"),
+            messageType: MessageType.MT_EVENT,
+            replyTo: new RoutingKey("the.reply.to"),
+            traceParent: new TraceParent("00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"),
+            traceState: new TraceState("vendor=value"));
+
+        var stjJson = System.Text.Json.JsonSerializer.Serialize(header, JsonSerialisationOptions.Options);
+        var newtonsoftJson = JsonConvert.SerializeObject(header);
+
+        var stj = JObject.Parse(stjJson);
+        var newtonsoft = JObject.Parse(newtonsoftJson);
+
+        // Property *names* differ across stacks (STJ uses camelCase per
+        // JsonSerialisationOptions; Newtonsoft default is PascalCase). Both serializers
+        // tolerate either casing on read, so what matters for cross-stack interop is that
+        // the property *values* (the bare strings emitted by the four custom converters)
+        // are identical. That's what this pin asserts.
+        foreach (var (stjName, newtonsoftName) in new[]
+                 {
+                     ("topic", "Topic"),
+                     ("replyTo", "ReplyTo"),
+                     ("traceParent", "TraceParent"),
+                     ("traceState", "TraceState")
+                 })
+        {
+            var stjToken = stj[stjName];
+            var newtonsoftToken = newtonsoft[newtonsoftName];
+            Assert.NotNull(stjToken);
+            Assert.NotNull(newtonsoftToken);
+            Assert.Equal(JTokenType.String, stjToken!.Type);
+            Assert.Equal(JTokenType.String, newtonsoftToken!.Type);
+            Assert.Equal(stjToken.Value<string>(), newtonsoftToken.Value<string>());
+        }
+    }
+}

--- a/tests/Paramore.Brighter.Core.Tests/MessageSerialisation/When_Round_Tripping_A_Baggage_Through_Newtonsoft.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageSerialisation/When_Round_Tripping_A_Baggage_Through_Newtonsoft.cs
@@ -1,0 +1,31 @@
+using System.Linq;
+using Newtonsoft.Json;
+using Paramore.Brighter.Observability;
+using Xunit;
+
+namespace Paramore.Brighter.Core.Tests.MessageSerialisation;
+
+// Regression pin for issue #4149 (symptom 2) — Baggage implements
+// IEnumerable<KeyValuePair<string, string?>> but exposes Add(string, string) only.
+// Without a Newtonsoft converter, Newtonsoft infers a list-shaped target, finds no
+// matching Add(KeyValuePair<...>) overload, and throws JsonSerializationException on
+// deserialization. The fix ships NBaggageConverter and attributes it on the class so
+// default JsonConvert calls pick it up.
+public class BaggageNewtonsoftRoundTripTests
+{
+    [Fact]
+    public void When_Round_Tripping_A_Baggage_Through_Newtonsoft_The_Entries_Survive()
+    {
+        var baggage = new Baggage();
+        baggage.Add("user", "alice");
+        baggage.Add("tenant", "acme");
+
+        var json = JsonConvert.SerializeObject(baggage);
+        var roundTripped = JsonConvert.DeserializeObject<Baggage>(json);
+
+        Assert.NotNull(roundTripped);
+        var entries = roundTripped!.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+        Assert.Equal("alice", entries["user"]);
+        Assert.Equal("acme", entries["tenant"]);
+    }
+}

--- a/tests/Paramore.Brighter.Core.Tests/MessageSerialisation/When_Round_Tripping_A_Message_Header_Through_Newtonsoft.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageSerialisation/When_Round_Tripping_A_Message_Header_Through_Newtonsoft.cs
@@ -1,0 +1,44 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Paramore.Brighter.Core.Tests.MessageSerialisation;
+
+// Regression pin for issue #4149 (symptom 1) — prior to the fix, the
+// [Newtonsoft.Json.JsonConverter] attributes on MessageHeader.Topic, ReplyTo, TraceParent
+// and TraceState pointed at the System.Text.Json converter types, causing Newtonsoft.Json
+// to throw InvalidCastException when building the contract for MessageHeader. Newtonsoft
+// resolves the contract for the whole type up front, so a single mis-targeted attribute
+// breaks serialisation of *any* property on the type — meaning all four attributes must
+// be fixed together. This pin only covers serialisation + on-the-wire shape; full
+// Newtonsoft round-trip of a MessageHeader also requires the Baggage Newtonsoft converter
+// (symptom 2) which is covered by a separate test.
+public class MessageHeaderNewtonsoftRoundTripTests
+{
+    [Fact]
+    public void When_Serializing_A_Message_Header_Through_Newtonsoft_Custom_Converter_Properties_Are_Bare_Strings()
+    {
+        var header = new MessageHeader(
+            messageId: "id-1",
+            topic: new RoutingKey("the.topic"),
+            messageType: MessageType.MT_EVENT,
+            replyTo: new RoutingKey("the.reply.to"),
+            traceParent: new TraceParent("00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"),
+            traceState: new TraceState("vendor=value"));
+
+        var json = JsonConvert.SerializeObject(header);
+        var parsed = JObject.Parse(json);
+
+        Assert.Equal(JTokenType.String, parsed["Topic"]!.Type);
+        Assert.Equal("the.topic", parsed["Topic"]!.Value<string>());
+
+        Assert.Equal(JTokenType.String, parsed["ReplyTo"]!.Type);
+        Assert.Equal("the.reply.to", parsed["ReplyTo"]!.Value<string>());
+
+        Assert.Equal(JTokenType.String, parsed["TraceParent"]!.Type);
+        Assert.Equal("00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01", parsed["TraceParent"]!.Value<string>());
+
+        Assert.Equal(JTokenType.String, parsed["TraceState"]!.Type);
+        Assert.Equal("vendor=value", parsed["TraceState"]!.Value<string>());
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the two scoped symptoms in #4149 so `MessageHeader` and `Baggage` round-trip cleanly through `Newtonsoft.Json` with default settings (e.g. for apps persisting the inbox/outbox via Cosmos SDK's `CosmosJsonNetSerializer`).

- **Symptom 1** — `MessageHeader.Topic`, `ReplyTo`, `TraceParent`, `TraceState` had `[Newtonsoft.Json.JsonConverter(typeof(...))]` attributes pointing at the *STJ* converter types, causing Newtonsoft to throw `InvalidCastException` when resolving the contract for the whole `MessageHeader` type. Swapped to the existing `N*` Newtonsoft siblings in `Paramore.Brighter.NJsonConverters`.
- **Symptom 2** — `Baggage` implements `IEnumerable<KeyValuePair<string, string?>>` but exposes only `Add(string, string)`, so Newtonsoft inferred a list target and failed to populate it. Added `NBaggageConverter` mirroring the STJ wire shape, plus class-level `[JsonConverter(...)]` attributes (both STJ and Newtonsoft) on `Baggage` so default serializer settings on either stack pick the converter up automatically.

## Out of scope

`System.Net.Mime.ContentType.Parameters` on `MessageHeader.ContentType` has the same shape problem on the Newtonsoft side. The STJ side ships no custom converter for it today either, so this change matches existing parity and leaves `ContentType` for a follow-up. End-to-end Newtonsoft deserialisation of a full `MessageHeader` therefore still fails on `ContentType` until that follow-up lands; consumers can register their own `NContentTypeConverter` for now.

## Wire format

- `Baggage`: STJ and Newtonsoft emit byte-identical JSON (`[{"Key":"...","Value":"..."}]`). Pinned by a cross-stack round-trip test.
- `MessageHeader` custom-converter properties: values are identical, but property *names* differ (STJ camelCase via `JsonSerialisationOptions.Options` vs Newtonsoft default PascalCase). Both serializers tolerate either casing on read, so cross-stack interop works at the deserialiser level. Pinned by a value-parity test that documents the casing gap.

## Test plan

- [x] Added regression tests in `tests/Paramore.Brighter.Core.Tests/MessageSerialisation/`:
  - `When_Round_Tripping_A_Message_Header_Through_Newtonsoft` — symptom 1
  - `When_Round_Tripping_A_Baggage_Through_Newtonsoft` — symptom 2
  - `When_Baggage_Crosses_Stj_And_Newtonsoft` — cross-stack round-trip parity
  - `When_Message_Header_Custom_Properties_Cross_Stj_And_Newtonsoft` — value parity, documents casing gap
- [x] All 60 `MessageSerialisation` tests pass; full `Paramore.Brighter.Core.Tests` suite green (734 passed, 7 pre-existing skips).
- [ ] CI green on net8/net9/net10 across the matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)