### PR TITLE
Await in-memory publish confirmation handling

### DIFF
--- a/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaMessageProducer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaMessageProducer.cs
@@ -73,12 +73,10 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
         private bool _hasFatalProducerError;
         private readonly InstrumentationOptions _instrumentation;
         private event Func<PublishConfirmationResult, Task>? _onMessagePublishedAsync;
-        // Confirmation raises run on worker tasks (never on Confluent's poll thread); this counter and
-        // TCS let Dispose wait for those callbacks — including the awaited Outbox mark-dispatched —
-        // after Flush() has drained the delivery reports themselves. Guarded by _confirmationStateLock.
-        private readonly object _confirmationStateLock = new();
-        private int _inFlightConfirmationCallbacks;
-        private TaskCompletionSource<bool>? _confirmationCallbacksCompleted;
+        // Confirmation raises run on worker tasks (never on Confluent's poll thread); the tracker
+        // lets Dispose wait for those callbacks — including the awaited Outbox mark-dispatched —
+        // after Flush() has drained the delivery reports themselves.
+        private readonly InFlightCallbackTracker _confirmationCallbacks = new();
 
         public KafkaMessageProducer(
             KafkaMessagingGatewayConfiguration configuration, 
@@ -450,20 +448,14 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
             // invoke so a faulting subscriber is logged rather than left as an unobserved Task exception
             // (which can escalate via TaskScheduler.UnobservedTaskException). Brighter's own mediator
             // callback is already self-contained; this guards any other subscriber and the broker thread.
-            // The in-flight counter must be released on every path or dispose would block on its timeout.
-            BeginConfirmationCallback();
+            // The in-flight tracker must be released on every path or dispose would block on its timeout.
+            _confirmationCallbacks.Begin();
             Task.Run(async () =>
             {
                 try
                 {
                     OnMessagePublished?.Invoke(result);
-
-                    var handlers = _onMessagePublishedAsync;
-                    if (handlers is not null)
-                    {
-                        foreach (Func<PublishConfirmationResult, Task> handler in handlers.GetInvocationList())
-                            await handler(result);
-                    }
+                    await _onMessagePublishedAsync.InvokeAllAsync(result);
                 }
                 catch (Exception ex)
                 {
@@ -471,57 +463,15 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
                 }
                 finally
                 {
-                    EndConfirmationCallback();
+                    _confirmationCallbacks.End();
                 }
             });
         }
 
-        private void BeginConfirmationCallback()
-        {
-            lock (_confirmationStateLock)
-            {
-                if (_inFlightConfirmationCallbacks == 0)
-                    _confirmationCallbacksCompleted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-
-                _inFlightConfirmationCallbacks++;
-            }
-        }
-
-        private void EndConfirmationCallback()
-        {
-            lock (_confirmationStateLock)
-            {
-                _inFlightConfirmationCallbacks--;
-
-                if (_inFlightConfirmationCallbacks == 0)
-                    _confirmationCallbacksCompleted?.TrySetResult(true);
-            }
-        }
-
         private void WaitForConfirmationCallbacks()
         {
-            Task? callbacksCompleted;
-            lock (_confirmationStateLock)
-            {
-                if (_inFlightConfirmationCallbacks == 0)
-                    return;
-
-                callbacksCompleted = _confirmationCallbacksCompleted?.Task;
-            }
-
-            if (callbacksCompleted is null)
-                return;
-
-            if (!callbacksCompleted.Wait(TimeSpan.FromMilliseconds(ConfirmationCallbacksShutdownTimeoutMs)))
-            {
-                int inFlightCallbacks;
-                lock (_confirmationStateLock)
-                {
-                    inFlightCallbacks = _inFlightConfirmationCallbacks;
-                }
-
-                Log.FailedToAwaitConfirmationCallbacks(s_logger, inFlightCallbacks, ConfirmationCallbacksShutdownTimeoutMs);
-            }
+            if (!_confirmationCallbacks.TryWait(TimeSpan.FromMilliseconds(ConfirmationCallbacksShutdownTimeoutMs), out int stillInFlight))
+                Log.FailedToAwaitConfirmationCallbacks(s_logger, stillInFlight, ConfirmationCallbacksShutdownTimeoutMs);
         }
 
         private static partial class Log

--- a/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaMessageProducer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaMessageProducer.cs
@@ -32,13 +32,26 @@ using Paramore.Brighter.Tasks;
 
 namespace Paramore.Brighter.MessagingGateway.Kafka
 {
-    public partial class KafkaMessageProducer : KafkaMessagingGateway, IAmAMessageProducerSync, IAmAMessageProducerAsync, ISupportPublishConfirmation
+    public partial class KafkaMessageProducer : KafkaMessagingGateway, IAmAMessageProducerSync, IAmAMessageProducerAsync, ISupportPublishConfirmation, ISupportPublishConfirmationAsync
     {
+        // Bounds the dispose-time wait for confirmation callbacks still running after Flush() has
+        // drained the delivery reports; without it a hung Outbox write would block dispose forever.
+        private const int ConfirmationCallbacksShutdownTimeoutMs = 5000;
+
         /// <summary>
         /// Action taken when a message is published, following receipt of a confirmation from the broker
         /// see https://www.rabbitmq.com/blog/2011/02/10/introducing-publisher-confirms#how-confirms-work for more
         /// </summary>
         public event Action<PublishConfirmationResult>? OnMessagePublished;
+
+        /// <inheritdoc cref="ISupportPublishConfirmationAsync.UseAsyncPublishConfirmation"/>
+        bool ISupportPublishConfirmationAsync.UseAsyncPublishConfirmation => true;
+
+        event Func<PublishConfirmationResult, Task> ISupportPublishConfirmationAsync.OnMessagePublishedAsync
+        {
+            add => _onMessagePublishedAsync += value;
+            remove => _onMessagePublishedAsync -= value;
+        }
       
         /// <summary>
         /// The publication configuration for this producer
@@ -59,6 +72,13 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
         private KafkaMessagePublisher? _publisher;
         private bool _hasFatalProducerError;
         private readonly InstrumentationOptions _instrumentation;
+        private event Func<PublishConfirmationResult, Task>? _onMessagePublishedAsync;
+        // Confirmation raises run on worker tasks (never on Confluent's poll thread); this counter and
+        // TCS let Dispose wait for those callbacks — including the awaited Outbox mark-dispatched —
+        // after Flush() has drained the delivery reports themselves. Guarded by _confirmationStateLock.
+        private readonly object _confirmationStateLock = new();
+        private int _inFlightConfirmationCallbacks;
+        private TaskCompletionSource<bool>? _confirmationCallbacksCompleted;
 
         public KafkaMessageProducer(
             KafkaMessagingGatewayConfiguration configuration, 
@@ -373,7 +393,10 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
         {
             if (disposing)
             {
+                // Flush drains the delivery reports; the callbacks they spawned (including the
+                // awaited Outbox mark-dispatched) may still be running, so wait for those too.
                 Flush();
+                WaitForConfirmationCallbacks();
                 _producer?.Dispose();
             }
         }
@@ -427,17 +450,78 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
             // invoke so a faulting subscriber is logged rather than left as an unobserved Task exception
             // (which can escalate via TaskScheduler.UnobservedTaskException). Brighter's own mediator
             // callback is already self-contained; this guards any other subscriber and the broker thread.
-            Task.Run(() =>
+            // The in-flight counter must be released on every path or dispose would block on its timeout.
+            BeginConfirmationCallback();
+            Task.Run(async () =>
             {
                 try
                 {
                     OnMessagePublished?.Invoke(result);
+
+                    var handlers = _onMessagePublishedAsync;
+                    if (handlers is not null)
+                    {
+                        foreach (Func<PublishConfirmationResult, Task> handler in handlers.GetInvocationList())
+                            await handler(result);
+                    }
                 }
                 catch (Exception ex)
                 {
                     Log.PublishConfirmationRaiseFault(s_logger, ex);
                 }
+                finally
+                {
+                    EndConfirmationCallback();
+                }
             });
+        }
+
+        private void BeginConfirmationCallback()
+        {
+            lock (_confirmationStateLock)
+            {
+                if (_inFlightConfirmationCallbacks == 0)
+                    _confirmationCallbacksCompleted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+                _inFlightConfirmationCallbacks++;
+            }
+        }
+
+        private void EndConfirmationCallback()
+        {
+            lock (_confirmationStateLock)
+            {
+                _inFlightConfirmationCallbacks--;
+
+                if (_inFlightConfirmationCallbacks == 0)
+                    _confirmationCallbacksCompleted?.TrySetResult(true);
+            }
+        }
+
+        private void WaitForConfirmationCallbacks()
+        {
+            Task? callbacksCompleted;
+            lock (_confirmationStateLock)
+            {
+                if (_inFlightConfirmationCallbacks == 0)
+                    return;
+
+                callbacksCompleted = _confirmationCallbacksCompleted?.Task;
+            }
+
+            if (callbacksCompleted is null)
+                return;
+
+            if (!callbacksCompleted.Wait(TimeSpan.FromMilliseconds(ConfirmationCallbacksShutdownTimeoutMs)))
+            {
+                int inFlightCallbacks;
+                lock (_confirmationStateLock)
+                {
+                    inFlightCallbacks = _inFlightConfirmationCallbacks;
+                }
+
+                Log.FailedToAwaitConfirmationCallbacks(s_logger, inFlightCallbacks, ConfirmationCallbacksShutdownTimeoutMs);
+            }
         }
 
         private static partial class Log
@@ -462,6 +546,9 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
             
             [LoggerMessage(LogLevel.Error, "KafkaMessageProducer: There was an error sending to topic {Topic})")]
             public static partial void KafkaExceptionError(ILogger logger, Exception exception, string topic);
+
+            [LoggerMessage(LogLevel.Warning, "Failed to await {CallbackCount} confirmation callbacks after {TimeoutMs}ms when shutting down")]
+            public static partial void FailedToAwaitConfirmationCallbacks(ILogger logger, int callbackCount, int timeoutMs);
         }
     }
 }

--- a/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaMessageProducer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaMessageProducer.cs
@@ -36,6 +36,9 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
     {
         // Bounds the dispose-time wait for confirmation callbacks still running after Flush() has
         // drained the delivery reports; without it a hung Outbox write would block dispose forever.
+        // Fixed rather than configurable: KafkaPublication has no confirm-wait setting (unlike
+        // RmqPublication's WaitForConfirmsTimeOutInMilliseconds), and none of its existing timeouts
+        // describe this wait. 5s matches the RMQ.Async producer's active-sends shutdown bound.
         private const int ConfirmationCallbacksShutdownTimeoutMs = 5000;
 
         /// <summary>

--- a/src/Paramore.Brighter.MessagingGateway.RMQ.Async/RmqMessageProducer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ.Async/RmqMessageProducer.cs
@@ -247,7 +247,7 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
             // the registered tag in flight without a corresponding broker ack — remove it so disposal does
             // not block waiting on a confirmation that will never arrive.
             if (pendingDeliveryTag.HasValue)
-                RemovePendingConfirmations(pendingDeliveryTag.Value, multiple: false);
+                RemovePendingConfirmations(pendingDeliveryTag.Value, multiple: false, beginCallbacks: false);
 
             CompleteSend();
         }
@@ -460,7 +460,7 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
 
     private bool PublishesOnChannel(TimeSpan delay) => delay == TimeSpan.Zero || DelaySupported || Scheduler == null;
 
