### PR TITLE
fix: preserve MessageHeader.Bag keys verbatim through serialization (#4151)

### DIFF
--- a/src/Paramore.Brighter/JsonConverters/JsonSerialisationOptions.cs
+++ b/src/Paramore.Brighter/JsonConverters/JsonSerialisationOptions.cs
@@ -8,8 +8,10 @@ namespace Paramore.Brighter.JsonConverters
     /// <summary>
     /// Global Configuration for the Json Serializer
     /// We provide custom type converters, particularly around serializing objects so that they appear as types not JsonElement
-    /// The camelCase property will convert a key, such as a header bag key, to camelCase if you use UpperCase and so if you expect
-    /// an UpperCase property you will find that it is now a camelCase one. It is best to use camelCase names for this reason
+    /// The <see cref="JsonSerializerOptions.PropertyNamingPolicy"/> (camelCase) applies to C# property names only.
+    /// Dictionary keys — such as <see cref="MessageHeader.Bag"/> keys — are serialized verbatim by
+    /// <see cref="Serialization.DictionaryStringObjectJsonConverter"/>, so a key written as "SessionId" is read back
+    /// as "SessionId".
     /// </summary>
     public static class JsonSerialisationOptions
     {

--- a/src/Paramore.Brighter/MessageHeader.cs
+++ b/src/Paramore.Brighter/MessageHeader.cs
@@ -154,8 +154,9 @@ namespace Paramore.Brighter
 
         /// <summary>
         /// A property bag that can be used for extended header attributes.
-        /// Use camelCase for the key names if you intend to read it yourself, as when converted to and from Json serializers will tend convert the property
-        /// name from UpperCase to camelCase
+        /// Key names round-trip verbatim through Brighter's serialization, so you can read a key back
+        /// using the exact name you wrote (for example "SessionId"); Brighter no longer applies a naming
+        /// policy to bag keys.
         /// </summary>
         /// <value>The bag.</value>
         public Dictionary<string, object> Bag { get; set; } = new();

--- a/src/Paramore.Brighter/Serialization/DictionaryStringObjectJsonConverter.cs
+++ b/src/Paramore.Brighter/Serialization/DictionaryStringObjectJsonConverter.cs
@@ -53,18 +53,21 @@ namespace Paramore.Brighter.Serialization
 
             foreach (var entry in dictionary)
             {
+                //Bag keys are arbitrary user-defined identifiers, not C# property names, so they must
+                //round-trip verbatim. We deliberately do NOT apply PropertyNamingPolicy here: doing so
+                //rewrote keys such as "SessionId" to "sessionId", silently breaking consumers that look
+                //the key up by its original name (see #4151 / #4054).
                 var propertyName = entry.Key;
-                var convertedPropName = options.PropertyNamingPolicy?.ConvertName(propertyName) ?? propertyName;
 
                 if (entry.Value != null)
                 {
-                    writer.WritePropertyName(convertedPropName);
+                    writer.WritePropertyName(propertyName);
                     var valueConverter = new ObjectToInferredTypesConverter();
                     valueConverter.Write(writer, entry.Value, options);
                 }
                 else
                 {
-                    writer.WriteNull(convertedPropName);
+                    writer.WriteNull(propertyName);
                 }
             }
 

--- a/tests/Paramore.Brighter.Core.Tests/CloudEvents/When_migrating_subject_from_bag_to_header.cs
+++ b/tests/Paramore.Brighter.Core.Tests/CloudEvents/When_migrating_subject_from_bag_to_header.cs
@@ -8,31 +8,33 @@ using Xunit;
 namespace Paramore.Brighter.Core.Tests.CloudEvents;
 
 /// <summary>
-/// Demonstrates the V9 → V10 migration issue for Subject (PR #4132).
-/// In V9, users put Subject in the Bag and the Bag preserved PascalCase keys.
-/// In V10, the Bag serialization applies camelCase to dictionary keys, so "Subject" becomes "subject",
-/// causing downstream consumers (e.g. Python Lambdas reading SNS notifications) to fail with KeyError.
-/// The fix is to use MessageHeader.Subject instead of the Bag, which feeds the native SNS Subject field.
+/// Covers the V9 → V10 migration for Subject (PR #4132), and the root-cause fix for #4151 / #4054.
+/// In V9, users put Subject in the Bag and the Bag preserved PascalCase keys. V10 briefly applied the
+/// camelCase naming policy to dictionary keys, so "Subject" became "subject" and downstream consumers
+/// (e.g. Python Lambdas reading SNS notifications) failed with KeyError. Bag keys are arbitrary user
+/// identifiers, not C# property names, so the naming policy is no longer applied to them and the key
+/// now round-trips verbatim. Using MessageHeader.Subject (which feeds the native SNS Subject field)
+/// remains the recommended pattern.
 /// </summary>
 public class When_migrating_subject_from_bag_to_header
 {
     [Fact]
-    public void When_subject_is_in_bag_serialization_converts_to_camelCase()
+    public void When_subject_is_in_bag_serialization_preserves_the_key_verbatim()
     {
-        //Arrange - V9 pattern: user puts Subject in the Bag with PascalCase key
+        //Arrange - V9 pattern: user puts Subject in the Bag with a PascalCase key
         var message = new Message(
             new MessageHeader(Id.Random(), new RoutingKey("Test.Topic"), MessageType.MT_EVENT),
             new MessageBody("{\"orderId\": 123}"));
 
         message.Header.Bag.Add("Subject", "OrderAccepted");
 
-        //Act - serialize the Bag as V10 does (using JsonSerialisationOptions with CamelCase policy)
+        //Act - serialize the Bag through Brighter's options
         var bagJson = JsonSerializer.Serialize(message.Header.Bag, JsonSerialisationOptions.Options);
 
-        //Assert - the key is now camelCase, so a consumer looking for "Subject" won't find it
+        //Assert - the key survives verbatim, so a consumer looking for "Subject" still finds it
         using var doc = JsonDocument.Parse(bagJson);
-        Assert.True(doc.RootElement.TryGetProperty("subject", out _), "Bag key should be serialized as camelCase 'subject'");
-        Assert.False(doc.RootElement.TryGetProperty("Subject", out _), "Bag key 'Subject' should not survive serialization as PascalCase");
+        Assert.True(doc.RootElement.TryGetProperty("Subject", out _), "Bag key 'Subject' should survive serialization verbatim");
+        Assert.False(doc.RootElement.TryGetProperty("subject", out _), "Bag key should not be rewritten to camelCase 'subject'");
     }
 
     [Fact]

--- a/tests/Paramore.Brighter.Core.Tests/MessageSerialisation/When_A_Bag_Key_Round_Trips_Through_Brighter_Json_Options.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageSerialisation/When_A_Bag_Key_Round_Trips_Through_Brighter_Json_Options.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using Paramore.Brighter.JsonConverters;
+using Xunit;
+
+namespace Paramore.Brighter.Core.Tests.MessageSerialisation;
+
+// Root-cause pin for #4151 / #4054: Header.Bag keys are arbitrary user identifiers, not C#
+// property names, so they must round-trip verbatim through Brighter's serialization. Applying
+// PropertyNamingPolicy (camelCase by default) to dictionary keys rewrites "SessionId" to
+// "sessionId", which silently breaks consumers that look the key up by its original name.
+public class BagKeyRoundTripTests
+{
+    [Theory]
+    [InlineData("SessionId")]   // PascalCase — the key that camelCase mangles to "sessionId"
+    [InlineData("PartitionKey")]
+    [InlineData("customer.header")] // already lowercase — must also be untouched
+    public void When_Round_Tripping_A_Bag_Key_It_Survives_Verbatim(string key)
+    {
+        var bag = new Dictionary<string, object> { [key] = "a-value" };
+
+        var json = JsonSerializer.Serialize(bag, JsonSerialisationOptions.Options);
+        var roundTripped = JsonSerializer.Deserialize<Dictionary<string, object>>(json, JsonSerialisationOptions.Options);
+
+        Assert.NotNull(roundTripped);
+        Assert.True(roundTripped!.ContainsKey(key), $"expected the bag key '{key}' to survive verbatim");
+        Assert.Equal("a-value", roundTripped[key]);
+    }
+}

--- a/tests/Paramore.Brighter.Core.Tests/MessageSerialisation/When_A_Bag_Key_Round_Trips_Through_Brighter_Json_Options.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageSerialisation/When_A_Bag_Key_Round_Trips_Through_Brighter_Json_Options.cs
@@ -26,4 +26,24 @@ public class BagKeyRoundTripTests
         Assert.True(roundTripped!.ContainsKey(key), $"expected the bag key '{key}' to survive verbatim");
         Assert.Equal("a-value", roundTripped[key]);
     }
+
+    [Fact]
+    public void When_Round_Tripping_A_Message_Header_A_Pascal_Case_Bag_Key_Is_Readable()
+    {
+        //guards the real user-facing path: the Bag as wired into MessageHeader serialization,
+        //not just a bare dictionary through the converter
+        var header = new MessageHeader(
+            messageId: Id.Random(),
+            topic: new RoutingKey("Test.Topic"),
+            messageType: MessageType.MT_EVENT);
+        header.Bag["SessionId"] = "order-42";
+
+        var json = JsonSerializer.Serialize(header, JsonSerialisationOptions.Options);
+        var roundTripped = JsonSerializer.Deserialize<MessageHeader>(json, JsonSerialisationOptions.Options);
+
+        Assert.NotNull(roundTripped);
+        Assert.True(roundTripped!.Bag.TryGetValue("SessionId", out var sessionId),
+            "expected the PascalCase bag key 'SessionId' to be readable after a MessageHeader round-trip");
+        Assert.Equal("order-42", sessionId);
+    }
 }


### PR DESCRIPTION
## What

Fixes #4151 at the root: `MessageHeader.Bag` keys now round-trip **verbatim** through Brighter's serialization instead of being rewritten by the camelCase naming policy.

Closes #4151.
Closes #4214.

## Root cause

`DictionaryStringObjectJsonConverter.Write` applied `JsonSerialisationOptions.Options.PropertyNamingPolicy` (default `JsonNamingPolicy.CamelCase`) to dictionary **keys** as well as property names. A bag key written as `"SessionId"` was therefore serialized as `"sessionId"`. Bag keys are arbitrary user-defined identifiers, not C# property names, so any consumer that looks the key up by its original name missed it — silently.

Note (from review): `DictionaryStringObjectJsonConverter.Read` never applied the policy — it reads keys via `reader.GetString()` verbatim. So `Write` and `Read` were **asymmetric**, and even a same-process serialize→deserialize already mangled PascalCase keys. This change makes `Write` symmetric with the existing `Read`, rather than introducing new behaviour.

This is the shared root cause behind a cluster of issues/bugs:
- #4054 / #4205 — ASB `SessionId` dropped after an Outbox round-trip.
- #4132 — `Subject` put in the Bag arrived camelCased, breaking downstream consumers (e.g. Python Lambdas reading SNS notifications by PascalCase key); that PR worked around it by moving `Subject` to `MessageHeader.Subject`.
- #4214 — the survey of other exact-match bag lookups (RocketMQ `Keys`/`Tag`, AWS `messageDeduplicationId`, core `ProducerTopic`, ASB scheduler).

### Origin of the mutation

Traced to the converter's introduction in #1531 — the key transformation was copied from the reference implementation the converter is *based on* (Josef Ottoson's), not added to fix a specific Brighter problem. So there is no known behaviour that intentionally relies on it.

