### PR TITLE
samples: add Tutorials/02-FirstMessage, the sample behind tutorial rung 2

### DIFF
--- a/Brighter.slnx
+++ b/Brighter.slnx
@@ -151,6 +151,13 @@
     <Project Path="samples/Transforms/MassTransit/MassTransitSide/MassTransitSide.csproj" />
     <Project Path="samples/Transforms/MassTransit/MBrigtherSide/MBrigtherSide.csproj" />
   </Folder>
+  <Folder Name="/samples/Tutorials/" />
+  <Folder Name="/samples/Tutorials/02-FirstMessage/">
+    <File Path="samples/Tutorials/02-FirstMessage/README.md" />
+    <Project Path="samples/Tutorials/02-FirstMessage/Greetings/Greetings.csproj" />
+    <Project Path="samples/Tutorials/02-FirstMessage/GreetingsReceiver/GreetingsReceiver.csproj" />
+    <Project Path="samples/Tutorials/02-FirstMessage/GreetingsSender/GreetingsSender.csproj" />
+  </Folder>
   <Folder Name="/samples/Validation/">
     <File Path="samples\Validation\README.md" />
     <Project Path="samples/Validation/DataAnnotationsSample/DataAnnotationsSample.csproj" />

--- a/Brighter.slnx
+++ b/Brighter.slnx
@@ -151,7 +151,9 @@
     <Project Path="samples/Transforms/MassTransit/MassTransitSide/MassTransitSide.csproj" />
     <Project Path="samples/Transforms/MassTransit/MBrigtherSide/MBrigtherSide.csproj" />
   </Folder>
-  <Folder Name="/samples/Tutorials/" />
+  <Folder Name="/samples/Tutorials/">
+    <File Path="samples/Tutorials/README.md" />
+  </Folder>
   <Folder Name="/samples/Tutorials/02-FirstMessage/">
     <File Path="samples/Tutorials/02-FirstMessage/README.md" />
     <Project Path="samples/Tutorials/02-FirstMessage/Greetings/Greetings.csproj" />

