### PR TITLE
Kafka: add ErrorLogLevel hook to classify/suppress non-fatal error-callback log level

### DIFF
--- a/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaMessageConsumer.cs
+++ b/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaMessageConsumer.cs
@@ -62,6 +62,7 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
         private static readonly TimeSpan s_commitSyncTimeout = TimeSpan.FromSeconds(5);
         private readonly ITimer _sweeperTimer;
         private bool _hasFatalError;
+        private readonly Func<Error, LogLevel>? _errorLogLevel;
         private bool _isClosed;
         private readonly RoutingKey? _deadLetterRoutingKey;
         private readonly RoutingKey? _invalidMessageRoutingKey;
@@ -104,6 +105,7 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
         /// <param name="makeChannels">Should we create infrastructure (topics) where it does not exist or check. Defaults to Create</param>
         /// <param name="configHook">Allows you to modify the Kafka client configuration before a consumer is created.</param>
         /// <param name="timeProvider">The <see cref="TimeProvider"/> used to create the timer for sweeping uncommitted offsets. Defaults to <see cref="TimeProvider.System"/> if not specified. Can be overridden for testing purposes.</param>
+        /// <param name="errorLogLevel">Allows you to classify or suppress the log level of non-fatal errors raised by the underlying Kafka consumer. Returning <see cref="LogLevel.None"/> suppresses the log entirely. Does not affect fatal handling, which is driven solely by <see cref="Error.IsFatal"/>. Defaults to <see langword="null"/>, logging fatal errors at <see cref="LogLevel.Error"/> and non-fatal at <see cref="LogLevel.Warning"/>.</param>
         /// <param name="deadLetterRoutingKey">If we support a dead letter topic what is the <see cref="RoutingKey"/></param>
         /// <param name="invalidMessageRoutingKey">If we support an invalid message topic what is the <see cref="RoutingKey"/></param>
         /// <param name="scheduler">Optional scheduler for delayed requeue operations. When provided, the lazily-created
@@ -132,7 +134,8 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
             RoutingKey? invalidMessageRoutingKey = null,
             TimeProvider? timeProvider = null,
             IAmAMessageScheduler? scheduler = null,
