### PR TITLE
fix(asb): add SequenceNumber to ReservedHeaders to prevent duplicate key on redelivery

### DIFF
--- a/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/ASBConstants.cs
+++ b/src/Paramore.Brighter.MessagingGateway.AzureServiceBus/ASBConstants.cs
@@ -24,7 +24,7 @@
         public const string TraceParent = "cloudevents:traceparent";
         public const string TraceState = "cloudevents:tracestate";
 
-        public static readonly string[] ReservedHeaders = [LockTokenHeaderBagKey, MessageTypeHeaderBagKey, HandledCountHeaderBagKey, ReplyToHeaderBagKey, SessionIdKey
+        public static readonly string[] ReservedHeaders = [LockTokenHeaderBagKey, SequenceNumberBagKey, MessageTypeHeaderBagKey, HandledCountHeaderBagKey, ReplyToHeaderBagKey, SessionIdKey
         ];
     }
 }

--- a/tests/Paramore.Brighter.AzureServiceBus.Tests/MessagingGateway/When_A_Deferred_Message_Is_Redelivered.cs
+++ b/tests/Paramore.Brighter.AzureServiceBus.Tests/MessagingGateway/When_A_Deferred_Message_Is_Redelivered.cs
@@ -1,28 +1,3 @@
-#region Licence
-
-/* The MIT License (MIT)
-Copyright © 2014 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE. */
-
-#endregion
-
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/tests/Paramore.Brighter.AzureServiceBus.Tests/MessagingGateway/When_A_Deferred_Message_Is_Redelivered.cs
+++ b/tests/Paramore.Brighter.AzureServiceBus.Tests/MessagingGateway/When_A_Deferred_Message_Is_Redelivered.cs
@@ -1,0 +1,105 @@
+#region Licence
+
+/* The MIT License (MIT)
+Copyright © 2014 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Paramore.Brighter.AzureServiceBus.Tests.TestDoubles;
+using Paramore.Brighter.MessagingGateway.AzureServiceBus;
+using Xunit;
+
+namespace Paramore.Brighter.AzureServiceBus.Tests.MessagingGateway;
+
+/// <summary>
+/// Covers the bug where DeferMessageAction caused a requeued message to carry
+/// SequenceNumber in ApplicationProperties. On redelivery, MapToBrighterMessage
+/// would throw ArgumentException (duplicate key) because SequenceNumber was
+/// already added from the native broker property.
+/// Fix: SequenceNumber is in ASBConstants.ReservedHeaders so it is never written
+/// to ApplicationProperties during requeue.
+/// </summary>
+[Trait("Category", "ASB")]
+public class When_A_Deferred_Message_Is_Redelivered
+{
+    private readonly AzureServiceBusMesssageCreator _creator;
+
+    public When_A_Deferred_Message_Is_Redelivered()
+    {
+        var subscription = new AzureServiceBusSubscription<ASBTestCommand>(
+            subscriptionName: new SubscriptionName("test-sub"),
+            channelName: new ChannelName("test-channel"),
+            routingKey: new RoutingKey("test-topic"),
+            messagePumpType: MessagePumpType.Reactor);
+
+        _creator = new AzureServiceBusMesssageCreator(subscription);
+    }
+
+    [Fact]
+    public void When_a_deferred_message_is_redelivered_it_does_not_throw_a_duplicate_key_exception()
+    {
+        // Arrange — first delivery from ASB
+        var firstDelivery = new BrokeredMessage
+        {
+            MessageBodyValue = Encoding.UTF8.GetBytes("{\"key\":\"value\"}"),
+            ApplicationProperties = new Dictionary<string, object>
+            {
+                { "MessageType", "MT_COMMAND" }
+            },
+            LockToken = Guid.NewGuid().ToString(),
+            SequenceNumber = 100L,
+            Id = Guid.NewGuid().ToString(),
+            CorrelationId = Guid.NewGuid().ToString(),
+            ContentType = "application/json"
+        };
+
+        // First receive — handler will throw DeferMessageAction, triggering a requeue
+        var brighterMessage = _creator.MapToBrighterMessage(firstDelivery);
+
+        // Simulate requeue: Brighter calls ConvertToServiceBusMessage and republishes.
+        // SequenceNumber must NOT appear in ApplicationProperties of the requeued message.
+        var requeued = AzureServiceBusMessagePublisher.ConvertToServiceBusMessage(brighterMessage);
+        Assert.False(requeued.ApplicationProperties.ContainsKey("SequenceNumber"),
+            "SequenceNumber must not be written to ApplicationProperties on requeue — " +
+            "it is a broker-assigned property and must stay in ReservedHeaders.");
+
+        // Arrange — second delivery (redelivery of the requeued message with the same sequence number)
+        var secondDelivery = new BrokeredMessage
+        {
+            MessageBodyValue = Encoding.UTF8.GetBytes("{\"key\":\"value\"}"),
+            ApplicationProperties = requeued.ApplicationProperties
+                .ToDictionary(kvp => kvp.Key, kvp => kvp.Value),
+            LockToken = Guid.NewGuid().ToString(),
+            SequenceNumber = firstDelivery.SequenceNumber,
+            Id = firstDelivery.Id,
+            CorrelationId = firstDelivery.CorrelationId,
+            ContentType = "application/json"
+        };
+
+        // Act & Assert — must not throw ArgumentException: duplicate key SequenceNumber
+        var redelivered = _creator.MapToBrighterMessage(secondDelivery);
+        Assert.Equal(firstDelivery.SequenceNumber, redelivered.Header.Bag["SequenceNumber"]);
+    }
+}

--- a/tests/Paramore.Brighter.AzureServiceBus.Tests/MessagingGateway/When_Converting_A_Message_With_Local_Headers.cs
+++ b/tests/Paramore.Brighter.AzureServiceBus.Tests/MessagingGateway/When_Converting_A_Message_With_Local_Headers.cs
@@ -8,6 +8,26 @@ namespace Paramore.Brighter.AzureServiceBus.Tests.MessagingGateway;
 public class AzureServiceBusMessagePublisherLocalHeaderTests
 {
     [Fact]
+    public void When_Converting_A_Message_The_SequenceNumber_Bag_Entry_Is_Not_Written_To_ApplicationProperties()
+    {
+        // SequenceNumber is a broker-assigned system property on every delivery.
+        // It must not round-trip through ApplicationProperties — if it did, a requeued
+        // message would arrive back with SequenceNumber in both its native property and
+        // ApplicationProperties, causing a duplicate-key crash in MapToBrighterMessage.
+        var header = new MessageHeader(
+            messageId: Guid.NewGuid().ToString(),
+            topic: new RoutingKey("test.topic"),
+            messageType: MessageType.MT_COMMAND);
+        header.Bag["SequenceNumber"] = 42L;
+
+        var message = new Message(header, new MessageBody("body"));
+
+        var asbMessage = AzureServiceBusMessagePublisher.ConvertToServiceBusMessage(message);
+
+        Assert.False(asbMessage.ApplicationProperties.ContainsKey("SequenceNumber"));
+    }
+
+    [Fact]
     public void When_Converting_A_Message_The_ProducerTopic_Local_Header_Is_Stripped()
     {
         var header = new MessageHeader(


### PR DESCRIPTION
## Summary

- `SequenceNumber` was surfaced in the message header bag (`AzureServiceBusMesssageCreator.cs:110`) but not added to `ASBConstants.ReservedHeaders`
- On requeue (`DeferMessageAction`), the publisher serialised it into `ApplicationProperties` of the outgoing message
- On redelivery, `MapToBrighterMessage` added the native broker `SequenceNumber` (line 110), then hit the stale copy in `ApplicationProperties` (line 114), throwing `ArgumentException: An item with the same key has already been added. Key: SequenceNumber`
- Fix: add `SequenceNumberBagKey` to `ReservedHeaders` — the same protection `LockToken` has always had

## Test plan

- [ ] `When_Converting_A_Message_The_SequenceNumber_Bag_Entry_Is_Not_Written_To_ApplicationProperties` — asserts the fix: `SequenceNumber` is absent from `ApplicationProperties` after `ConvertToServiceBusMessage`
- [ ] `When_a_deferred_message_is_redelivered_it_does_not_throw_a_duplicate_key_exception` — full round-trip: receive → requeue → receive again without `ArgumentException`
- [ ] `When_mapping_a_message_the_sequence_number_is_added_to_the_header_bag` — existing test confirms `SequenceNumber` still reaches the consumer bag after the fix

Closes https://github.com/BrighterCommand/Brighter/issues/4186

🤖 Generated with [Claude Code](https://claude.ai/code)