-    private IReadOnlyCollection<PendingConfirmation> RemovePendingConfirmations(ulong deliveryTag, bool multiple, bool beginCallbacks = false)
+    private IReadOnlyCollection<PendingConfirmation> RemovePendingConfirmations(ulong deliveryTag, bool multiple, bool beginCallbacks)
     {
         lock (_stateLock)
         {
@@ -522,39 +522,38 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
         Channel?.BasicNacksAsync -= OnPublishFailed;
     }
 
-    private async Task OnPublishFailed(object sender, BasicNackEventArgs e)
-    {
-        foreach (var confirmation in RemovePendingConfirmations(e.DeliveryTag, e.Multiple, beginCallbacks: true))
-        {
-            await RaiseConfirmationCallbacksAsync(new PublishConfirmationResult(false, confirmation.MessageId, confirmation.Topic, confirmation.Context));
-            Log.FailedToPublishMessageAsync(s_logger, confirmation.MessageId.Value);
-        }
-    }
+    private Task OnPublishFailed(object sender, BasicNackEventArgs e) => SettleConfirmationsAsync(e.DeliveryTag, e.Multiple, success: false);
 
-    private async Task OnPublishSucceeded(object sender, BasicAckEventArgs e)
+    private Task OnPublishSucceeded(object sender, BasicAckEventArgs e) => SettleConfirmationsAsync(e.DeliveryTag, e.Multiple, success: true);
+
+    private async Task SettleConfirmationsAsync(ulong deliveryTag, bool multiple, bool success)
     {
-        foreach (var confirmation in RemovePendingConfirmations(e.DeliveryTag, e.Multiple, beginCallbacks: true))
+        // Raise the whole batch concurrently, then await it: a multiple-ack's callbacks (each an
+        // Outbox mark-dispatched) overlap rather than serializing on the channel's ack-dispatch
+        // loop, while awaiting the batch preserves backpressure on that loop.
+        var raiseTasks = new List<Task>();
+        foreach (var confirmation in RemovePendingConfirmations(deliveryTag, multiple, beginCallbacks: true))
         {
-            await RaiseConfirmationCallbacksAsync(new PublishConfirmationResult(true, confirmation.MessageId, confirmation.Topic, confirmation.Context));
-            Log.PublishedMessage(s_logger, confirmation.MessageId.Value);
+            if (success)
+                Log.PublishedMessage(s_logger, confirmation.MessageId.Value);
+            else
+                Log.FailedToPublishMessageAsync(s_logger, confirmation.MessageId.Value);
+
+            raiseTasks.Add(RaiseConfirmationCallbacksAsync(new PublishConfirmationResult(success, confirmation.MessageId, confirmation.Topic, confirmation.Context)));
         }
+
+        await Task.WhenAll(raiseTasks);
     }
 
     private async Task RaiseConfirmationCallbacksAsync(PublishConfirmationResult result)
     {
-        // These handlers run on the channel's ack-dispatch loop, which awaits them; a subscriber
-        // fault must not abort remaining confirmations in a multiple-ack batch or fault the loop,
-        // and the in-flight counter must be released on every path or disposal would hang.
+        // A subscriber fault must not abort the other confirmations in the batch or fault the
+        // ack-dispatch loop, and the in-flight counter must be released on every path or disposal
+        // would hang.
         try
         {
             OnMessagePublished?.Invoke(result);
-
-            var handlers = _onMessagePublishedAsync;
-            if (handlers is not null)
-            {
-                foreach (Func<PublishConfirmationResult, Task> handler in handlers.GetInvocationList())
-                    await handler(result);
-            }
+            await _onMessagePublishedAsync.InvokeAllAsync(result);
         }
         catch (Exception ex)
         {
@@ -595,7 +594,7 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
         [LoggerMessage(LogLevel.Warning, "Failed to await {CallbackCount} confirmation callbacks after {TimeoutMs}ms when shutting down")]
         public static partial void FailedToAwaitConfirmationCallbacks(ILogger logger, int callbackCount, int timeoutMs);
 
-        [LoggerMessage(LogLevel.Warning, "Confirmation callback for message {MessageId} faulted; the message is left un-dispatched for the Sweeper to retry")]
+        [LoggerMessage(LogLevel.Warning, "Confirmation callback for message {MessageId} faulted; remaining confirmations continue")]
         public static partial void ConfirmationCallbackFault(ILogger logger, string messageId, Exception exception);
     }
 }

--- a/src/Paramore.Brighter.MessagingGateway.RMQ.Async/RmqMessageProducer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ.Async/RmqMessageProducer.cs
@@ -46,7 +46,7 @@ namespace Paramore.Brighter.MessagingGateway.RMQ.Async;
 /// The <see cref="RmqMessageProducer"/> is used by a client to talk to a server and abstracts the infrastructure for inter-process communication away from clients.
 /// It handles subscription establishment, request sending and error handling
 /// </summary>
-public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducerSync, IAmAMessageProducerAsync, ISupportPublishConfirmation
+public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducerSync, IAmAMessageProducerAsync, ISupportPublishConfirmation, ISupportPublishConfirmationAsync
 {
     private readonly InstrumentationOptions _instrumentationOptions;
     private static readonly ILogger s_logger = ApplicationLogging.CreateLogger<RmqMessageProducer>();
@@ -66,12 +66,26 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
     // The base guard separately protects channel and pool cleanup after producer shutdown.
     private int _activeSends;
     private int _disposed;
+    // Confirmations whose broker ack has arrived but whose awaited callbacks are still running.
+    // Guarded by _stateLock; _publisherConfirmationsCompleted only completes when both the pending
+    // dictionary and this counter are drained, so disposal waits for the full confirmation pipeline.
+    private int _inFlightConfirmationCallbacks;
+    private event Func<PublishConfirmationResult, Task>? _onMessagePublishedAsync;
 
     /// <summary>
     /// Action taken when a message is published, following receipt of a confirmation from the broker
     /// see https://www.rabbitmq.com/blog/2011/02/10/introducing-publisher-confirms#how-confirms-work for more
     /// </summary>
     public event Action<PublishConfirmationResult>? OnMessagePublished;
+
+    /// <inheritdoc cref="ISupportPublishConfirmationAsync.UseAsyncPublishConfirmation"/>
+    bool ISupportPublishConfirmationAsync.UseAsyncPublishConfirmation => true;
+
+    event Func<PublishConfirmationResult, Task> ISupportPublishConfirmationAsync.OnMessagePublishedAsync
+    {
+        add => _onMessagePublishedAsync += value;
+        remove => _onMessagePublishedAsync -= value;
+    }
 
     /// <summary>
     /// The publication configuration for this producer
@@ -368,7 +382,11 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
         // and drained active sends, so the producer send path cannot replace Channel while this snapshot is taken.
         lock (_stateLock)
         {
-            if (Channel is not { IsOpen: true } || _pendingConfirmations.Count == 0)
+            // Broker acks need an open channel to arrive; in-flight callbacks (ack received, awaited
+            // handler still running) complete regardless of channel state, so wait for those even
+            // when the channel has closed.
+            var brokerAcksOutstanding = Channel is { IsOpen: true } && _pendingConfirmations.Count > 0;
+            if (!brokerAcksOutstanding && _inFlightConfirmationCallbacks == 0)
                 return;
 
             if (waitMilliseconds == 0)
@@ -388,22 +406,27 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
         }
 
         int pendingConfirmations;
+        int inFlightCallbacks;
         lock (_stateLock)
         {
             pendingConfirmations = _pendingConfirmations.Count;
+            inFlightCallbacks = _inFlightConfirmationCallbacks;
         }
 
-        if (pendingConfirmations == 0)
-            return;
+        if (pendingConfirmations > 0)
+            Log.FailedToAwaitPublisherConfirms(s_logger, pendingConfirmations, waitMilliseconds);
 
-        Log.FailedToAwaitPublisherConfirms(s_logger, pendingConfirmations, waitMilliseconds);
+        if (inFlightCallbacks > 0)
+            Log.FailedToAwaitConfirmationCallbacks(s_logger, inFlightCallbacks, waitMilliseconds);
     }
 
     private void AddPendingConfirmation(ulong deliveryTag, PendingConfirmation confirmation)
     {
         lock (_stateLock)
         {
-            if (_pendingConfirmations.Count == 0)
+            // Reset only when the previous drain fully completed; replacing a still-pending source
+            // would orphan a waiter that captured the old Task (its completion would never fire).
+            if (_publisherConfirmationsCompleted.Task.IsCompleted)
                 _publisherConfirmationsCompleted = NewPendingTaskCompletionSource();
 
             _pendingConfirmations[deliveryTag] = confirmation;
@@ -415,13 +438,29 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
         lock (_stateLock)
         {
             _pendingConfirmations.Clear();
+            CompleteConfirmationsIfDrainedLocked();
+        }
+    }
+
+    // Callers must hold _stateLock.
+    private void CompleteConfirmationsIfDrainedLocked()
+    {
+        if (_pendingConfirmations.Count == 0 && _inFlightConfirmationCallbacks == 0)
             _publisherConfirmationsCompleted.TrySetResult(true);
+    }
+
+    private void EndConfirmationCallback()
+    {
+        lock (_stateLock)
+        {
+            _inFlightConfirmationCallbacks--;
+            CompleteConfirmationsIfDrainedLocked();
         }
     }
 
     private bool PublishesOnChannel(TimeSpan delay) => delay == TimeSpan.Zero || DelaySupported || Scheduler == null;
 
-    private IReadOnlyCollection<PendingConfirmation> RemovePendingConfirmations(ulong deliveryTag, bool multiple)
+    private IReadOnlyCollection<PendingConfirmation> RemovePendingConfirmations(ulong deliveryTag, bool multiple, bool beginCallbacks = false)
     {
         lock (_stateLock)
         {
@@ -435,8 +474,13 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
 
             var confirmations = RemoveConfirmationsLocked(deliveryTagsToRemove);
 
-            if (_pendingConfirmations.Count == 0)
-                _publisherConfirmationsCompleted.TrySetResult(true);
+            // The ack/nack handlers raise a callback per removed confirmation; keep the drain TCS
+            // pending until each one calls EndConfirmationCallback. The orphan-cleanup path in
+            // SendWithDelayAsync raises no callbacks, so it leaves beginCallbacks false.
+            if (beginCallbacks)
+                _inFlightConfirmationCallbacks += confirmations.Count;
+
+            CompleteConfirmationsIfDrainedLocked();
 
             return confirmations;
         }
@@ -478,26 +522,48 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
         Channel?.BasicNacksAsync -= OnPublishFailed;
     }
 
-    private Task OnPublishFailed(object sender, BasicNackEventArgs e)
+    private async Task OnPublishFailed(object sender, BasicNackEventArgs e)
     {
-        foreach (var confirmation in RemovePendingConfirmations(e.DeliveryTag, e.Multiple))
+        foreach (var confirmation in RemovePendingConfirmations(e.DeliveryTag, e.Multiple, beginCallbacks: true))
         {
-            OnMessagePublished?.Invoke(new PublishConfirmationResult(false, confirmation.MessageId, confirmation.Topic, confirmation.Context));
+            await RaiseConfirmationCallbacksAsync(new PublishConfirmationResult(false, confirmation.MessageId, confirmation.Topic, confirmation.Context));
             Log.FailedToPublishMessageAsync(s_logger, confirmation.MessageId.Value);
         }
-
-        return Task.CompletedTask;
     }
 
-    private Task OnPublishSucceeded(object sender, BasicAckEventArgs e)
+    private async Task OnPublishSucceeded(object sender, BasicAckEventArgs e)
     {
-        foreach (var confirmation in RemovePendingConfirmations(e.DeliveryTag, e.Multiple))
+        foreach (var confirmation in RemovePendingConfirmations(e.DeliveryTag, e.Multiple, beginCallbacks: true))
         {
-            OnMessagePublished?.Invoke(new PublishConfirmationResult(true, confirmation.MessageId, confirmation.Topic, confirmation.Context));
+            await RaiseConfirmationCallbacksAsync(new PublishConfirmationResult(true, confirmation.MessageId, confirmation.Topic, confirmation.Context));
             Log.PublishedMessage(s_logger, confirmation.MessageId.Value);
         }
+    }
 
-        return Task.CompletedTask;
+    private async Task RaiseConfirmationCallbacksAsync(PublishConfirmationResult result)
+    {
+        // These handlers run on the channel's ack-dispatch loop, which awaits them; a subscriber
+        // fault must not abort remaining confirmations in a multiple-ack batch or fault the loop,
+        // and the in-flight counter must be released on every path or disposal would hang.
+        try
+        {
+            OnMessagePublished?.Invoke(result);
+
+            var handlers = _onMessagePublishedAsync;
+            if (handlers is not null)
+            {
+                foreach (Func<PublishConfirmationResult, Task> handler in handlers.GetInvocationList())
+                    await handler(result);
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.ConfirmationCallbackFault(s_logger, result.MessageId.Value, ex);
+        }
+        finally
+        {
+            EndConfirmationCallback();
+        }
     }
 
     private static partial class Log
@@ -525,6 +591,12 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
 
         [LoggerMessage(LogLevel.Information, "Published message: {MessageId}")]
         public static partial void PublishedMessage(ILogger logger, string messageId);
+
+        [LoggerMessage(LogLevel.Warning, "Failed to await {CallbackCount} confirmation callbacks after {TimeoutMs}ms when shutting down")]
+        public static partial void FailedToAwaitConfirmationCallbacks(ILogger logger, int callbackCount, int timeoutMs);
+
+        [LoggerMessage(LogLevel.Warning, "Confirmation callback for message {MessageId} faulted; the message is left un-dispatched for the Sweeper to retry")]
+        public static partial void ConfirmationCallbackFault(ILogger logger, string messageId, Exception exception);
     }
 }
 

--- a/src/Paramore.Brighter.MessagingGateway.RMQ.Async/RmqMessageProducer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ.Async/RmqMessageProducer.cs
@@ -453,7 +453,12 @@ public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducer
     {
         lock (_stateLock)
         {
-            _inFlightConfirmationCallbacks--;
+            // An unbalanced decrement would drive the count negative and the drain TCS would never
+            // complete; assert loudly in debug builds and refuse to go below zero in release.
+            Debug.Assert(_inFlightConfirmationCallbacks > 0, "EndConfirmationCallback called without a matching beginCallbacks removal");
+            if (_inFlightConfirmationCallbacks > 0)
+                _inFlightConfirmationCallbacks--;
+
             CompleteConfirmationsIfDrainedLocked();
         }
     }

--- a/src/Paramore.Brighter.MessagingGateway.RMQ.Sync/RmqMessageProducer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ.Sync/RmqMessageProducer.cs
@@ -60,12 +60,10 @@ namespace Paramore.Brighter.MessagingGateway.RMQ.Sync
         private readonly int _waitForConfirmsTimeOutInMilliseconds;
         private event Func<PublishConfirmationResult, Task>? _onMessagePublishedAsync;
         // The ack/nack handlers run on the client's connection loop, which must never block on a
-        // subscriber, so awaited callbacks run on worker tasks. This counter and TCS let Dispose wait
-        // for them — including the awaited Outbox mark-dispatched — after WaitForConfirms has drained
-        // the broker acks themselves. Guarded by _confirmationStateLock.
-        private readonly object _confirmationStateLock = new();
-        private int _inFlightConfirmationCallbacks;
-        private TaskCompletionSource<bool>? _confirmationCallbacksCompleted;
+        // subscriber, so awaited callbacks run on worker tasks. The tracker lets Dispose wait for
+        // them — including the awaited Outbox mark-dispatched — after WaitForConfirms has drained
+        // the broker acks themselves.
+        private readonly InFlightCallbackTracker _confirmationCallbacks = new();
 
         /// <summary>
         /// Action taken when a message is published, following receipt of a confirmation from the broker
@@ -284,15 +282,14 @@ namespace Paramore.Brighter.MessagingGateway.RMQ.Sync
                 return;
 
             // Awaited callbacks must not block the connection loop (WaitForConfirms depends on it to
-            // process acks), so they run on a worker task; Dispose waits on the in-flight counter,
+            // process acks), so they run on a worker task; Dispose waits on the in-flight tracker,
             // which must be released on every path or that wait would hang until its timeout.
-            BeginConfirmationCallback();
+            _confirmationCallbacks.Begin();
             Task.Run(async () =>
             {
                 try
                 {
-                    foreach (Func<PublishConfirmationResult, Task> handler in handlers.GetInvocationList())
-                        await handler(result);
+                    await handlers.InvokeAllAsync(result);
                 }
                 catch (Exception ex)
                 {
@@ -300,31 +297,9 @@ namespace Paramore.Brighter.MessagingGateway.RMQ.Sync
                 }
                 finally
                 {
-                    EndConfirmationCallback();
+                    _confirmationCallbacks.End();
                 }
             });
-        }
-
-        private void BeginConfirmationCallback()
-        {
-            lock (_confirmationStateLock)
-            {
-                if (_inFlightConfirmationCallbacks == 0)
-                    _confirmationCallbacksCompleted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-
-                _inFlightConfirmationCallbacks++;
-            }
-        }
-
-        private void EndConfirmationCallback()
-        {
-            lock (_confirmationStateLock)
-            {
-                _inFlightConfirmationCallbacks--;
-
-                if (_inFlightConfirmationCallbacks == 0)
-                    _confirmationCallbacksCompleted?.TrySetResult(true);
-            }
         }
 
         private void WaitForConfirmationCallbacks()
@@ -333,28 +308,8 @@ namespace Paramore.Brighter.MessagingGateway.RMQ.Sync
             if (_waitForConfirmsTimeOutInMilliseconds == 0)
                 return;
 
-            Task? callbacksCompleted;
-            lock (_confirmationStateLock)
-            {
-                if (_inFlightConfirmationCallbacks == 0)
-                    return;
-
-                callbacksCompleted = _confirmationCallbacksCompleted?.Task;
-            }
-
-            if (callbacksCompleted is null)
-                return;
-
-            if (!callbacksCompleted.Wait(TimeSpan.FromMilliseconds(_waitForConfirmsTimeOutInMilliseconds)))
-            {
-                int inFlightCallbacks;
-                lock (_confirmationStateLock)
-                {
-                    inFlightCallbacks = _inFlightConfirmationCallbacks;
-                }
-
-                Log.FailedToAwaitConfirmationCallbacks(s_logger, inFlightCallbacks, _waitForConfirmsTimeOutInMilliseconds);
-            }
+            if (!_confirmationCallbacks.TryWait(TimeSpan.FromMilliseconds(_waitForConfirmsTimeOutInMilliseconds), out int stillInFlight))
+                Log.FailedToAwaitConfirmationCallbacks(s_logger, stillInFlight, _waitForConfirmsTimeOutInMilliseconds);
         }
 
         private static partial class Log