-            IGroupProtocol? groupProtocol = null)
+            IGroupProtocol? groupProtocol = null,
+            Func<Error, LogLevel>? errorLogLevel = null)
         {
             if (groupId is null)
                 throw new ConfigurationException("You must set a GroupId for the consumer");
@@ -141,6 +144,7 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
             
             _configuration = configuration ?? throw new ConfigurationException("You must set a KafkaMessagingGatewayConfiguration to connect to a broker");
             _scheduler = scheduler;
+            _errorLogLevel = errorLogLevel;
 
             _deadLetterRoutingKey = deadLetterRoutingKey;
             _invalidMessageRoutingKey = invalidMessageRoutingKey;
@@ -789,15 +793,19 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
         {
             // Latch: once librdkafka reports a fatal error the consumer is unrecoverable. Errors arrive
             // in bursts, so we must never clear the latch when a later non-fatal error follows a fatal one.
+            // This is authoritative and is never influenced by the ErrorLogLevel hook.
             if (error.IsFatal)
                 _hasFatalError = true;
 
+            // The hook only classifies/suppresses logging; when absent we preserve the default behaviour
+            // of logging fatal errors at Error and non-fatal at Warning. LogLevel.None suppresses the log.
+            var logLevel = _errorLogLevel?.Invoke(error) ?? (error.IsFatal ? LogLevel.Error : LogLevel.Warning);
+            if (logLevel == LogLevel.None)
+                return;
+
             // Log against the error we actually received, independent of the latch, so a non-fatal error
             // that arrives after a fatal one is still logged as non-fatal.
-            if (error.IsFatal)
-                Log.FatalError(s_logger, error.Code, error.Reason, true);
-            else
-                Log.NonFatalError(s_logger, error.Code, error.Reason, false);
+            Log.KafkaError(s_logger, logLevel, error.Code, error.Reason, error.IsFatal);
         }
 
         private void CheckHasPartitions()
@@ -1240,11 +1248,12 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
             [LoggerMessage(LogLevel.Information, "Partitions for consumer lost {Channels}")]
             public static partial void PartitionsLost(ILogger logger, string channels);
             
-            [LoggerMessage(LogLevel.Error, "Code: {ErrorCode}, Reason: {ErrorMessage}, Fatal: {FatalError}")]
-            public static partial void FatalError(ILogger logger, ErrorCode errorCode, string errorMessage, bool fatalError);
-            
-            [LoggerMessage(LogLevel.Warning, "Code: {ErrorCode}, Reason: {ErrorMessage}, Fatal: {FatalError}")]
-            public static partial void NonFatalError(ILogger logger, ErrorCode errorCode, string errorMessage, bool fatalError);
+            // A dynamic-level logger cannot use the [LoggerMessage] attribute with a fixed Level, so we log
+            // through the ILogger directly. Named placeholders are preserved for structured logging providers.
+            public static void KafkaError(ILogger logger, LogLevel logLevel, ErrorCode errorCode, string errorMessage, bool fatalError)
+            {
+                logger.Log(logLevel, "Code: {ErrorCode}, Reason: {ErrorMessage}, Fatal: {FatalError}", errorCode, errorMessage, fatalError);
+            }
             
             [LoggerMessage(LogLevel.Information, "Kafka consumer subscribing to {Topic}")]
             public static partial void SubscribingToTopic(ILogger logger, RoutingKey topic);

--- a/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaMessageConsumerFactory.cs
+++ b/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaMessageConsumerFactory.cs
@@ -100,6 +100,7 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
                 topicFindTimeout: kafkaSubscription.TopicFindTimeout,
                 makeChannels: kafkaSubscription.MakeChannels,
                 configHook: kafkaSubscription.ConfigHook,
+                errorLogLevel: kafkaSubscription.ErrorLogLevel,
                 deadLetterRoutingKey: deadLetterRoutingKey,
                 invalidMessageRoutingKey: invalidMessageRoutingKey,
                 timeProvider: kafkaSubscription.TimeProvider,

--- a/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaSubscription.cs
+++ b/src/Paramore.Brighter.MessagingGateway.Kafka/KafkaSubscription.cs
@@ -24,6 +24,7 @@ THE SOFTWARE. */
 
 using System;
 using Confluent.Kafka;
+using Microsoft.Extensions.Logging;
 
 namespace Paramore.Brighter.MessagingGateway.Kafka
 {
@@ -54,6 +55,16 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
         /// Used to set properties that Brighter does not expose
         /// </summary>
         public Action<ConsumerConfig>? ConfigHook { get; set; }
+
+        /// <summary>
+        /// Allows you to classify or suppress the log level of non-fatal errors raised by the
+        /// underlying Kafka consumer. The hook is passed each error and returns the level at
+        /// which it should be logged; returning <see cref="LogLevel.None"/> suppresses the log
+        /// entry entirely. This only affects logging: fatal handling is unchanged and
+        /// <see cref="Error.IsFatal"/> remains authoritative, so a fatal error is always latched
+        /// regardless of the level returned.
+        /// </summary>
+        public Func<Error, LogLevel>? ErrorLogLevel { get; set; }
         
         /// <summary>
         /// Only one consumer in a group can read from a partition at any one time; this preserves ordering
@@ -215,7 +226,8 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
             PartitionAssignmentStrategy partitionAssignmentStrategy = PartitionAssignmentStrategy.RoundRobin,
             Action<ConsumerConfig>? configHook = null,
             RoutingKey? deadLetterRoutingKey = null,
-            RoutingKey? invalidMessageRoutingKey = null)
+            RoutingKey? invalidMessageRoutingKey = null,
+            Func<Error, LogLevel>? errorLogLevel = null)
             : base(subscriptionName, channelName, routingKey,  requestType, getRequestType, bufferSize,
                 noOfPerformers, timeOut, requeueCount, requeueDelay, unacceptableMessageLimit, messagePumpType, channelFactory, makeChannels, emptyChannelDelay, channelFailureDelay, unacceptableMessageLimitWindow)
         {
@@ -234,6 +246,7 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
             DeadLetterRoutingKey = deadLetterRoutingKey;
             InvalidMessageRoutingKey = invalidMessageRoutingKey;
             ConfigHook = configHook;
+            ErrorLogLevel = errorLogLevel;
         }
     }
 
@@ -277,6 +290,7 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
         /// <param name="configHook">Allows you to modify the Kafka client configuration before a consumer is created. Used to set properties that Brighter does not expose</param>
         /// <param name="deadLetterRoutingKey">The routing key for the dead letter channel. Optional.</param>
         /// <param name="invalidMessageRoutingKey">The routing key for the invalid message channel. Optional.</param>