## Fix

Stop applying the naming policy to dictionary keys — write them verbatim. `PropertyNamingPolicy` still governs real `MessageHeader` property names, so the property wire format is unchanged; **only Bag keys** are affected.

### Scope

`DictionaryStringObjectJsonConverter` is registered globally in `JsonSerialisationOptions` and applies to **every** `Dictionary<string, object?>` Brighter serializes (`MessageHeader.Bag`, `RequestContext` bags, outbox/scheduler payloads, any internal dictionary) — not just `MessageHeader.Bag`. This is intended: dictionary keys are data, not property names, and should not be case-mangled. Because `Read` never applied the policy, no in-process consumer could have depended on the old `Write` casing.

## Why this closes #4214

#4214 catalogued the other exact-match `Bag.TryGetValue(constant)` lookups that the camelCase policy could break (RocketMQ `Keys`/`Tag`, AWS `messageDeduplicationId`, core `ProducerTopic`; plus the ASB scheduler, which reads an empty bag and was never live). Now that keys round-trip verbatim under **any** policy, every one of those lookups is correct as written — the "make each read site policy-aware" direction #4214 proposed is no longer needed. The #4205 policy-aware reader (`ASBConstants.IsBagKey`) is retained for ASB only, as a belt-and-braces compat shim for messages persisted under the old camelCasing during an upgrade drain.

