### PR TITLE
Update RocketMQ.Client to 5.2.1 and fix RocketMQ test suite

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -138,7 +138,7 @@
     <PackageVersion Include="Quartz.Extensions.DependencyInjection" Version="3.18.1" />
     <PackageVersion Include="Quartz.Extensions.Hosting" Version="3.18.1" />
     <PackageVersion Include="RabbitMQ.Client" Version="7.2.1" />
-    <PackageVersion Include="RocketMQ.Client" Version="5.1.0" />
+    <PackageVersion Include="RocketMQ.Client" Version="5.2.1" />
     <PackageVersion Include="Serilog" Version="4.3.1" />
     <PackageVersion Include="Serilog.Extensions.Hosting" Version="10.0.0" />
     <PackageVersion Include="Serilog.Extensions.Logging" Version="10.0.0" />

--- a/docker-compose-rocketmq.yaml
+++ b/docker-compose-rocketmq.yaml
@@ -3,7 +3,7 @@ version: '3.8'
 services:
   # RocketMQ Nameserver (Service Discovery)
   nameserver:
-    image: apache/rocketmq
+    image: apache/rocketmq:5.4.0
     platform: linux/amd64
     container_name: rocketmq-nameserver
     ports:
@@ -19,7 +19,7 @@ services:
 
   # RocketMQ Broker (Message Storage)
   broker:
-    image: apache/rocketmq
+    image: apache/rocketmq:5.4.0
     platform: linux/amd64
     container_name: rocketmq-broker
     ports:
@@ -43,18 +43,18 @@ services:
       retries: 10
   
   proxy:
-    image: apache/rocketmq
+    image: apache/rocketmq:5.4.0
     platform: linux/amd64
     container_name: rmqproxy
     depends_on:
       - broker
       - nameserver
     ports:
-      - "8081:8081"   # HTTP endpoint (for REST API)
-      - "9877:9877"   # gRPC endpoint (for clients)
+      - "8081:8081"   # gRPC endpoint (for clients)
+      - "9877:9877"   # Reserved (no service listens here by default)
     environment:
       - NAMESRV_ADDR=nameserver:9876
-      - JAVA_OPT_EXT=-Xms64m -Xmx64m -Xmn32m -XX:MaxDirectMemorySize=64m -XX:MaxMetaspaceSize=96m
+      - JAVA_OPT_EXT=-Xms64m -Xmx512m -Xmn32m -XX:MaxDirectMemorySize=64m -XX:MaxMetaspaceSize=96m
     command: sh mqproxy
     healthcheck: 
       test: [ "CMD", "sh", "-c", "netstat -an | grep 8081" ]
@@ -62,11 +62,11 @@ services:
       timeout: 10s
       retries: 10
     
-  # Service to create the RocketMQ topic
+  # Service to create the RocketMQ topics
   create-topic:
-    image: apache/rocketmq # Use the same RocketMQ image to get mqadmin tool
+    image: apache/rocketmq:5.4.0 # Use the same RocketMQ image to get mqadmin tool
     platform: linux/amd64
-    command: > # Multi-line command to create the topic
+    command: > # Multi-line command to create the topics
       sh -c "
             echo 'Waiting for broker to be healthy...' &&
             until curl -s http://broker:10911/ &>/dev/null; do
@@ -83,6 +83,9 @@ services:
             /home/rocketmq/rocketmq-5.4.0/bin/mqadmin updateTopic -n nameserver:9876 -t rmq_dlq_source -c DefaultCluster -r 1 -w 1 -a +message.type=NORMAL &&
             /home/rocketmq/rocketmq-5.4.0/bin/mqadmin updateTopic -n nameserver:9876 -t rmq_dlq_target -c DefaultCluster -r 1 -w 1 -a +message.type=NORMAL &&
             /home/rocketmq/rocketmq-5.4.0/bin/mqadmin updateTopic -n nameserver:9876 -t rmq_dlq_invalid -c DefaultCluster -r 1 -w 1 -a +message.type=NORMAL &&