+        /// <param name="errorLogLevel">Allows you to classify or suppress the log level of non-fatal errors raised by the underlying Kafka consumer. Optional.</param>
         public KafkaSubscription(SubscriptionName? subscriptionName = null,
             ChannelName? channelName = null,
             RoutingKey? routingKey = null,
@@ -305,7 +319,8 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
             PartitionAssignmentStrategy partitionAssignmentStrategy = PartitionAssignmentStrategy.RoundRobin,
             Action<ConsumerConfig>? configHook = null,
             RoutingKey? deadLetterRoutingKey = null,
-            RoutingKey? invalidMessageRoutingKey = null)
+            RoutingKey? invalidMessageRoutingKey = null,
+            Func<Error, LogLevel>? errorLogLevel = null)
             : base(
                 subscriptionName ?? new SubscriptionName(typeof(T).FullName!),
                 channelName ?? new ChannelName(typeof(T).FullName!),
@@ -336,7 +351,8 @@ namespace Paramore.Brighter.MessagingGateway.Kafka
                 partitionAssignmentStrategy,
                 configHook,
                 deadLetterRoutingKey,
-                invalidMessageRoutingKey)
+                invalidMessageRoutingKey,
+                errorLogLevel)
         {
         }
     }

--- a/tests/Paramore.Brighter.Kafka.Tests/Initializer.cs
+++ b/tests/Paramore.Brighter.Kafka.Tests/Initializer.cs
@@ -10,7 +10,7 @@ namespace Paramore.Brighter.Kafka.Tests
         [ModuleInitializer]
         public static void InitializeTestLogger()
         {
-            var logger = new LoggerConfiguration().WriteTo.TestCorrelator().CreateLogger();
+            var logger = new LoggerConfiguration().MinimumLevel.Debug().WriteTo.TestCorrelator().CreateLogger();
             ApplicationLogging.LoggerFactory = new LoggerFactory().AddSerilog(logger);
         }
     }

--- a/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/When_error_log_level_downgrades_an_error_code_should_log_at_downgraded_level.cs
+++ b/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/When_error_log_level_downgrades_an_error_code_should_log_at_downgraded_level.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Linq;
+using Confluent.Kafka;
+using Microsoft.Extensions.Logging;
+using Paramore.Brighter.MessagingGateway.Kafka;
+using Serilog.Events;
+using Serilog.Sinks.TestCorrelator;
+using Xunit;
+
+namespace Paramore.Brighter.Kafka.Tests.MessagingGateway;
+
+[Trait("Category", "Kafka")]
+[Collection("Kafka")]
+public class When_error_log_level_downgrades_an_error_code_should_log_at_downgraded_level : IDisposable
+{
+    private readonly KafkaMessageConsumer _consumer;
+
+    public When_error_log_level_downgrades_an_error_code_should_log_at_downgraded_level()
+    {
+        //Arrange - the hook downgrades idle socket timeouts to Debug, leaving every other error at its default
+        _consumer = new KafkaMessageConsumer(
+            new KafkaMessagingGatewayConfiguration
+            {
+                Name = "test", BootStrapServers = ["localhost:9092"]
+            },
+            routingKey: new RoutingKey("test.topic"),
+            groupId: "test-group",
+            offsetDefault: AutoOffsetReset.Earliest,
+            numPartitions: 1,
+            replicationFactor: 1,
+            makeChannels: OnMissingChannel.Assume,
+            errorLogLevel: error => error.Code == ErrorCode.Local_TimedOut ? LogLevel.Debug : LogLevel.Warning
+        );
+    }
+
+    [Fact]
+    public void When_the_error_log_level_downgrades_an_error_code_it_is_logged_at_that_level()
+    {
+        using var context = TestCorrelator.CreateContext();
+
+        //Act
+        _consumer.HandleError(new Error(ErrorCode.Local_TimedOut, "an idle socket non fatal timeout", isFatal: false));
+
+        //Assert - the downgraded error is logged at Debug, not Warning
+        var nonFatalEvent = TestCorrelator.GetLogEventsFromCurrentContext()
+            .Single(e => e.RenderMessage().Contains("an idle socket non fatal timeout"));
+        Assert.Equal(LogEventLevel.Debug, nonFatalEvent.Level);
+    }
+
+    public void Dispose()
+    {
+        _consumer?.Dispose();
+    }
+}

