### PR TITLE
samples: add Tutorials/04-Kafka, the sample behind tutorial rung 4

### DIFF
--- a/Brighter.slnx
+++ b/Brighter.slnx
@@ -166,6 +166,12 @@
     <Project Path="samples/Tutorials/03-DurableOutbox/GreetingsReceiver/GreetingsReceiver.csproj" />
     <Project Path="samples/Tutorials/03-DurableOutbox/GreetingsSender/GreetingsSender.csproj" />
   </Folder>
+  <Folder Name="/samples/Tutorials/04-Kafka/">
+    <File Path="samples/Tutorials/04-Kafka/README.md" />
+    <Project Path="samples/Tutorials/04-Kafka/Greetings/Greetings.csproj" />
+    <Project Path="samples/Tutorials/04-Kafka/GreetingsReceiver/GreetingsReceiver.csproj" />
+    <Project Path="samples/Tutorials/04-Kafka/GreetingsSender/GreetingsSender.csproj" />
+  </Folder>
   <Folder Name="/samples/Validation/">
     <File Path="samples\Validation\README.md" />
     <Project Path="samples/Validation/DataAnnotationsSample/DataAnnotationsSample.csproj" />

--- a/samples/Tutorials/02-FirstMessage/README.md
+++ b/samples/Tutorials/02-FirstMessage/README.md
@@ -70,6 +70,6 @@ those is a concept a reader meeting a broker for the first time has to park, so 
 drops all four and adds nothing. It also has no message mapper: `JsonMessageMapper<T>` is
 Brighter's default, and a tutorial should not write code the framework already supplies.
 
-Rung 3 adds a durable Outbox to this sample; rung 4 swaps the transport for Kafka. Each is
-one readable delta from this one, which is why this is deliberately the smallest thing that
-still crosses a broker.
+[Rung 3](../03-DurableOutbox) adds a durable Outbox to this sample; [rung 4](../04-Kafka)
+swaps the transport for Kafka. Each is one readable delta from this one, which is why this is
+deliberately the smallest thing that still crosses a broker.

--- a/samples/Tutorials/03-DurableOutbox/README.md
+++ b/samples/Tutorials/03-DurableOutbox/README.md
@@ -124,3 +124,10 @@ The reference samples use Dapper, and Dapper is a fine choice. This one uses
 claim of this rung is that your write and Brighter's write share a transaction, and an
 explicit assignment argues that better than an extension method that takes `tx` as its third
 argument.
+
+## Where this sits on the ladder
+
+This rung and [rung 4](../04-Kafka) are each one delta from
+[rung 2](../02-FirstMessage) rather than from each other: this one keeps RabbitMQ and adds
+durability, rung 4 keeps the shape and swaps the transport for Kafka. Neither depends on the
+other, so they can be read in either order.