@@ -383,7 +338,7 @@ namespace Paramore.Brighter.MessagingGateway.RMQ.Sync
             [LoggerMessage(LogLevel.Warning, "Failed to await {CallbackCount} confirmation callbacks after {TimeoutMs}ms when shutting down")]
             public static partial void FailedToAwaitConfirmationCallbacks(ILogger logger, int callbackCount, int timeoutMs);
 
-            [LoggerMessage(LogLevel.Warning, "Confirmation callback for message {MessageId} faulted; the message is left un-dispatched for the Sweeper to retry")]
+            [LoggerMessage(LogLevel.Warning, "Confirmation callback for message {MessageId} faulted; remaining confirmations continue")]
             public static partial void ConfirmationCallbackFault(ILogger logger, string messageId, Exception exception);
         }
     }

--- a/src/Paramore.Brighter.MessagingGateway.RMQ.Sync/RmqMessageProducer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ.Sync/RmqMessageProducer.cs
@@ -223,12 +223,14 @@ namespace Paramore.Brighter.MessagingGateway.RMQ.Sync
             GC.SuppressFinalize(this);
         }
         
-        public  ValueTask DisposeAsync()
+        public ValueTask DisposeAsync()
         {
-            var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            // The sync client has no async teardown, so dispose runs synchronously here; returning
+            // default gives the caller a completed ValueTask. (Previously this returned a
+            // TaskCompletionSource task that was never completed, so awaiting it hung forever.)
             Dispose(true);
             GC.SuppressFinalize(this);
-            return new ValueTask(tcs.Task);
+            return default;
         }
 
         protected override void Dispose(bool disposing)

--- a/src/Paramore.Brighter.MessagingGateway.RMQ.Sync/RmqMessageProducer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RMQ.Sync/RmqMessageProducer.cs
@@ -48,7 +48,7 @@ namespace Paramore.Brighter.MessagingGateway.RMQ.Sync
     /// an Async operation.
     /// </remarks>
     /// </summary>
-    public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducerSync, IAmAMessageProducerAsync, ISupportPublishConfirmation
+    public partial class RmqMessageProducer : RmqMessageGateway, IAmAMessageProducerSync, IAmAMessageProducerAsync, ISupportPublishConfirmation, ISupportPublishConfirmationAsync
     {
         private readonly InstrumentationOptions _instrumentationOptions;
         private static readonly ILogger s_logger = ApplicationLogging.CreateLogger<RmqMessageProducer>();
@@ -58,12 +58,29 @@ namespace Paramore.Brighter.MessagingGateway.RMQ.Sync
         private readonly ConcurrentDictionary<ulong, PendingConfirmation> _pendingConfirmations = new ConcurrentDictionary<ulong, PendingConfirmation>();
         private bool _confirmsSelected;
         private readonly int _waitForConfirmsTimeOutInMilliseconds;
+        private event Func<PublishConfirmationResult, Task>? _onMessagePublishedAsync;
+        // The ack/nack handlers run on the client's connection loop, which must never block on a
+        // subscriber, so awaited callbacks run on worker tasks. This counter and TCS let Dispose wait
+        // for them — including the awaited Outbox mark-dispatched — after WaitForConfirms has drained
+        // the broker acks themselves. Guarded by _confirmationStateLock.
+        private readonly object _confirmationStateLock = new();
+        private int _inFlightConfirmationCallbacks;
+        private TaskCompletionSource<bool>? _confirmationCallbacksCompleted;
 
         /// <summary>
         /// Action taken when a message is published, following receipt of a confirmation from the broker
         /// see https://www.rabbitmq.com/blog/2011/02/10/introducing-publisher-confirms#how-confirms-work for more
         /// </summary>
         public event Action<PublishConfirmationResult>? OnMessagePublished;
+
+        /// <inheritdoc cref="ISupportPublishConfirmationAsync.UseAsyncPublishConfirmation"/>
+        bool ISupportPublishConfirmationAsync.UseAsyncPublishConfirmation => true;
+
+        event Func<PublishConfirmationResult, Task> ISupportPublishConfirmationAsync.OnMessagePublishedAsync
+        {
+            add => _onMessagePublishedAsync += value;
+            remove => _onMessagePublishedAsync -= value;
+        }
 
         /// <summary>
         /// The publication configuration for this producer
@@ -228,6 +245,10 @@ namespace Paramore.Brighter.MessagingGateway.RMQ.Sync
                     if (timedOut)
                         Log.FailedToAwaitPublisherConfirms(s_logger);
                 }
+
+                // WaitForConfirms drains the broker acks; the callbacks those acks spawned (including
+                // the awaited Outbox mark-dispatched) run on worker tasks, so wait for them too.
+                WaitForConfirmationCallbacks();
             }
 
             base.Dispose(disposing);
@@ -237,7 +258,7 @@ namespace Paramore.Brighter.MessagingGateway.RMQ.Sync
         {
             if (_pendingConfirmations.TryGetValue(e.DeliveryTag, out PendingConfirmation confirmation))
             {
-                OnMessagePublished?.Invoke(new PublishConfirmationResult(false, confirmation.MessageId, confirmation.Topic, confirmation.Context));
+                RaisePublishConfirmation(new PublishConfirmationResult(false, confirmation.MessageId, confirmation.Topic, confirmation.Context));
                 _pendingConfirmations.TryRemove(e.DeliveryTag, out PendingConfirmation _);
                 Log.FailedToPublishMessage(s_logger, confirmation.MessageId.Value);
             }
@@ -247,9 +268,92 @@ namespace Paramore.Brighter.MessagingGateway.RMQ.Sync
         {
             if (_pendingConfirmations.TryGetValue(e.DeliveryTag, out PendingConfirmation confirmation))
             {
-                OnMessagePublished?.Invoke(new PublishConfirmationResult(true, confirmation.MessageId, confirmation.Topic, confirmation.Context));
+                RaisePublishConfirmation(new PublishConfirmationResult(true, confirmation.MessageId, confirmation.Topic, confirmation.Context));
                 _pendingConfirmations.TryRemove(e.DeliveryTag, out PendingConfirmation _);
                 Log.PublishedMessageInformation(s_logger, confirmation.MessageId.Value);
+            }
+        }
+
+        private void RaisePublishConfirmation(PublishConfirmationResult result)
+        {
+            // The sync event stays on the connection loop thread, matching its long-standing behavior.
+            OnMessagePublished?.Invoke(result);
+
+            var handlers = _onMessagePublishedAsync;
+            if (handlers is null)
+                return;
+
+            // Awaited callbacks must not block the connection loop (WaitForConfirms depends on it to
+            // process acks), so they run on a worker task; Dispose waits on the in-flight counter,
+            // which must be released on every path or that wait would hang until its timeout.
+            BeginConfirmationCallback();
+            Task.Run(async () =>
+            {
+                try
+                {
+                    foreach (Func<PublishConfirmationResult, Task> handler in handlers.GetInvocationList())
+                        await handler(result);
+                }
+                catch (Exception ex)
+                {
+                    Log.ConfirmationCallbackFault(s_logger, result.MessageId.Value, ex);
+                }
+                finally
+                {
+                    EndConfirmationCallback();
+                }
+            });
+        }
+
+        private void BeginConfirmationCallback()
+        {
+            lock (_confirmationStateLock)
+            {
+                if (_inFlightConfirmationCallbacks == 0)
+                    _confirmationCallbacksCompleted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+                _inFlightConfirmationCallbacks++;
+            }
+        }
+
+        private void EndConfirmationCallback()
+        {
+            lock (_confirmationStateLock)
+            {
+                _inFlightConfirmationCallbacks--;
+
+                if (_inFlightConfirmationCallbacks == 0)
+                    _confirmationCallbacksCompleted?.TrySetResult(true);
+            }
+        }
+
+        private void WaitForConfirmationCallbacks()
+        {
+            // Timeout 0 means the user opted out of confirm waits at shutdown; honor that here too.
+            if (_waitForConfirmsTimeOutInMilliseconds == 0)
+                return;
+
+            Task? callbacksCompleted;
+            lock (_confirmationStateLock)
+            {
+                if (_inFlightConfirmationCallbacks == 0)
+                    return;
+
+                callbacksCompleted = _confirmationCallbacksCompleted?.Task;
+            }
+
+            if (callbacksCompleted is null)
+                return;
+
+            if (!callbacksCompleted.Wait(TimeSpan.FromMilliseconds(_waitForConfirmsTimeOutInMilliseconds)))
+            {
+                int inFlightCallbacks;
+                lock (_confirmationStateLock)
+                {
+                    inFlightCallbacks = _inFlightConfirmationCallbacks;
+                }
+
+                Log.FailedToAwaitConfirmationCallbacks(s_logger, inFlightCallbacks, _waitForConfirmsTimeOutInMilliseconds);
             }
         }
 
@@ -275,6 +379,12 @@ namespace Paramore.Brighter.MessagingGateway.RMQ.Sync
 
             [LoggerMessage(LogLevel.Information, "Published message: {MessageId}")]
             public static partial void PublishedMessageInformation(ILogger logger, string? messageId);
+
+            [LoggerMessage(LogLevel.Warning, "Failed to await {CallbackCount} confirmation callbacks after {TimeoutMs}ms when shutting down")]
+            public static partial void FailedToAwaitConfirmationCallbacks(ILogger logger, int callbackCount, int timeoutMs);
+
+            [LoggerMessage(LogLevel.Warning, "Confirmation callback for message {MessageId} faulted; the message is left un-dispatched for the Sweeper to retry")]
+            public static partial void ConfirmationCallbackFault(ILogger logger, string messageId, Exception exception);
         }
     }
 