--- a/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/When_error_log_level_is_null_should_log_fatal_at_error_and_non_fatal_at_warning.cs
+++ b/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/When_error_log_level_is_null_should_log_fatal_at_error_and_non_fatal_at_warning.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Linq;
+using Confluent.Kafka;
+using Paramore.Brighter.MessagingGateway.Kafka;
+using Serilog.Events;
+using Serilog.Sinks.TestCorrelator;
+using Xunit;
+
+namespace Paramore.Brighter.Kafka.Tests.MessagingGateway;
+
+[Trait("Category", "Kafka")]
+[Collection("Kafka")]
+public class When_error_log_level_is_null_should_log_fatal_at_error_and_non_fatal_at_warning : IDisposable
+{
+    private readonly KafkaMessageConsumer _consumer;
+
+    public When_error_log_level_is_null_should_log_fatal_at_error_and_non_fatal_at_warning()
+    {
+        //Arrange - no ErrorLogLevel hook is configured, so the default classification must apply
+        _consumer = new KafkaMessageConsumer(
+            new KafkaMessagingGatewayConfiguration
+            {
+                Name = "test", BootStrapServers = ["localhost:9092"]
+            },
+            routingKey: new RoutingKey("test.topic"),
+            groupId: "test-group",
+            offsetDefault: AutoOffsetReset.Earliest,
+            numPartitions: 1,
+            replicationFactor: 1,
+            makeChannels: OnMissingChannel.Assume
+        );
+    }
+
+    [Fact]
+    public void When_no_error_log_level_is_configured_fatal_errors_log_at_error_and_non_fatal_at_warning()
+    {
+        using var context = TestCorrelator.CreateContext();
+
+        //Act
+        _consumer.HandleError(new Error(ErrorCode.Local_Fatal, "a fatal consumer error", isFatal: true));
+        _consumer.HandleError(new Error(ErrorCode.Local_TimedOut, "an idle socket non fatal timeout", isFatal: false));
+
+        //Assert - the default behaviour is preserved: fatal at Error, non-fatal at Warning
+        var events = TestCorrelator.GetLogEventsFromCurrentContext().ToList();
+
+        var fatalEvent = events.Single(e => e.RenderMessage().Contains("a fatal consumer error"));
+        Assert.Equal(LogEventLevel.Error, fatalEvent.Level);
+
+        var nonFatalEvent = events.Single(e => e.RenderMessage().Contains("an idle socket non fatal timeout"));
+        Assert.Equal(LogEventLevel.Warning, nonFatalEvent.Level);
+    }
+
+    public void Dispose()
+    {
+        _consumer?.Dispose();
+    }
+}

--- a/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/When_error_log_level_returns_none_should_suppress_logging.cs
+++ b/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/When_error_log_level_returns_none_should_suppress_logging.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Linq;
+using Confluent.Kafka;
+using Microsoft.Extensions.Logging;
+using Paramore.Brighter.MessagingGateway.Kafka;
+using Serilog.Sinks.TestCorrelator;
+using Xunit;
+
+namespace Paramore.Brighter.Kafka.Tests.MessagingGateway;
+
+[Trait("Category", "Kafka")]
+[Collection("Kafka")]
+public class When_error_log_level_returns_none_should_suppress_logging : IDisposable
+{
+    private readonly KafkaMessageConsumer _consumer;
+
+    public When_error_log_level_returns_none_should_suppress_logging()
+    {
+        //Arrange - the hook returns LogLevel.None for the error code we want to silence
+        _consumer = new KafkaMessageConsumer(
+            new KafkaMessagingGatewayConfiguration
+            {
+                Name = "test", BootStrapServers = ["localhost:9092"]
+            },
+            routingKey: new RoutingKey("test.topic"),
+            groupId: "test-group",
+            offsetDefault: AutoOffsetReset.Earliest,
+            numPartitions: 1,
+            replicationFactor: 1,
+            makeChannels: OnMissingChannel.Assume,
+            errorLogLevel: error => error.Code == ErrorCode.Local_TimedOut ? LogLevel.None : LogLevel.Warning
+        );
+    }
+
+    [Fact]
+    public void When_the_error_log_level_returns_none_the_error_is_not_logged()
+    {
+        using var context = TestCorrelator.CreateContext();
+
+        //Act
+        _consumer.HandleError(new Error(ErrorCode.Local_TimedOut, "an idle socket non fatal timeout", isFatal: false));
+
+        //Assert - no log event is written for the suppressed error
+        var matchingEvents = TestCorrelator.GetLogEventsFromCurrentContext()
+            .Count(e => e.RenderMessage().Contains("an idle socket non fatal timeout"));
+        Assert.Equal(0, matchingEvents);
+    }
+
+    public void Dispose()
+    {
+        _consumer?.Dispose();
+    }
+}

