### PR TITLE
Await in-memory publish confirmation handling

### DIFF
--- a/src/Paramore.Brighter/ISupportPublishConfirmationAsync.cs
+++ b/src/Paramore.Brighter/ISupportPublishConfirmationAsync.cs
@@ -1,0 +1,34 @@
+#region Licence
+/* The MIT License (MIT)
+Copyright © 2026 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+using System;
+using System.Threading.Tasks;
+
+namespace Paramore.Brighter
+{
+    internal interface ISupportPublishConfirmationAsync
+    {
+        event Func<PublishConfirmationResult, Task> OnMessagePublishedAsync;
+    }
+}

--- a/src/Paramore.Brighter/InMemoryMessageProducer.cs
+++ b/src/Paramore.Brighter/InMemoryMessageProducer.cs
@@ -38,13 +38,14 @@ namespace Paramore.Brighter
     /// The in-memory producer is mainly intended for usage with tests. It allows you to send messages to a bus and
     /// then inspect the messages that have been sent.
     /// </summary>
-    public sealed class InMemoryMessageProducer : IAmAMessageProducerSync, IAmAMessageProducerAsync, IAmABulkMessageProducerAsync, ISupportPublishConfirmation
+    public sealed class InMemoryMessageProducer : IAmAMessageProducerSync, IAmAMessageProducerAsync, IAmABulkMessageProducerAsync, ISupportPublishConfirmation, ISupportPublishConfirmationAsync
     {
         private readonly IAmABus _bus;
         private readonly InstrumentationOptions _instrumentationOptions;
         private readonly System.Threading.Channels.Channel<WorkItem> _channel =
             System.Threading.Channels.Channel.CreateUnbounded<WorkItem>(new UnboundedChannelOptions { SingleReader = true });
         private readonly List<Task> _raiseTasks = new(); // drain worker is single-threaded; read only after worker completes
+        private event Func<PublishConfirmationResult, Task>? OnMessagePublishedAsync;
         // volatile so a DisposeAsync on another thread sees the worker the CAS winner publishes (NFR-3)
         private volatile Task? _worker;
         private int _pumpStarted; // 0 = not started, 1 = started; CAS guard
@@ -125,6 +126,12 @@ namespace Paramore.Brighter
         /// What action should we take on confirmation that a message has been published to a broker
         /// </summary>
         public event Action<PublishConfirmationResult>? OnMessagePublished;
+
+        event Func<PublishConfirmationResult, Task> ISupportPublishConfirmationAsync.OnMessagePublishedAsync
+        {
+            add => OnMessagePublishedAsync += value;
+            remove => OnMessagePublishedAsync -= value;
+        }
 
         /// <summary>
         /// Dispose of the producer. Blocks until any in-flight async pump has fully drained
@@ -241,11 +248,11 @@ namespace Paramore.Brighter
         {
             if (PublishFailurePredicate?.Invoke(message) == true)
             {
-                OnMessagePublished?.Invoke(new PublishConfirmationResult(false, message.Id, message.Header.Topic, null));
+                RaisePublishConfirmation(new PublishConfirmationResult(false, message.Id, message.Header.Topic, null));
                 return;
             }
             _bus.Enqueue(message);
-            OnMessagePublished?.Invoke(new PublishConfirmationResult(true, message.Id, message.Header.Topic, null));
+            RaisePublishConfirmation(new PublishConfirmationResult(true, message.Id, message.Header.Topic, null));
         }
 
         private async Task DrainAsync()
@@ -256,17 +263,31 @@ namespace Paramore.Brighter
                 {
                     var failResult = new PublishConfirmationResult(false, item.Message.Id, item.Message.Header.Topic, item.Context);
                     _raiseTasks.Add(Task.Run(() => OnMessagePublished?.Invoke(failResult)));
+                    await RaisePublishConfirmationAsync(failResult);
                     continue;
                 }
                 _bus.Enqueue(item.Message);
                 var successResult = new PublishConfirmationResult(true, item.Message.Id, item.Message.Header.Topic, item.Context);
-                // NOTE: when the subscriber is an async-void callback (as the mediator's success branch is, which
-                // awaits MarkDispatchedAsync), Invoke returns at its first await — so this raise Task completes, and
-                // DisposeAsync's drain therefore awaits, only up to that first await, NOT the whole callback. Do not
-                // rely on DisposeAsync having flushed a success-path MarkDispatched. The failure path has no await
-                // before TripTopic, so it does drain to completion (which the trip/isolation tests depend on).
                 _raiseTasks.Add(Task.Run(() => OnMessagePublished?.Invoke(successResult)));
+                await RaisePublishConfirmationAsync(successResult);
             }
+        }
+
+        private void RaisePublishConfirmation(PublishConfirmationResult result)
+        {
+            OnMessagePublished?.Invoke(result);
+            if (OnMessagePublishedAsync is not null)
+                BrighterAsyncContext.Run(() => RaisePublishConfirmationAsync(result));
+        }
+
+        private async Task RaisePublishConfirmationAsync(PublishConfirmationResult result)
+        {
+            var handlers = OnMessagePublishedAsync;
+            if (handlers is null)
+                return;
+
+            foreach (Func<PublishConfirmationResult, Task> handler in handlers.GetInvocationList())
+                await handler(result);
         }
 
         /// <summary>

--- a/src/Paramore.Brighter/OutboxProducerMediator.cs
+++ b/src/Paramore.Brighter/OutboxProducerMediator.cs
@@ -764,81 +764,88 @@ namespace Paramore.Brighter
         /// <returns></returns>
         private void ConfigureAsyncPublisherCallbackMaybe(IAmAMessageProducerAsync producer, RequestContext requestContext)
         {
+            if (producer is ISupportPublishConfirmationAsync asyncConfirmingProducer)
+            {
+                asyncConfirmingProducer.OnMessagePublishedAsync += result =>
+                    HandleAsyncPublishConfirmation(result, requestContext);
+                return;
+            }
+
             if (producer is ISupportPublishConfirmation confirmingProducer)
             {
                 confirmingProducer.OnMessagePublished += async delegate(PublishConfirmationResult result)
                 {
-                    // Emit a standalone confirmation span FIRST on every invocation (success or
-                    // failure). It links back to the original publish span (when its context was
-                    // captured at send time) rather than reopening it, and degrades to no link when
-                    // the context is absent. The observability work is isolated in try/catch so a
-                    // tracing fault can never destabilise the producer thread (NFR-4); the span is
-                    // disposed in the finally so it starts and stops within the callback (NFR-2).
-                    Activity? confirmationSpan = null;
-                    try
-                    {
-                        var links = result.PublishSpanContext is { } publishContext
-                            ? new[] { new ActivityLink(publishContext) }
-                            : null;
-                        confirmationSpan = _tracer?.CreateConfirmationSpan(
-                            result.MessageId, result.Topic, result.Success, links);
-                    }
-                    catch (Exception ex)
-                    {
-                        Log.ConfirmationObservabilityFault(s_logger, ex);
-                    }
-
-                    try
-                    {
-                        if (result.Success)
-                        {
-                            Log.SentMessage(s_logger, result.MessageId.Value);
-                            if (_asyncOutbox != null)
-                            {
-                                // Explicitly re-parent the MarkDispatched DB span to the confirmation
-                                // span (S2): CreateDbSpan parents from requestContext.Span, so we pass a
-                                // per-callback copy whose Span is S2 rather than relying on the ambient
-                                // Activity.Current fallback (C-6). A copy is required because
-                                // RequestContext.Span is thread-keyed and its setter ignores null, so we
-                                // must not mutate the shared construction-time context.
-                                var dispatchedContext = (RequestContext)requestContext.CreateCopy();
-                                dispatchedContext.Span = confirmationSpan;
-                                await ExecuteWithResiliencePipelineAsync(
-                                    async ct =>
-                                        await _asyncOutbox.MarkDispatchedAsync(result.MessageId, dispatchedContext, _timeProvider.GetUtcNow(),
-                                            cancellationToken: ct),
-                                    dispatchedContext
-                                );
-                            }
-                        }
-                        else
-                        {
-                            Log.ConfirmationFailed(s_logger, result.MessageId.Value, result.Topic?.Value ?? string.Empty);
-                            // Trip the breaker on the wire topic (result.Topic == message.Header.Topic),
-                            // not the Publication topic — exact parity with the non-confirmation send
-                            // failure path (see DispatchAsync). TripTopic safely no-ops on null/empty.
-                            TripTopic(result.Topic);
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        // This delegate is async void: an exception that escapes it is unobserved on the
-                        // producer's broker/threadpool thread and is process-terminating by default. Keep the
-                        // safety LOCAL and obvious rather than relying on ExecuteWithResiliencePipelineAsync
-                        // happening to absorb the MarkDispatched path — a future caller (or a throwing breaker,
-                        // logger or context copy) must not be able to crash the producer. The message is left
-                        // un-dispatched, so the Sweeper will retry it (C-1); we log at Warning, not Error,
-                        // because nothing is lost.
-                        Log.ConfirmationDispatchError(s_logger, result.MessageId.Value, result.Topic?.Value ?? string.Empty, ex);
-                    }
-                    finally
-                    {
-                        // End via the tracer (not raw Dispose) so the end time is stamped from the tracer's
-                        // TimeProvider — matching the start time set in CreateConfirmationSpan — and a
-                        // successful span gets Ok status, consistent with every other span in this file.
-                        _tracer?.EndSpan(confirmationSpan);
-                    }
+                    await HandleAsyncPublishConfirmation(result, requestContext);
                 };
+            }
+        }
+
+        private async Task HandleAsyncPublishConfirmation(PublishConfirmationResult result, RequestContext requestContext)
+        {
+            // Emit a standalone confirmation span FIRST on every invocation (success or
+            // failure). It links back to the original publish span (when its context was
+            // captured at send time) rather than reopening it, and degrades to no link when
+            // the context is absent. The observability work is isolated in try/catch so a
+            // tracing fault can never destabilise the producer thread (NFR-4); the span is
+            // disposed in the finally so it starts and stops within the callback (NFR-2).
+            Activity? confirmationSpan = null;
+            try
+            {
+                var links = result.PublishSpanContext is { } publishContext
+                    ? new[] { new ActivityLink(publishContext) }
+                    : null;
+                confirmationSpan = _tracer?.CreateConfirmationSpan(
+                    result.MessageId, result.Topic, result.Success, links);
+            }
+            catch (Exception ex)
+            {
+                Log.ConfirmationObservabilityFault(s_logger, ex);
+            }
+
+            try
+            {
+                if (result.Success)
+                {
+                    Log.SentMessage(s_logger, result.MessageId.Value);
+                    if (_asyncOutbox != null)
+                    {
+                        // Explicitly re-parent the MarkDispatched DB span to the confirmation
+                        // span (S2): CreateDbSpan parents from requestContext.Span, so we pass a
+                        // per-callback copy whose Span is S2 rather than relying on the ambient
+                        // Activity.Current fallback (C-6). A copy is required because
+                        // RequestContext.Span is thread-keyed and its setter ignores null, so we
+                        // must not mutate the shared construction-time context.
+                        var dispatchedContext = (RequestContext)requestContext.CreateCopy();
+                        dispatchedContext.Span = confirmationSpan;
+                        await ExecuteWithResiliencePipelineAsync(
+                            async ct =>
+                                await _asyncOutbox.MarkDispatchedAsync(result.MessageId, dispatchedContext, _timeProvider.GetUtcNow(),
+                                    cancellationToken: ct),
+                            dispatchedContext
+                        );
+                    }
+                }
+                else
+                {
+                    Log.ConfirmationFailed(s_logger, result.MessageId.Value, result.Topic?.Value ?? string.Empty);
+                    // Trip the breaker on the wire topic (result.Topic == message.Header.Topic),
+                    // not the Publication topic — exact parity with the non-confirmation send
+                    // failure path (see DispatchAsync). TripTopic safely no-ops on null/empty.
+                    TripTopic(result.Topic);
+                }
+            }
+            catch (Exception ex)
+            {
+                // The callback must not allow a failed dispatch update to crash the producer. The
+                // message remains undispatched, so the Sweeper will retry it.
+                Log.ConfirmationDispatchError(s_logger, result.MessageId.Value, result.Topic?.Value ?? string.Empty, ex);
+            }
+            finally
+            {
+                // End via the tracer (not raw Dispose) so the end time is stamped from the tracer's
+                // TimeProvider — matching the start time set in CreateConfirmationSpan — and a
+                // successful span gets Ok status, consistent with every other span in this file.
+                _tracer?.EndSpan(confirmationSpan);
             }
         }
 


### PR DESCRIPTION
## Summary

- add an internal Task-returning publish-confirmation callback without changing the public producer API
- make the in-memory confirmation pump await the mediator's full async dispatch update
- keep RabbitMQ, Kafka, and other broker producers on the existing confirmation event

## Root cause

The mediator subscribed an `async void` handler to `ISupportPublishConfirmation.OnMessagePublished`. The in-memory producer's drain task therefore completed at the handler's first incomplete await, allowing `DisposeAsync()` to return before `MarkDispatchedAsync` finished. Increased test parallelism exposed that race.

## Validation

- `dotnet build src/Paramore.Brighter/Paramore.Brighter.csproj -c Release --no-restore`
- `dotnet build tests/Paramore.Brighter.Core.Tests/Paramore.Brighter.Core.Tests.csproj -c Release`
- Existing confirmation regression test retained; tests were not executed because repository instructions require separate approval.

Closes #4243