### PR TITLE
fix: trim optional whitespace in W3C baggage delimiters (#4173)

### DIFF
--- a/src/Paramore.Brighter/Observability/Baggage.cs
+++ b/src/Paramore.Brighter/Observability/Baggage.cs
@@ -113,7 +113,9 @@ public class Baggage : IEnumerable<KeyValuePair<string, string?>>
             if (keyValue.Length != 2)
                 throw new ArgumentException($"Invalid tracestate format: {pair}", nameof(baggage));
 
-            Add(keyValue[0], keyValue[1]);
+            // The W3C baggage spec (https://www.w3.org/TR/baggage/#definition) permits optional
+            // whitespace (OWS) around the ',' and '=' delimiters, so trim it before validating.
+            Add(keyValue[0].Trim(), keyValue[1].Trim());
         }
     }
 

--- a/tests/Paramore.Brighter.Core.Tests/MessageSerialisation/When_Loading_Baggage_With_Optional_Whitespace.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageSerialisation/When_Loading_Baggage_With_Optional_Whitespace.cs
@@ -1,0 +1,32 @@
+using System.Linq;
+using Paramore.Brighter.Observability;
+using Xunit;
+
+namespace Paramore.Brighter.Core.Tests.MessageSerialisation;
+
+// Regression pin for issue #4173 — Sentry (and any W3C-conformant producer) emits the
+// baggage header with optional whitespace (OWS) around the "," and "=" delimiters, e.g.
+// "sentry-trace_id = abc, sentry-public_key = def". The W3C baggage spec
+// (https://www.w3.org/TR/baggage/#definition) permits OWS around those delimiters, so the
+// surrounding whitespace must be trimmed before the key/value are validated.
+public class LoadBaggageWhitespaceTests
+{
+    [Fact]
+    public void When_Loading_Baggage_With_Optional_Whitespace_Around_Delimiters_The_Entries_Are_Parsed()
+    {
+        // Arrange — a real Sentry baggage header with OWS around '=' and ','
+        const string sentryBaggage =
+            "sentry-trace_id = 5ad257b8d9100d1a5dd03b424db74400, " +
+            "sentry-public_key = 1457b9474f0a1771a57da2a09fda6cdc, " +
+            "sentry-sampled = true";
+
+        // Act
+        var baggage = Baggage.FromString(sentryBaggage);
+
+        // Assert — keys and values are trimmed of the optional whitespace
+        var entries = baggage.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+        Assert.Equal("5ad257b8d9100d1a5dd03b424db74400", entries["sentry-trace_id"]);
+        Assert.Equal("1457b9474f0a1771a57da2a09fda6cdc", entries["sentry-public_key"]);
+        Assert.Equal("true", entries["sentry-sampled"]);
+    }
+}


### PR DESCRIPTION
## Problem

Fixes #4173.

Sentry (and other W3C-conformant producers) emit the `baggage` header with optional whitespace (OWS) around the `,` and `=` delimiters, e.g.:

```
baggage: sentry-trace_id = 5ad257b8d9100d1a5dd03b424db74400, sentry-public_key = 1457b9474f0a1771a57da2a09fda6cdc, sentry-sampled = true
```

`Baggage.LoadBaggage` split on `,` then `=` **without trimming**, so the key became `"sentry-trace_id "` (trailing space) and the value `" 5ad2…"` (leading space). Both then failed the W3C `KeyRegex`/`ValueRegex`, throwing `ArgumentException: Invalid key format`. On the consumer side this surfaced as a failed message parse and the message being rejected:

```
System.ArgumentException: Invalid key format (Parameter 'key')
   at Paramore.Brighter.Observability.Baggage.Add(...)
   at Paramore.Brighter.Observability.Baggage.LoadBaggage(...)
```

The [W3C baggage spec](https://www.w3.org/TR/baggage/#definition) explicitly permits OWS around those delimiters, so the surrounding whitespace must be stripped before validation.

## Fix

Trim each key and value after splitting in `LoadBaggage`:

```csharp
// The W3C baggage spec permits optional whitespace (OWS) around the ',' and '=' delimiters.
Add(keyValue[0].Trim(), keyValue[1].Trim());
```

## Tests

Added a regression test (`When_Loading_Baggage_With_Optional_Whitespace`) using the real Sentry header from the issue. RED → GREEN; all existing Baggage/TraceState tests stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)