--- a/src/Paramore.Brighter/ISupportPublishConfirmationAsync.cs
+++ b/src/Paramore.Brighter/ISupportPublishConfirmationAsync.cs
@@ -1,6 +1,6 @@
 #region Licence
 /* The MIT License (MIT)
-Copyright © 2026 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+Copyright © 2026 Tom Longhurst <30480171+thomhurst@users.noreply.github.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Paramore.Brighter/ISupportPublishConfirmationAsync.cs
+++ b/src/Paramore.Brighter/ISupportPublishConfirmationAsync.cs
@@ -29,6 +29,8 @@ namespace Paramore.Brighter
 {
     internal interface ISupportPublishConfirmationAsync
     {
+        bool UseAsyncPublishConfirmation { get; }
+
         event Func<PublishConfirmationResult, Task> OnMessagePublishedAsync;
     }
 }

--- a/src/Paramore.Brighter/ISupportPublishConfirmationAsync.cs
+++ b/src/Paramore.Brighter/ISupportPublishConfirmationAsync.cs
@@ -27,10 +27,33 @@ using System.Threading.Tasks;
 
 namespace Paramore.Brighter
 {
-    internal interface ISupportPublishConfirmationAsync
+    /// <summary>
+    /// A producer that can raise its publish confirmation through an awaitable callback. Where
+    /// <see cref="ISupportPublishConfirmation.OnMessagePublished"/> is fire-and-forget (an async
+    /// subscriber becomes async void, so the producer cannot observe when the handler finishes),
+    /// <see cref="OnMessagePublishedAsync"/> returns a <see cref="Task"/> the producer awaits — or
+    /// tracks to completion — before it considers the confirmation handled. This lets a producer's
+    /// dispose path drain the full confirmation pipeline (for example the Outbox mark-dispatched
+    /// write) rather than only the receipt of the broker's ack.
+    /// </summary>
+    public interface ISupportPublishConfirmationAsync
     {
+        /// <summary>
+        /// When <see langword="true"/>, the mediator subscribes <see cref="OnMessagePublishedAsync"/>
+        /// (awaited) instead of <see cref="ISupportPublishConfirmation.OnMessagePublished"/>
+        /// (fire-and-forget) for its confirmation callback. Broker-backed producers should return
+        /// <see langword="true"/>; the <see cref="InMemoryMessageProducer"/> exposes it as an opt-in
+        /// because its awaited path also defers the send to a background pump.
+        /// </summary>
         bool UseAsyncPublishConfirmation { get; }
 
+        /// <summary>
+        /// Fired when a confirmation is received that a message has been published. Unlike
+        /// <see cref="ISupportPublishConfirmation.OnMessagePublished"/>, the producer awaits (or
+        /// tracks) the returned <see cref="Task"/>, so disposal does not complete while a handler
+        /// is still running. Handlers are expected to be non-throwing; producers isolate handler
+        /// faults so one bad subscriber cannot halt confirmation processing.
+        /// </summary>
         event Func<PublishConfirmationResult, Task> OnMessagePublishedAsync;
     }
 }

--- a/src/Paramore.Brighter/ISupportPublishConfirmationAsync.cs
+++ b/src/Paramore.Brighter/ISupportPublishConfirmationAsync.cs
@@ -1,0 +1,34 @@
+#region Licence
+/* The MIT License (MIT)
+Copyright © 2026 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+using System;
+using System.Threading.Tasks;
+
+namespace Paramore.Brighter
+{
+    internal interface ISupportPublishConfirmationAsync
+    {
+        event Func<PublishConfirmationResult, Task> OnMessagePublishedAsync;
+    }
+}

--- a/src/Paramore.Brighter/InMemoryMessageProducer.cs
+++ b/src/Paramore.Brighter/InMemoryMessageProducer.cs
@@ -38,13 +38,14 @@ namespace Paramore.Brighter
     /// The in-memory producer is mainly intended for usage with tests. It allows you to send messages to a bus and
     /// then inspect the messages that have been sent.
     /// </summary>
-    public sealed class InMemoryMessageProducer : IAmAMessageProducerSync, IAmAMessageProducerAsync, IAmABulkMessageProducerAsync, ISupportPublishConfirmation
+    public sealed class InMemoryMessageProducer : IAmAMessageProducerSync, IAmAMessageProducerAsync, IAmABulkMessageProducerAsync, ISupportPublishConfirmation, ISupportPublishConfirmationAsync
     {
         private readonly IAmABus _bus;
         private readonly InstrumentationOptions _instrumentationOptions;
         private readonly System.Threading.Channels.Channel<WorkItem> _channel =
             System.Threading.Channels.Channel.CreateUnbounded<WorkItem>(new UnboundedChannelOptions { SingleReader = true });
         private readonly List<Task> _raiseTasks = new(); // drain worker is single-threaded; read only after worker completes
+        private event Func<PublishConfirmationResult, Task>? OnMessagePublishedAsync;
         // volatile so a DisposeAsync on another thread sees the worker the CAS winner publishes (NFR-3)
         private volatile Task? _worker;
         private int _pumpStarted; // 0 = not started, 1 = started; CAS guard
@@ -125,6 +126,12 @@ namespace Paramore.Brighter
         /// What action should we take on confirmation that a message has been published to a broker
         /// </summary>
         public event Action<PublishConfirmationResult>? OnMessagePublished;
+
+        event Func<PublishConfirmationResult, Task> ISupportPublishConfirmationAsync.OnMessagePublishedAsync
+        {
+            add => OnMessagePublishedAsync += value;
+            remove => OnMessagePublishedAsync -= value;
+        }
 
         /// <summary>
         /// Dispose of the producer. Blocks until any in-flight async pump has fully drained
@@ -241,11 +248,11 @@ namespace Paramore.Brighter
         {
             if (PublishFailurePredicate?.Invoke(message) == true)
             {
-                OnMessagePublished?.Invoke(new PublishConfirmationResult(false, message.Id, message.Header.Topic, null));
+                RaisePublishConfirmation(new PublishConfirmationResult(false, message.Id, message.Header.Topic, null));
                 return;
             }
             _bus.Enqueue(message);
-            OnMessagePublished?.Invoke(new PublishConfirmationResult(true, message.Id, message.Header.Topic, null));
+            RaisePublishConfirmation(new PublishConfirmationResult(true, message.Id, message.Header.Topic, null));
         }
 
         private async Task DrainAsync()
@@ -256,17 +263,31 @@ namespace Paramore.Brighter
                 {
                     var failResult = new PublishConfirmationResult(false, item.Message.Id, item.Message.Header.Topic, item.Context);
                     _raiseTasks.Add(Task.Run(() => OnMessagePublished?.Invoke(failResult)));
+                    await RaisePublishConfirmationAsync(failResult);
                     continue;
                 }
                 _bus.Enqueue(item.Message);
                 var successResult = new PublishConfirmationResult(true, item.Message.Id, item.Message.Header.Topic, item.Context);
-                // NOTE: when the subscriber is an async-void callback (as the mediator's success branch is, which
-                // awaits MarkDispatchedAsync), Invoke returns at its first await — so this raise Task completes, and
-                // DisposeAsync's drain therefore awaits, only up to that first await, NOT the whole callback. Do not
-                // rely on DisposeAsync having flushed a success-path MarkDispatched. The failure path has no await
-                // before TripTopic, so it does drain to completion (which the trip/isolation tests depend on).
                 _raiseTasks.Add(Task.Run(() => OnMessagePublished?.Invoke(successResult)));
+                await RaisePublishConfirmationAsync(successResult);
             }
+        }
+
+        private void RaisePublishConfirmation(PublishConfirmationResult result)
+        {
+            OnMessagePublished?.Invoke(result);
+            if (OnMessagePublishedAsync is not null)
+                BrighterAsyncContext.Run(() => RaisePublishConfirmationAsync(result));
+        }
+
+        private async Task RaisePublishConfirmationAsync(PublishConfirmationResult result)
+        {
+            var handlers = OnMessagePublishedAsync;
+            if (handlers is null)
+                return;
+
+            foreach (Func<PublishConfirmationResult, Task> handler in handlers.GetInvocationList())
+                await handler(result);
         }
 
         /// <summary>

--- a/src/Paramore.Brighter/InMemoryMessageProducer.cs
+++ b/src/Paramore.Brighter/InMemoryMessageProducer.cs
@@ -45,7 +45,7 @@ namespace Paramore.Brighter
         private readonly System.Threading.Channels.Channel<WorkItem> _channel =
             System.Threading.Channels.Channel.CreateUnbounded<WorkItem>(new UnboundedChannelOptions { SingleReader = true });
         private readonly List<Task> _raiseTasks = new(); // drain worker is single-threaded; read only after worker completes
-        private event Func<PublishConfirmationResult, Task>? OnMessagePublishedAsync;
+        private event Func<PublishConfirmationResult, Task>? _onMessagePublishedAsync;
         // volatile so a DisposeAsync on another thread sees the worker the CAS winner publishes (NFR-3)
         private volatile Task? _worker;
         private int _pumpStarted; // 0 = not started, 1 = started; CAS guard
@@ -129,8 +129,8 @@ namespace Paramore.Brighter
 
         event Func<PublishConfirmationResult, Task> ISupportPublishConfirmationAsync.OnMessagePublishedAsync
         {
-            add => OnMessagePublishedAsync += value;
-            remove => OnMessagePublishedAsync -= value;
+            add => _onMessagePublishedAsync += value;
+            remove => _onMessagePublishedAsync -= value;
         }
 
         /// <summary>
@@ -277,13 +277,14 @@ namespace Paramore.Brighter
         private void RaisePublishConfirmation(PublishConfirmationResult result)
         {
             OnMessagePublished?.Invoke(result);
-            if (OnMessagePublishedAsync is not null)
+            // Defensive fallback for in-assembly subscribers; this blocks the send until handlers finish.
+            if (_onMessagePublishedAsync is not null)
                 BrighterAsyncContext.Run(() => RaisePublishConfirmationAsync(result));
         }
 
         private async Task RaisePublishConfirmationAsync(PublishConfirmationResult result)
         {
-            var handlers = OnMessagePublishedAsync;
+            var handlers = _onMessagePublishedAsync;
             if (handlers is null)
                 return;
 

--- a/src/Paramore.Brighter/InMemoryMessageProducer.cs
+++ b/src/Paramore.Brighter/InMemoryMessageProducer.cs
@@ -29,6 +29,8 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Paramore.Brighter.Logging;
 using Paramore.Brighter.Observability;
 using Paramore.Brighter.Tasks;
 
@@ -38,8 +40,9 @@ namespace Paramore.Brighter
     /// The in-memory producer is mainly intended for usage with tests. It allows you to send messages to a bus and
     /// then inspect the messages that have been sent.
     /// </summary>
-    public sealed class InMemoryMessageProducer : IAmAMessageProducerSync, IAmAMessageProducerAsync, IAmABulkMessageProducerAsync, ISupportPublishConfirmation, ISupportPublishConfirmationAsync
+    public sealed partial class InMemoryMessageProducer : IAmAMessageProducerSync, IAmAMessageProducerAsync, IAmABulkMessageProducerAsync, ISupportPublishConfirmation, ISupportPublishConfirmationAsync
     {
+        private static readonly ILogger s_logger = ApplicationLogging.CreateLogger<InMemoryMessageProducer>();
         private readonly IAmABus _bus;
         private readonly InstrumentationOptions _instrumentationOptions;
         private readonly System.Threading.Channels.Channel<WorkItem> _channel =
@@ -267,13 +270,28 @@ namespace Paramore.Brighter
                 {
                     var failResult = new PublishConfirmationResult(false, item.Message.Id, item.Message.Header.Topic, item.Context);
                     _raiseTasks.Add(Task.Run(() => OnMessagePublished?.Invoke(failResult)));
-                    await _onMessagePublishedAsync.InvokeAllAsync(failResult);
+                    await RaiseConfirmationCallbacksAsync(failResult);
                     continue;
                 }
                 _bus.Enqueue(item.Message);
                 var successResult = new PublishConfirmationResult(true, item.Message.Id, item.Message.Header.Topic, item.Context);
                 _raiseTasks.Add(Task.Run(() => OnMessagePublished?.Invoke(successResult)));
-                await _onMessagePublishedAsync.InvokeAllAsync(successResult);
+                await RaiseConfirmationCallbacksAsync(successResult);
+            }
+        }
+
+        private async Task RaiseConfirmationCallbacksAsync(PublishConfirmationResult result)
+        {
+            // A faulting subscriber must not fault the drain worker: that would strand the remaining
+            // queued items and re-surface out of DisposeAsync's await of the worker. Mirrors the
+            // broker producers' per-confirmation isolation.
+            try
+            {
+                await _onMessagePublishedAsync.InvokeAllAsync(result);
+            }
+            catch (Exception ex)
+            {
+                Log.ConfirmationCallbackFault(s_logger, result.MessageId.Value, ex);
             }
         }
 
@@ -332,7 +350,13 @@ namespace Paramore.Brighter
                 return;
             }
 
-            throw new ConfigurationException($"Cannot requeue {message.Id} with delay; no scheduler is configured. Configure a scheduler via MessageSchedulerFactory in IAmProducersConfiguration."); 
+            throw new ConfigurationException($"Cannot requeue {message.Id} with delay; no scheduler is configured. Configure a scheduler via MessageSchedulerFactory in IAmProducersConfiguration.");
+        }
+
+        private static partial class Log
+        {
+            [LoggerMessage(LogLevel.Warning, "Confirmation callback for message {MessageId} faulted; remaining confirmations continue")]
+            public static partial void ConfirmationCallbackFault(ILogger logger, string messageId, Exception exception);
         }
     }
 }

--- a/src/Paramore.Brighter/InMemoryMessageProducer.cs
+++ b/src/Paramore.Brighter/InMemoryMessageProducer.cs
@@ -257,6 +257,7 @@ namespace Paramore.Brighter
 
         private async Task DrainAsync()
         {
+            // External Action subscribers remain fire-and-forget; mediator confirmations use the awaited event.
             await foreach (var item in _channel.Reader.ReadAllAsync(CancellationToken.None))
             {
                 if (PublishFailurePredicate?.Invoke(item.Message) == true)

--- a/src/Paramore.Brighter/InMemoryMessageProducer.cs
+++ b/src/Paramore.Brighter/InMemoryMessageProducer.cs
@@ -269,16 +269,31 @@ namespace Paramore.Brighter
                 if (PublishFailurePredicate?.Invoke(item.Message) == true)
                 {
                     var failResult = new PublishConfirmationResult(false, item.Message.Id, item.Message.Header.Topic, item.Context);
-                    _raiseTasks.Add(Task.Run(() => OnMessagePublished?.Invoke(failResult)));
+                    RaiseActionSubscribers(failResult);
                     await RaiseConfirmationCallbacksAsync(failResult);
                     continue;
                 }
                 _bus.Enqueue(item.Message);
                 var successResult = new PublishConfirmationResult(true, item.Message.Id, item.Message.Header.Topic, item.Context);
-                _raiseTasks.Add(Task.Run(() => OnMessagePublished?.Invoke(successResult)));
+                RaiseActionSubscribers(successResult);
                 await RaiseConfirmationCallbacksAsync(successResult);
             }
         }
+
+        private void RaiseActionSubscribers(PublishConfirmationResult result) =>
+            // Isolated like the awaited path: a throwing Action subscriber would otherwise fault its
+            // raise task and re-surface out of DisposeAsync's Task.WhenAll over _raiseTasks.
+            _raiseTasks.Add(Task.Run(() =>
+            {
+                try
+                {
+                    OnMessagePublished?.Invoke(result);
+                }
+                catch (Exception ex)
+                {
+                    Log.ConfirmationCallbackFault(s_logger, result.MessageId.Value, ex);
+                }
+            }));
 
         private async Task RaiseConfirmationCallbacksAsync(PublishConfirmationResult result)
         {

--- a/src/Paramore.Brighter/InMemoryMessageProducer.cs
+++ b/src/Paramore.Brighter/InMemoryMessageProducer.cs
@@ -246,13 +246,16 @@ namespace Paramore.Brighter
 
         private void Enqueue(Message message)
         {
+            // The awaited event fires only on the deferred pump (UseAsyncPublishConfirmation true);
+            // the synchronous path raises the fire-and-forget event only, preserving its non-blocking
+            // send contract.
             if (PublishFailurePredicate?.Invoke(message) == true)
             {
-                RaisePublishConfirmation(new PublishConfirmationResult(false, message.Id, message.Header.Topic, null));
+                OnMessagePublished?.Invoke(new PublishConfirmationResult(false, message.Id, message.Header.Topic, null));
                 return;
             }
             _bus.Enqueue(message);
-            RaisePublishConfirmation(new PublishConfirmationResult(true, message.Id, message.Header.Topic, null));
+            OnMessagePublished?.Invoke(new PublishConfirmationResult(true, message.Id, message.Header.Topic, null));
         }
 
         private async Task DrainAsync()
@@ -264,32 +267,14 @@ namespace Paramore.Brighter
                 {
                     var failResult = new PublishConfirmationResult(false, item.Message.Id, item.Message.Header.Topic, item.Context);
                     _raiseTasks.Add(Task.Run(() => OnMessagePublished?.Invoke(failResult)));
-                    await RaisePublishConfirmationAsync(failResult);
+                    await _onMessagePublishedAsync.InvokeAllAsync(failResult);
                     continue;
                 }
                 _bus.Enqueue(item.Message);
                 var successResult = new PublishConfirmationResult(true, item.Message.Id, item.Message.Header.Topic, item.Context);
                 _raiseTasks.Add(Task.Run(() => OnMessagePublished?.Invoke(successResult)));
-                await RaisePublishConfirmationAsync(successResult);
+                await _onMessagePublishedAsync.InvokeAllAsync(successResult);
             }
-        }
-
-        private void RaisePublishConfirmation(PublishConfirmationResult result)
-        {
-            OnMessagePublished?.Invoke(result);
-            // Defensive fallback for in-assembly subscribers; this blocks the send until handlers finish.
-            if (_onMessagePublishedAsync is not null)
-                BrighterAsyncContext.Run(() => RaisePublishConfirmationAsync(result));
-        }
-
-        private async Task RaisePublishConfirmationAsync(PublishConfirmationResult result)
-        {
-            var handlers = _onMessagePublishedAsync;
-            if (handlers is null)
-                return;
-
-            foreach (Func<PublishConfirmationResult, Task> handler in handlers.GetInvocationList())
-                await handler(result);
         }
 
         /// <summary>

--- a/src/Paramore.Brighter/OutboxProducerMediator.cs
+++ b/src/Paramore.Brighter/OutboxProducerMediator.cs
@@ -764,7 +764,7 @@ namespace Paramore.Brighter
         /// <returns></returns>
         private void ConfigureAsyncPublisherCallbackMaybe(IAmAMessageProducerAsync producer, RequestContext requestContext)
         {
-            if (producer is ISupportPublishConfirmationAsync asyncConfirmingProducer)
+            if (producer is ISupportPublishConfirmationAsync { UseAsyncPublishConfirmation: true } asyncConfirmingProducer)
             {
                 asyncConfirmingProducer.OnMessagePublishedAsync += result =>
                     HandleAsyncPublishConfirmation(result, requestContext);

--- a/src/Paramore.Brighter/OutboxProducerMediator.cs
+++ b/src/Paramore.Brighter/OutboxProducerMediator.cs
@@ -773,34 +773,15 @@ namespace Paramore.Brighter
 
             if (producer is ISupportPublishConfirmation confirmingProducer)
             {
-                confirmingProducer.OnMessagePublished += async delegate(PublishConfirmationResult result)
-                {
-                    await HandleAsyncPublishConfirmation(result, requestContext);
-                };
+                // Discard, not async void: HandleAsyncPublishConfirmation catches its own faults, and a
+                // discarded task cannot tear down the raising thread the way an async void throw would.
+                confirmingProducer.OnMessagePublished += result => _ = HandleAsyncPublishConfirmation(result, requestContext);
             }
         }
 
         private async Task HandleAsyncPublishConfirmation(PublishConfirmationResult result, RequestContext requestContext)
         {
-            // Emit a standalone confirmation span FIRST on every invocation (success or
-            // failure). It links back to the original publish span (when its context was
-            // captured at send time) rather than reopening it, and degrades to no link when
-            // the context is absent. The observability work is isolated in try/catch so a
-            // tracing fault can never destabilise the producer thread (NFR-4); the span is
-            // disposed in the finally so it starts and stops within the callback (NFR-2).
-            Activity? confirmationSpan = null;
-            try
-            {
-                var links = result.PublishSpanContext is { } publishContext
-                    ? new[] { new ActivityLink(publishContext) }
-                    : null;
-                confirmationSpan = _tracer?.CreateConfirmationSpan(
-                    result.MessageId, result.Topic, result.Success, links);
-            }
-            catch (Exception ex)
-            {
-                Log.ConfirmationObservabilityFault(s_logger, ex);
-            }
+            var confirmationSpan = StartConfirmationSpan(result);
 
             try
             {
@@ -846,6 +827,31 @@ namespace Paramore.Brighter
             }
         }
 
+        /// <summary>
+        /// Emit a standalone confirmation span FIRST on every confirmation callback (success or
+        /// failure). It links back to the original publish span (when its context was captured at
+        /// send time) rather than reopening it, and degrades to no link when the context is absent.
+        /// The observability work is isolated in try/catch so a tracing fault can never destabilise
+        /// the producer thread (NFR-4); end the span via <see cref="EndConfirmationSpan"/> in the
+        /// callback's finally so it starts and stops within the callback (NFR-2).
+        /// </summary>
+        private Activity? StartConfirmationSpan(PublishConfirmationResult result)
+        {
+            try
+            {
+                var links = result.PublishSpanContext is { } publishContext
+                    ? new[] { new ActivityLink(publishContext) }
+                    : null;
+                return _tracer?.CreateConfirmationSpan(
+                    result.MessageId, result.Topic, result.Success, links);
+            }
+            catch (Exception ex)
+            {
+                Log.ConfirmationObservabilityFault(s_logger, ex);
+                return null;
+            }
+        }
+
         private void EndConfirmationSpan(Activity? confirmationSpan)
         {
             try
@@ -871,25 +877,7 @@ namespace Paramore.Brighter
             {
                 producerSync.OnMessagePublished += delegate(PublishConfirmationResult result)
                 {
-                    // Emit a standalone confirmation span FIRST on every invocation (success or
-                    // failure). It links back to the original publish span (when its context was
-                    // captured at send time) rather than reopening it, and degrades to no link when
-                    // the context is absent. The observability work is isolated in try/catch so a
-                    // tracing fault can never destabilise the producer thread (NFR-4); the span is
-                    // disposed in the finally so it starts and stops within the callback (NFR-2).
-                    Activity? confirmationSpan = null;
-                    try
-                    {
-                        var links = result.PublishSpanContext is { } publishContext
-                            ? new[] { new ActivityLink(publishContext) }
-                            : null;
-                        confirmationSpan = _tracer?.CreateConfirmationSpan(
-                            result.MessageId, result.Topic, result.Success, links);
-                    }
-                    catch (Exception ex)
-                    {
-                        Log.ConfirmationObservabilityFault(s_logger, ex);
-                    }
+                    var confirmationSpan = StartConfirmationSpan(result);
 
                     try
                     {

--- a/src/Paramore.Brighter/OutboxProducerMediator.cs
+++ b/src/Paramore.Brighter/OutboxProducerMediator.cs
@@ -842,10 +842,20 @@ namespace Paramore.Brighter
             }
             finally
             {
-                // End via the tracer (not raw Dispose) so the end time is stamped from the tracer's
-                // TimeProvider — matching the start time set in CreateConfirmationSpan — and a
-                // successful span gets Ok status, consistent with every other span in this file.
+                EndConfirmationSpan(confirmationSpan);
+            }
+        }
+
+        private void EndConfirmationSpan(Activity? confirmationSpan)
+        {
+            try
+            {
+                // End via the tracer so its TimeProvider stamps the end consistently with the start.
                 _tracer?.EndSpan(confirmationSpan);
+            }
+            catch (Exception ex)
+            {
+                Log.ConfirmationObservabilityFault(s_logger, ex);
             }
         }
 
@@ -923,10 +933,7 @@ namespace Paramore.Brighter
                     }
                     finally
                     {
-                        // End via the tracer (not raw Dispose) so the end time is stamped from the tracer's
-                        // TimeProvider — matching the start time set in CreateConfirmationSpan — and a
-                        // successful span gets Ok status, consistent with every other span in this file.
-                        _tracer?.EndSpan(confirmationSpan);
+                        EndConfirmationSpan(confirmationSpan);
                     }
                 };
                 return true;

--- a/src/Paramore.Brighter/OutboxProducerMediator.cs
+++ b/src/Paramore.Brighter/OutboxProducerMediator.cs
@@ -764,81 +764,88 @@ namespace Paramore.Brighter
         /// <returns></returns>
         private void ConfigureAsyncPublisherCallbackMaybe(IAmAMessageProducerAsync producer, RequestContext requestContext)
         {
+            if (producer is ISupportPublishConfirmationAsync asyncConfirmingProducer)
+            {
+                asyncConfirmingProducer.OnMessagePublishedAsync += result =>
+                    HandleAsyncPublishConfirmation(result, requestContext);
+                return;
+            }
+
             if (producer is ISupportPublishConfirmation confirmingProducer)
             {
                 confirmingProducer.OnMessagePublished += async delegate(PublishConfirmationResult result)
                 {
-                    // Emit a standalone confirmation span FIRST on every invocation (success or
-                    // failure). It links back to the original publish span (when its context was
-                    // captured at send time) rather than reopening it, and degrades to no link when
-                    // the context is absent. The observability work is isolated in try/catch so a
-                    // tracing fault can never destabilise the producer thread (NFR-4); the span is
-                    // disposed in the finally so it starts and stops within the callback (NFR-2).
-                    Activity? confirmationSpan = null;
-                    try
-                    {
-                        var links = result.PublishSpanContext is { } publishContext
-                            ? new[] { new ActivityLink(publishContext) }
-                            : null;
-                        confirmationSpan = _tracer?.CreateConfirmationSpan(
-                            result.MessageId, result.Topic, result.Success, links);
-                    }
-                    catch (Exception ex)
-                    {
-                        Log.ConfirmationObservabilityFault(s_logger, ex);
-                    }
-
-                    try
-                    {
-                        if (result.Success)
-                        {
-                            Log.SentMessage(s_logger, result.MessageId.Value);
-                            if (_asyncOutbox != null)
-                            {
-                                // Explicitly re-parent the MarkDispatched DB span to the confirmation
-                                // span (S2): CreateDbSpan parents from requestContext.Span, so we pass a
-                                // per-callback copy whose Span is S2 rather than relying on the ambient
-                                // Activity.Current fallback (C-6). A copy is required because
-                                // RequestContext.Span is thread-keyed and its setter ignores null, so we
-                                // must not mutate the shared construction-time context.
-                                var dispatchedContext = (RequestContext)requestContext.CreateCopy();
-                                dispatchedContext.Span = confirmationSpan;
-                                await ExecuteWithResiliencePipelineAsync(
-                                    async ct =>
-                                        await _asyncOutbox.MarkDispatchedAsync(result.MessageId, dispatchedContext, _timeProvider.GetUtcNow(),
-                                            cancellationToken: ct),
-                                    dispatchedContext
-                                );
-                            }
-                        }
-                        else
-                        {
-                            Log.ConfirmationFailed(s_logger, result.MessageId.Value, result.Topic?.Value ?? string.Empty);
-                            // Trip the breaker on the wire topic (result.Topic == message.Header.Topic),
-                            // not the Publication topic — exact parity with the non-confirmation send
-                            // failure path (see DispatchAsync). TripTopic safely no-ops on null/empty.
-                            TripTopic(result.Topic);
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        // This delegate is async void: an exception that escapes it is unobserved on the
-                        // producer's broker/threadpool thread and is process-terminating by default. Keep the
-                        // safety LOCAL and obvious rather than relying on ExecuteWithResiliencePipelineAsync
-                        // happening to absorb the MarkDispatched path — a future caller (or a throwing breaker,
-                        // logger or context copy) must not be able to crash the producer. The message is left
-                        // un-dispatched, so the Sweeper will retry it (C-1); we log at Warning, not Error,
-                        // because nothing is lost.
-                        Log.ConfirmationDispatchError(s_logger, result.MessageId.Value, result.Topic?.Value ?? string.Empty, ex);
-                    }
-                    finally
-                    {
-                        // End via the tracer (not raw Dispose) so the end time is stamped from the tracer's
-                        // TimeProvider — matching the start time set in CreateConfirmationSpan — and a
-                        // successful span gets Ok status, consistent with every other span in this file.
-                        _tracer?.EndSpan(confirmationSpan);
-                    }
+                    await HandleAsyncPublishConfirmation(result, requestContext);
                 };
+            }
+        }
+
+        private async Task HandleAsyncPublishConfirmation(PublishConfirmationResult result, RequestContext requestContext)
+        {
+            // Emit a standalone confirmation span FIRST on every invocation (success or
+            // failure). It links back to the original publish span (when its context was
+            // captured at send time) rather than reopening it, and degrades to no link when
+            // the context is absent. The observability work is isolated in try/catch so a
+            // tracing fault can never destabilise the producer thread (NFR-4); the span is
+            // disposed in the finally so it starts and stops within the callback (NFR-2).
+            Activity? confirmationSpan = null;
+            try
+            {
+                var links = result.PublishSpanContext is { } publishContext
+                    ? new[] { new ActivityLink(publishContext) }
+                    : null;
+                confirmationSpan = _tracer?.CreateConfirmationSpan(
+                    result.MessageId, result.Topic, result.Success, links);
+            }
+            catch (Exception ex)
+            {
+                Log.ConfirmationObservabilityFault(s_logger, ex);
+            }
+
+            try
+            {
+                if (result.Success)
+                {
+                    Log.SentMessage(s_logger, result.MessageId.Value);
+                    if (_asyncOutbox != null)
+                    {
+                        // Explicitly re-parent the MarkDispatched DB span to the confirmation
+                        // span (S2): CreateDbSpan parents from requestContext.Span, so we pass a
+                        // per-callback copy whose Span is S2 rather than relying on the ambient
+                        // Activity.Current fallback (C-6). A copy is required because
+                        // RequestContext.Span is thread-keyed and its setter ignores null, so we
+                        // must not mutate the shared construction-time context.
+                        var dispatchedContext = (RequestContext)requestContext.CreateCopy();
+                        dispatchedContext.Span = confirmationSpan;
+                        await ExecuteWithResiliencePipelineAsync(
+                            async ct =>
+                                await _asyncOutbox.MarkDispatchedAsync(result.MessageId, dispatchedContext, _timeProvider.GetUtcNow(),
+                                    cancellationToken: ct),
+                            dispatchedContext
+                        );
+                    }
+                }
+                else
+                {
+                    Log.ConfirmationFailed(s_logger, result.MessageId.Value, result.Topic?.Value ?? string.Empty);
+                    // Trip the breaker on the wire topic (result.Topic == message.Header.Topic),
+                    // not the Publication topic — exact parity with the non-confirmation send
+                    // failure path (see DispatchAsync). TripTopic safely no-ops on null/empty.
+                    TripTopic(result.Topic);
+                }
+            }
+            catch (Exception ex)
+            {
+                // The callback must not allow a failed dispatch update to crash the producer. The
+                // message remains undispatched, so the Sweeper will retry it.
+                Log.ConfirmationDispatchError(s_logger, result.MessageId.Value, result.Topic?.Value ?? string.Empty, ex);
+            }
+            finally
+            {
+                // End via the tracer (not raw Dispose) so the end time is stamped from the tracer's
+                // TimeProvider — matching the start time set in CreateConfirmationSpan — and a
+                // successful span gets Ok status, consistent with every other span in this file.
+                _tracer?.EndSpan(confirmationSpan);
             }
         }
 

--- a/src/Paramore.Brighter/PublishConfirmationExtensions.cs
+++ b/src/Paramore.Brighter/PublishConfirmationExtensions.cs
@@ -1,6 +1,6 @@
 #region Licence
 /* The MIT License (MIT)
-Copyright © 2026 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+Copyright © 2026 Tom Longhurst <30480171+thomhurst@users.noreply.github.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Paramore.Brighter/PublishConfirmationExtensions.cs
+++ b/src/Paramore.Brighter/PublishConfirmationExtensions.cs
@@ -1,0 +1,52 @@
+#region Licence
+/* The MIT License (MIT)
+Copyright © 2026 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+using System;
+using System.Threading.Tasks;
+
+namespace Paramore.Brighter
+{
+    /// <summary>
+    /// Helpers for raising publish-confirmation callbacks.
+    /// </summary>
+    public static class PublishConfirmationExtensions
+    {
+        /// <summary>
+        /// Invokes every subscriber of an <see cref="ISupportPublishConfirmationAsync.OnMessagePublishedAsync"/>
+        /// event, awaiting each in subscription order. This is the canonical raise for the awaited
+        /// confirmation event: sequential (never concurrent) invocation, over a snapshot of the
+        /// invocation list. A null <paramref name="handlers"/> (no subscribers) is a no-op.
+        /// </summary>
+        /// <param name="handlers">The event's backing delegate; may be null or multicast.</param>
+        /// <param name="result">The confirmation to deliver to each subscriber.</param>
+        public static async Task InvokeAllAsync(this Func<PublishConfirmationResult, Task>? handlers, PublishConfirmationResult result)
+        {
+            if (handlers is null)
+                return;
+
+            foreach (Func<PublishConfirmationResult, Task> handler in handlers.GetInvocationList())
+                await handler(result);
+        }
+    }
+}

--- a/src/Paramore.Brighter/PublishConfirmationExtensions.cs
+++ b/src/Paramore.Brighter/PublishConfirmationExtensions.cs
@@ -28,7 +28,9 @@ using System.Threading.Tasks;
 namespace Paramore.Brighter
 {
     /// <summary>
-    /// Helpers for raising publish-confirmation callbacks.
+    /// Helpers for raising publish-confirmation callbacks. Public so that Brighter's transport
+    /// packages can consume them across the assembly boundary; producers implementing
+    /// <see cref="ISupportPublishConfirmationAsync"/> are the intended callers.
     /// </summary>
     public static class PublishConfirmationExtensions
     {

--- a/src/Paramore.Brighter/PublishConfirmationExtensions.cs
+++ b/src/Paramore.Brighter/PublishConfirmationExtensions.cs
@@ -39,6 +39,9 @@ namespace Paramore.Brighter
         /// event, awaiting each in subscription order. This is the canonical raise for the awaited
         /// confirmation event: sequential (never concurrent) invocation, over a snapshot of the
         /// invocation list. A null <paramref name="handlers"/> (no subscribers) is a no-op.
+        /// A throwing subscriber propagates its exception and skips the remaining subscribers for
+        /// that confirmation — callers (the producers) wrap the whole raise in a per-confirmation
+        /// catch, so a fault is contained to one confirmation, not one subscriber.
         /// </summary>
         /// <param name="handlers">The event's backing delegate; may be null or multicast.</param>
         /// <param name="result">The confirmation to deliver to each subscriber.</param>

--- a/src/Paramore.Brighter/Tasks/InFlightCallbackTracker.cs
+++ b/src/Paramore.Brighter/Tasks/InFlightCallbackTracker.cs
@@ -1,6 +1,6 @@
 #region Licence
 /* The MIT License (MIT)
-Copyright © 2026 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+Copyright © 2026 Tom Longhurst <30480171+thomhurst@users.noreply.github.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Paramore.Brighter/Tasks/InFlightCallbackTracker.cs
+++ b/src/Paramore.Brighter/Tasks/InFlightCallbackTracker.cs
@@ -78,6 +78,11 @@ namespace Paramore.Brighter.Tasks
         /// <summary>
         /// Blocks until all in-flight callbacks have completed, or the timeout elapses.
         /// </summary>
+        /// <remarks>
+        /// A <see cref="Begin"/> that races in after the wait has observed zero and returned is not
+        /// tracked by that wait — callers are expected to have stopped producing new callbacks
+        /// (e.g. drained the broker's acks) before waiting, as a shutdown path does.
+        /// </remarks>
         /// <param name="timeout">How long to wait for the drain.</param>
         /// <param name="stillInFlight">The number of callbacks still running when the wait ended.</param>
         /// <returns>True when the tracker drained within the timeout; false when callbacks remain.</returns>

--- a/src/Paramore.Brighter/Tasks/InFlightCallbackTracker.cs
+++ b/src/Paramore.Brighter/Tasks/InFlightCallbackTracker.cs
@@ -1,0 +1,113 @@
+#region Licence
+/* The MIT License (MIT)
+Copyright © 2026 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+using System;
+using System.Threading.Tasks;
+
+namespace Paramore.Brighter.Tasks
+{
+    /// <summary>
+    /// Counts callbacks a producer has started but not yet observed completing, so its dispose path
+    /// can wait for them to drain. Used by producers whose confirmation callbacks run on worker
+    /// tasks (they must not block a broker client's dispatch thread): the raise site calls
+    /// <see cref="Begin"/> before scheduling the callback and <see cref="End"/> in its finally, and
+    /// disposal calls <see cref="TryWait"/> after the broker's own acks have been drained.
+    /// </summary>
+    /// <remarks>
+    /// The drain waiter is allocated lazily by <see cref="TryWait"/>, so the per-callback cost on
+    /// the confirmation path is a single short lock, with no allocation.
+    /// </remarks>
+    public sealed class InFlightCallbackTracker
+    {
+        private readonly object _lock = new();
+        private int _inFlight;
+        private TaskCompletionSource<bool>? _drained;
+
+        /// <summary>
+        /// Records that a callback has been started. Every call must be balanced by exactly one
+        /// <see cref="End"/> (call it in a finally), or <see cref="TryWait"/> will wait out its
+        /// full timeout.
+        /// </summary>
+        public void Begin()
+        {
+            lock (_lock)
+            {
+                _inFlight++;
+            }
+        }
+
+        /// <summary>
+        /// Records that a callback has completed, releasing any drain waiter when it was the last
+        /// one in flight.
+        /// </summary>
+        public void End()
+        {
+            lock (_lock)
+            {
+                _inFlight--;
+
+                if (_inFlight == 0 && _drained is not null)
+                {
+                    _drained.TrySetResult(true);
+                    _drained = null;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Blocks until all in-flight callbacks have completed, or the timeout elapses.
+        /// </summary>
+        /// <param name="timeout">How long to wait for the drain.</param>
+        /// <param name="stillInFlight">The number of callbacks still running when the wait ended.</param>
+        /// <returns>True when the tracker drained within the timeout; false when callbacks remain.</returns>
+        public bool TryWait(TimeSpan timeout, out int stillInFlight)
+        {
+            Task drainedTask;
+            lock (_lock)
+            {
+                if (_inFlight == 0)
+                {
+                    stillInFlight = 0;
+                    return true;
+                }
+
+                _drained ??= new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                drainedTask = _drained.Task;
+            }
+
+            if (drainedTask.Wait(timeout))
+            {
+                stillInFlight = 0;
+                return true;
+            }
+
+            lock (_lock)
+            {
+                stillInFlight = _inFlight;
+            }
+
+            return stillInFlight == 0;
+        }
+    }
+}

--- a/src/Paramore.Brighter/Tasks/InFlightCallbackTracker.cs
+++ b/src/Paramore.Brighter/Tasks/InFlightCallbackTracker.cs
@@ -23,6 +23,7 @@ THE SOFTWARE. */
 #endregion
 
 using System;
