### PR TITLE
fix(#4250): match ASB scheduler SessionId/reserved-header bag lookups case-insensitively

### DIFF
--- a/src/Paramore.Brighter.MessageScheduler.Azure/AzureServiceBusScheduler.cs
+++ b/src/Paramore.Brighter.MessageScheduler.Azure/AzureServiceBusScheduler.cs
@@ -132,7 +132,7 @@ public class AzureServiceBusScheduler(
         azureServiceBusMessage.ApplicationProperties.Add(ASBConstants.ReplyToHeaderBagKey, message.Header.ReplyTo);
 
         foreach (var header in message.Header.Bag.Where(h =>
-                     !ASBConstants.ReservedHeaders.Contains(h.Key)
+                     !ASBConstants.IsReservedHeader(h.Key)
                      && !MessageHeader.IsLocalHeader(h.Key)))
         {
             azureServiceBusMessage.ApplicationProperties.Add(header.Key, header.Value);
@@ -144,11 +144,14 @@ public class AzureServiceBusScheduler(
         }
 
         var contentType = message.Header.ContentType ?? new ContentType(MediaTypeNames.Text.Plain);
-        
+
         azureServiceBusMessage.ContentType = contentType.ToString();
         azureServiceBusMessage.MessageId = message.Header.MessageId;
-        if (message.Header.Bag.TryGetValue(ASBConstants.SessionIdKey, out object? value))
-            azureServiceBusMessage.SessionId = value.ToString();
+        var sessionId = message.Header.Bag
+            .FirstOrDefault(h => ASBConstants.IsBagKey(h.Key, ASBConstants.SessionIdKey))
+            .Value;
+        if (sessionId is not null)
+            azureServiceBusMessage.SessionId = sessionId.ToString();
 
         return azureServiceBusMessage;
     }
@@ -167,6 +170,30 @@ public class AzureServiceBusScheduler(
                 LockTokenHeaderBagKey, MessageTypeHeaderBagKey, HandledCountHeaderBagKey, ReplyToHeaderBagKey,
                 SessionIdKey
             };
+
+        /// <summary>
+        /// Does a header bag <paramref name="key"/> refer to the reserved key <paramref name="reservedKey"/>?
+        /// Brighter's Outbox serializes the bag with <see cref="JsonSerialisationOptions.Options"/>, whose
+        /// <see cref="System.Text.Json.JsonSerializerOptions.PropertyNamingPolicy"/> rewrites bag keys — so a key
+        /// written as "SessionId" comes back transformed (for example "sessionId" or "session_id") depending on the
+        /// configured policy. We therefore match both the raw key and the key as the active naming policy would
+        /// render it, case-insensitively, so the lookup stays correct whatever policy the user configures.
+        /// </summary>
+        public static bool IsBagKey(string key, string reservedKey)
+        {
+            if (string.Equals(key, reservedKey, StringComparison.OrdinalIgnoreCase))
+                return true;
+
+            var namingPolicy = JsonSerialisationOptions.Options.PropertyNamingPolicy;
+            return namingPolicy is not null
+                   && string.Equals(key, namingPolicy.ConvertName(reservedKey), StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Is a header bag <paramref name="key"/> one of the <see cref="ReservedHeaders"/>, accounting for any
+        /// naming-policy transformation applied during an Outbox round-trip? See <see cref="IsBagKey"/>.
+        /// </summary>
+        public static bool IsReservedHeader(string key) => ReservedHeaders.Any(reserved => IsBagKey(key, reserved));
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
## Summary

Fixes #4250.

**Scope note:** #4250 originally reported this bug against both `AzureServiceBusMessagePublisher` and `AzureServiceBusScheduler`. Since filing it, I found that #4205 (merged, closing #4054) already fixed the publisher half with an `ASBConstants.IsBagKey`/`IsReservedHeader` helper, and #4215 (merged, closing #4151/#4214) fixed the underlying root cause (bag keys no longer get camelCased on write at all). Neither PR touched `AzureServiceBusScheduler`, which carries its own independent copy of `ASBConstants` and had the identical bug. This PR is now scoped to just that remaining gap.

`AzureServiceBusScheduler.ConvertToServiceBusMessage` looked up `Bag["SessionId"]` and filtered `ReservedHeaders` case-sensitively in PascalCase. An outbox-sourced message whose bag key comes back in a different casing (e.g. from an older camelCasing round-trip, or any other naming policy) would silently lose its `ServiceBusMessage.SessionId`, and the mismatched key would leak into `ApplicationProperties` instead of being recognised as reserved.

## Fix

Ports the exact `IsBagKey`/`IsReservedHeader` pattern #4205 introduced into `Paramore.Brighter.MessagingGateway.AzureServiceBus.ASBConstants`, into the scheduler's own nested `ASBConstants`, for consistency with the already-reviewed and merged approach rather than reintroducing a different one.

## Test plan

- [x] Scheduler project builds clean.
- [x] Confirmed against upstream `master`: upstream's existing `When_Converting_A_Message_With_A_Session_Id.cs` (added by #4205) still passes unaffected — this PR doesn't touch the publisher.
- [ ] No dedicated test for the scheduler itself: there is currently no test project for `Paramore.Brighter.MessageScheduler.Azure` in this repo. Applied by parity with the reviewed and tested publisher fix. Happy to add a test project as a follow-up if maintainers want that separated out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)