--- a/samples/Tutorials/02-FirstMessage/Greetings/GreetingEvent.cs
+++ b/samples/Tutorials/02-FirstMessage/Greetings/GreetingEvent.cs
@@ -1,0 +1,44 @@
+#region Licence
+/* The MIT License (MIT)
+Copyright © 2026 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+using Paramore.Brighter;
+
+namespace Greetings;
+
+/// <summary>
+/// The event both processes share. The sender publishes it; the receiver handles it.
+/// The property has a setter because the message is deserialized into a new instance
+/// by the receiver, which uses the parameterless constructor.
+/// </summary>
+public class GreetingEvent : Event
+{
+    public GreetingEvent() : base(Id.Random()) { }
+
+    public GreetingEvent(string greeting) : base(Id.Random())
+    {
+        Greeting = greeting;
+    }
+
+    public string Greeting { get; set; } = string.Empty;
+}

--- a/samples/Tutorials/02-FirstMessage/Greetings/Greetings.csproj
+++ b/samples/Tutorials/02-FirstMessage/Greetings/Greetings.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Paramore.Brighter\Paramore.Brighter.csproj" />
+  </ItemGroup>
+</Project>

--- a/samples/Tutorials/02-FirstMessage/Greetings/Greetings.csproj
+++ b/samples/Tutorials/02-FirstMessage/Greetings/Greetings.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\src\Paramore.Brighter\Paramore.Brighter.csproj" />

--- a/samples/Tutorials/02-FirstMessage/GreetingsReceiver/GreetingEventHandler.cs
+++ b/samples/Tutorials/02-FirstMessage/GreetingsReceiver/GreetingEventHandler.cs
@@ -1,0 +1,44 @@
+#region Licence
+/* The MIT License (MIT)
+Copyright © 2026 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+using System;
+using Greetings;
+using Paramore.Brighter;
+
+namespace GreetingsReceiver;
+
+/// <summary>
+/// The pump reads a message from the channel, the mapper turns it back into a
+/// <see cref="GreetingEvent"/>, and Brighter dispatches it here. This is a synchronous
+/// handler because the subscription runs a Reactor pump.
+/// </summary>
+public class GreetingEventHandler : RequestHandler<GreetingEvent>
+{
+    public override GreetingEvent Handle(GreetingEvent @event)
+    {
+        Console.WriteLine($"Received: {@event.Greeting}");
+
+        return base.Handle(@event);
+    }
+}

--- a/samples/Tutorials/02-FirstMessage/GreetingsReceiver/GreetingsReceiver.csproj
+++ b/samples/Tutorials/02-FirstMessage/GreetingsReceiver/GreetingsReceiver.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Paramore.Brighter.MessagingGateway.RMQ.Async\Paramore.Brighter.MessagingGateway.RMQ.Async.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Paramore.Brighter.ServiceActivator.Extensions.DependencyInjection\Paramore.Brighter.ServiceActivator.Extensions.DependencyInjection.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Paramore.Brighter.ServiceActivator.Extensions.Hosting\Paramore.Brighter.ServiceActivator.Extensions.Hosting.csproj" />
+    <ProjectReference Include="..\Greetings\Greetings.csproj" />
+  </ItemGroup>
+</Project>

--- a/samples/Tutorials/02-FirstMessage/GreetingsReceiver/GreetingsReceiver.csproj
+++ b/samples/Tutorials/02-FirstMessage/GreetingsReceiver/GreetingsReceiver.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
     <OutputType>Exe</OutputType>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />

--- a/samples/Tutorials/02-FirstMessage/GreetingsReceiver/Program.cs
+++ b/samples/Tutorials/02-FirstMessage/GreetingsReceiver/Program.cs
@@ -32,7 +32,12 @@ using Paramore.Brighter.ServiceActivator.Extensions.DependencyInjection;
 using Paramore.Brighter.ServiceActivator.Extensions.Hosting;
 
 // A subscription is the consuming half of a publication: the queue to read, the routing
-// key bound to it, and how the pump should run.
+// key bound to it, and how the pump should run. This is also the process that declares
+// the queue and its binding, which is why it has to be running before the sender posts.
+//
+// isDurable defaults to false, so the queue does not survive a broker restart. That is a
+// property of the *queue*, and it is a different question from whether a message survives
+// the *sender* crashing — which is what rung 3's durable Outbox is about.
 var subscriptions = new Subscription[]
 {
     new RmqSubscription<GreetingEvent>(

--- a/samples/Tutorials/02-FirstMessage/GreetingsReceiver/Program.cs
+++ b/samples/Tutorials/02-FirstMessage/GreetingsReceiver/Program.cs
@@ -1,0 +1,66 @@
+#region Licence
+/* The MIT License (MIT)
+Copyright © 2026 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+using System;
+using Greetings;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Paramore.Brighter;
+using Paramore.Brighter.MessagingGateway.RMQ.Async;
+using Paramore.Brighter.ServiceActivator.Extensions.DependencyInjection;
+using Paramore.Brighter.ServiceActivator.Extensions.Hosting;
+
+// A subscription is the consuming half of a publication: the queue to read, the routing
+// key bound to it, and how the pump should run.
+var subscriptions = new Subscription[]
+{
+    new RmqSubscription<GreetingEvent>(
+        new SubscriptionName("greeting.subscription"),
+        new ChannelName("greeting.event"),
+        new RoutingKey("greeting.event"),
+        messagePumpType: MessagePumpType.Reactor,
+        makeChannels: OnMissingChannel.Create)
+};
+
+var rmqConnection = new RmqMessagingGatewayConnection
+{
+    AmpqUri = new AmqpUriSpecification(new Uri("amqp://guest:guest@localhost:5672")),
+    Exchange = new Exchange("paramore.brighter.exchange")
+};
+
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.Services
+    .AddConsumers(options =>
+    {
+        options.Subscriptions = subscriptions;
+        options.DefaultChannelFactory = new ChannelFactory(new RmqMessageConsumerFactory(rmqConnection));
+    })
+    .AutoFromAssemblies();
+
+builder.Services.AddHostedService<ServiceActivatorHostedService>();
+
+var host = builder.Build();
+
+await host.RunAsync();

--- a/samples/Tutorials/02-FirstMessage/GreetingsReceiver/Program.cs
+++ b/samples/Tutorials/02-FirstMessage/GreetingsReceiver/Program.cs
@@ -33,7 +33,10 @@ using Paramore.Brighter.ServiceActivator.Extensions.Hosting;
 
 // A subscription is the consuming half of a publication: the queue to read, the routing
 // key bound to it, and how the pump should run. This is also the process that declares
-// the queue and its binding, which is why it has to be running before the sender posts.
+// the queue and its binding, which is why it has to run first the first time.
+//
+// Naming GreetingEvent here is also what loads the Greetings assembly. AutoFromAssemblies
+// below scans the assemblies loaded so far, so reordering this beneath it is a silent no-op.
 //
 // isDurable defaults to false, so the queue does not survive a broker restart. That is a
 // property of the *queue*, and it is a different question from whether a message survives

--- a/samples/Tutorials/02-FirstMessage/GreetingsSender/GreetingsSender.csproj
+++ b/samples/Tutorials/02-FirstMessage/GreetingsSender/GreetingsSender.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
     <OutputType>Exe</OutputType>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />

--- a/samples/Tutorials/02-FirstMessage/GreetingsSender/GreetingsSender.csproj
+++ b/samples/Tutorials/02-FirstMessage/GreetingsSender/GreetingsSender.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Paramore.Brighter.Extensions.DependencyInjection\Paramore.Brighter.Extensions.DependencyInjection.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Paramore.Brighter.MessagingGateway.RMQ.Async\Paramore.Brighter.MessagingGateway.RMQ.Async.csproj" />
+    <ProjectReference Include="..\Greetings\Greetings.csproj" />
+  </ItemGroup>
+</Project>

--- a/samples/Tutorials/02-FirstMessage/GreetingsSender/Program.cs
+++ b/samples/Tutorials/02-FirstMessage/GreetingsSender/Program.cs
@@ -55,12 +55,15 @@ builder.Services
     .AutoFromAssemblies();
 
 // The host is built but never run: Post is synchronous, so all we need from it is the
-// container. Disposing it lets the producer finish confirming delivery before we exit.
-// Rung 3 does run the host, because it hosts the Outbox Sweeper.
-using var host = builder.Build();
+// container. Rung 3 does run the host, because it hosts the Outbox Sweeper.
+using (var host = builder.Build())
+{
+    var commandProcessor = host.Services.GetRequiredService<IAmACommandProcessor>();
 
-var commandProcessor = host.Services.GetRequiredService<IAmACommandProcessor>();
-
-commandProcessor.Post(new GreetingEvent("Hello from the sender"));
+    commandProcessor.Post(new GreetingEvent("Hello from the sender"));
+}
+// Publisher confirms are asynchronous: Post returns once the message is on its way, and the
+// broker's acknowledgement arrives later. Disposing the host waits for it, which is why the
+// success message belongs after this brace and not before it.
 
 Console.WriteLine("Published greeting.event");

--- a/samples/Tutorials/02-FirstMessage/GreetingsSender/Program.cs
+++ b/samples/Tutorials/02-FirstMessage/GreetingsSender/Program.cs
@@ -37,6 +37,9 @@ var rmqConnection = new RmqMessagingGatewayConnection
 };
 
 // A publication tells Brighter where a request type goes: which routing key, on which broker.
+// Naming GreetingEvent here is also what loads the Greetings assembly, which matters below:
+// AutoFromAssemblies scans the assemblies loaded so far, so anything it must find has to have
+// been touched before the call. Reordering this below the registration is a silent no-op.
 var producerRegistry = new RmqProducerRegistryFactory(
     rmqConnection,
     [
@@ -63,7 +66,9 @@ using (var host = builder.Build())
     commandProcessor.Post(new GreetingEvent("Hello from the sender"));
 }
 // Publisher confirms are asynchronous: Post returns once the message is on its way, and the
-// broker's acknowledgement arrives later. Disposing the host waits for it, which is why the
-// success message belongs after this brace and not before it.
-
+// broker's acknowledgement arrives later. Disposing the host waits for it — bounded by
+// RmqPublication.WaitForConfirmsTimeOutInMilliseconds, 500ms by default — which is why this
+// line sits after the brace. Note what it does and does not say: the broker has had its
+// chance to confirm. A nack surfaces as a log line rather than an exception, so this message
+// means "sent", not "accepted".
 Console.WriteLine("Published greeting.event");

--- a/samples/Tutorials/02-FirstMessage/GreetingsSender/Program.cs
+++ b/samples/Tutorials/02-FirstMessage/GreetingsSender/Program.cs
@@ -1,0 +1,63 @@
+#region Licence
+/* The MIT License (MIT)
+Copyright © 2026 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+using System;
+using Greetings;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Paramore.Brighter;
+using Paramore.Brighter.Extensions.DependencyInjection;
+using Paramore.Brighter.MessagingGateway.RMQ.Async;
+
+var rmqConnection = new RmqMessagingGatewayConnection
+{
+    AmpqUri = new AmqpUriSpecification(new Uri("amqp://guest:guest@localhost:5672")),
+    Exchange = new Exchange("paramore.brighter.exchange")
+};
+
+// A publication tells Brighter where a request type goes: which routing key, on which broker.
+var producerRegistry = new RmqProducerRegistryFactory(
+    rmqConnection,
+    [
+        new RmqPublication<GreetingEvent>
+        {
+            Topic = new RoutingKey("greeting.event"),
+            MakeChannels = OnMissingChannel.Create
+        }
+    ]).Create();
+
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.Services
+    .AddBrighter()
+    .AddProducers(configure => configure.ProducerRegistry = producerRegistry)
+    .AutoFromAssemblies();
+
+using var host = builder.Build();
+
+var commandProcessor = host.Services.GetRequiredService<IAmACommandProcessor>();
+
+commandProcessor.Post(new GreetingEvent("Hello from the sender"));
+
+Console.WriteLine("Published greeting.event");

--- a/samples/Tutorials/02-FirstMessage/GreetingsSender/Program.cs
+++ b/samples/Tutorials/02-FirstMessage/GreetingsSender/Program.cs
@@ -54,6 +54,9 @@ builder.Services
     .AddProducers(configure => configure.ProducerRegistry = producerRegistry)
     .AutoFromAssemblies();
 
+// The host is built but never run: Post is synchronous, so all we need from it is the
+// container. Disposing it lets the producer finish confirming delivery before we exit.
+// Rung 3 does run the host, because it hosts the Outbox Sweeper.
 using var host = builder.Build();
 
 var commandProcessor = host.Services.GetRequiredService<IAmACommandProcessor>();

--- a/samples/Tutorials/02-FirstMessage/README.md
+++ b/samples/Tutorials/02-FirstMessage/README.md
@@ -1,8 +1,10 @@
 # 02 — Your First Message Over a Broker
 
-The sample behind rung 2 of the *Get Started* tutorial ladder in the Brighter
-documentation. Every code block on that page is this code, so please keep the two in step:
-if you change a file here, the tutorial page needs the same edit.
+The sample behind rung 2 of the *Get Started* tutorial ladder in the
+[Brighter documentation](https://brightercommand.gitbook.io/paramore-brighter-documentation).
+Every code block on the page *Your First Message Over a Broker* is this code, so please keep
+the two in step: if you change a file here, the tutorial page needs the same edit. CI can
+prove this compiles; nothing can prove the page still matches it.
 
 One event goes from a sender process, over a RabbitMQ exchange, to a receiver process that
 handles it.
@@ -15,7 +17,8 @@ From the repository root:
 docker compose -f docker-compose-rmq.yaml up -d
 ```
 
-Then, in two terminals — the receiver first, because it is the one that declares the queue:
+Then, in two terminals — **the receiver first**, because it is the process that declares the
+queue and the binding:
 
 ```bash
 dotnet run --project samples/Tutorials/02-FirstMessage/GreetingsReceiver
@@ -26,6 +29,27 @@ dotnet run --project samples/Tutorials/02-FirstMessage/GreetingsSender
 ```
 
 The receiver prints `Received: Hello from the sender` and keeps running; Ctrl+C stops it.
+
+**If you ran the sender first, nothing arrives.** The sender declares the exchange, but no
+queue is bound to it yet, so RabbitMQ drops the message — and the publish still succeeds,
+so the sender reports no error. Start the receiver, then run the sender again.
+
+Both halves are visible at <http://localhost:15672> (guest/guest): the
+`paramore.brighter.exchange` exchange, the `greeting.event` queue, and the binding between
+them on routing key `greeting.event`. When you are done:
+
+```bash
+docker compose -f docker-compose-rmq.yaml down
+```
+
+## Why the topic is a bare string in three places
+
+`"greeting.event"` appears in the sender's publication and twice in the receiver's
+subscription, as the channel name and the routing key. A shared constant would be tidier and
+is deliberately not used: the lesson of this rung is that two independently deployed
+processes agree on a name over the wire, and the sender and receiver are the same two
+processes precisely because they *cannot* share code in the general case. Seeing the string
+on both sides is the point.
 
 ## Why this is not `samples/TaskQueue/RMQTaskQueue`
 

--- a/samples/Tutorials/02-FirstMessage/README.md
+++ b/samples/Tutorials/02-FirstMessage/README.md
@@ -1,0 +1,40 @@
+# 02 — Your First Message Over a Broker
+
+The sample behind rung 2 of the *Get Started* tutorial ladder in the Brighter
+documentation. Every code block on that page is this code, so please keep the two in step:
+if you change a file here, the tutorial page needs the same edit.
+
+One event goes from a sender process, over a RabbitMQ exchange, to a receiver process that
+handles it.
+
+## Running it
+
+From the repository root:
+
+```bash
+docker compose -f docker-compose-rmq.yaml up -d
+```
+
+Then, in two terminals — the receiver first, because it is the one that declares the queue:
+
+```bash
+dotnet run --project samples/Tutorials/02-FirstMessage/GreetingsReceiver
+```
+
+```bash
+dotnet run --project samples/Tutorials/02-FirstMessage/GreetingsSender
+```
+
+The receiver prints `Received: Hello from the sender` and keeps running; Ctrl+C stops it.
+
+## Why this is not `samples/TaskQueue/RMQTaskQueue`
+
+`RMQTaskQueue` is the reference sample for RabbitMQ and earns its extras — Serilog, a
+`CustomPublicationFinder`, a second event type, an explicit scheduler factory. Each of
+those is a concept a reader meeting a broker for the first time has to park, so this sample
+drops all four and adds nothing. It also has no message mapper: `JsonMessageMapper<T>` is
+Brighter's default, and a tutorial should not write code the framework already supplies.
+
+Rung 3 adds a durable Outbox to this sample; rung 4 swaps the transport for Kafka. Each is
+one readable delta from this one, which is why this is deliberately the smallest thing that
+still crosses a broker.

--- a/samples/Tutorials/02-FirstMessage/README.md
+++ b/samples/Tutorials/02-FirstMessage/README.md
@@ -30,9 +30,15 @@ dotnet run --project samples/Tutorials/02-FirstMessage/GreetingsSender
 
 The receiver prints `Received: Hello from the sender` and keeps running; Ctrl+C stops it.
 
-**If you ran the sender first, nothing arrives.** The sender declares the exchange, but no
-queue is bound to it yet, so RabbitMQ drops the message — and the publish still succeeds,
-so the sender reports no error. Start the receiver, then run the sender again.
+**If you ran the sender first on a fresh broker, nothing arrives.** The sender declares the
+exchange, but no queue is bound to it yet, so RabbitMQ drops the message — and the publish
+still succeeds, so the sender reports no error. Start the receiver, then run the sender
+again.
+
+Order only matters that first time. The queue is declared `autoDelete: false`, so once the
+receiver has run, the queue and its binding outlive the receiver process and survive until
+the broker restarts. After that you can run the sender with nothing listening and the
+message waits in the queue for the receiver to come back.
 
 Both halves are visible at <http://localhost:15672> (guest/guest): the
 `paramore.brighter.exchange` exchange, the `greeting.event` queue, and the binding between

--- a/samples/Tutorials/02-FirstMessage/README.md
+++ b/samples/Tutorials/02-FirstMessage/README.md
@@ -17,6 +17,11 @@ From the repository root:
 docker compose -f docker-compose-rmq.yaml up -d
 ```
 
+That command returns before RabbitMQ is accepting connections — the compose file has no
+healthcheck — so give the broker a few seconds. It is ready when
+<http://localhost:15672> answers. Starting the apps too early prints connection failures
+until the broker comes up; that is the broker, not the sample.
+
 Then, in two terminals — **the receiver first**, because it is the process that declares the
 queue and the binding:
 

--- a/samples/Tutorials/README.md
+++ b/samples/Tutorials/README.md
@@ -1,0 +1,20 @@
+# Tutorial samples
+
+The code behind the *Get Started* tutorial ladder in the
+[Brighter documentation](https://brightercommand.gitbook.io/paramore-brighter-documentation).
+Each rung is one readable delta from the one below it, so a reader — and a reviewer — can
+diff two of them and see exactly what a feature costs.
+
+| Rung | Teaches | Sample |
+|---|---|---|
+| 1 | A command, a handler, no broker | [`samples/CommandProcessor/HelloWorld`](../CommandProcessor/HelloWorld) — reused as-is, which is why there is no `01-` directory here |
+| 2 | One event over a RabbitMQ exchange, two processes | [`02-FirstMessage`](02-FirstMessage) |
+
+Rungs 3 (a durable Postgres Outbox) and 4 (Kafka) are planned and will land here as separate
+pull requests.
+
+These samples are deliberately smaller than the reference samples they derive from. Where a
+sample under `samples/TaskQueue/` shows a feature properly, the tutorial version shows the
+least that still works — see each rung's README for what it drops and why. **If you change a
+file here, the matching tutorial page needs the same edit**: CI proves this code compiles, but
+nothing proves the page still matches it.


### PR DESCRIPTION
## What this is

The Brighter documentation is growing a **Get Started ladder**: four tutorials, each one readable delta from the one below it. Rung 1 reuses `samples/CommandProcessor/HelloWorld` unchanged and is [already published](https://brightercommand.gitbook.io/paramore-brighter-documentation/get-started/tutorialfirstcommand). This is **rung 2's sample** — one event, over a RabbitMQ exchange, from a sender process to a receiver process.

Every code block on the tutorial page will be *this* code. That is why the sample belongs here rather than inside a markdown fence: CI compiles it, so it cannot rot quietly.

```
samples/Tutorials/02-FirstMessage/
├── README.md
├── Greetings/            GreetingEvent — the type both processes share
├── GreetingsSender/      publication + AddProducers + Post
└── GreetingsReceiver/    subscription + AddConsumers + the handler
```

## Why not just point the tutorial at `RMQTaskQueue`?

`RMQTaskQueue` is the reference sample for RabbitMQ and earns its extras. This one drops four of them, because each is a concept a reader meeting a broker for the first time has to park:

- Serilog
- `CustomPublicationFinder`
- a second event type (`FarewellEvent`)
- an explicit `InMemorySchedulerFactory`

**`RMQTaskQueue` itself is untouched** — those extras are why it exists, and trimming them there would destroy its teaching purpose.

It also carries **no message mapper**. `JsonMessageMapper<T>` is the registered default (`ServiceCollectionMessageMapperRegistryBuilder.cs:49`), so hand-writing one would teach a reader to write code the framework already supplies.

> ⚠️ Worth a separate issue: the XML doc comments on `IBrighterBuilder.AutoFromAssemblies`, `MapperRegistry` and `MapperRegistryFromAssemblies` all say *"We use `CloudEventJsonMessageMapper` as the default"*. The field says `JsonMessageMapper<>`, and the wire format on a real run agrees with the field — the published body is `{"greeting":…,"correlationId":null,"id":…}` with `contentType: application/json`, not a CloudEvents envelope. The comments are wrong, not the code.

## Evidence

**Run end to end**, against `rabbitmq:management` from `docker-compose-rmq.yaml`, before this was committed:

```text
info: Paramore.Brighter.MessagingGateway.RMQ.Async.RmqMessageConsumer[784437019]
      RmqMessageConsumer: Created consumer for queue greeting.event with routing key greeting.event via exchange paramore.brighter.exchange
...
Received: Hello from the sender
info: Paramore.Brighter.MessagingGateway.RMQ.Async.RmqMessageConsumer[22364147]
      RmqMessageConsumer: Acknowledging message 01a038b0-…-8da33fd8c939 as completed with delivery tag 1
```

`GreetingEvent.Greeting` has a **setter** for a reason worth stating: `System.Text.Json` picks the parameterless constructor when a type offers two, so a get-only property arrives empty at the receiver.

**Registered in `Brighter.slnx`.** Being under `samples/` does not make a project built — CI runs `dotnet build` at the root, which resolves to the solution, and `samples/WebAPI/WebAPI_mTLS_TestHarness/TodoApi` (#4272, fix open at #4274) sits in the directory without being in the build. After this change the solution names **112** sample projects against **113** on disk, and `TodoApi` is the only difference:

```text
$ comm -23 <(git ls-files 'samples/**/*.csproj' | sort) <(grep -o 'samples/[^"]*\.csproj' Brighter.slnx | sort)
samples/WebAPI/WebAPI_mTLS_TestHarness/TodoApi/TodoApi.csproj
```

All three projects build clean in `Release`, 0 warnings and 0 errors.

## Note on the CI check

`master` has been red on one `net10.0` test in `Paramore.Brighter.Transforms.Adaptors.Tests` while `net9.0` passes. If that check fails here it is not this change — please read *which* check failed.

## What comes next

Rung 3 adds a durable Outbox to this sample; rung 4 swaps the transport for Kafka. Each will be a separate PR, and each is one readable delta from this one — which is why this is deliberately the smallest thing that still crosses a broker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)