--- a/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/When_error_log_level_suppresses_logs_should_still_latch_fatal_error.cs
+++ b/tests/Paramore.Brighter.Kafka.Tests/MessagingGateway/When_error_log_level_suppresses_logs_should_still_latch_fatal_error.cs
@@ -1,0 +1,48 @@
+using System;
+using Confluent.Kafka;
+using Microsoft.Extensions.Logging;
+using Paramore.Brighter.MessagingGateway.Kafka;
+using Xunit;
+
+namespace Paramore.Brighter.Kafka.Tests.MessagingGateway;
+
+[Trait("Category", "Kafka")]
+[Collection("Kafka")]
+public class When_error_log_level_suppresses_logs_should_still_latch_fatal_error : IDisposable
+{
+    private readonly KafkaMessageConsumer _consumer;
+
+    public When_error_log_level_suppresses_logs_should_still_latch_fatal_error()
+    {
+        //Arrange - the hook suppresses every log entry; fatal handling must be unaffected
+        _consumer = new KafkaMessageConsumer(
+            new KafkaMessagingGatewayConfiguration
+            {
+                Name = "test", BootStrapServers = ["localhost:9092"]
+            },
+            routingKey: new RoutingKey("test.topic"),
+            groupId: "test-group",
+            offsetDefault: AutoOffsetReset.Earliest,
+            numPartitions: 1,
+            replicationFactor: 1,
+            makeChannels: OnMissingChannel.Assume,
+            errorLogLevel: _ => LogLevel.None
+        );
+    }
+
+    [Fact]
+    public void When_the_error_log_level_suppresses_logging_the_fatal_error_is_still_latched()
+    {
+        //Act - even though the hook suppresses the log call, the fatal error must still latch the consumer
+        _consumer.HandleError(new Error(ErrorCode.Local_Fatal, "a fatal consumer error", isFatal: true));
+        var exception = Record.Exception(() => _consumer.Receive(TimeSpan.Zero));
+
+        //Assert - the latch fires purely from error.IsFatal, independent of the hook
+        Assert.IsType<ChannelFailureException>(exception);
+    }
+
+    public void Dispose()
+    {
+        _consumer?.Dispose();
+    }
+}


### PR DESCRIPTION
## Description
Adds `KafkaSubscription.ErrorLogLevel` (`Func<Error, LogLevel>?`), wired through `KafkaMessageConsumerFactory` into `KafkaMessageConsumer.HandleError`, so applications can classify or suppress the log level of non-fatal librdkafka error-callback events — e.g. downgrading `Local_TimedOut` idle-coordinator noise from Confluent Cloud instead of it flooding logs at `Warning`.

- `LogLevel.None` suppresses the log entirely.
- The hook never influences fatal handling: `_hasFatalError` remains latched purely from `Error.IsFatal`, regardless of what the hook returns.
- When the hook is null, current behavior is preserved exactly (fatal → `Error`, non-fatal → `Warning`).
- Replaces the fixed-level private `FatalError`/`NonFatalError` `LoggerMessage`s with a single dynamic-level `Log.KafkaError` via `ILogger.Log`, since `[LoggerMessage]` can't express a dynamic `Level`.

## Related Issues
Closes #4226

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [Contributing Guide](../blob/master/CONTRIBUTING.md)
- [x] I have checked the [documentation](https://brightercommand.gitbook.io/paramore-brighter-documentation/) for relevant guidance
- [x] I have added/updated XML documentation for any public API changes
- [x] I have added/updated tests as appropriate
- [x] My changes follow the existing code style and conventions

## Additional Notes
- **Shared test-infra change**: `tests/.../Initializer.cs` now uses `MinimumLevel.Debug()` for the TestCorrelator Serilog logger, so Debug-level log assertions are capturable (needed for the suppression/downgrade tests). Verified against a clean-`master` baseline: full Kafka suite (114 tests) has a byte-identical failure set before/after (76 pre-existing, broker-dependent failures), so this introduces no regressions.
- **Pre-existing failure, not introduced here**: `ConsumerConfigHookTests` fails on clean `master` too — it requires a live Kafka broker for `makeChannels: Create` → topic metadata lookup.
- `Log.FatalError`/`NonFatalError` were `private` (nested in a `private static partial class`); their only callers were `HandleError`, so removing them is **not** a public API break. No `PublicAPI.Shipped.txt`/`PublicApiAnalyzers` exist in this repo to update.
- **Binary compatibility note**: the new `errorLogLevel`/`ErrorLogLevel` constructor parameters are appended last with a default value (source-compatible, matches the existing pattern used for `TimeProvider`/`scheduler`/`groupProtocol`). This is source-compatible but, like any optional-parameter addition, is not binary-compatible for callers pre-compiled against the old signature without recompiling — inherent to this approach and consistent with how the constructors have grown previously.
- **Minor logging delta**: the new `Log.KafkaError` call has no `EventId` (defaults to `EventId(0)`), whereas the replaced `FatalError`/`NonFatalError` had generator-assigned opaque IDs. These were never documented or stable (the issue itself notes Brighter assigns no explicit EventId to `NonFatalError`), but flagging in case any consumer was keying off them.