## Tests

- `BagKeyRoundTripTests` — pins that PascalCase (`SessionId`, `PartitionKey`) and lowercase (`customer.header`) bag keys survive verbatim, both through the converter directly and through a full `MessageHeader` round-trip.
- `When_migrating_subject_from_bag_to_header` — previously a **characterisation test** that asserted the bug (`converts_to_camelCase`); now asserts the key is preserved. The `Header.Subject` guidance from #4132 remains valid and those tests are unchanged.
- Full `Paramore.Brighter.Core.Tests`: 849 passed, 0 failed, 7 skipped. The only test that changed behaviour was the characterisation test above.

## Risk / reviewer notes

- **In-flight wire compatibility (drain window):** messages already written to a persistent Outbox/queue under the old camelCasing hold keys like `"sessionId"`; after this change they are read back verbatim. Code looking for `"SessionId"` won't match during the drain. ASB is covered by the #4205 policy-aware reader; the other gateways folded in from #4214 (RocketMQ, AWS, core `ProducerTopic`) have **no** such shim, so their pre-upgrade in-flight messages would miss the lookup during the drain — transient and niche, but worth a release-notes callout.
- **Not exercised here:** the persistent-outbox suites (SQL / Mongo / DynamoDB) need live infra. They store the same JSON and read keys back with the same literal, so no key-level regression is expected, but they should be run in CI before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)