### PR TITLE
samples: PostgreSQL as both transport and Outbox

### DIFF
--- a/Brighter.slnx
+++ b/Brighter.slnx
@@ -100,6 +100,7 @@
     <Project Path="samples/TaskQueue/PostgresTaskQueue/Greetings/Greetings.csproj" />
     <Project Path="samples/TaskQueue/PostgresTaskQueue/GreetingsReceiverConsole/GreetingsReceiverConsole.csproj" />
     <Project Path="samples/TaskQueue/PostgresTaskQueue/GreetingsSender/GreetingsSender.csproj" />
+    <Project Path="samples/TaskQueue/PostgresTaskQueue/GreetingsSenderWithOutbox/GreetingsSenderWithOutbox.csproj" />
   </Folder>
   <Folder Name="/samples/TaskQueue/RedisTaskQueue/">
     <Project Path="samples/TaskQueue/RedisTaskQueue/Greetings/Greetings.csproj" />

--- a/samples/TaskQueue/PostgresTaskQueue/GreetingsSenderWithOutbox/AddGreeting.cs
+++ b/samples/TaskQueue/PostgresTaskQueue/GreetingsSenderWithOutbox/AddGreeting.cs
@@ -1,0 +1,51 @@
+#region Licence
+/* The MIT License (MIT)
+Copyright © 2026 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+using Paramore.Brighter;
+
+namespace GreetingsSenderWithOutbox;
+
+/// <summary>
+/// The instruction to record a greeting and tell the world about it. Unlike
+/// <see cref="Greetings.Ports.Commands.GreetingEvent"/> this never leaves the process, so it
+/// lives here in the sender rather than in the shared Greetings library: a command is
+/// addressed to one handler, and that handler is in this assembly.
+/// </summary>
+public class AddGreeting : Command
+{
+    public AddGreeting(string greeting, bool failBeforeCommit = false) : base(Id.Random())
+    {
+        Greeting = greeting;
+        FailBeforeCommit = failBeforeCommit;
+    }
+
+    public string Greeting { get; }
+
+    /// <summary>
+    /// Set by the <c>--fail</c> switch. It exists so the sample can run the unhappy path: the
+    /// handler throws after the business row and the message are both written and before the
+    /// commit, which is the only interesting moment in the whole sample.
+    /// </summary>
+    public bool FailBeforeCommit { get; }
+}

--- a/samples/TaskQueue/PostgresTaskQueue/GreetingsSenderWithOutbox/AddGreetingHandlerAsync.cs
+++ b/samples/TaskQueue/PostgresTaskQueue/GreetingsSenderWithOutbox/AddGreetingHandlerAsync.cs
@@ -1,0 +1,114 @@
+#region Licence
+/* The MIT License (MIT)
+Copyright © 2026 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+using System;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using Greetings.Ports.Commands;
+using Paramore.Brighter;
+
+namespace GreetingsSenderWithOutbox;
+
+/// <summary>
+/// The whole point of this sample. The business row and the outgoing message are written on
+/// the same connection inside the same transaction, so PostgreSQL commits both or neither —
+/// and because the queue store table is in that same database, the message never leaves it.
+/// </summary>
+public class AddGreetingHandlerAsync : RequestHandlerAsync<AddGreeting>
+{
+    private readonly IAmATransactionConnectionProvider _transactionProvider;
+    private readonly IAmACommandProcessor _postBox;
+
+    public AddGreetingHandlerAsync(
+        IAmATransactionConnectionProvider transactionProvider,
+        IAmACommandProcessor postBox)
+    {
+        _transactionProvider = transactionProvider;
+        _postBox = postBox;
+    }
+
+    public override async Task<AddGreeting> HandleAsync(
+        AddGreeting addGreeting,
+        CancellationToken cancellationToken = default)
+    {
+        // Ask the provider for the connection and transaction rather than opening your own.
+        // This is the shared unit of work: the Outbox writes through the same pair, which is
+        // what makes the two writes below one atomic act instead of two hopeful ones.
+        DbConnection connection = await _transactionProvider.GetConnectionAsync(cancellationToken);
+        DbTransaction transaction = await _transactionProvider.GetTransactionAsync(cancellationToken);
+
+        try
+        {
+            // 1. Your write, to your table. Brighter neither knows nor cares what this is.
+            await using (DbCommand command = connection.CreateCommand())
+            {
+                command.Transaction = transaction;
+                command.CommandText = "insert into Greeting (Message) values (@message)";
+
+                DbParameter message = command.CreateParameter();
+                message.ParameterName = "message";
+                message.Value = addGreeting.Greeting;
+                command.Parameters.Add(message);
+
+                await command.ExecuteNonQueryAsync(cancellationToken);
+            }
+
+            // 2. Brighter's write, to the Outbox table, on that same transaction. Nothing has
+            // reached the queue store table yet — DepositPostAsync only stores the message.
+            await _postBox.DepositPostAsync(
+                new GreetingEvent(addGreeting.Greeting),
+                _transactionProvider,
+                cancellationToken: cancellationToken);
+
+            // The deliberate failure the --fail switch runs. Both writes are pending right
+            // now; neither is committed. Throwing here is the experiment.
+            if (addGreeting.FailBeforeCommit)
+            {
+                throw new InvalidOperationException(
+                    "Deliberate failure, after both writes and before the commit");
+            }
+
+            // 3. Both, or neither.
+            await _transactionProvider.CommitAsync(cancellationToken);
+        }
+        catch (Exception)
+        {
+            // Rolling back discards your row and the message together. There is no window in
+            // which the greeting exists but the message does not, or the other way round.
+            await _transactionProvider.RollbackAsync(cancellationToken);
+            throw;
+        }
+        finally
+        {
+            _transactionProvider.Close();
+        }
+
+        // Note what is NOT here: ClearOutboxAsync. The message sits in the Outbox until the
+        // Sweeper picks it up and inserts it into the queue store table. Call ClearOutboxAsync
+        // here instead and it dispatches immediately, at the cost of doing the send on the
+        // request thread.
+        return await base.HandleAsync(addGreeting, cancellationToken);
+    }
+}

--- a/samples/TaskQueue/PostgresTaskQueue/GreetingsSenderWithOutbox/GreetingsSenderWithOutbox.csproj
+++ b/samples/TaskQueue/PostgresTaskQueue/GreetingsSenderWithOutbox/GreetingsSenderWithOutbox.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Npgsql" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Paramore.Brighter.BoxProvisioning.PostgreSql\Paramore.Brighter.BoxProvisioning.PostgreSql.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Paramore.Brighter.BoxProvisioning\Paramore.Brighter.BoxProvisioning.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Paramore.Brighter.Extensions.DependencyInjection\Paramore.Brighter.Extensions.DependencyInjection.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Paramore.Brighter.MessagingGateway.Postgres\Paramore.Brighter.MessagingGateway.Postgres.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Paramore.Brighter.Outbox.Hosting\Paramore.Brighter.Outbox.Hosting.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Paramore.Brighter.Outbox.PostgreSql\Paramore.Brighter.Outbox.PostgreSql.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Paramore.Brighter.PostgreSql\Paramore.Brighter.PostgreSql.csproj" />
+    <ProjectReference Include="..\Greetings\Greetings.csproj" />
+  </ItemGroup>
+</Project>

--- a/samples/TaskQueue/PostgresTaskQueue/GreetingsSenderWithOutbox/Program.cs
+++ b/samples/TaskQueue/PostgresTaskQueue/GreetingsSenderWithOutbox/Program.cs
@@ -1,0 +1,158 @@
+#region Licence
+/* The MIT License (MIT)
+Copyright © 2026 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+using System;
+using System.Data.Common;
+using System.Linq;
+using System.Threading.Tasks;
+using Greetings.Ports.Commands;
+using GreetingsSenderWithOutbox;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Npgsql;
+using Paramore.Brighter;
+using Paramore.Brighter.BoxProvisioning;
+using Paramore.Brighter.BoxProvisioning.PostgreSql;
+using Paramore.Brighter.Extensions.DependencyInjection;
+using Paramore.Brighter.MessagingGateway.Postgres;
+using Paramore.Brighter.Outbox.Hosting;
+using Paramore.Brighter.Outbox.PostgreSql;
+using Paramore.Brighter.PostgreSql;
+
+const string connectionString =
+    "Host=localhost;Port=5432;Username=postgres;Password=password;Database=brightertests";
+
+// The Greeting table is yours: your schema, your migrations, your problem. The two Brighter
+// tables below are Brighter's. Do not let the three blur.
+await CreateGreetingTableAsync(connectionString);
+
+// The pivot of this sample. One configuration object names both Brighter tables, because the
+// queue store and the Outbox are two parameters on the same type. That is the whole reason a
+// single PostgreSQL database can be broker and Outbox at once: there is nothing to reconcile.
+// Both names below are the defaults, spelled out because naming them is the point.
+var configuration = new RelationalDatabaseConfiguration(
+    connectionString,
+    outBoxTableName: "Outbox",
+    queueStoreTable: "Queue");
+
+// The transport takes the same object, wrapped. PostgresMessagingGatewayConnection is a
+// holder — it adds no settings of its own.
+var connection = new PostgresMessagingGatewayConnection(configuration);
+
+// Naming GreetingEvent here is also what loads the Greetings assembly, which AutoFromAssemblies
+// below needs to have happened already. MakeChannels.Create is what creates the queue store
+// table, so the Outbox table is provisioned by UseBoxProvisioning and the queue table by the
+// transport itself — two routes, one database.
+var producerRegistry = new PostgresProducerRegistryFactory(
+    connection,
+    [
+        new PostgresPublication<GreetingEvent>
+        {
+            Topic = new RoutingKey("greeting.event"),
+            MakeChannels = OnMissingChannel.Create
+        }
+    ]).Create();
+
+var builder = Host.CreateApplicationBuilder(args);
+
+// Easy to leave out, and the failure is nowhere near the omission. TransactionProvider below
+// is given as a *type*, so the container activates PostgreSqlTransactionProvider, and its
+// constructor asks for exactly this interface. Without this line the host starts, provisions
+// the Outbox and only then fails, on the first attempt to resolve a command processor.
+builder.Services.AddSingleton<IAmARelationalDatabaseConfiguration>(configuration);
+
+builder.Services
+    .AddBrighter()
+    .AddProducers(configure =>
+    {
+        configure.ProducerRegistry = producerRegistry;
+
+        // These three make the Outbox durable and, more to the point, make it share the
+        // handler's transaction. The transaction provider is the important one: it is what
+        // lets the handler hand Brighter a transaction the handler itself opened.
+        configure.Outbox = new PostgreSqlOutbox(configuration);
+        configure.ConnectionProvider = typeof(PostgreSqlConnectionProvider);
+        configure.TransactionProvider = typeof(PostgreSqlTransactionProvider);
+    })
+    .AutoFromAssemblies()
+
+    // Creates and migrates the Outbox table at startup. It owns that table and nothing else.
+    .UseBoxProvisioning(options => options.AddPostgreSqlOutbox(configuration))
+
+    // The Sweeper: a hosted service that wakes on a timer, finds undispatched messages in the
+    // Outbox and sends them — here, into the queue store table in the same database. Both
+    // values are the defaults, spelled out because the delay they produce is visible.
+    .UseOutboxSweeper(options =>
+    {
+        options.TimerInterval = 5;
+        options.MinimumMessageAge = TimeSpan.FromSeconds(5);
+    });
+
+var host = builder.Build();
+
+// StartAsync rather than RunAsync, because we have work to do between starting the host and
+// waiting on it. Starting is what provisions the Outbox table and starts the Sweeper, so it
+// has to happen before the send rather than after.
+await host.StartAsync();
+
+var commandProcessor = host.Services.GetRequiredService<IAmACommandProcessor>();
+var failBeforeCommit = args.Contains("--fail");
+
+// The failing run says something different so you can prove it is absent afterwards rather
+// than counting rows.
+var greeting = failBeforeCommit ? "This greeting will not survive" : "Hello from the sender";
+
+try
+{
+    await commandProcessor.SendAsync(new AddGreeting(greeting, failBeforeCommit));
+
+    Console.WriteLine("Committed. The greeting and the message are both in PostgreSQL.");
+    Console.WriteLine("Waiting for the Sweeper to move it to the queue table. Ctrl+C to stop.");
+}
+catch (Exception e)
+{
+    Console.WriteLine($"Rolled back: {e.Message}");
+    Console.WriteLine("Neither the greeting nor the message was written. Ctrl+C to stop.");
+}
+
+await host.WaitForShutdownAsync();
+
+// Your table, created by your code. Plain ADO.NET: this is deliberately not going through
+// Brighter, because it is not Brighter's table.
+static async Task CreateGreetingTableAsync(string connection)
+{
+    await using var postgres = new NpgsqlConnection(connection);
+    await postgres.OpenAsync();
+
+    await using DbCommand command = postgres.CreateCommand();
+    command.CommandText =
+        """
+        create table if not exists Greeting (
+            Id      serial primary key,
+            Message text not null
+        )
+        """;
+
+    await command.ExecuteNonQueryAsync();
+}

--- a/samples/TaskQueue/PostgresTaskQueue/GreetingsSenderWithOutbox/README.md
+++ b/samples/TaskQueue/PostgresTaskQueue/GreetingsSenderWithOutbox/README.md
@@ -1,0 +1,52 @@
+# Greetings Sender with a PostgreSQL Outbox
+
+This sender is the `PostgresTaskQueue` sample with a Transactional Outbox added, so **one
+PostgreSQL database is both the broker and the Outbox**. The business row and the message
+announcing it commit in a single transaction; the Sweeper then moves the message into the
+queue store table in that same database, and `GreetingsReceiverConsole` — unchanged — consumes
+it.
+
+It accompanies the [Use PostgreSQL for Both Transport and Outbox](https://brightercommand.gitbook.io/paramore-brighter-documentation/transports/postgresqlmessagebroker/postgresqltransportandoutbox)
+guide.
+
+## What it shows
+
+`RelationalDatabaseConfiguration` takes `queueStoreTable` and `outBoxTableName` as two
+parameters on **one** object, which is why this composition needs no reconciling. The two
+tables are provisioned by different routes on purpose:
+
+| Table | Created by | Name in `pg_class` |
+|---|---|---|
+| `Queue` | the transport, from `MakeChannels = OnMissingChannel.Create` | `Queue` — the configured name, quoted as written |
+| `Outbox` | `UseBoxProvisioning(… .AddPostgreSqlOutbox(…))` at startup | `outbox` — lowercased, then quoted |
+| `greeting` | this sample's own DDL; not Brighter's table | `greeting` |
+
+The Outbox folds to lower case deliberately, so a configured `"Outbox"` matches the table
+older Brighter versions created unquoted — see `PgIdentifier`. It means
+`select * from "Outbox"` fails while `select * from "Queue"` succeeds.
+
+## Running it
+
+```bash
+docker compose -f docker-compose-postgres.yaml up -d
+
+# Deposit a greeting and its message in one transaction, then let the Sweeper dispatch it
+dotnet run --project samples/TaskQueue/PostgresTaskQueue/GreetingsSenderWithOutbox
+
+# In a second terminal, consume it
+dotnet run --project samples/TaskQueue/PostgresTaskQueue/GreetingsReceiverConsole
+```
+
+The Sweeper runs every 5 seconds and ignores messages younger than 5 seconds, so expect the
+dispatch five to ten seconds after the send. Watch for
+`Found 1 to clear out of amount 100` followed by
+`Decoupled invocation of message: Topic:greeting.event`.
+
+Run it with `--fail` to throw between the two writes and the commit:
+
+```bash
+dotnet run --project samples/TaskQueue/PostgresTaskQueue/GreetingsSenderWithOutbox -- --fail
+```
+
+Neither the greeting nor the message survives — the row counts in `greeting` and `outbox` are
+unchanged, which is the point of putting them in one transaction.


### PR DESCRIPTION
Adds `GreetingsSenderWithOutbox` to the existing `PostgresTaskQueue` sample, so one PostgreSQL database is both the broker and the Outbox.

The existing `GreetingsSender` calls `Post` directly. This one deposits the message in a PostgreSQL Outbox inside the same transaction as its business write, and lets the Sweeper move it into the queue store table in the same database. `GreetingsReceiverConsole` consumes it **unchanged** — no edit to any existing file except `Brighter.slnx`.

### What it shows

`RelationalDatabaseConfiguration` takes `queueStoreTable` and `outBoxTableName` as two parameters on **one** object, so this composition needs no second configuration to reconcile. The two tables are provisioned by different routes, on purpose:

| Table | Created by | Name in `pg_class` |
|---|---|---|
| `Queue` | the transport, from `MakeChannels = OnMissingChannel.Create` | `Queue` |
| `Outbox` | `UseBoxProvisioning(… .AddPostgreSqlOutbox(…))` | `outbox` |

That asymmetry is deliberate on the Outbox side (`PgIdentifier` lowercases-then-quotes so a configured `"Outbox"` matches the table older versions created unquoted), while `PostgresMessagingGateway` quotes the configured name as written. It is worth a reader knowing, because `select * from "Outbox"` fails while `select * from "Queue"` succeeds.

### Verification

Built, and **run** against this repository's own `docker-compose-postgres.yaml`:

- happy path — deposit, then `Found 1 to clear out of amount 100` and `Decoupled invocation of message: Topic:greeting.event`, then the receiver prints the greeting and logs `Deleted the message … on the queue greeting.event`
- `--fail` — throws between the two writes and the commit; `greeting` and `outbox` row counts are both unchanged, so neither survived

Registered in `Brighter.slnx` in this PR, so CI compiles it.

### Why

It is the companion sample for a *Use PostgreSQL for Both Transport and Outbox* how-to in the Docs repository, answering [Docs#67](https://github.com/BrighterCommand/Docs/issues/67). Tutorial and guide code that lives only inside a markdown fence rots silently; in `samples/` it is compiled by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0146UueHL6H3zGBGTYwz7GtL