+using System.Diagnostics;
 using System.Threading.Tasks;
 
 namespace Paramore.Brighter.Tasks
@@ -36,7 +37,9 @@ namespace Paramore.Brighter.Tasks
     /// </summary>
     /// <remarks>
     /// The drain waiter is allocated lazily by <see cref="TryWait"/>, so the per-callback cost on
-    /// the confirmation path is a single short lock, with no allocation.
+    /// the confirmation path is a single short lock, with no allocation. Public so that Brighter's
+    /// transport packages can consume it across the assembly boundary; it is not intended as a
+    /// general-purpose synchronization primitive.
     /// </remarks>
     public sealed class InFlightCallbackTracker
     {
@@ -65,7 +68,11 @@ namespace Paramore.Brighter.Tasks
         {
             lock (_lock)
             {
-                _inFlight--;
+                // An unbalanced End would drive the count negative and the drain waiter would never
+                // release; assert loudly in debug builds and refuse to go below zero in release.
+                Debug.Assert(_inFlight > 0, "InFlightCallbackTracker.End called without a matching Begin");
+                if (_inFlight > 0)
+                    _inFlight--;
 
                 if (_inFlight == 0 && _drained is not null)
                 {

--- a/tests/Paramore.Brighter.Core.Tests/Confirmation/TestDoubles/GatedAsyncOutbox.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Confirmation/TestDoubles/GatedAsyncOutbox.cs
@@ -1,6 +1,6 @@
 #region Licence
 /* The MIT License (MIT)
-Copyright © 2026 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+Copyright © 2026 Tom Longhurst <30480171+thomhurst@users.noreply.github.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/tests/Paramore.Brighter.Core.Tests/Confirmation/TestDoubles/GatedAsyncOutbox.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Confirmation/TestDoubles/GatedAsyncOutbox.cs
@@ -1,0 +1,151 @@
+#region Licence
+/* The MIT License (MIT)
+Copyright © 2026 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Transactions;
+using Paramore.Brighter.Observability;
+
+namespace Paramore.Brighter.Core.Tests.Confirmation.TestDoubles;
+
+internal sealed class GatedAsyncOutbox : IAmAnOutboxAsync<Message, CommittableTransaction>
+{
+    private readonly TaskCompletionSource _allowDispatch = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly TaskCompletionSource _dispatchCompleted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly TaskCompletionSource _dispatchStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly InMemoryOutbox _inner = new(TimeProvider.System);
+
+    public Task DispatchCompleted => _dispatchCompleted.Task;
+    public Task DispatchStarted => _dispatchStarted.Task;
+
+    public IAmABrighterTracer? Tracer
+    {
+        set => _inner.Tracer = value;
+    }
+
+    public bool ContinueOnCapturedContext
+    {
+        get => _inner.ContinueOnCapturedContext;
+        set => _inner.ContinueOnCapturedContext = value;
+    }
+
+    public void AllowDispatch() => _allowDispatch.TrySetResult();
+
+    public bool WasDispatched(Id id, RequestContext requestContext) =>
+        _inner.DispatchedMessages(TimeSpan.Zero, requestContext).Any(message => message.Id == id);
+
+    public Task AddAsync(
+        Message message,
+        RequestContext requestContext,
+        int outBoxTimeout = -1,
+        IAmABoxTransactionProvider<CommittableTransaction>? transactionProvider = null,
+        CancellationToken cancellationToken = default) =>
+        _inner.AddAsync(message, requestContext, outBoxTimeout, transactionProvider, cancellationToken);
+
+    public Task AddAsync(
+        IEnumerable<Message> messages,
+        RequestContext? requestContext,
+        int outBoxTimeout = -1,
+        IAmABoxTransactionProvider<CommittableTransaction>? transactionProvider = null,
+        CancellationToken cancellationToken = default) =>
+        _inner.AddAsync(messages, requestContext, outBoxTimeout, transactionProvider, cancellationToken);
+
+    public Task DeleteAsync(
+        Id[] messageIds,
+        RequestContext requestContext,
+        Dictionary<string, object>? args = null,
+        CancellationToken cancellationToken = default) =>
+        _inner.DeleteAsync(messageIds, requestContext, args, cancellationToken);
+
+    public Task<IEnumerable<Message>> DispatchedMessagesAsync(
+        TimeSpan dispatchedSince,
+        RequestContext requestContext,
+        int pageSize = 100,
+        int pageNumber = 1,
+        int outboxTimeout = -1,
+        Dictionary<string, object>? args = null,
+        CancellationToken cancellationToken = default) =>
+        _inner.DispatchedMessagesAsync(
+            dispatchedSince, requestContext, pageSize, pageNumber, outboxTimeout, args, cancellationToken);
+
+    public Task<Message> GetAsync(
+        Id messageId,
+        RequestContext requestContext,
+        int outBoxTimeout = -1,
+        Dictionary<string, object>? args = null,
+        CancellationToken cancellationToken = default) =>
+        _inner.GetAsync(messageId, requestContext, outBoxTimeout, args, cancellationToken);
+
+    public Task<IEnumerable<Message>> GetAsync(
+        IEnumerable<Id> messageIds,
+        RequestContext requestContext,
+        int outBoxTimeout = -1,
+        Dictionary<string, object>? args = null,
+        CancellationToken cancellationToken = default) =>
+        _inner.GetAsync(messageIds, requestContext, outBoxTimeout, args, cancellationToken);
+
+    public async Task MarkDispatchedAsync(
+        Id id,
+        RequestContext requestContext,
+        DateTimeOffset? dispatchedAt = null,
+        Dictionary<string, object>? args = null,
+        CancellationToken cancellationToken = default)
+    {
+        _dispatchStarted.TrySetResult();
+        await _allowDispatch.Task.WaitAsync(cancellationToken);
+        await _inner.MarkDispatchedAsync(id, requestContext, dispatchedAt, args, cancellationToken);
+        _dispatchCompleted.TrySetResult();
+    }
+
+    public Task MarkDispatchedAsync(
+        IEnumerable<Id> ids,
+        RequestContext requestContext,
+        DateTimeOffset? dispatchedAt = null,
+        Dictionary<string, object>? args = null,
+        CancellationToken cancellationToken = default) =>
+        _inner.MarkDispatchedAsync(ids, requestContext, dispatchedAt, args, cancellationToken);
+
+    public Task<IEnumerable<Message>> OutstandingMessagesAsync(
+        TimeSpan dispatchedSince,
+        RequestContext requestContext,
+        int pageSize = 100,
+        int pageNumber = 1,
+        IEnumerable<RoutingKey>? trippedTopics = null,
+        Dictionary<string, object>? args = null,
+        CancellationToken cancellationToken = default) =>
+        _inner.OutstandingMessagesAsync(
+            dispatchedSince, requestContext, pageSize, pageNumber, trippedTopics, args, cancellationToken);
+
+    public Task<int> GetOutstandingMessageCountAsync(
+        TimeSpan dispatchedSince,
+        RequestContext? requestContext,
+        int maxCount = 100,
+        Dictionary<string, object>? args = null,
+        CancellationToken cancellationToken = default) =>
+        _inner.GetOutstandingMessageCountAsync(
+            dispatchedSince, requestContext, maxCount, args, cancellationToken);
+}

--- a/tests/Paramore.Brighter.Core.Tests/Confirmation/TestDoubles/StubConfirmingProducerAsync.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Confirmation/TestDoubles/StubConfirmingProducerAsync.cs
@@ -1,6 +1,6 @@
 #region Licence
 /* The MIT License (MIT)
-Copyright © 2026 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+Copyright © 2026 Tom Longhurst <30480171+thomhurst@users.noreply.github.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/tests/Paramore.Brighter.Core.Tests/Confirmation/TestDoubles/StubConfirmingProducerAsync.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Confirmation/TestDoubles/StubConfirmingProducerAsync.cs
@@ -64,13 +64,7 @@ internal sealed class StubConfirmingProducerAsync(RoutingKey topic) : IAmAMessag
     public async Task RaiseConfirmationAsync(PublishConfirmationResult result)
     {
         OnMessagePublished?.Invoke(result);
-
-        var handlers = _onMessagePublishedAsync;
-        if (handlers is null)
-            return;
-
-        foreach (Func<PublishConfirmationResult, Task> handler in handlers.GetInvocationList())
-            await handler(result);
+        await _onMessagePublishedAsync.InvokeAllAsync(result);
     }
 
     public ValueTask DisposeAsync() => default;

--- a/tests/Paramore.Brighter.Core.Tests/Confirmation/TestDoubles/StubConfirmingProducerAsync.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Confirmation/TestDoubles/StubConfirmingProducerAsync.cs
@@ -1,0 +1,77 @@
+#region Licence
+/* The MIT License (MIT)
+Copyright © 2026 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Paramore.Brighter.Core.Tests.Confirmation.TestDoubles;
+
+/// <summary>
+/// Mimics a broker-backed producer's confirmation surface: it always reports
+/// <see cref="ISupportPublishConfirmationAsync.UseAsyncPublishConfirmation"/> as true (as the RMQ and
+/// Kafka producers do) and awaits the async subscribers when a confirmation is raised, so a test can
+/// observe whether the mediator's full callback (including the Outbox mark-dispatched) was awaited.
+/// </summary>
+internal sealed class StubConfirmingProducerAsync(RoutingKey topic) : IAmAMessageProducerAsync, ISupportPublishConfirmation, ISupportPublishConfirmationAsync
+{
+    private event Func<PublishConfirmationResult, Task>? _onMessagePublishedAsync;
+
+    public event Action<PublishConfirmationResult>? OnMessagePublished;
+
+    public bool UseAsyncPublishConfirmation => true;
+
+    event Func<PublishConfirmationResult, Task> ISupportPublishConfirmationAsync.OnMessagePublishedAsync
+    {
+        add => _onMessagePublishedAsync += value;
+        remove => _onMessagePublishedAsync -= value;
+    }
+
+    public Publication Publication { get; } = new() { Topic = topic };
+
+    public Activity? Span { get; set; }
+
+    public IAmAMessageScheduler? Scheduler { get; set; }
+
+    public bool SyncCallbackSubscribed => OnMessagePublished is not null;
+
+    public Task SendAsync(Message message, CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+    public Task SendWithDelayAsync(Message message, TimeSpan? delay, CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+    public async Task RaiseConfirmationAsync(PublishConfirmationResult result)
+    {
+        OnMessagePublished?.Invoke(result);
+
+        var handlers = _onMessagePublishedAsync;
+        if (handlers is null)
+            return;
+
+        foreach (Func<PublishConfirmationResult, Task> handler in handlers.GetInvocationList())
+            await handler(result);
+    }
+
+    public ValueTask DisposeAsync() => default;
+}

--- a/tests/Paramore.Brighter.Core.Tests/Confirmation/TestDoubles/ThrowingConfirmationTracer.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Confirmation/TestDoubles/ThrowingConfirmationTracer.cs
@@ -30,11 +30,11 @@ using Paramore.Brighter.Observability;
 namespace Paramore.Brighter.Core.Tests.Confirmation.TestDoubles
 {
     /// <summary>
-    /// A tracer test double that throws from <see cref="CreateConfirmationSpan"/> to exercise the
-    /// confirmation callback's error-isolation path (NFR-4 / AC-14). Every other member is an inert
-    /// no-op: the confirmation failure path under test only invokes the confirmation span.
+    /// A tracer test double that throws while starting or ending a confirmation span to exercise
+    /// the confirmation callback's error-isolation path (NFR-4 / AC-14). Every other member is an
+    /// inert no-op.
     /// </summary>
-    internal sealed class ThrowingConfirmationTracer : IAmABrighterTracer
+    internal sealed class ThrowingConfirmationTracer(bool throwOnEndSpan = false) : IAmABrighterTracer
     {
         public ActivitySource ActivitySource { get; } = new("Paramore.Brighter.Tests.Throwing");
 
@@ -44,7 +44,12 @@ namespace Paramore.Brighter.Core.Tests.Confirmation.TestDoubles
             bool success,
             ActivityLink[]? links = null,
             InstrumentationOptions options = InstrumentationOptions.All)
-            => throw new InvalidOperationException("Observability failure injected by the test");
+        {
+            if (!throwOnEndSpan)
+                throw new InvalidOperationException("Observability failure injected by the test");
+
+            return null;
+        }
 
         public Activity? CreateSpan(MessagePumpSpanOperation operation, Message message, MessagingSystem messagingSystem,
             InstrumentationOptions options = InstrumentationOptions.All, string? serializedHeader = null) => null;
@@ -86,7 +91,11 @@ namespace Paramore.Brighter.Core.Tests.Confirmation.TestDoubles
         public Activity? CreateProducerSpan(Publication publication, Message? message, Activity? parentActivity,
             InstrumentationOptions instrumentationOptions = InstrumentationOptions.All) => null;
 
-        public void EndSpan(Activity? span) { }
+        public void EndSpan(Activity? span)
+        {
+            if (throwOnEndSpan)
+                throw new InvalidOperationException("Observability failure injected by the test");
+        }
 
         public void EndSpans(ConcurrentDictionary<string, Activity> handlerSpans) { }
 

--- a/tests/Paramore.Brighter.Core.Tests/Confirmation/When_broker_style_producer_confirms_should_await_dispatch.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Confirmation/When_broker_style_producer_confirms_should_await_dispatch.cs
@@ -1,6 +1,6 @@
 #region Licence
 /* The MIT License (MIT)
-Copyright © 2026 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+Copyright © 2026 Tom Longhurst <30480171+thomhurst@users.noreply.github.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/tests/Paramore.Brighter.Core.Tests/Confirmation/When_broker_style_producer_confirms_should_await_dispatch.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Confirmation/When_broker_style_producer_confirms_should_await_dispatch.cs
@@ -1,0 +1,109 @@
+#region Licence
+/* The MIT License (MIT)
+Copyright © 2026 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Transactions;
+using Paramore.Brighter.CircuitBreaker;
+using Paramore.Brighter.Core.Tests.Confirmation.TestDoubles;
+using Paramore.Brighter.Extensions;
+using Polly.Registry;
+using Xunit;
+
+namespace Paramore.Brighter.Core.Tests.Confirmation;
+
+public class BrokerStyleAsyncConfirmationTests
+{
+    private static readonly RoutingKey s_topic = new("Broker.Style.Confirmation.Topic");
+
+    [Fact]
+    public async Task When_broker_style_producer_confirms_should_await_dispatch()
+    {
+        // Arrange
+        var requestContext = new RequestContext();
+        var message = CreateMessage();
+        var outbox = new GatedAsyncOutbox();
+        await outbox.AddAsync(message, requestContext);
+        var producer = new StubConfirmingProducerAsync(s_topic);
+        ConfigureMediator(producer, outbox);
+
+        // Act: raise the confirmation as a broker ack handler would; the producer awaits the
+        // mediator's callback, so the raise must not complete until the outbox gate opens.
+        var raiseTask = producer.RaiseConfirmationAsync(
+            new PublishConfirmationResult(true, message.Id, s_topic, null));
+        await outbox.DispatchStarted.WaitAsync(TimeSpan.FromSeconds(1));
+
+        try
+        {
+            // Assert
+            await Assert.ThrowsAsync<TimeoutException>(
+                async () => await raiseTask.WaitAsync(TimeSpan.FromMilliseconds(100)));
+        }
+        finally
+        {
+            outbox.AllowDispatch();
+            await raiseTask.WaitAsync(TimeSpan.FromSeconds(1));
+        }
+
+        Assert.True(outbox.WasDispatched(message.Id, requestContext));
+    }
+
+    [Fact]
+    public void When_producer_supports_async_confirmation_mediator_should_not_subscribe_sync_event()
+    {
+        // Arrange
+        var producer = new StubConfirmingProducerAsync(s_topic);
+
+        // Act
+        ConfigureMediator(producer, new GatedAsyncOutbox());
+
+        // Assert: the mediator must register exactly one callback — the awaited async event — or a
+        // confirmation would be handled twice (once awaited, once fire-and-forget).
+        Assert.False(producer.SyncCallbackSubscribed);
+    }
+
+    private static Message CreateMessage() => new(
+        new MessageHeader(Id.Random(), s_topic, MessageType.MT_EVENT),
+        new MessageBody("test"));
+
+    private static void ConfigureMediator(StubConfirmingProducerAsync producer, IAmAnOutbox outbox)
+    {
+        var producerRegistry = new ProducerRegistry(
+            new Dictionary<RoutingKey, IAmAMessageProducer> { [s_topic] = producer });
+
+        _ = new OutboxProducerMediator<Message, CommittableTransaction>(
+            producerRegistry,
+            new ResiliencePipelineRegistry<string>().AddBrighterDefault(),
+            new MessageMapperRegistry(
+                new SimpleMessageMapperFactory(_ => throw new NotImplementedException()),
+                new SimpleMessageMapperFactoryAsync(_ => throw new NotImplementedException())),
+            new EmptyMessageTransformerFactory(),
+            new EmptyMessageTransformerFactoryAsync(),
+            tracer: null,
+            new FindPublicationByPublicationTopicOrRequestType(),
+            outbox,
+            new InMemoryOutboxCircuitBreaker());
+    }
+}

--- a/tests/Paramore.Brighter.Core.Tests/Confirmation/When_concurrent_same_topic_confirmations_fail_should_not_lose_trips.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Confirmation/When_concurrent_same_topic_confirmations_fail_should_not_lose_trips.cs
@@ -52,11 +52,10 @@ namespace Paramore.Brighter.Core.Tests.Confirmation
         public ConcurrentConfirmationFailureTripTests()
         {
             // Arrange: a producer whose confirmations always fail, wired to a mediator whose tracer
-            // gates every callback on a barrier so all failures trip the breaker concurrently.
+            // gates every callback on a barrier so concurrent sends trip the breaker concurrently.
             var bus = new InternalBus();
             _producer = new InMemoryMessageProducer(bus, new Publication { Topic = _topic })
             {
-                UseAsyncPublishConfirmation = true,
                 PublishFailurePredicate = _ => true
             };
 
@@ -85,11 +84,11 @@ namespace Paramore.Brighter.Core.Tests.Confirmation
         {
             using var context = TestCorrelator.CreateContext();
 
-            // Act: send N messages on the same topic; their failed confirmations rendezvous on the
-            // barrier and then trip the breaker concurrently. DisposeAsync drains and awaits them.
-            for (var i = 0; i < ConcurrentFailures; i++)
-                await _producer.SendAsync(NewMessage());
-            await _producer.DisposeAsync();
+            // Act: send N messages concurrently on the same topic; their failed confirmations
+            // rendezvous on the barrier and then trip the breaker concurrently.
+            var sendTasks = Enumerable.Range(0, ConcurrentFailures)
+                .Select(_ => Task.Run(() => _producer.Send(NewMessage())));
+            await Task.WhenAll(sendTasks);
 
             // Assert: every concurrent failure ran to completion — N Warnings were logged (none lost
             // to the race) and the topic ends tripped (order-independent end state).

--- a/tests/Paramore.Brighter.Core.Tests/Confirmation/When_disposing_async_confirmation_producer_should_await_callback.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Confirmation/When_disposing_async_confirmation_producer_should_await_callback.cs
@@ -1,6 +1,6 @@
 #region Licence
 /* The MIT License (MIT)
-Copyright © 2026 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+Copyright © 2026 Tom Longhurst <30480171+thomhurst@users.noreply.github.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/tests/Paramore.Brighter.Core.Tests/Confirmation/When_disposing_async_confirmation_producer_should_await_callback.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Confirmation/When_disposing_async_confirmation_producer_should_await_callback.cs
@@ -23,7 +23,9 @@ THE SOFTWARE. */
 #endregion
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using System.Transactions;
 using Paramore.Brighter.CircuitBreaker;
@@ -98,6 +100,32 @@ public class AsyncPublishConfirmationTests
             await sendTask.WaitAsync(TimeSpan.FromSeconds(1));
             await outbox.DispatchCompleted.WaitAsync(TimeSpan.FromSeconds(1));
         }
+    }
+
+    [Fact]
+    public async Task When_disposing_with_concurrent_sends_should_drain_every_confirmation()
+    {
+        // Arrange
+        var producer = new InMemoryMessageProducer(new InternalBus(), new Publication { Topic = s_topic })
+        {
+            UseAsyncPublishConfirmation = true
+        };
+        var confirmed = new ConcurrentBag<string>();
+        ((ISupportPublishConfirmationAsync)producer).OnMessagePublishedAsync += async result =>
+        {
+            await Task.Yield();
+            confirmed.Add(result.MessageId.Value);
+        };
+        var messages = Enumerable.Range(0, 5).Select(_ => CreateMessage()).ToArray();
+
+        // Act: concurrent sends race the pump start; dispose must still drain every callback.
+        await Task.WhenAll(messages.Select(message => Task.Run(() => producer.Send(message))));
+        await producer.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(2));
+
+        // Assert
+        Assert.Equal(
+            messages.Select(message => message.Id.Value).OrderBy(id => id),
+            confirmed.OrderBy(id => id));
     }
 
     [Fact]

--- a/tests/Paramore.Brighter.Core.Tests/Confirmation/When_disposing_async_confirmation_producer_should_await_callback.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Confirmation/When_disposing_async_confirmation_producer_should_await_callback.cs
@@ -1,0 +1,125 @@
+#region Licence
+/* The MIT License (MIT)
+Copyright © 2026 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Transactions;
+using Paramore.Brighter.CircuitBreaker;
+using Paramore.Brighter.Core.Tests.Confirmation.TestDoubles;
+using Paramore.Brighter.Extensions;
+using Polly.Registry;
+using Xunit;
+
+namespace Paramore.Brighter.Core.Tests.Confirmation;
+
+public class AsyncPublishConfirmationTests
+{
+    private static readonly RoutingKey s_topic = new("Async.Publish.Confirmation.Topic");
+
+    [Fact]
+    public async Task When_disposing_async_confirmation_producer_should_await_callback()
+    {
+        // Arrange
+        var requestContext = new RequestContext();
+        var message = CreateMessage();
+        var outbox = new GatedAsyncOutbox();
+        await outbox.AddAsync(message, requestContext);
+        var producer = new InMemoryMessageProducer(new InternalBus(), new Publication { Topic = s_topic })
+        {
+            UseAsyncPublishConfirmation = true
+        };
+        ConfigureMediator(producer, outbox);
+
+        // Act
+        producer.Send(message);
+        await outbox.DispatchStarted.WaitAsync(TimeSpan.FromSeconds(1));
+        var disposeTask = producer.DisposeAsync().AsTask();
+
+        try
+        {
+            // Assert
+            await Assert.ThrowsAsync<TimeoutException>(
+                async () => await disposeTask.WaitAsync(TimeSpan.FromMilliseconds(100)));
+        }
+        finally
+        {
+            outbox.AllowDispatch();
+            await disposeTask.WaitAsync(TimeSpan.FromSeconds(1));
+        }
+
+        Assert.True(outbox.WasDispatched(message.Id, requestContext));
+    }
+
+    [Fact]
+    public async Task When_async_confirmation_is_off_should_not_wait_for_async_dispatch()
+    {
+        // Arrange
+        var requestContext = new RequestContext();
+        var message = CreateMessage();
+        var outbox = new GatedAsyncOutbox();
+        await outbox.AddAsync(message, requestContext);
+        var producer = new InMemoryMessageProducer(new InternalBus(), new Publication { Topic = s_topic });
+        ConfigureMediator(producer, outbox);
+
+        // Act
+        var sendTask = Task.Run(() => producer.Send(message));
+        await outbox.DispatchStarted.WaitAsync(TimeSpan.FromSeconds(1));
+
+        try
+        {
+            // Assert
+            await sendTask.WaitAsync(TimeSpan.FromSeconds(1));
+        }
+        finally
+        {
+            outbox.AllowDispatch();
+            await sendTask.WaitAsync(TimeSpan.FromSeconds(1));
+            await outbox.DispatchCompleted.WaitAsync(TimeSpan.FromSeconds(1));
+        }
+    }
+
+    private static Message CreateMessage() => new(
+        new MessageHeader(Id.Random(), s_topic, MessageType.MT_EVENT),
+        new MessageBody("test"));
+
+    private static void ConfigureMediator(InMemoryMessageProducer producer, IAmAnOutbox outbox)
+    {
+        var producerRegistry = new ProducerRegistry(
+            new Dictionary<RoutingKey, IAmAMessageProducer> { [s_topic] = producer });
+
+        _ = new OutboxProducerMediator<Message, CommittableTransaction>(
+            producerRegistry,
+            new ResiliencePipelineRegistry<string>().AddBrighterDefault(),
+            new MessageMapperRegistry(
+                new SimpleMessageMapperFactory(_ => throw new NotImplementedException()),
+                new SimpleMessageMapperFactoryAsync(_ => throw new NotImplementedException())),
+            new EmptyMessageTransformerFactory(),
+            new EmptyMessageTransformerFactoryAsync(),
+            tracer: null,
+            new FindPublicationByPublicationTopicOrRequestType(),
+            outbox,
+            new InMemoryOutboxCircuitBreaker());
+    }
+}

--- a/tests/Paramore.Brighter.Core.Tests/Confirmation/When_disposing_async_confirmation_producer_should_await_callback.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Confirmation/When_disposing_async_confirmation_producer_should_await_callback.cs
@@ -100,6 +100,33 @@ public class AsyncPublishConfirmationTests
         }
     }
 
+    [Fact]
+    public async Task When_an_async_confirmation_subscriber_throws_dispose_still_drains()
+    {
+        // Arrange
+        var producer = new InMemoryMessageProducer(new InternalBus(), new Publication { Topic = s_topic })
+        {
+            UseAsyncPublishConfirmation = true
+        };
+        var confirmed = new List<string>();
+        ((ISupportPublishConfirmationAsync)producer).OnMessagePublishedAsync += result =>
+        {
+            confirmed.Add(result.MessageId.Value);
+            throw new InvalidOperationException("subscriber fault");
+        };
+        var firstMessage = CreateMessage();
+        var secondMessage = CreateMessage();
+
+        // Act: the first callback's throw must not fault the drain worker, strand the second
+        // message, or re-surface out of DisposeAsync.
+        producer.Send(firstMessage);
+        producer.Send(secondMessage);
+        await producer.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(2));
+
+        // Assert
+        Assert.Equal(new[] { firstMessage.Id.Value, secondMessage.Id.Value }, confirmed);
+    }
+
     private static Message CreateMessage() => new(
         new MessageHeader(Id.Random(), s_topic, MessageType.MT_EVENT),
         new MessageBody("test"));

--- a/tests/Paramore.Brighter.Core.Tests/Confirmation/When_ending_confirmation_span_throws_should_continue_draining.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Confirmation/When_ending_confirmation_span_throws_should_continue_draining.cs
@@ -1,6 +1,6 @@
 #region Licence
 /* The MIT License (MIT)
-Copyright © 2026 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+Copyright © 2026 Tom Longhurst <30480171+thomhurst@users.noreply.github.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/tests/Paramore.Brighter.Core.Tests/Confirmation/When_ending_confirmation_span_throws_should_continue_draining.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Confirmation/When_ending_confirmation_span_throws_should_continue_draining.cs
@@ -1,0 +1,88 @@
+#region Licence
+/* The MIT License (MIT)
+Copyright © 2026 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Transactions;
+using Paramore.Brighter.CircuitBreaker;
+using Paramore.Brighter.Core.Tests.Confirmation.TestDoubles;
+using Paramore.Brighter.Extensions;
+using Polly.Registry;
+using Serilog.Events;
+using Serilog.Sinks.TestCorrelator;
+using Xunit;
+
+namespace Paramore.Brighter.Core.Tests.Confirmation;
+
+public class ConfirmationSpanEndIsolationTests
+{
+    [Fact]
+    public async Task When_ending_confirmation_span_throws_should_continue_draining()
+    {
+        // Arrange
+        const int messageCount = 2;
+        var topic = new RoutingKey("Confirmation.EndSpan.Throws.Topic");
+        var circuitBreaker = new InMemoryOutboxCircuitBreaker();
+        var producer = new InMemoryMessageProducer(new InternalBus(), new Publication { Topic = topic })
+        {
+            UseAsyncPublishConfirmation = true,
+            PublishFailurePredicate = _ => true
+        };
+        var producerRegistry = new ProducerRegistry(
+            new Dictionary<RoutingKey, IAmAMessageProducer> { [topic] = producer });
+
+        _ = new OutboxProducerMediator<Message, CommittableTransaction>(
+            producerRegistry,
+            new ResiliencePipelineRegistry<string>().AddBrighterDefault(),
+            new MessageMapperRegistry(
+                new SimpleMessageMapperFactory(_ => throw new NotImplementedException()),
+                new SimpleMessageMapperFactoryAsync(_ => throw new NotImplementedException())),
+            new EmptyMessageTransformerFactory(),
+            new EmptyMessageTransformerFactoryAsync(),
+            tracer: new ThrowingConfirmationTracer(throwOnEndSpan: true),
+            new FindPublicationByPublicationTopicOrRequestType(),
+            outboxCircuitBreaker: circuitBreaker);
+
+        using var context = TestCorrelator.CreateContext();
+
+        // Act
+        for (var i = 0; i < messageCount; i++)
+        {
+            producer.Send(new Message(
+                new MessageHeader(Id.Random(), topic, MessageType.MT_EVENT),
+                new MessageBody("test")));
+        }
+
+        await producer.DisposeAsync();
+
+        // Assert
+        var confirmationWarnings = TestCorrelator.GetLogEventsFromCurrentContext()
+            .Where(logEvent => logEvent.Level == LogEventLevel.Warning)
+            .Where(logEvent => logEvent.RenderMessage().Contains(topic.Value))
+            .ToList();
+        Assert.Equal(messageCount, confirmationWarnings.Count);
+        Assert.Contains(topic, circuitBreaker.TrippedTopics);
+    }
+}

--- a/tests/Paramore.Brighter.Core.Tests/MessageDispatch/Reactor/When_a_message_dispatcher_restarts_a_connection_after_all_connections_have_stopped.cs
+++ b/tests/Paramore.Brighter.Core.Tests/MessageDispatch/Reactor/When_a_message_dispatcher_restarts_a_connection_after_all_connections_have_stopped.cs
@@ -82,9 +82,18 @@ namespace Paramore.Brighter.Core.Tests.MessageDispatch.Reactor
             var message = new MyEventMessageMapper().MapToMessage(@event, _publication);
             _bus.Enqueue(message);
             await Task.Delay(500);
-            
+
             _timeProvider.Advance(TimeSpan.FromSeconds(2)); //This will trigger requeue of not acked/rejected messages
-            
+
+            // Poll rather than rely on the fixed delay having been enough: under parallel test load
+            // the reopened consumer can need longer than 500ms to consume and ack the message.
+            var deadline = DateTime.UtcNow.AddSeconds(10);
+            while (_bus.Stream(_routingKey).Any() && DateTime.UtcNow < deadline)
+            {
+                await Task.Delay(100);
+                _timeProvider.Advance(TimeSpan.FromSeconds(2));
+            }
+
             Assert.Empty(_bus.Stream(_routingKey));
             Assert.Equal(DispatcherState.DS_RUNNING, _dispatcher.State);
             Assert.Single(_dispatcher.Consumers);

--- a/tests/Paramore.Brighter.Core.Tests/Tasks/InFlightCallbackTrackerTests.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Tasks/InFlightCallbackTrackerTests.cs
@@ -1,6 +1,6 @@
 #region Licence
 /* The MIT License (MIT)
-Copyright © 2026 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+Copyright © 2026 Tom Longhurst <30480171+thomhurst@users.noreply.github.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/tests/Paramore.Brighter.Core.Tests/Tasks/InFlightCallbackTrackerTests.cs
+++ b/tests/Paramore.Brighter.Core.Tests/Tasks/InFlightCallbackTrackerTests.cs
@@ -1,0 +1,92 @@
+#region Licence
+/* The MIT License (MIT)
+Copyright © 2026 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+using System;
+using System.Threading.Tasks;
+using Paramore.Brighter.Tasks;
+using Xunit;
+
+namespace Paramore.Brighter.Core.Tests.Tasks;
+
+public class InFlightCallbackTrackerTests
+{
+    [Fact]
+    public void When_nothing_in_flight_TryWait_returns_true_immediately()
+    {
+        var tracker = new InFlightCallbackTracker();
+
+        Assert.True(tracker.TryWait(TimeSpan.Zero, out int stillInFlight));
+        Assert.Equal(0, stillInFlight);
+    }
+
+    [Fact]
+    public async Task When_callbacks_in_flight_TryWait_blocks_until_the_last_End()
+    {
+        var tracker = new InFlightCallbackTracker();
+        tracker.Begin();
+        tracker.Begin();
+
+        var wait = Task.Run(() => tracker.TryWait(TimeSpan.FromSeconds(5), out _));
+
+        await Assert.ThrowsAsync<TimeoutException>(
+            async () => await wait.WaitAsync(TimeSpan.FromMilliseconds(100)));
+
+        tracker.End();
+        await Assert.ThrowsAsync<TimeoutException>(
+            async () => await wait.WaitAsync(TimeSpan.FromMilliseconds(100)));
+
+        tracker.End();
+        Assert.True(await wait.WaitAsync(TimeSpan.FromSeconds(1)));
+    }
+
+    [Fact]
+    public void When_the_timeout_elapses_TryWait_returns_false_with_the_remaining_count()
+    {
+        var tracker = new InFlightCallbackTracker();
+        tracker.Begin();
+        tracker.Begin();
+        tracker.Begin();
+
+        Assert.False(tracker.TryWait(TimeSpan.FromMilliseconds(50), out int stillInFlight));
+        Assert.Equal(3, stillInFlight);
+    }
+
+    [Fact]
+    public async Task When_a_drain_has_completed_the_tracker_is_reusable()
+    {
+        var tracker = new InFlightCallbackTracker();
+
+        tracker.Begin();
+        tracker.End();
+        Assert.True(tracker.TryWait(TimeSpan.Zero, out _));
+
+        tracker.Begin();
+        var wait = Task.Run(() => tracker.TryWait(TimeSpan.FromSeconds(5), out _));
+        await Assert.ThrowsAsync<TimeoutException>(
+            async () => await wait.WaitAsync(TimeSpan.FromMilliseconds(100)));
+
+        tracker.End();
+        Assert.True(await wait.WaitAsync(TimeSpan.FromSeconds(1)));
+    }
+}

--- a/tests/Paramore.Brighter.RMQ.Sync.Tests/MessagingGateway/Reactor/When_disposing_a_producer_asynchronously_should_complete.cs
+++ b/tests/Paramore.Brighter.RMQ.Sync.Tests/MessagingGateway/Reactor/When_disposing_a_producer_asynchronously_should_complete.cs
@@ -1,6 +1,6 @@
 #region Licence
 /* The MIT License (MIT)
-Copyright © 2026 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+Copyright © 2026 Tom Longhurst <30480171+thomhurst@users.noreply.github.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/tests/Paramore.Brighter.RMQ.Sync.Tests/MessagingGateway/Reactor/When_disposing_a_producer_asynchronously_should_complete.cs
+++ b/tests/Paramore.Brighter.RMQ.Sync.Tests/MessagingGateway/Reactor/When_disposing_a_producer_asynchronously_should_complete.cs
@@ -1,0 +1,48 @@
+#region Licence
+/* The MIT License (MIT)
+Copyright © 2026 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+using System;
+using System.Threading.Tasks;
+using Paramore.Brighter.MessagingGateway.RMQ.Sync;
+using Xunit;
+
+namespace Paramore.Brighter.RMQ.Sync.Tests.MessagingGateway.Reactor;
+
+public class RmqMessageProducerDisposeAsyncTests
+{
+    [Fact]
+    public async Task When_disposing_a_producer_asynchronously_should_complete()
+    {
+        // DisposeAsync previously returned a TaskCompletionSource task that was never completed,
+        // so awaiting it hung forever; this pins the fix.
+        var rmqConnection = new RmqMessagingGatewayConnection
+        {
+            AmpqUri = new AmqpUriSpecification(new Uri("amqp://guest:guest@localhost:5672/%2f")),
+            Exchange = new Exchange("paramore.brighter.exchange")
+        };
+        var producer = new RmqMessageProducer(rmqConnection);
+
+        await producer.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+    }
+}


### PR DESCRIPTION
## Summary

- add a public `Task`-returning publish-confirmation callback (`ISupportPublishConfirmationAsync`) alongside the existing fire-and-forget event
- make the in-memory confirmation pump await the mediator's full async dispatch update
- roll the awaited callback out to the broker producers (per review): RMQ.Async awaits it on the ack loop; RMQ.Sync and Kafka track the callbacks with a shared `InFlightCallbackTracker` and drain them at dispose
- consolidate shared plumbing: `InvokeAllAsync` for the awaited multicast raise, `StartConfirmationSpan`/`EndConfirmationSpan` in the mediator, and a discard-lambda instead of `async void` for the sync-event fallback

## Behavioural note (for release notes)

RMQ.Async ack processing is now paced by the confirmation callback: the outbox `MarkDispatchedAsync` write is awaited on the channel's ack-dispatch loop (fanned out concurrently within a multiple-ack batch), so a slow outbox slows ack draining for that producer's channel. This is intentional backpressure — previously the write raced dispose and could be lost to a sweeper re-delivery.

The wait is not bounded by Brighter itself: the default `CommandProcessor.OutboxProducer` resilience pipeline is retry-only, so the effective bound is the outbox client's own timeout (e.g. DB command timeout). Operators who want a hard ceiling can add a Polly timeout strategy to the `CommandProcessor.OutboxProducer` pipeline. Nothing is lost either way — an unmarked message is re-swept.

A multiple-ack batch settles its `MarkDispatchedAsync` writes concurrently (`Task.WhenAll`), so under RMQ.Async the configured outbox must tolerate concurrent `MarkDispatchedAsync` calls; standard connection-per-call DB outboxes do.

Also fixed in passing: `RMQ.Sync.RmqMessageProducer.DisposeAsync` previously returned a `TaskCompletionSource` task that was never completed, so awaiting it hung forever; it now completes after the synchronous dispose (which this PR routes the confirmation drain through).

## Root cause

The mediator subscribed an `async void` handler to `ISupportPublishConfirmation.OnMessagePublished`. The in-memory producer's drain task therefore completed at the handler's first incomplete await, allowing `DisposeAsync()` to return before `MarkDispatchedAsync` finished. Increased test parallelism exposed that race. The same gap existed for the broker producers: their dispose paths waited for broker acks but not for the outbox `MarkDispatchedAsync` those acks trigger.

## Validation

- `Paramore.Brighter.Core.Tests`: 855 passed, 0 failed (7 pre-existing skips)
- `Paramore.Brighter.InMemory.Tests`: 144 passed, 0 failed
- New tests: dispose-awaits-callback (gated outbox), default-path stays non-blocking, span-teardown isolation, broker-style producer awaits `MarkDispatchedAsync`, mediator registers exactly one callback
- RMQ.Async/RMQ.Sync/Kafka producer and test projects build clean; their integration suites need broker infrastructure and were not run here

Closes #4243