--- a/samples/Tutorials/04-Kafka/Greetings/GreetingEvent.cs
+++ b/samples/Tutorials/04-Kafka/Greetings/GreetingEvent.cs
@@ -1,0 +1,44 @@
+#region Licence
+/* The MIT License (MIT)
+Copyright © 2026 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+using Paramore.Brighter;
+
+namespace Greetings;
+
+/// <summary>
+/// The event both processes share. The sender publishes it; the receiver handles it.
+/// The property has a setter because the message is deserialized into a new instance
+/// by the receiver, which uses the parameterless constructor.
+/// </summary>
+public class GreetingEvent : Event
+{
+    public GreetingEvent() : base(Id.Random()) { }
+
+    public GreetingEvent(string greeting) : base(Id.Random())
+    {
+        Greeting = greeting;
+    }
+
+    public string Greeting { get; set; } = string.Empty;
+}

--- a/samples/Tutorials/04-Kafka/Greetings/Greetings.csproj
+++ b/samples/Tutorials/04-Kafka/Greetings/Greetings.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Paramore.Brighter\Paramore.Brighter.csproj" />
+  </ItemGroup>
+</Project>

--- a/samples/Tutorials/04-Kafka/GreetingsReceiver/GreetingEventHandler.cs
+++ b/samples/Tutorials/04-Kafka/GreetingsReceiver/GreetingEventHandler.cs
@@ -1,0 +1,44 @@
+#region Licence
+/* The MIT License (MIT)
+Copyright © 2026 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+using System;
+using Greetings;
+using Paramore.Brighter;
+
+namespace GreetingsReceiver;
+
+/// <summary>
+/// The pump reads a message from the channel, the mapper turns it back into a
+/// <see cref="GreetingEvent"/>, and Brighter dispatches it here. This is a synchronous
+/// handler because the subscription runs a Reactor pump.
+/// </summary>
+public class GreetingEventHandler : RequestHandler<GreetingEvent>
+{
+    public override GreetingEvent Handle(GreetingEvent @event)
+    {
+        Console.WriteLine($"Received: {@event.Greeting}");
+
+        return base.Handle(@event);
+    }
+}

--- a/samples/Tutorials/04-Kafka/GreetingsReceiver/GreetingsReceiver.csproj
+++ b/samples/Tutorials/04-Kafka/GreetingsReceiver/GreetingsReceiver.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Paramore.Brighter.MessagingGateway.Kafka\Paramore.Brighter.MessagingGateway.Kafka.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Paramore.Brighter.ServiceActivator.Extensions.DependencyInjection\Paramore.Brighter.ServiceActivator.Extensions.DependencyInjection.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Paramore.Brighter.ServiceActivator.Extensions.Hosting\Paramore.Brighter.ServiceActivator.Extensions.Hosting.csproj" />
+    <ProjectReference Include="..\Greetings\Greetings.csproj" />
+  </ItemGroup>
+</Project>

--- a/samples/Tutorials/04-Kafka/GreetingsReceiver/Program.cs
+++ b/samples/Tutorials/04-Kafka/GreetingsReceiver/Program.cs
@@ -43,13 +43,18 @@ var kafkaConfiguration = new KafkaMessagingGatewayConfiguration
 // half each. Two instances with *different* group ids would each get all three and both would
 // see every greeting.
 //
-// messagePumpType is the default and is written out because it is the point of this rung.
+// messagePumpType is KafkaSubscription<T>'s own default — note the generic; the non-generic
+// KafkaSubscription defaults to MessagePumpType.Unknown. It is written out anyway, because it
+// is the point of this rung.
 // A Reactor pump is a single thread per performer, and noOfPerformers defaults to 1 — so one
 // instance is one member with one thread, draining its partitions in turn. That single thread
 // is why per-key ordering holds; it is not that Brighter runs a pump per partition.
 //
 // numOfPartitions matches the publication so that whichever process reaches an empty broker
-// first creates the same three-partition topic.
+// first creates the same three-partition topic. Keep the two in step if you change either:
+// when the topic already exists and does not match, Brighter logs "topic is misconfigured =>
+// NumPartitions should be ..." as a *warning* and carries on, so raising one side alone gives
+// you a puzzling half-working sample rather than an error.
 var subscriptions = new Subscription[]
 {
     new KafkaSubscription<GreetingEvent>(

--- a/samples/Tutorials/04-Kafka/GreetingsReceiver/Program.cs
+++ b/samples/Tutorials/04-Kafka/GreetingsReceiver/Program.cs
@@ -1,0 +1,80 @@
+#region Licence
+/* The MIT License (MIT)
+Copyright © 2026 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+using System;
+using Greetings;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Paramore.Brighter;
+using Paramore.Brighter.MessagingGateway.Kafka;
+using Paramore.Brighter.ServiceActivator.Extensions.DependencyInjection;
+using Paramore.Brighter.ServiceActivator.Extensions.Hosting;
+
+var kafkaConfiguration = new KafkaMessagingGatewayConfiguration
+{
+    Name = "greetings.receiver",
+    BootStrapServers = ["localhost:9092"]
+};
+
+// groupId is the delta from rung 2, and it is what makes a second copy of this process
+// interesting rather than redundant. Every instance sharing a group id is one member of one
+// consumer group, and Kafka gives each member a disjoint set of partitions: run one instance
+// and it holds all three, start a second and Kafka rebalances the group so they hold roughly
+// half each. Two instances with *different* group ids would each get all three and both would
+// see every greeting.
+//
+// messagePumpType is the default and is written out because it is the point of this rung.
+// A Reactor pump is a single thread per performer, and noOfPerformers defaults to 1 — so one
+// instance is one member with one thread, draining its partitions in turn. That single thread
+// is why per-key ordering holds; it is not that Brighter runs a pump per partition.
+//
+// numOfPartitions matches the publication so that whichever process reaches an empty broker
+// first creates the same three-partition topic.
+var subscriptions = new Subscription[]
+{
+    new KafkaSubscription<GreetingEvent>(
+        new SubscriptionName("greeting.subscription"),
+        new ChannelName("greeting.event"),
+        new RoutingKey("greeting.event"),
+        groupId: "greeting.readers",
+        numOfPartitions: 3,
+        messagePumpType: MessagePumpType.Reactor,
+        makeChannels: OnMissingChannel.Create)
+};
+
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.Services
+    .AddConsumers(options =>
+    {
+        options.Subscriptions = subscriptions;
+        options.DefaultChannelFactory = new ChannelFactory(new KafkaMessageConsumerFactory(kafkaConfiguration));
+    })
+    .AutoFromAssemblies();
+
+builder.Services.AddHostedService<ServiceActivatorHostedService>();
+
+var host = builder.Build();
+
+await host.RunAsync();

--- a/samples/Tutorials/04-Kafka/GreetingsReceiver/Program.cs
+++ b/samples/Tutorials/04-Kafka/GreetingsReceiver/Program.cs
@@ -22,7 +22,6 @@ THE SOFTWARE. */
 
 #endregion
 
-using System;
 using Greetings;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;

--- a/samples/Tutorials/04-Kafka/GreetingsSender/GreetingsSender.csproj
+++ b/samples/Tutorials/04-Kafka/GreetingsSender/GreetingsSender.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Paramore.Brighter.Extensions.DependencyInjection\Paramore.Brighter.Extensions.DependencyInjection.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Paramore.Brighter.MessagingGateway.Kafka\Paramore.Brighter.MessagingGateway.Kafka.csproj" />
+    <ProjectReference Include="..\Greetings\Greetings.csproj" />
+  </ItemGroup>
+</Project>

--- a/samples/Tutorials/04-Kafka/GreetingsSender/Program.cs
+++ b/samples/Tutorials/04-Kafka/GreetingsSender/Program.cs
@@ -43,7 +43,7 @@ var kafkaConfiguration = new KafkaMessagingGatewayConfiguration
 // A publication tells Brighter where a request type goes: which topic, on which broker.
 // NumPartitions is the delta from rung 2. A RabbitMQ queue is one ordered stream; a Kafka
 // topic is NumPartitions of them, and that is what gives a consumer group something to