+            /home/rocketmq/rocketmq-5.4.0/bin/mqadmin updateTopic -n nameserver:9876 -t orders -c DefaultCluster -r 1 -w 1 -a +message.type=NORMAL &&
+            /home/rocketmq/rocketmq-5.4.0/bin/mqadmin updateTopic -n nameserver:9876 -t orders-dlq -c DefaultCluster -r 1 -w 1 -a +message.type=NORMAL &&
+            /home/rocketmq/rocketmq-5.4.0/bin/mqadmin updateTopic -n nameserver:9876 -t orders-invalid -c DefaultCluster -r 1 -w 1 -a +message.type=NORMAL &&
 
             echo 'Creating generated test topics...' &&
 

--- a/src/Paramore.Brighter.MessagingGateway.RocketMQ/RocketMessageConsumer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RocketMQ/RocketMessageConsumer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Net.Mime;
@@ -32,6 +32,18 @@ public partial class RocketMessageConsumer(SimpleConsumer consumer,
     : IAmAMessageConsumerAsync, IAmAMessageConsumerSync
 {
     private static readonly ILogger s_logger = ApplicationLogging.CreateLogger<RocketMessageConsumer>();
+
+    /// <summary>
+    /// The routing key of the dead letter queue topic, when configured.
+    /// Rejected messages are forwarded to this topic.
+    /// </summary>
+    public RoutingKey? DeadLetterRoutingKey { get; } = deadLetterRoutingKey;
+
+    /// <summary>
+    /// The routing key of the invalid message topic, when configured.
+    /// Messages rejected as <see cref="RejectionReason.Unacceptable"/> are forwarded to this topic.
+    /// </summary>
+    public RoutingKey? InvalidMessageRoutingKey { get; } = invalidMessageRoutingKey;
 
     // Thread-safe: message pumps are single-threaded per consumer, so null-coalescing
     // assignment in GetProducerForRouteAsync() cannot race.
@@ -126,7 +138,7 @@ public partial class RocketMessageConsumer(SimpleConsumer consumer,
 
         Log.RejectingMessage(s_logger, message.Id.Value);
 
-        if (deadLetterRoutingKey == null && invalidMessageRoutingKey == null)
+        if (DeadLetterRoutingKey == null && InvalidMessageRoutingKey == null)
         {
             if (reason != null)
                 Log.NoChannelsConfiguredForRejection(s_logger, message.Id.Value, reason.RejectionReason.ToString());
@@ -214,10 +226,10 @@ public partial class RocketMessageConsumer(SimpleConsumer consumer,
 
     private async Task<RocketMqMessageProducer?> GetProducerForRouteAsync(RoutingKey routingKey)
     {
-        if (routingKey == invalidMessageRoutingKey)
-            return _invalidMessageProducer ??= await CreateProducerAsync(invalidMessageRoutingKey);
-        if (routingKey == deadLetterRoutingKey)
-            return _deadLetterProducer ??= await CreateProducerAsync(deadLetterRoutingKey);
+        if (routingKey == InvalidMessageRoutingKey)
+            return _invalidMessageProducer ??= await CreateProducerAsync(InvalidMessageRoutingKey);
+        if (routingKey == DeadLetterRoutingKey)
+            return _deadLetterProducer ??= await CreateProducerAsync(DeadLetterRoutingKey);
         return null;
     }
 
@@ -264,10 +276,10 @@ public partial class RocketMessageConsumer(SimpleConsumer consumer,
     {
         return rejectionReason switch 
         {
-            RejectionReason.Unacceptable when invalidMessageRoutingKey != null => (invalidMessageRoutingKey, true, false),
-            RejectionReason.Unacceptable when deadLetterRoutingKey  != null => (deadLetterRoutingKey, true, true),
+            RejectionReason.Unacceptable when InvalidMessageRoutingKey != null => (InvalidMessageRoutingKey, true, false),
+            RejectionReason.Unacceptable when DeadLetterRoutingKey  != null => (DeadLetterRoutingKey, true, true),
             RejectionReason.Unacceptable =>  (null, false, false),
-            _ when deadLetterRoutingKey != null =>(deadLetterRoutingKey, true, false),
+            _ when DeadLetterRoutingKey != null =>(DeadLetterRoutingKey, true, false),
             _ => (null, false, false)
         };
     }

--- a/src/Paramore.Brighter.MessagingGateway.RocketMQ/RocketMessageConsumer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RocketMQ/RocketMessageConsumer.cs
@@ -33,9 +33,6 @@ public partial class RocketMessageConsumer(SimpleConsumer consumer,
 {
     private static readonly ILogger s_logger = ApplicationLogging.CreateLogger<RocketMessageConsumer>();
 
-    private readonly RocketMessagingGatewayConnection? _connection = connection;
-    private readonly RoutingKey? _deadLetterRoutingKey = deadLetterRoutingKey;
-    private readonly RoutingKey? _invalidMessageRoutingKey = invalidMessageRoutingKey;
     // Thread-safe: message pumps are single-threaded per consumer, so null-coalescing
     // assignment in GetProducerForRouteAsync() cannot race.
     private RocketMqMessageProducer? _deadLetterProducer;
@@ -100,14 +97,18 @@ public partial class RocketMessageConsumer(SimpleConsumer consumer,
     /// <inheritdoc />
     public void Nack(Message message)
     {
-        // No-op for RocketMQ: invisibility timeout will expire and message will become available for redelivery
+        BrighterAsyncContext.Run(() => NackAsync(message));
     }
 
     /// <inheritdoc />
-    public Task NackAsync(Message message, CancellationToken cancellationToken = default)
+    public async Task NackAsync(Message message, CancellationToken cancellationToken = default)
     {
-        // No-op for RocketMQ: invisibility timeout will expire and message will become available for redelivery
-        return Task.CompletedTask;
+        if (!message.Header.Bag.TryGetValue("ReceiptHandle", out var handler) || handler is not MessageView view)
+        {
+            return;
+        }
+
+        await consumer.ChangeInvisibleDuration(view, TimeSpan.Zero);
     }
 
     /// <inheritdoc />
@@ -125,7 +126,7 @@ public partial class RocketMessageConsumer(SimpleConsumer consumer,
 
         Log.RejectingMessage(s_logger, message.Id.Value);
 
-        if (_deadLetterRoutingKey == null && _invalidMessageRoutingKey == null)
+        if (deadLetterRoutingKey == null && invalidMessageRoutingKey == null)
         {
             if (reason != null)
                 Log.NoChannelsConfiguredForRejection(s_logger, message.Id.Value, reason.RejectionReason.ToString());
@@ -213,28 +214,28 @@ public partial class RocketMessageConsumer(SimpleConsumer consumer,
 
     private async Task<RocketMqMessageProducer?> GetProducerForRouteAsync(RoutingKey routingKey)
     {
-        if (routingKey == _invalidMessageRoutingKey)
-            return _invalidMessageProducer ??= await CreateProducerAsync(_invalidMessageRoutingKey);
-        if (routingKey == _deadLetterRoutingKey)
-            return _deadLetterProducer ??= await CreateProducerAsync(_deadLetterRoutingKey);
+        if (routingKey == invalidMessageRoutingKey)
+            return _invalidMessageProducer ??= await CreateProducerAsync(invalidMessageRoutingKey);
+        if (routingKey == deadLetterRoutingKey)
+            return _deadLetterProducer ??= await CreateProducerAsync(deadLetterRoutingKey);
         return null;
     }
 
     private async Task<RocketMqMessageProducer?> CreateProducerAsync(RoutingKey? routingKey)
     {
-        if (routingKey == null || _connection == null)
+        if (routingKey == null || connection == null)
             return null;
 
         try
         {
             var rocketProducer = await new Producer.Builder()
-                .SetClientConfig(_connection.ClientConfig)
-                .SetMaxAttempts(_connection.MaxAttempts)
+                .SetClientConfig(connection.ClientConfig)
+                .SetMaxAttempts(connection.MaxAttempts)
                 .SetTopics(routingKey.Value)
                 .Build();
 
             return new RocketMqMessageProducer(
-                _connection,
+                connection,
                 rocketProducer,
                 new RocketMqPublication { Topic = routingKey });
         }
@@ -261,22 +262,14 @@ public partial class RocketMessageConsumer(SimpleConsumer consumer,
     private (RoutingKey? routingKey, bool foundProducer, bool isFallingBackToDlq) DetermineRejectionRoute(
         RejectionReason rejectionReason)
     {
-        switch (rejectionReason)
+        return rejectionReason switch 
         {
-            case RejectionReason.Unacceptable:
-                if (_invalidMessageRoutingKey != null)
-                    return (_invalidMessageRoutingKey, true, false);
-                if (_deadLetterRoutingKey != null)
-                    return (_deadLetterRoutingKey, true, true);
-                return (null, false, false);
-
-            case RejectionReason.DeliveryError:
-            case RejectionReason.None:
-            default:
-                if (_deadLetterRoutingKey != null)
-                    return (_deadLetterRoutingKey, true, false);
-                return (null, false, false);
-        }
+            RejectionReason.Unacceptable when invalidMessageRoutingKey != null => (invalidMessageRoutingKey, true, false),
+            RejectionReason.Unacceptable when deadLetterRoutingKey  != null => (deadLetterRoutingKey, true, true),
+            RejectionReason.Unacceptable =>  (null, false, false),
+            _ when deadLetterRoutingKey != null =>(deadLetterRoutingKey, true, false),
+            _ => (null, false, false)
+        };
     }
 
     private static Message CreateMessage(MessageView message)

--- a/src/Paramore.Brighter.MessagingGateway.RocketMQ/RocketMqMessageProducer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.RocketMQ/RocketMqMessageProducer.cs
@@ -82,8 +82,12 @@ public class RocketMqMessageProducer(
             .AddProperty(HeaderNames.MessageType, message.Header.MessageType.ToString())
             .AddProperty(HeaderNames.TimeStamp, message.Header.TimeStamp.ToRfc3339())
             .AddProperty(HeaderNames.Source, message.Header.Source.ToString())
-            .AddProperty(HeaderNames.SpecVersion, message.Header.SpecVersion)
-            .AddProperty(HeaderNames.Baggage, message.Header.Baggage.ToString());
+            .AddProperty(HeaderNames.SpecVersion, message.Header.SpecVersion);
+
+        if (message.Header.Baggage.Any())
+        {
+            builder.AddProperty(HeaderNames.Baggage, message.Header.Baggage.ToString());
+        }
 
         if (message.Header.Type != CloudEventsType.Empty)
         {

--- a/tests/Paramore.Brighter.RocketMQ.Tests/MessagingGateway/RocketMqMessageGatewayProvider.cs
+++ b/tests/Paramore.Brighter.RocketMQ.Tests/MessagingGateway/RocketMqMessageGatewayProvider.cs
@@ -1,4 +1,4 @@
-﻿#region Licence
+#region Licence
 
 /* The MIT License (MIT)
 Copyright © 2014 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
@@ -47,8 +47,8 @@ public class RocketMqMessageGatewayProvider
         ["When_a_message_consumer_reads_multiple_messages_should_receive_all_messages"] = "gen_r_multi_msg",
         ["When_multiple_threads_try_to_post_a_message_at_the_same_time_should_not_throw_exception"] = "gen_r_multi_thread",
         ["When_sending_a_message_should_propagate_activity_context"] = "gen_r_activity",
-        ["When_requeing_a_failed_message_should_receive_message_again"] = "gen_r_requeue",
-        ["When_requeing_a_failed_message_with_delay_should_receive_message_again"] = "gen_r_requeue_delay",
+        ["When_requeuing_a_failed_message_should_receive_message_again"] = "gen_r_requeue",
+        ["When_requeuing_a_failed_message_with_delay_should_receive_message_again"] = "gen_r_requeue_delay",
         ["When_requeuing_a_message_too_many_times_should_move_to_dead_letter_queue"] = "gen_r_dlq",
         ["When_reading_a_delayed_message_via_the_messaging_gateway_should_delay_delivery"] = "gen_r_delayed_msg",
         ["When_posting_a_message_with_partition_key_via_the_messaging_gateway_should_be_received"] = "gen_r_partition_key",
@@ -58,8 +58,8 @@ public class RocketMqMessageGatewayProvider
         ["When_a_message_consumer_reads_multiple_messages_should_receive_all_messages_async"] = "gen_p_multi_msg",
         ["When_multiple_threads_try_to_post_a_message_at_the_same_time_should_not_throw_exception_async"] = "gen_p_multi_thread",
         ["When_sending_a_message_should_propagate_activity_context_async"] = "gen_p_activity",
-        ["When_requeing_a_failed_message_should_receive_message_again_async"] = "gen_p_requeue",
-        ["When_requeing_a_failed_message_with_delay_should_receive_message_again_async"] = "gen_p_requeue_delay",
+        ["When_requeuing_a_failed_message_should_receive_message_again_async"] = "gen_p_requeue",
+        ["When_requeuing_a_failed_message_with_delay_should_receive_message_again_async"] = "gen_p_requeue_delay",
         ["When_requeuing_a_message_too_many_times_should_move_to_dead_letter_queue_async"] = "gen_p_dlq",
         ["When_reading_a_delayed_message_via_the_messaging_gateway_should_delay_delivery_async"] = "gen_p_delayed_msg",
         ["When_posting_a_message_with_partition_key_via_the_messaging_gateway_should_be_received_async"] = "gen_p_partition_key",

--- a/tests/Paramore.Brighter.RocketMQ.Tests/MessagingGateway/When_creating_rocket_consumer_with_dlq_subscription_should_pass_routing_keys.cs
+++ b/tests/Paramore.Brighter.RocketMQ.Tests/MessagingGateway/When_creating_rocket_consumer_with_dlq_subscription_should_pass_routing_keys.cs
@@ -23,7 +23,6 @@ THE SOFTWARE. */
 #endregion
 
 using System;
-using System.Reflection;
 using Paramore.Brighter.MessagingGateway.RocketMQ;
 using Paramore.Brighter.RocketMQ.Tests.TestDoubles;
 using Paramore.Brighter.RocketMQ.Tests.Utils;
@@ -55,6 +54,7 @@ public class RocketConsumerFactoryDlqTests : IDisposable
             subscriptionName: new SubscriptionName("test-subscription"),
             channelName: new ChannelName("test-channel"),
             routingKey: new RoutingKey("orders"),
+            consumerGroup: Guid.NewGuid().ToString(),
             messagePumpType: MessagePumpType.Reactor,
             deadLetterRoutingKey: dlqRoutingKey,
             invalidMessageRoutingKey: invalidRoutingKey
@@ -64,31 +64,13 @@ public class RocketConsumerFactoryDlqTests : IDisposable
         _consumer = _factory.Create(subscription);
 
         // Assert - verify the factory passed routing keys to the consumer
-        Assert.NotNull(_consumer);
+        var consumer = Assert.IsType<RocketMessageConsumer>(_consumer);
 
-        var consumerType = _consumer.GetType();
-        var dlqField = consumerType.GetField("_deadLetterRoutingKey",
-            BindingFlags.NonPublic | BindingFlags.Instance);
-        var invalidField = consumerType.GetField("_invalidMessageRoutingKey",
-            BindingFlags.NonPublic | BindingFlags.Instance);
-        var connectionField = consumerType.GetField("_connection",
-            BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.NotNull(consumer.DeadLetterRoutingKey);
+        Assert.Equal("orders-dlq", consumer.DeadLetterRoutingKey.Value);
 
-        Assert.NotNull(dlqField);
-        Assert.NotNull(invalidField);
-        Assert.NotNull(connectionField);
-
-        var actualDlq = dlqField.GetValue(_consumer) as RoutingKey;
-        var actualInvalid = invalidField.GetValue(_consumer) as RoutingKey;
-        var actualConnection = connectionField.GetValue(_consumer);
-
-        Assert.NotNull(actualDlq);
-        Assert.Equal("orders-dlq", actualDlq.Value);
-
-        Assert.NotNull(actualInvalid);
-        Assert.Equal("orders-invalid", actualInvalid.Value);
-
-        Assert.NotNull(actualConnection);
+        Assert.NotNull(consumer.InvalidMessageRoutingKey);
+        Assert.Equal("orders-invalid", consumer.InvalidMessageRoutingKey.Value);
     }
 
     public void Dispose()


### PR DESCRIPTION
## Description

Updates the RocketMQ client (`RocketMQ.Client` 5.1.0 → 5.2.1) and fixes the RocketMQ test suite, which had been silently broken (the RocketMQ CI job is currently disabled, so regressions went unnoticed).

Client upgrade (`772490a7a`):

- Bump `RocketMQ.Client` to 5.2.1 and migrate `RocketMessageConsumer` to its APIs — real `Nack` via `ChangeInvisibleDuration` instead of a no-op, and primary-constructor parameter capture in place of explicit fields.

Test suite fixes (`4990be010`):

- **Producer: empty Baggage property rejected.** `RocketMqMessageProducer` unconditionally added the `CE_baggage` property; an empty `Baggage` (the default) stringifies to `""`, which the client's `Message.Builder.AddProperty` rejects (`value should not be null or white space`, validation present since client 5.1.0). Every `Send`/`SendAsync` threw — this alone accounted for 24 of 35 test failures. The property is now only added when the baggage has entries.
- **Topic map typos.** `RocketMqMessageGatewayProvider.s_topicMap` used `When_requeing_...` keys vs. the actual `When_requeuing_...` test method names, so four requeue tests fell through to non-existent topics and died with `NotFoundException`.
- **`RocketConsumerFactoryDlqTests` rework.** The test could never pass: it built a subscription without a consumer group (which defaulted to `string.Empty` and fails the client's `SetConsumerGroup` regex), and it asserted via reflection on private fields removed in the client-upgrade commit. It now passes a random consumer group and asserts on the new public `RocketMessageConsumer.DeadLetterRoutingKey` / `InvalidMessageRoutingKey` properties instead of implementation details.
- **`docker-compose-rocketmq.yaml`:** image pinned (`apache/rocketmq:5.4.0`, matching the hardcoded mqadmin paths), proxy heap raised to `-Xmx512m`, `orders`/`orders-dlq`/`orders-invalid` topics added, and misleading port comments corrected (8081 is the gRPC endpoint clients use).

## Related Issues

<!-- Link any related issues: Fixes #123, Closes #456 -->

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [Contributing Guide](../blob/master/CONTRIBUTING.md)
- [x] I have checked the [documentation](https://brightercommand.gitbook.io/paramore-brighter-documentation/) for relevant guidance
- [x] I have added/updated XML documentation for any public API changes
- [x] I have added/updated tests as appropriate
- [x] My changes follow the existing code style and conventions

## Additional Notes

- Verified against a local RocketMQ broker (topics provisioned by the compose file with correct `message.type` attributes): all code-level failures are resolved, including the previously broken DLQ/reject and consumer-factory tests.
- Remaining suite instability is environmental, not Brighter code: `ReceiveMessage` long-polls through the local podman-forwarded proxy intermittently hang until the client deadline (`HTTP/2 CANCEL` → `DeadlineExceeded`). Reproduced standalone with the raw 5.2.1 client (no Brighter code) on both broker 5.4.0 and 5.5.0 — likely the rootless port-forwarding breaking long-lived gRPC streams, or a proxy-side long-poll issue (cf. apache/rocketmq#10615, fixed in the upcoming 5.5.1). Tests that receive timely broker responses all pass.
