### PR TITLE
samples: add Tutorials/03-DurableOutbox, the sample behind tutorial rung 3

### DIFF
--- a/Brighter.slnx
+++ b/Brighter.slnx
@@ -160,6 +160,12 @@
     <Project Path="samples/Tutorials/02-FirstMessage/GreetingsReceiver/GreetingsReceiver.csproj" />
     <Project Path="samples/Tutorials/02-FirstMessage/GreetingsSender/GreetingsSender.csproj" />
   </Folder>
+  <Folder Name="/samples/Tutorials/03-DurableOutbox/">
+    <File Path="samples/Tutorials/03-DurableOutbox/README.md" />
+    <Project Path="samples/Tutorials/03-DurableOutbox/Greetings/Greetings.csproj" />
+    <Project Path="samples/Tutorials/03-DurableOutbox/GreetingsReceiver/GreetingsReceiver.csproj" />
+    <Project Path="samples/Tutorials/03-DurableOutbox/GreetingsSender/GreetingsSender.csproj" />
+  </Folder>
   <Folder Name="/samples/Validation/">
     <File Path="samples\Validation\README.md" />
     <Project Path="samples/Validation/DataAnnotationsSample/DataAnnotationsSample.csproj" />

--- a/samples/Tutorials/03-DurableOutbox/Greetings/GreetingEvent.cs
+++ b/samples/Tutorials/03-DurableOutbox/Greetings/GreetingEvent.cs
@@ -1,0 +1,44 @@
+#region Licence
+/* The MIT License (MIT)
+Copyright © 2026 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+using Paramore.Brighter;
+
+namespace Greetings;
+
+/// <summary>
+/// The event both processes share. The sender publishes it; the receiver handles it.
+/// The property has a setter because the message is deserialized into a new instance
+/// by the receiver, which uses the parameterless constructor.
+/// </summary>
+public class GreetingEvent : Event
+{
+    public GreetingEvent() : base(Id.Random()) { }
+
+    public GreetingEvent(string greeting) : base(Id.Random())
+    {
+        Greeting = greeting;
+    }
+
+    public string Greeting { get; set; } = string.Empty;
+}

--- a/samples/Tutorials/03-DurableOutbox/Greetings/Greetings.csproj
+++ b/samples/Tutorials/03-DurableOutbox/Greetings/Greetings.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Paramore.Brighter\Paramore.Brighter.csproj" />
+  </ItemGroup>
+</Project>

--- a/samples/Tutorials/03-DurableOutbox/GreetingsReceiver/GreetingEventHandler.cs
+++ b/samples/Tutorials/03-DurableOutbox/GreetingsReceiver/GreetingEventHandler.cs
@@ -1,0 +1,44 @@
+#region Licence
+/* The MIT License (MIT)
+Copyright © 2026 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+using System;
+using Greetings;
+using Paramore.Brighter;
+
+namespace GreetingsReceiver;
+
+/// <summary>
+/// The pump reads a message from the channel, the mapper turns it back into a
+/// <see cref="GreetingEvent"/>, and Brighter dispatches it here. This is a synchronous
+/// handler because the subscription runs a Reactor pump.
+/// </summary>
+public class GreetingEventHandler : RequestHandler<GreetingEvent>
+{
+    public override GreetingEvent Handle(GreetingEvent @event)
+    {
+        Console.WriteLine($"Received: {@event.Greeting}");
+
+        return base.Handle(@event);
+    }
+}

--- a/samples/Tutorials/03-DurableOutbox/GreetingsReceiver/GreetingsReceiver.csproj
+++ b/samples/Tutorials/03-DurableOutbox/GreetingsReceiver/GreetingsReceiver.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Paramore.Brighter.MessagingGateway.RMQ.Async\Paramore.Brighter.MessagingGateway.RMQ.Async.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Paramore.Brighter.ServiceActivator.Extensions.DependencyInjection\Paramore.Brighter.ServiceActivator.Extensions.DependencyInjection.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Paramore.Brighter.ServiceActivator.Extensions.Hosting\Paramore.Brighter.ServiceActivator.Extensions.Hosting.csproj" />
+    <ProjectReference Include="..\Greetings\Greetings.csproj" />
+  </ItemGroup>
+</Project>

--- a/samples/Tutorials/03-DurableOutbox/GreetingsReceiver/Program.cs
+++ b/samples/Tutorials/03-DurableOutbox/GreetingsReceiver/Program.cs
@@ -1,0 +1,74 @@
+#region Licence
+/* The MIT License (MIT)
+Copyright © 2026 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+using System;
+using Greetings;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Paramore.Brighter;
+using Paramore.Brighter.MessagingGateway.RMQ.Async;
+using Paramore.Brighter.ServiceActivator.Extensions.DependencyInjection;
+using Paramore.Brighter.ServiceActivator.Extensions.Hosting;
+
+// A subscription is the consuming half of a publication: the queue to read, the routing
+// key bound to it, and how the pump should run. This is also the process that declares
+// the queue and its binding, which is why it has to run first the first time.
+//
+// Naming GreetingEvent here is also what loads the Greetings assembly. AutoFromAssemblies
+// below scans the assemblies loaded so far, so reordering this beneath it is a silent no-op.
+//
+// isDurable defaults to false, so the queue does not survive a broker restart. That is a
+// property of the *queue*, and it is a different question from whether a message survives
+// the *sender* crashing — which is what rung 3's durable Outbox is about.
+var subscriptions = new Subscription[]
+{
+    new RmqSubscription<GreetingEvent>(
+        new SubscriptionName("greeting.subscription"),
+        new ChannelName("greeting.event"),
+        new RoutingKey("greeting.event"),
+        messagePumpType: MessagePumpType.Reactor,
+        makeChannels: OnMissingChannel.Create)
+};
+
+var rmqConnection = new RmqMessagingGatewayConnection
+{
+    AmpqUri = new AmqpUriSpecification(new Uri("amqp://guest:guest@localhost:5672")),
+    Exchange = new Exchange("paramore.brighter.exchange")
+};
+
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.Services
+    .AddConsumers(options =>
+    {
+        options.Subscriptions = subscriptions;
+        options.DefaultChannelFactory = new ChannelFactory(new RmqMessageConsumerFactory(rmqConnection));
+    })
+    .AutoFromAssemblies();
+
+builder.Services.AddHostedService<ServiceActivatorHostedService>();
+
+var host = builder.Build();
+
+await host.RunAsync();

--- a/samples/Tutorials/03-DurableOutbox/GreetingsSender/AddGreeting.cs
+++ b/samples/Tutorials/03-DurableOutbox/GreetingsSender/AddGreeting.cs
@@ -1,0 +1,51 @@
+#region Licence
+/* The MIT License (MIT)
+Copyright © 2026 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+using Paramore.Brighter;
+
+namespace GreetingsSender;
+
+/// <summary>
+/// The instruction to record a greeting and tell the world about it. Unlike
+/// <see cref="Greetings.GreetingEvent"/> this never leaves the process, so it lives here in
+/// the sender rather than in the shared Greetings library: a command is addressed to one
+/// handler, and that handler is in this assembly.
+/// </summary>
+public class AddGreeting : Command
+{
+    public AddGreeting(string greeting, bool failBeforeCommit = false) : base(Id.Random())
+    {
+        Greeting = greeting;
+        FailBeforeCommit = failBeforeCommit;
+    }
+
+    public string Greeting { get; }
+
+    /// <summary>
+    /// Set by the <c>--fail</c> switch. It exists so the tutorial can run the unhappy path:
+    /// the handler throws after the row and the message are both written and before the
+    /// commit, which is the only interesting moment in the whole sample.
+    /// </summary>
+    public bool FailBeforeCommit { get; }
+}

--- a/samples/Tutorials/03-DurableOutbox/GreetingsSender/AddGreetingHandlerAsync.cs
+++ b/samples/Tutorials/03-DurableOutbox/GreetingsSender/AddGreetingHandlerAsync.cs
@@ -1,0 +1,113 @@
+#region Licence
+/* The MIT License (MIT)
+Copyright © 2026 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+using System;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using Greetings;
+using Paramore.Brighter;
+
+namespace GreetingsSender;
+
+/// <summary>
+/// The whole point of rung 3. The business row and the outgoing message are written on the
+/// same connection inside the same transaction, so the database commits both or neither.
+/// </summary>
+public class AddGreetingHandlerAsync : RequestHandlerAsync<AddGreeting>
+{
+    private readonly IAmATransactionConnectionProvider _transactionProvider;
+    private readonly IAmACommandProcessor _postBox;
+
+    public AddGreetingHandlerAsync(
+        IAmATransactionConnectionProvider transactionProvider,
+        IAmACommandProcessor postBox)
+    {
+        _transactionProvider = transactionProvider;
+        _postBox = postBox;
+    }
+
+    public override async Task<AddGreeting> HandleAsync(
+        AddGreeting addGreeting,
+        CancellationToken cancellationToken = default)
+    {
+        // Ask the provider for the connection and transaction rather than opening your own.
+        // This is the shared unit of work: the Outbox writes through the same pair, which is
+        // what makes the two writes below one atomic act instead of two hopeful ones.
+        DbConnection connection = await _transactionProvider.GetConnectionAsync(cancellationToken);
+        DbTransaction transaction = await _transactionProvider.GetTransactionAsync(cancellationToken);
+
+        try
+        {
+            // 1. Your write, to your table. Brighter neither knows nor cares what this is.
+            await using (DbCommand command = connection.CreateCommand())
+            {
+                command.Transaction = transaction;
+                command.CommandText = "insert into Greeting (Message) values (@message)";
+
+                DbParameter message = command.CreateParameter();
+                message.ParameterName = "message";
+                message.Value = addGreeting.Greeting;
+                command.Parameters.Add(message);
+
+                await command.ExecuteNonQueryAsync(cancellationToken);
+            }
+
+            // 2. Brighter's write, to the Outbox table, on that same transaction. Nothing has
+            // gone to RabbitMQ yet — DepositPostAsync only stores the message.
+            await _postBox.DepositPostAsync(
+                new GreetingEvent(addGreeting.Greeting),
+                _transactionProvider,
+                cancellationToken: cancellationToken);
+
+            // The deliberate failure the tutorial's last step runs. Both writes are pending
+            // right now; neither is committed. Throwing here is the experiment.
+            if (addGreeting.FailBeforeCommit)
+            {
+                throw new InvalidOperationException(
+                    "Deliberate failure, after both writes and before the commit");
+            }
+
+            // 3. Both, or neither.
+            await _transactionProvider.CommitAsync(cancellationToken);
+        }
+        catch (Exception)
+        {
+            // Rolling back discards your row and the message together. There is no window in
+            // which the greeting exists but the message does not, or the other way round.
+            await _transactionProvider.RollbackAsync(cancellationToken);
+            throw;
+        }
+        finally
+        {
+            _transactionProvider.Close();
+        }
+
+        // Note what is NOT here: ClearOutboxAsync. The message sits in the Outbox until the
+        // Sweeper picks it up, which is the delay this rung exists to show you. Call
+        // ClearOutboxAsync here instead and it dispatches immediately, at the cost of doing
+        // the send on the request thread.
+        return await base.HandleAsync(addGreeting, cancellationToken);
+    }
+}

--- a/samples/Tutorials/03-DurableOutbox/GreetingsSender/GreetingsSender.csproj
+++ b/samples/Tutorials/03-DurableOutbox/GreetingsSender/GreetingsSender.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Npgsql" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Paramore.Brighter.BoxProvisioning\Paramore.Brighter.BoxProvisioning.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Paramore.Brighter.BoxProvisioning.PostgreSql\Paramore.Brighter.BoxProvisioning.PostgreSql.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Paramore.Brighter.Extensions.DependencyInjection\Paramore.Brighter.Extensions.DependencyInjection.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Paramore.Brighter.MessagingGateway.RMQ.Async\Paramore.Brighter.MessagingGateway.RMQ.Async.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Paramore.Brighter.Outbox.Hosting\Paramore.Brighter.Outbox.Hosting.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Paramore.Brighter.Outbox.PostgreSql\Paramore.Brighter.Outbox.PostgreSql.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Paramore.Brighter.PostgreSql\Paramore.Brighter.PostgreSql.csproj" />
+    <ProjectReference Include="..\Greetings\Greetings.csproj" />
+  </ItemGroup>
+</Project>

--- a/samples/Tutorials/03-DurableOutbox/GreetingsSender/Program.cs
+++ b/samples/Tutorials/03-DurableOutbox/GreetingsSender/Program.cs
@@ -1,0 +1,163 @@
+#region Licence
+/* The MIT License (MIT)
+Copyright © 2026 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+using System;
+using System.Data.Common;
+using System.Linq;
+using System.Threading.Tasks;
+using Greetings;
+using GreetingsSender;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Npgsql;
+using Paramore.Brighter;
+using Paramore.Brighter.BoxProvisioning;
+using Paramore.Brighter.BoxProvisioning.PostgreSql;
+using Paramore.Brighter.Extensions.DependencyInjection;
+using Paramore.Brighter.MessagingGateway.RMQ.Async;
+using Paramore.Brighter.Outbox.Hosting;
+using Paramore.Brighter.Outbox.PostgreSql;
+using Paramore.Brighter.PostgreSql;
+
+const string connectionString =
+    "Host=localhost;Port=5432;Username=postgres;Password=password;Database=brightertests";
+
+// Two tables live in this database and they have different owners. Greeting is yours: your
+// schema, your migrations, your problem, and the line below is the whole of this sample's
+// answer to that. The Outbox table is Brighter's, and UseBoxProvisioning creates it further
+// down. Do not let the two blur — Brighter does not manage your schema.
+await CreateGreetingTableAsync(connectionString);
+
+// The Outbox and the provisioner both need to know where the database is and what the table
+// is called. RelationalDatabaseConfiguration defaults the name to "Outbox".
+var outboxConfiguration = new RelationalDatabaseConfiguration(connectionString);
+
+var rmqConnection = new RmqMessagingGatewayConnection
+{
+    AmpqUri = new AmqpUriSpecification(new Uri("amqp://guest:guest@localhost:5672")),
+    Exchange = new Exchange("paramore.brighter.exchange")
+};
+
+// Unchanged from rung 2: the publication says where GreetingEvent goes. Naming the type here
+// is also what loads the Greetings assembly, which AutoFromAssemblies below needs to have
+// happened already — moving this line beneath the registration is a silent no-op.
+var producerRegistry = new RmqProducerRegistryFactory(
+    rmqConnection,
+    [
+        new RmqPublication<GreetingEvent>
+        {
+            Topic = new RoutingKey("greeting.event"),
+            MakeChannels = OnMissingChannel.Create
+        }
+    ]).Create();
+
+var builder = Host.CreateApplicationBuilder(args);
+
+// The configuration goes into the container as well as into the two calls below, and this
+// line is easy to leave out. TransactionProvider is given as a *type*, so the container
+// activates PostgreSqlTransactionProvider, and its constructor asks for exactly this
+// interface. Without it the host starts, provisions the Outbox and only then fails, on the
+// first attempt to resolve a command processor.
+builder.Services.AddSingleton<IAmARelationalDatabaseConfiguration>(outboxConfiguration);
+
+builder.Services
+    .AddBrighter()
+    .AddProducers(configure =>
+    {
+        configure.ProducerRegistry = producerRegistry;
+
+        // Rung 2 had none of these three lines and got an in-memory Outbox by default: good
+        // enough to make Post work, gone the moment the process is. These three make it
+        // durable. The transaction provider is the important one — it is what lets the
+        // handler hand Brighter a transaction that the handler itself opened.
+        configure.Outbox = new PostgreSqlOutbox(outboxConfiguration);
+        configure.ConnectionProvider = typeof(PostgreSqlConnectionProvider);
+        configure.TransactionProvider = typeof(PostgreSqlTransactionProvider);
+    })
+    .AutoFromAssemblies()
+
+    // Creates and migrates the Outbox table at startup, before anything else runs. It owns
+    // that table and nothing else; the Greeting table above was yours to create. This needs
+    // rights to CREATE TABLE, which the Docker Postgres has and your production database
+    // very likely does not — see the Box Provisioning page for the alternative.
+    .UseBoxProvisioning(options => options.AddPostgreSqlOutbox(outboxConfiguration))
+
+    // The Sweeper: a hosted service that wakes on a timer, finds undispatched messages in the
+    // Outbox and sends them. Both values below are the defaults, spelled out because the
+    // delay they produce is the thing this rung teaches — a message is picked up on the first
+    // tick after it is MinimumMessageAge old, so expect five to ten seconds.
+    .UseOutboxSweeper(options =>
+    {
+        options.TimerInterval = 5;
+        options.MinimumMessageAge = TimeSpan.FromSeconds(5);
+    });
+
+var host = builder.Build();
+
+// StartAsync rather than RunAsync, because we have work to do between starting the host and
+// waiting on it. Starting is what provisions the Outbox table and starts the Sweeper, so it
+// has to happen before the send rather than after.
+await host.StartAsync();
+
+var commandProcessor = host.Services.GetRequiredService<IAmACommandProcessor>();
+var failBeforeCommit = args.Contains("--fail");
+
+// The failing run says something different so you can prove it is absent afterwards rather
+// than counting rows: a table that still holds one greeting is only interesting if you can
+// see which greeting it is.
+var greeting = failBeforeCommit ? "This greeting will not survive" : "Hello from the sender";
+
+try
+{
+    await commandProcessor.SendAsync(new AddGreeting(greeting, failBeforeCommit));
+
+    Console.WriteLine("Committed. The greeting and the message are both in Postgres.");
+    Console.WriteLine("Waiting for the Sweeper to dispatch it. Ctrl+C to stop.");
+}
+catch (Exception e)
+{
+    Console.WriteLine($"Rolled back: {e.Message}");
+    Console.WriteLine("Neither the greeting nor the message was written. Ctrl+C to stop.");
+}
+
+await host.WaitForShutdownAsync();
+
+// Your table, created by your code. Plain ADO.NET: this is deliberately not going through
+// Brighter, because it is not Brighter's table.
+static async Task CreateGreetingTableAsync(string connection)
+{
+    await using var postgres = new NpgsqlConnection(connection);
+    await postgres.OpenAsync();
+
+    await using DbCommand command = postgres.CreateCommand();
+    command.CommandText =
+        """
+        create table if not exists Greeting (
+            Id      serial primary key,
+            Message text not null
+        )
+        """;
+
+    await command.ExecuteNonQueryAsync();
+}

--- a/samples/Tutorials/03-DurableOutbox/README.md
+++ b/samples/Tutorials/03-DurableOutbox/README.md
@@ -1,0 +1,126 @@
+# 03 — Adding a Durable Outbox
+
+The sample behind rung 3 of the *Get Started* tutorial ladder in the
+[Brighter documentation](https://brightercommand.gitbook.io/paramore-brighter-documentation).
+Every code block on the page *Adding a Durable Outbox* is this code, so please keep the two
+in step: if you change a file here, the tutorial page needs the same edit. CI can prove this
+compiles; nothing can prove the page still matches it.
+
+This is [`02-FirstMessage`](../02-FirstMessage) with a durable Outbox. A greeting is written
+to a business table and the message announcing it is written to the Outbox — both in one
+Postgres transaction — and the Outbox Sweeper dispatches it to RabbitMQ a few seconds later.
+
+## Running it
+
+From the repository root, start both containers:
+
+```bash
+docker compose -f docker-compose-postgres.yaml up -d
+docker compose -f docker-compose-rmq.yaml up -d
+```
+
+Neither command waits for its service to accept connections — the compose files have no
+healthchecks — so give them a few seconds. RabbitMQ is ready when
+<http://localhost:15672> answers.
+
+Then, in two terminals, the receiver first — it is still the process that declares the queue
+and the binding:
+
+```bash
+dotnet run --project samples/Tutorials/03-DurableOutbox/GreetingsReceiver
+```
+
+```bash
+dotnet run --project samples/Tutorials/03-DurableOutbox/GreetingsSender
+```
+
+The sender prints `Committed.` almost at once and then waits. About ten seconds later the
+receiver prints `Received: Hello from the sender`. **That gap is the point of this sample**:
+the send is not on the request path any more. `DepositPostAsync` stored the message in
+Postgres and returned; the Sweeper found it on a later tick and sent it. Ctrl+C stops either
+process.
+
+The delay is `TimerInterval` and `MinimumMessageAge` in `Program.cs`, five seconds each: a
+message is dispatched on the first tick that finds it old enough. You do not have to take
+that on trust — the Outbox row records both moments:
+
+```bash
+docker exec -it $(docker ps -qf name=postgres) psql -U postgres -d brightertests \
+  -c 'select timestamp, dispatched, dispatched - timestamp as sweep_delay from Outbox;'
+```
+
+Both tables are worth looking at:
+
+```bash
+docker exec -it $(docker ps -qf name=postgres) \
+  psql -U postgres -d brightertests -c 'select * from Greeting;' \
+                   -c 'select messageid, topic, dispatched from Outbox;'
+```
+
+`Greeting` is the sample's own table. `Outbox` is Brighter's, and `dispatched` stays null
+until the Sweeper sends the message — run that query within the first few seconds and you
+will catch it null, which is the durable Outbox doing its job in one column.
+
+### The interesting run
+
+```bash
+dotnet run --project samples/Tutorials/03-DurableOutbox/GreetingsSender -- --fail
+```
+
+The handler throws after writing the greeting *and* depositing the message, and before the
+commit. Query both tables afterwards: there is no `This greeting will not survive` row in
+`Greeting` and no new row in `Outbox`. Neither write survived, because they were never two
+writes — they were one transaction.
+
+One thing that will look odd: `Greeting.Id` skips a number after a failed run, because
+Postgres allocates from the sequence before the rollback and does not give it back. Nothing
+was lost; ids are not a count.
+
+When you are done:
+
+```bash
+docker compose -f docker-compose-rmq.yaml down
+docker compose -f docker-compose-postgres.yaml down -v
+```
+
+## What this adds to rung 2, and where
+
+Every difference is in `GreetingsSender`. `Greetings/GreetingEvent.cs` and the whole of
+`GreetingsReceiver` are byte-for-byte the files from `02-FirstMessage`, so `diff -r` against
+that directory shows exactly what a durable Outbox costs and nothing else.
+
+| Added | Why |
+|---|---|
+| `AddGreeting` + `AddGreetingHandlerAsync` | Rung 2's sender called `Post` straight from `Main`. A transaction needs somewhere to live, and a handler is where Brighter puts one |
+| `Outbox`, `ConnectionProvider`, `TransactionProvider` on `AddProducers` | Rung 2 took the default in-memory Outbox. These three make it Postgres |
+| `AddSingleton<IAmARelationalDatabaseConfiguration>` | `TransactionProvider` is given as a *type*, so the container activates it, and its constructor asks for this. Leave it out and the host starts, provisions the Outbox, and fails on the first resolve of a command processor |
+| `UseBoxProvisioning(o => o.AddPostgreSqlOutbox(cfg))` | Creates and migrates the Outbox table at startup, so there is no second terminal and no migration project |
+| `UseOutboxSweeper(...)` | Hosts the Sweeper in this process. It is a `IHostedService`, which is why the sender now runs a host instead of building one and throwing it away |
+| `CreateGreetingTableAsync` | The `Greeting` table. **Brighter does not create this** — see below |
+
+## Two tables, two owners
+
+`UseBoxProvisioning` creates the **Outbox** table and nothing else. `Greeting` is the
+application's table and the application creates it, in plain ADO.NET at the bottom of
+`Program.cs`. The two sit in one database and are committed by one transaction, which
+makes it easy to assume Brighter manages both. It does not, and a reader who believes it does
+will go looking for a migration feature that is not there.
+
+Box Provisioning also needs rights to `CREATE TABLE`, which the Docker Postgres here has and
+a production database very often does not. It is one of two options; the other is to create
+the Outbox table yourself from the supplied DDL.
+
+## Why `ClearOutboxAsync` is missing
+
+`samples/WebAPI/WebAPI_Dapper` calls `ClearOutboxAsync` immediately after the commit, which
+dispatches the message there and then instead of waiting for the Sweeper. That is usually the
+right trade — but it hides the thing this rung is teaching. Leaving it out makes the Outbox
+visible: you can watch the row sit undispatched and then go.
+
+## Why the sender writes with plain ADO.NET
+
+The reference samples use Dapper, and Dapper is a fine choice. This one uses
+`DbCommand` directly so that `command.Transaction = transaction` is on the page. The whole
+claim of this rung is that your write and Brighter's write share a transaction, and an
+explicit assignment argues that better than an extension method that takes `tx` as its third
+argument.

--- a/samples/Tutorials/README.md
+++ b/samples/Tutorials/README.md
@@ -9,9 +9,9 @@ diff two of them and see exactly what a feature costs.
 |---|---|---|
 | 1 | A command, a handler, no broker | [`samples/CommandProcessor/HelloWorld`](../CommandProcessor/HelloWorld) — reused as-is, which is why there is no `01-` directory here |
 | 2 | One event over a RabbitMQ exchange, two processes | [`02-FirstMessage`](02-FirstMessage) |
+| 3 | A durable Postgres Outbox, one transaction, the Sweeper | [`03-DurableOutbox`](03-DurableOutbox) |
 
-Rungs 3 (a durable Postgres Outbox) and 4 (Kafka) are planned and will land here as separate
-pull requests.
+Rung 4 (Kafka) is planned and will land here as a separate pull request.
 
 These samples are deliberately smaller than the reference samples they derive from. Where a
 sample under `samples/TaskQueue/` shows a feature properly, the tutorial version shows the


### PR DESCRIPTION
Rung 3 of the *Get Started* tutorial ladder, following [#4275](https://github.com/BrighterCommand/Brighter/pull/4275) (rung 2). This is `02-FirstMessage` with a durable Postgres Outbox: a greeting is written to a business table and the message announcing it is deposited into the Outbox **in the same transaction**, and the Outbox Sweeper — hosted in this process — dispatches it a few seconds later.

## The delta is legible on purpose

Every difference from rung 2 is inside `GreetingsSender`. `Greetings/GreetingEvent.cs`, `Greetings/Greetings.csproj` and the whole of `GreetingsReceiver` are **byte-identical** to rung 2's, asserted with `cmp`:

```
IDENTICAL  Greetings/GreetingEvent.cs
IDENTICAL  Greetings/Greetings.csproj
IDENTICAL  GreetingsReceiver/GreetingEventHandler.cs
IDENTICAL  GreetingsReceiver/GreetingsReceiver.csproj
IDENTICAL  GreetingsReceiver/Program.cs
```

So `diff -r samples/Tutorials/02-FirstMessage samples/Tutorials/03-DurableOutbox` shows exactly what a durable Outbox costs and nothing else — which is the review I would most like.

## It was run, not just compiled

Against `docker-compose-postgres.yaml` and `docker-compose-rmq.yaml`, from a **torn-down, empty database** (`\dt` → *Did not find any tables*) and a fresh broker.

**Happy path.** The Outbox row caught mid-flight, six seconds in:

```
        message        | dispatched
-----------------------+------------
 Hello from the sender |
```

and after the sweep, with the delay read off the row's own columns rather than a stopwatch:

```
           timestamp           |          dispatched           |   sweep_delay
-------------------------------+-------------------------------+-----------------
 2026-08-26 07:57:29.440688+00 | 2026-08-26 07:57:39.496415+00 | 00:00:10.055727
```

Receiver: `Received: Hello from the sender`.

**Failure path** (`dotnet run --project samples/Tutorials/03-DurableOutbox/GreetingsSender -- --fail`). The handler throws after both writes and before the commit:

```
Rolled back: Deliberate failure, after both writes and before the commit
Neither the greeting nor the message was written. Ctrl+C to stop.
```

Neither table gains a row — `This greeting will not survive` is absent from `Greeting`, no new `Outbox` row — and the receiver stays silent. That is the whole argument of the rung, and it is run rather than reasoned about.

## Three things worth knowing if you extend this

- **`IAmARelationalDatabaseConfiguration` has to be in the container.** `TransactionProvider` is supplied as a *type*, so the container activates `PostgreSqlTransactionProvider`, whose constructor asks for that interface. Omit the registration and the host starts, provisions the Outbox successfully, and *only then* fails on the first resolve of a command processor — a confusing place to land. Every relational sample in this repo already registers it; none of the docs I worked from mentioned it, so it is called out in a comment and in the README.
- **`UseBoxProvisioning` owns the Outbox table and nothing else.** `Greeting` is the sample's own table, created by the sample's own startup code in plain ADO.NET. The two sit in one database and commit in one transaction, which makes it easy to assume Brighter manages both — so the sample says twice that it does not.
- **`ClearOutboxAsync` is deliberately absent.** `WebAPI_Dapper` calls it after the commit and is right to; here the wait for the Sweeper *is* the behaviour being taught, so leaving it out makes the Outbox visible.

The handler uses `DbCommand` directly rather than Dapper so that `command.Transaction = transaction` is on the page — the claim of this rung is that your write and Brighter's write share a transaction, and an explicit assignment argues it better than a third positional argument.

## Solution registration

All three projects are in `Brighter.slnx` under `/samples/Tutorials/03-DurableOutbox/`, and the full-solution build names all three:

```
Greetings -> .../03-DurableOutbox/Greetings/bin/Release/net9.0/Greetings.dll
GreetingsReceiver -> .../03-DurableOutbox/GreetingsReceiver/bin/Release/net9.0/GreetingsReceiver.dll
GreetingsSender -> .../03-DurableOutbox/GreetingsSender/bin/Release/net9.0/GreetingsSender.dll
```

`dotnet build Brighter.slnx -c Release`: **0 errors, and 0 of the warnings come from this sample.**

Diffing every tracked sample `.csproj` against the solution leaves one entry unregistered, and it is the pre-existing [#4272](https://github.com/BrighterCommand/Brighter/issues/4272) case (`WebAPI_mTLS_TestHarness/TodoApi`), not one of these.

## A note on CI

[#4276](https://github.com/BrighterCommand/Brighter/issues/4276) — the `JustSaying` converter registration race — can redden `build` on either TFM regardless of this diff. If `build` fails, please check *which* test before suspecting the sample.

🤖 Generated with [Claude Code](https://claude.com/claude-code)