-// share out. MakeChannels.Create means the sender creates the topic if it is missing, with
+// share out. OnMissingChannel.Create means the sender creates the topic if it is missing, with
 // this many partitions.
 //
 // Two defaults are doing quiet work here, and the ordering this rung teaches depends on both:

--- a/samples/Tutorials/04-Kafka/GreetingsSender/Program.cs
+++ b/samples/Tutorials/04-Kafka/GreetingsSender/Program.cs
@@ -90,8 +90,8 @@ using (var host = builder.Build())
         {
             // The partition key is how you choose a partition, and the partition is the only
             // thing Kafka orders. Keying on the recipient sends every one of alice's greetings
-            // to the same partition, so they arrive in the order they were sent — while bob's
-            // and carol's are free to be handled on other partitions.
+            // to the same partition, so they arrive in the order they were sent — while grace's
+            // and mia's are free to be handled on other partitions.
             //
             // No message mapper is needed for this. JsonMessageMapper<T> is Brighter's
             // registered default for both the sync and the async path, and it already reads
@@ -107,4 +107,4 @@ using (var host = builder.Build())
 // returns, and the broker's acknowledgement arrives on a delivery report later. Disposing the
 // host flushes that queue and waits for the reports, which is why this line sits after the
 // brace rather than inside the loop.
-Console.WriteLine("Published 9 greetings to greeting.event");
+Console.WriteLine($"Published {recipients.Length * 3} greetings to greeting.event");

--- a/samples/Tutorials/04-Kafka/GreetingsSender/Program.cs
+++ b/samples/Tutorials/04-Kafka/GreetingsSender/Program.cs
@@ -1,0 +1,110 @@
+#region Licence
+/* The MIT License (MIT)
+Copyright © 2026 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+using System;
+using Greetings;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Paramore.Brighter;
+using Paramore.Brighter.Extensions.DependencyInjection;
+using Paramore.Brighter.MessagingGateway.Kafka;
+
+// Kafka is reached through a bootstrap server list rather than a single connection string.
+// The client asks any broker in the list for the cluster's real topology, so one entry is
+// enough to learn on; a production cluster names several so that startup survives one being
+// down.
+var kafkaConfiguration = new KafkaMessagingGatewayConfiguration
+{
+    Name = "greetings.sender",
+    BootStrapServers = ["localhost:9092"]
+};
+
+// A publication tells Brighter where a request type goes: which topic, on which broker.
+// NumPartitions is the delta from rung 2. A RabbitMQ queue is one ordered stream; a Kafka
+// topic is NumPartitions of them, and that is what gives a consumer group something to
+// share out. MakeChannels.Create means the sender creates the topic if it is missing, with
+// this many partitions.
+//
+// Naming GreetingEvent here is also what loads the Greetings assembly, which matters below:
+// AutoFromAssemblies scans the assemblies loaded so far, so anything it must find has to have
+// been touched before the call. Reordering this below the registration is a silent no-op.
+var producerRegistry = new KafkaProducerRegistryFactory(
+    kafkaConfiguration,
+    [
+        new KafkaPublication<GreetingEvent>
+        {
+            Topic = new RoutingKey("greeting.event"),
+            NumPartitions = 3,
+            MakeChannels = OnMissingChannel.Create
+        }
+    ]).Create();
+
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.Services
+    .AddBrighter()
+    .AddProducers(configure => configure.ProducerRegistry = producerRegistry)
+    .AutoFromAssemblies();
+
+// Three recipients, three greetings each, sent round-robin so that the three streams are
+// interleaved on the wire.
+//
+// These three names are not arbitrary. Kafka picks the partition by hashing the key —
+// crc32(key) % 3 here — so you do not get to choose it, and with three keys over three
+// partitions there is only a 2-in-9 chance that they land one apiece. The first three names
+// this sample tried, "alice", "bob" and "carol", all hashed to partition 2, which a single
+// consumer hides completely: it drains all three partitions and everything still arrives in
+// order. These three were checked against the broker.
+string[] recipients = ["alice", "grace", "mia"];
+
+// The host is built but never run: Post is synchronous, so all we need from it is the
+// container. Rung 3 does run the host, because it hosts the Outbox Sweeper.
+using (var host = builder.Build())
+{
+    var commandProcessor = host.Services.GetRequiredService<IAmACommandProcessor>();
+
+    for (var i = 1; i <= 3; i++)
+    {
+        foreach (var recipient in recipients)
+        {
+            // The partition key is how you choose a partition, and the partition is the only
+            // thing Kafka orders. Keying on the recipient sends every one of alice's greetings
+            // to the same partition, so they arrive in the order they were sent — while bob's
+            // and carol's are free to be handled on other partitions.
+            //
+            // No message mapper is needed for this. JsonMessageMapper<T> is Brighter's
+            // registered default for both the sync and the async path, and it already reads
+            // the key out of the request context onto the message header.
+            var context = new RequestContext();
+            context.Bag[RequestContextBagNames.PartitionKey] = recipient;
+
+            commandProcessor.Post(new GreetingEvent($"Hello {recipient} #{i}"), context);
+        }
+    }
+}
+// Delivery to Kafka is asynchronous: Post hands the message to the producer's send queue and
+// returns, and the broker's acknowledgement arrives on a delivery report later. Disposing the
+// host flushes that queue and waits for the reports, which is why this line sits after the
+// brace rather than inside the loop.
+Console.WriteLine("Published 9 greetings to greeting.event");

--- a/samples/Tutorials/04-Kafka/GreetingsSender/Program.cs
+++ b/samples/Tutorials/04-Kafka/GreetingsSender/Program.cs
@@ -46,6 +46,12 @@ var kafkaConfiguration = new KafkaMessagingGatewayConfiguration
 // share out. MakeChannels.Create means the sender creates the topic if it is missing, with
 // this many partitions.
 //
+// Two defaults are doing quiet work here, and the ordering this rung teaches depends on both:
+// EnableIdempotence is true and MaxInFlightRequestsPerConnection is 1. Without them a retry
+// could reorder messages *within* a partition, and no amount of careful keying would help.
+// Acquiring the idempotence id is also what logs "Failed to acquire idempotence PID ...
+// retrying" if you start the sender before the broker has finished booting.
+//
 // Naming GreetingEvent here is also what loads the Greetings assembly, which matters below:
 // AutoFromAssemblies scans the assemblies loaded so far, so anything it must find has to have
 // been touched before the call. Reordering this below the registration is a silent no-op.
@@ -70,13 +76,18 @@ builder.Services
 // Three recipients, three greetings each, sent round-robin so that the three streams are
 // interleaved on the wire.
 //
-// These three names are not arbitrary. Kafka picks the partition by hashing the key —
-// crc32(key) % 3 here — so you do not get to choose it, and with three keys over three
-// partitions there is only a 2-in-9 chance that they land one apiece. The first three names
-// this sample tried, "alice", "bob" and "carol", all hashed to partition 2, which a single
-// consumer hides completely: it drains all three partitions and everything still arrives in
-// order. These three were checked against the broker.
+// These three names are not arbitrary. Kafka picks the partition by hashing the key, so you
+// do not get to choose it, and with three keys over three partitions there is only a 2-in-9
+// chance that they land one apiece. The first three names this sample tried, "alice", "bob"
+// and "carol", all hashed to the same partition — which a single consumer hides completely,
+// because it drains all three partitions and everything still arrives in order.
+//
+// These three were checked against the broker rather than calculated. The hash is
+// crc32(key) % partition-count for librdkafka, which the Confluent .NET client wraps; the
+// Java client uses murmur2 and would scatter the same three names differently. So the 2/0/1
+// mapping below holds for this client at exactly three partitions and nowhere else.
 string[] recipients = ["alice", "grace", "mia"];
+const int greetingsPerRecipient = 3;
 
 // The host is built but never run: Post is synchronous, so all we need from it is the
 // container. Rung 3 does run the host, because it hosts the Outbox Sweeper.
@@ -84,7 +95,7 @@ using (var host = builder.Build())
 {
     var commandProcessor = host.Services.GetRequiredService<IAmACommandProcessor>();
 
-    for (var i = 1; i <= 3; i++)
+    for (var i = 1; i <= greetingsPerRecipient; i++)
     {
         foreach (var recipient in recipients)
         {
@@ -107,4 +118,4 @@ using (var host = builder.Build())
 // returns, and the broker's acknowledgement arrives on a delivery report later. Disposing the
 // host flushes that queue and waits for the reports, which is why this line sits after the
 // brace rather than inside the loop.
-Console.WriteLine($"Published {recipients.Length * 3} greetings to greeting.event");
+Console.WriteLine($"Published {recipients.Length * greetingsPerRecipient} greetings to greeting.event");

--- a/samples/Tutorials/04-Kafka/README.md
+++ b/samples/Tutorials/04-Kafka/README.md
@@ -53,6 +53,12 @@ matter: Kafka retains what it accepts, and the subscription's `offsetDefault` is
 `AutoOffsetReset.Earliest`, so a receiver started afterwards reads the greetings that are
 already there.
 
+`BootStrapServers` here is a plaintext `localhost:9092` with no credentials, which is right for
+a broker on your own machine and wrong everywhere else. A real cluster wants `SecurityProtocol`
+and SASL credentials set on the `KafkaMessagingGatewayConfiguration` — worth saying because a
+bootstrap list is exactly the block that gets lifted into a service, and unlike rung 2's
+`guest:guest` there is no visible credential here to prompt the question.
+
 If you start the sender within a second or two of the broker, it may log
 `Failed to acquire idempotence PID from broker … Coordinator load in progress: retrying`.
 That is the broker still starting up and the producer doing what it says — retrying. It
@@ -177,6 +183,12 @@ That `LAG 1` is stable — it was still 1 a minute later. The sweeper drains its
 in no particular order and commits them in one call, so the offset that sticks is not
 necessarily the highest one it holds.
 
+**That last part is a Brighter defect, not Kafka semantics, and it is tracked as
+[#4281](https://github.com/BrighterCommand/Brighter/issues/4281).** A group that has handled
+everything ought to reach `LAG 0`. If that issue is fixed, the numbers below shrink and the
+`LAG 1` reading above disappears — the at-least-once lesson does not, because a rebalance can
+always arrive before a commit.
+
 So the rebalance redelivers whatever was uncommitted when it happened, and **when you start the
 second instance changes how much that is.** Measured on Brighter 10.7.0, nine greetings over
 three partitions:
@@ -215,8 +227,8 @@ commandProcessor.Post(new GreetingEvent($"Hello {recipient} #{i}"), context);
 
 The pump also runs as a **Reactor** rather than a Proactor, which is `KafkaSubscription<T>`'s
 own default — note the generic, since the non-generic `KafkaSubscription` defaults to
-`MessagePumpType.Unknown`. That is what makes the single-threaded ordering argument above visible in the code
-instead of asserted about it, and it means the handler is a plain synchronous
+`MessagePumpType.Unknown`. That is what makes the single-threaded ordering argument above
+visible in the code rather than asserted, and it means the handler is a plain synchronous
 `RequestHandler<GreetingEvent>` — the same file as rung 2's, byte for byte.
 
 ## What changed from rung 2

--- a/samples/Tutorials/04-Kafka/README.md
+++ b/samples/Tutorials/04-Kafka/README.md
@@ -80,11 +80,22 @@ promise across partitions, so the global send order is gone. Each recipient's th
 are still in sequence, because the partition key sends all of one recipient's greetings to
 one partition, and the Reactor pump is a single thread draining one partition at a time.
 
+One key per partition and a single-threaded pump are not quite the whole guarantee, and it is
+worth knowing what closes the gap: a producer retrying a failed send could otherwise reorder
+messages *within* a partition. `KafkaPublication` defaults to `EnableIdempotence = true` and
+`MaxInFlightRequestsPerConnection = 1`, which is what stops that — and acquiring the
+idempotence id is also what produces the `Failed to acquire idempotence PID` line above if you
+start too early.
+
 ## Why those three names
 
-Kafka chooses the partition by hashing the key — `crc32(key) % 3` for the default
-partitioner — so you do not choose it, you only choose the key. With three keys over three
-partitions there is a 2-in-9 chance they land one apiece.
+Kafka chooses the partition by hashing the key, so you do not choose it, you only choose the
+key. With three keys over three partitions there is a 2-in-9 chance they land one apiece.
+
+The hash is `crc32(key) % partition-count` for **librdkafka**, which the Confluent .NET client
+wraps, with `Partitioner.ConsistentRandom` as `KafkaPublication`'s default. The Java client
+uses murmur2 and would scatter these same names differently, so the mapping below is a fact
+about this client at exactly three partitions — not about Kafka.
 
 The first three names this sample used, `alice`, `bob` and `carol`, all hashed to partition
 **2**. Nothing looked wrong: one consumer holds every partition anyway, so all nine greetings
@@ -164,18 +175,24 @@ greeting.event  2          2               3               1
 
 That `LAG 1` is stable — it was still 1 a minute later. The sweeper drains its stored offsets
 in no particular order and commits them in one call, so the offset that sticks is not
-necessarily the highest.
+necessarily the highest one it holds.
 
-So the rebalance redelivers whatever was uncommitted when it happened:
+So the rebalance redelivers whatever was uncommitted when it happened, and **when you start the
+second instance changes how much that is.** Measured on Brighter 10.7.0, nine greetings over
+three partitions:
 
-| Second instance started | Redelivered (of 9) |
+| Second instance started | Redelivered |
 |---|---|
-| Before the first sweep, within a few seconds | **7** |
-| After the sweep | **3** — one per partition, on two separate runs |
+| Before the first sweep, within a few seconds | most of them — 7 of 9 |
+| After the sweep | a few — typically one per partition, 3 of 9 on two separate runs |
 
-Nothing is ever *lost*: every one of the nine distinct greetings is handled. But some are
-handled twice, and **no timing makes that number zero**. That is what at-least-once means, and
-it is why a handler doing real work — charging a card, sending an email — has to be idempotent.
+Treat those counts as an illustration rather than a promise: they depend on exactly what had
+been committed at the moment of the rebalance. **The part that is not an illustration is that
+nothing makes the number zero.**
+
+Nothing is ever *lost* either — every one of the nine distinct greetings is handled. But some
+are handled twice, and that is what at-least-once means. It is why a handler doing real work,
+charging a card or sending an email, has to be idempotent.
 
 ## Why this is not `samples/TaskQueue/KafkaTaskQueue`
 
@@ -196,8 +213,9 @@ context.Bag[RequestContextBagNames.PartitionKey] = recipient;
 commandProcessor.Post(new GreetingEvent($"Hello {recipient} #{i}"), context);
 ```
 
-The pump also runs as a **Reactor** rather than a Proactor, which is `KafkaSubscription`'s own
-default. That is what makes the single-threaded ordering argument above visible in the code
+The pump also runs as a **Reactor** rather than a Proactor, which is `KafkaSubscription<T>`'s
+own default — note the generic, since the non-generic `KafkaSubscription` defaults to
+`MessagePumpType.Unknown`. That is what makes the single-threaded ordering argument above visible in the code
 instead of asserted about it, and it means the handler is a plain synchronous
 `RequestHandler<GreetingEvent>` — the same file as rung 2's, byte for byte.
 

--- a/samples/Tutorials/04-Kafka/README.md
+++ b/samples/Tutorials/04-Kafka/README.md
@@ -129,31 +129,53 @@ call, not yours — across two runs of this sample the split came out `[1]` / `[
 
 ## A rebalance redelivers, and that is at-least-once
 
-After the rebalance, three greetings are handled a **second** time — one per partition. Both
-runs above showed exactly three, and the reason is visible in the group's offsets before the
-second instance starts:
+After the rebalance, some greetings are handled a **second** time. **How many depends on when
+you start the second instance**, and that is worth understanding rather than memorising,
+because the mechanism is the whole of Kafka's at-least-once guarantee.
 
-```text
-GROUP            TOPIC           PARTITION  CURRENT-OFFSET  LOG-END-OFFSET  LAG
-greeting.readers greeting.event  0          2               3               1
-greeting.readers greeting.event  1          2               3               1
-greeting.readers greeting.event  2          2               3               1
-```
-
-`commitBatchSize` defaults to **10** and each partition holds **3** messages, so the batch is
-never reached and the last message on each partition is still uncommitted when the partitions
-are revoked. Whoever picks the partition up starts from the committed offset and handles it
-again.
-
-Nothing is *lost* — all nine distinct greetings are handled, and Brighter does commit stored
-offsets for revoked partitions — but three are handled twice. **Kafka delivery here is
-at-least-once, so a handler that does real work has to be idempotent.** Check it for yourself
-with:
+Watch the committed offsets while the first instance runs on its own:
 
 ```bash
 docker exec kafka /opt/kafka/bin/kafka-consumer-groups.sh \
   --bootstrap-server localhost:9092 --describe --group greeting.readers
 ```
+
+**Immediately after all nine greetings are handled, nothing is committed at all:**
+
+```text
+TOPIC           PARTITION  CURRENT-OFFSET  LOG-END-OFFSET  LAG
+greeting.event  0          -               3               -
+greeting.event  1          -               3               -
+greeting.event  2          -               3               -
+```
+
+Handling a message *stores* an offset; it does not commit one. Brighter commits on two paths,
+and neither has run yet. The first is the batch: `commitBatchSize` defaults to **10** and each
+partition holds **3** messages, so it is never reached. The second is a timer —
+`sweepUncommittedOffsetsInterval`, default **30 seconds**.
+
+**Once that sweeper has fired, each partition sits one message short:**
+
+```text
+greeting.event  0          2               3               1
+greeting.event  1          2               3               1
+greeting.event  2          2               3               1
+```
+
+That `LAG 1` is stable — it was still 1 a minute later. The sweeper drains its stored offsets
+in no particular order and commits them in one call, so the offset that sticks is not
+necessarily the highest.
+
+So the rebalance redelivers whatever was uncommitted when it happened:
+
+| Second instance started | Redelivered (of 9) |
+|---|---|
+| Before the first sweep, within a few seconds | **7** |
+| After the sweep | **3** — one per partition, on two separate runs |
+
+Nothing is ever *lost*: every one of the nine distinct greetings is handled. But some are
+handled twice, and **no timing makes that number zero**. That is what at-least-once means, and
+it is why a handler doing real work — charging a card, sending an email — has to be idempotent.
 
 ## Why this is not `samples/TaskQueue/KafkaTaskQueue`
 

--- a/samples/Tutorials/04-Kafka/README.md
+++ b/samples/Tutorials/04-Kafka/README.md
@@ -1,0 +1,199 @@
+# 04 — Streaming with Kafka
+
+The sample behind rung 4 of the *Get Started* tutorial ladder in the
+[Brighter documentation](https://brightercommand.gitbook.io/paramore-brighter-documentation).
+Every code block on the page *Streaming with Kafka* is this code, so please keep the two in
+step: if you change a file here, the tutorial page needs the same edit. CI can prove this
+compiles; nothing can prove the page still matches it.
+
+The same one event as rung 2, over a three-partition Kafka topic, to a consumer group you can
+scale by starting a second copy of the receiver.
+
+## Running it
+
+From the repository root:
+
+```bash
+docker compose -f docker-compose-kafka.yaml up -d kafka
+```
+
+The `kafka` argument matters: the compose file also defines a schema registry and a control
+centre, and this sample needs neither. As with rung 2's broker, the command returns before
+Kafka is accepting connections. It is ready when this stops failing:
+
+```bash
+docker exec kafka /opt/kafka/bin/kafka-broker-api-versions.sh --bootstrap-server localhost:9092
+```
+
+Then, in two terminals — the receiver first, so that you can watch it take the partitions:
+
+```bash
+dotnet run --project samples/Tutorials/04-Kafka/GreetingsReceiver
+```
+
+```bash
+dotnet run --project samples/Tutorials/04-Kafka/GreetingsSender
+```
+
+The receiver logs its assignment, and on an empty broker that is all three partitions:
+
+```text
+Partition Added greeting.event : 0,greeting.event : 1,greeting.event : 2
+```
+
+The sender publishes nine greetings and prints `Published 9 greetings to greeting.event`.
+When you are done:
+
+```bash
+docker compose -f docker-compose-kafka.yaml down -v
+```
+
+Either process will create the topic if it is missing, so unlike rung 2 the order does not
+matter: Kafka retains what it accepts, and the subscription's `offsetDefault` is
+`AutoOffsetReset.Earliest`, so a receiver started afterwards reads the greetings that are
+already there.
+
+If you start the sender within a second or two of the broker, it may log
+`Failed to acquire idempotence PID from broker … Coordinator load in progress: retrying`.
+That is the broker still starting up and the producer doing what it says — retrying. It
+resolves itself.
+
+## The order they arrive in is not the order they were sent
+
+The sender interleaves three recipients — `alice`, `grace`, `mia`, three greetings each,
+round-robin. The receiver prints them grouped:
+
+```text
+Received: Hello alice #1
+Received: Hello alice #2
+Received: Hello alice #3
+Received: Hello grace #1
+Received: Hello grace #2
+Received: Hello grace #3
+Received: Hello mia #1
+Received: Hello mia #2
+Received: Hello mia #3
+```
+
+Both halves of that are the point. Kafka orders messages **within a partition** and makes no
+promise across partitions, so the global send order is gone. Each recipient's three greetings
+are still in sequence, because the partition key sends all of one recipient's greetings to
+one partition, and the Reactor pump is a single thread draining one partition at a time.
+
+## Why those three names
+
+Kafka chooses the partition by hashing the key — `crc32(key) % 3` for the default
+partitioner — so you do not choose it, you only choose the key. With three keys over three
+partitions there is a 2-in-9 chance they land one apiece.
+
+The first three names this sample used, `alice`, `bob` and `carol`, all hashed to partition
+**2**. Nothing looked wrong: one consumer holds every partition anyway, so all nine greetings
+arrived in the order they were sent and the sample appeared to work perfectly. It took asking
+the broker to see it:
+
+```bash
+docker exec kafka /opt/kafka/bin/kafka-console-consumer.sh \
+  --bootstrap-server localhost:9092 --topic greeting.event --from-beginning \
+  --max-messages 9 --property print.partition=true --property print.key=true \
+  --property print.value=false --timeout-ms 15000
+```
+
+`alice`, `grace` and `mia` were checked with that command and land on partitions 2, 0 and 1.
+Real keys are business identifiers and you take the partition the hash gives you; these are
+chosen so the sample has something to show.
+
+## Scaling the group
+
+Start a second copy of the receiver, with no arguments and no configuration change:
+
+```bash
+dotnet run --project samples/Tutorials/04-Kafka/GreetingsReceiver
+```
+
+Both share the `greeting.readers` group id, so Kafka treats them as two members of one group
+and rebalances. The first instance logs the revocation and what it kept, the second logs what
+it took:
+
+```text
+Partitions for consumer revoked greeting.event : [0],greeting.event : [1],greeting.event : [2]
+Partition Added greeting.event : 0,greeting.event : 2
+```
+
+```text
+Partition Added greeting.event : 1
+```
+
+The two sets are disjoint and cover all three partitions. Which instance gets which is Kafka's
+call, not yours — across two runs of this sample the split came out `[1]` / `[0,2]` and then
+`[0,2]` / `[1]`.
+
+## A rebalance redelivers, and that is at-least-once
+
+After the rebalance, three greetings are handled a **second** time — one per partition. Both
+runs above showed exactly three, and the reason is visible in the group's offsets before the
+second instance starts:
+
+```text
+GROUP            TOPIC           PARTITION  CURRENT-OFFSET  LOG-END-OFFSET  LAG
+greeting.readers greeting.event  0          2               3               1
+greeting.readers greeting.event  1          2               3               1
+greeting.readers greeting.event  2          2               3               1
+```
+
+`commitBatchSize` defaults to **10** and each partition holds **3** messages, so the batch is
+never reached and the last message on each partition is still uncommitted when the partitions
+are revoked. Whoever picks the partition up starts from the committed offset and handles it
+again.
+
+Nothing is *lost* — all nine distinct greetings are handled, and Brighter does commit stored
+offsets for revoked partitions — but three are handled twice. **Kafka delivery here is
+at-least-once, so a handler that does real work has to be idempotent.** Check it for yourself
+with:
+
+```bash
+docker exec kafka /opt/kafka/bin/kafka-consumer-groups.sh \
+  --bootstrap-server localhost:9092 --describe --group greeting.readers
+```
+
+## Why this is not `samples/TaskQueue/KafkaTaskQueue`
+
+`KafkaTaskQueue` is the reference sample for Kafka and earns its extras — a Polly
+`PolicyRegistry`, an explicit scheduler factory, a hosted service generating messages on a
+timer, and a hand-written message mapper. Each is a concept a reader meeting partitions for
+the first time has to park, so this sample drops all four.
+
+Dropping the mapper is the one worth explaining, because `KafkaTaskQueue` uses its mapper to
+set the partition key. It does not have to. `JsonMessageMapper<T>` is Brighter's registered
+default for **both** the sync and the async path, and it already reads the key from the
+request context onto the message header, so this sample sets it there:
+
+```csharp
+var context = new RequestContext();
+context.Bag[RequestContextBagNames.PartitionKey] = recipient;
+
+commandProcessor.Post(new GreetingEvent($"Hello {recipient} #{i}"), context);
+```
+
+The pump also runs as a **Reactor** rather than a Proactor, which is `KafkaSubscription`'s own
+default. That is what makes the single-threaded ordering argument above visible in the code
+instead of asserted about it, and it means the handler is a plain synchronous
+`RequestHandler<GreetingEvent>` — the same file as rung 2's, byte for byte.
+
+## What changed from rung 2
+
+This sample is rung 2 with the transport swapped, and `diff -r` says so — four files differ
+and three are untouched:
+
+```text
+samples/Tutorials/02-FirstMessage        samples/Tutorials/04-Kafka
+  Greetings/GreetingEvent.cs             identical
+  Greetings/Greetings.csproj             identical
+  GreetingsReceiver/GreetingEventHandler.cs   identical
+  GreetingsSender/Program.cs             Kafka publication, NumPartitions, partition key
+  GreetingsSender/GreetingsSender.csproj      Kafka gateway instead of RMQ
+  GreetingsReceiver/Program.cs           KafkaSubscription, groupId
+  GreetingsReceiver/GreetingsReceiver.csproj  Kafka gateway instead of RMQ
+```
+
+Rung 3 adds a durable Outbox to rung 2 and changes only the sender; this rung changes both
+ends, because a transport is something two processes have to agree on.

--- a/samples/Tutorials/README.md
+++ b/samples/Tutorials/README.md
@@ -10,8 +10,10 @@ diff two of them and see exactly what a feature costs.
 | 1 | A command, a handler, no broker | [`samples/CommandProcessor/HelloWorld`](../CommandProcessor/HelloWorld) — reused as-is, which is why there is no `01-` directory here |
 | 2 | One event over a RabbitMQ exchange, two processes | [`02-FirstMessage`](02-FirstMessage) |
 | 3 | A durable Postgres Outbox, one transaction, the Sweeper | [`03-DurableOutbox`](03-DurableOutbox) |
+| 4 | Partitions, a consumer group, per-key ordering, offsets | [`04-Kafka`](04-Kafka) |
 
-Rung 4 (Kafka) is planned and will land here as a separate pull request.
+Rungs 3 and 4 are each a delta from rung 2 rather than from each other: rung 3 keeps the
+transport and adds durability, rung 4 keeps the shape and swaps the transport.
 
 These samples are deliberately smaller than the reference samples they derive from. Where a
 sample under `samples/TaskQueue/` shows a feature properly, the tutorial version shows the


### PR DESCRIPTION
Rung 4 of the *Get Started* tutorial ladder, and the last sample the ladder needs. It is
`samples/Tutorials/02-FirstMessage` with the transport swapped for Kafka: one event over a
three-partition topic, to a consumer group you can scale by starting a second copy of the
receiver with no configuration change.

The tutorial page that quotes this code (`TutorialStreamingWithKafka.md`) follows in the Docs
repository, per the same convention as rungs 2 and 3 — the sample merges first.

## One readable delta from rung 2

Three of the seven files are byte-identical to `02-FirstMessage`'s, asserted with `cmp`:

```text
Greetings/GreetingEvent.cs                  identical
Greetings/Greetings.csproj                  identical
GreetingsReceiver/GreetingEventHandler.cs   identical
GreetingsSender/Program.cs                  Kafka publication, NumPartitions = 3, partition key
GreetingsSender/GreetingsSender.csproj      Kafka gateway instead of RMQ
GreetingsReceiver/Program.cs                KafkaSubscription, groupId
GreetingsReceiver/GreetingsReceiver.csproj  Kafka gateway instead of RMQ
```

Rung 3 changes only the sender; this rung changes both ends, because a transport is something
two processes have to agree on.

## Run, not just compiled

Against `docker-compose-kafka.yaml` from a torn-down broker, with both preconditions asserted
first — zero topics, zero receiver processes:

- One instance is assigned all three partitions
  (`Partition Added greeting.event : 0,greeting.event : 1,greeting.event : 2`).
- Nine greetings arrive **grouped by recipient rather than in send order**. The sender
  interleaves three recipients round-robin; the receiver prints alice #1–#3, then grace #1–#3,
  then mia #1–#3. Per-partition ordering is visible rather than argued about.
- A second instance triggers a rebalance. The first logs
  `Partitions for consumer revoked … [0],[1],[2]` and keeps a disjoint subset; the second takes
  the rest; together they cover all three.
- **The rebalance redelivers exactly three greetings, one per partition.** `commitBatchSize`
  defaults to 10 and each partition holds 3 messages, so the batch is never reached and the last
  message on each partition is uncommitted when partitions are revoked (`CURRENT-OFFSET 2`,
  `LOG-END-OFFSET 3`, `LAG 1` on all three). Nothing is lost; three are handled twice. That is
  at-least-once, and the README says so.

Both the rebalance and the redelivery count were observed on two clean runs, not one.

## Three things worth a reviewer's eye

**No message mapper.** `KafkaTaskQueue` writes one in order to set the partition key. It does
not have to: `JsonMessageMapper<T>` is the registered default for *both* the sync and the async
path (`ServiceCollectionMessageMapperRegistryBuilder`), and it already reads the key from the
request context onto the header (`JsonMessageMapper.cs:50`). So the sender sets
`RequestContextBagNames.PartitionKey` on a `RequestContext` and passes it to `Post`, and the
sample writes no mapper — which keeps it the same shape as rung 2.

**The recipient names are chosen, and the reason is in the code comment.** Kafka hashes the key
to pick a partition. The first three names tried — `alice`, `bob`, `carol` — all hashed to
partition 2. A single consumer holds every partition anyway, so all nine greetings arrived in
order and the sample looked perfect while demonstrating nothing; it took
`kafka-console-consumer.sh --property print.partition=true` to see it. `alice`, `grace` and
`mia` were checked against the broker and land on 2, 0 and 1.

**Reactor, deliberately.** `KafkaSubscription` already defaults to `MessagePumpType.Reactor`, so
the handler is a plain synchronous `RequestHandler<GreetingEvent>` — byte-identical to rung 2's
— and the single-threaded pump that makes per-key ordering hold is visible in the code.

## Solution registration

All three projects are in `Brighter.slnx` under `/samples/Tutorials/04-Kafka/`. Checked against
`git ls-files` rather than `find`:

```text
tracked .csproj: 252   named in Brighter.slnx: 251
in the repo but NOT in the solution:
    samples/WebAPI/WebAPI_mTLS_TestHarness/TodoApi/TodoApi.csproj
in the solution but NOT in the repo:
    (none)
```

The single unregistered project is the pre-existing #4272 case, untouched here — it is the
control for this check, not a finding.

## Note on CI

`build` is flaky on `master` independently of this branch — #4276, a shared-static race in
`RegisterConverters.Register()` that flips both TFM and test method between runs. If `build`
goes red, please check whether it is that before suspecting this sample.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0146UueHL6H3zGBGTYwz7GtL