### PR TITLE
Add TodoApi sample to Brighter.slnx so CI builds it

### DIFF
--- a/Brighter.slnx
+++ b/Brighter.slnx
@@ -193,6 +193,11 @@
     <Project Path="samples/WebAPI/WebAPI_EFCore/SalutationAnalytics/SalutationAnalytics.csproj" />
     <Project Path="samples/WebAPI/WebAPI_EFCore/SalutationApp/SalutationApp.csproj" />
   </Folder>
+  <Folder Name="/samples/WebAPI/WebAPI_mTLS_TestHarness/">
+    <File Path="samples/WebAPI/WebAPI_mTLS_TestHarness/README.md" />
+    <File Path="samples/WebAPI/WebAPI_mTLS_TestHarness/tests.http" />
+    <Project Path="samples/WebAPI/WebAPI_mTLS_TestHarness/TodoApi/TodoApi.csproj" />
+  </Folder>
   <Folder Name="/Solution Items/">
     <File Path=".editorconfig" />
     <File Path="Directory.Build.props" />


### PR DESCRIPTION
Fixes #4272.

`samples/WebAPI/WebAPI_mTLS_TestHarness/TodoApi/TodoApi.csproj` has been on disk since c8d27b2d1 (#3953, 2026-02-01) but was never referenced by `Brighter.slnx`. CI builds with `dotnet build` at the repository root, which resolves to the solution, so the sample has never been compiled by CI.

This adds a `/samples/WebAPI/WebAPI_mTLS_TestHarness/` folder following the pattern of the sibling WebAPI samples — the README, `tests.http`, and the project. Five added lines, nothing else touched.

Nothing was keeping it out: it targets `net10.0`, which 21 other samples already do and which CI installs, and its one `PackageReference` (`Swashbuckle.AspNetCore`) is already pinned in `Directory.Packages.props`.

### Verified

- `dotnet build …/TodoApi.csproj -c Release` → **Build succeeded, 0 errors**
- `dotnet sln Brighter.slnx list` now lists `TodoApi`; the solution parses and holds 243 projects
- `dotnet restore Brighter.slnx` succeeds with no new warnings
- sample `.csproj` entries in the solution go **109 → 110**, matching disk
- the check proposed in #4273 now returns clean against this branch

### One thing to expect

**`master` is currently red for an unrelated reason** — a single test in `Paramore.Brighter.Transforms.Adaptors.Tests` fails on `net10.0` while `net9.0` passes (most recent run: 31175401674). CI on this PR will likely show that same failure. It is pre-existing and not caused by this change; I have left it alone rather than bundling a fix into a solution-file PR.

Newly-built code does now enter the build, so if anything else surfaces it will be from `TodoApi` compiling for the first time. It builds clean locally on both the standalone project and a full solution restore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)