### PR TITLE
docs(samples): CompetingSender has no transaction to scope

### DIFF
--- a/samples/TaskQueue/MsSqlMessagingGateway/CompetingSender/Program.cs
+++ b/samples/TaskQueue/MsSqlMessagingGateway/CompetingSender/Program.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Transactions;
 using Events.Ports.Commands;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -86,30 +85,11 @@ internal sealed class RunCommandProcessor : BackgroundService
     {
         await Task.Yield();
 
-        // Post opens a SqlConnection and Enlist defaults to true, so each insert joins this
-        // transaction: an abandoned scope rolls the messages back with it.
-        // An explicit timeout: every Post is a round trip, and the shipped profile sends 250 of
-        // them inside this one scope. The default of 60 seconds is reachable against a remote
-        // container, and it aborts with a TransactionAbortedException that explains nothing.
-        using (var scope = new TransactionScope(TransactionScopeOption.RequiresNew,
-            new TransactionOptions
-            {
-                IsolationLevel = IsolationLevel.ReadCommitted,
-                Timeout = TimeSpan.FromMinutes(5)
-            },
-            TransactionScopeAsyncFlowOption.Enabled))
+        Console.WriteLine($"Sending {_repeatCount} command messages");
+        var sequenceNumber = 1;
+        for (int i = 0; i < _repeatCount && !stoppingToken.IsCancellationRequested; i++)
         {
-            Console.WriteLine($"Sending {_repeatCount} command messages");
-            var sequenceNumber = 1;
-            for (int i = 0; i < _repeatCount && !stoppingToken.IsCancellationRequested; i++)
-            {
-                _commandProcessor.Post(new CompetingConsumerCommand(sequenceNumber++));
-            }
-
-            // Only on a full run: completing a cancelled one would commit however many messages
-            // it reached, which is not what Ctrl-C means.
-            if (!stoppingToken.IsCancellationRequested)
-                scope.Complete();
+            _commandProcessor.Post(new CompetingConsumerCommand(sequenceNumber++));
         }
 
         // Nothing left to do: stop rather than leaving the reader to find Ctrl-C.

--- a/samples/TaskQueue/MsSqlMessagingGateway/README.md
+++ b/samples/TaskQueue/MsSqlMessagingGateway/README.md
@@ -88,30 +88,26 @@ certificate your clients trust, drop it.
 | Run | With | What you should see |
 |---|---|---|
 | `GreetingsSender` | `GreetingsReceiverConsole` | the sender provisions the Outbox, deposits and clears; the receiver prints the greeting once. Redelivery of the same id is de-duplicated, but you have to force one — see *Idempotence* |
-| `CompetingSender <count>` | two or more `CompetingReceiverConsole` | the count divided between the consumers — the split is arbitrary, and six messages across two receivers came out 3 and 3, 5 and 1, and 2 and 4 on three runs. The sender exits on its own; the receivers are hosts, so Ctrl-C when you have seen enough |
+| `CompetingSender <count>` | two or more `CompetingReceiverConsole` | the count divided between the consumers — the split is arbitrary, and six messages across two receivers came out 3 and 3, 4 and 2, and 3 and 3 on three runs. The sender exits on its own; the receivers are hosts, so Ctrl-C when you have seen enough |
 
 ### What the competing demo looks like from outside
 
-All the posts land inside one completed `TransactionScope`, so the receivers see nothing until the
-batch commits and then take it in a burst — with the shipped profile's count of 250, that is one
-commit of 250 rows. They never block on the open transaction: the dequeue uses
+Each `Post` commits on its own, so the receivers start taking messages while the sender is still
+sending. Polling `QueueData` through the shipped profile's count of 250, the rows arrive steadily
+rather than in one batch — first row to last in about 420 ms, nothing waiting on a commit at the
+end. Neither receiver blocks on the row the other is handling: the dequeue uses
 `with (rowlock, readpast)`.
 
-**If you add your own `INSERT` on a second connection inside that scope, the transaction promotes
-to MSDTC**, which on .NET is Windows-only. That promotion is the thing `GreetingsSender`'s Outbox
-route avoids, by keeping the message and your own write on one connection.
+### Do not wrap `Post` in a `TransactionScope`
 
-### `Post` joins your transaction when the broker is your database
+**When the broker is your database, `Post` joins your ambient transaction.** It opens a
+`SqlConnection`, `Enlist` defaults to `true`, and the insert into the queue table enlists like any
+other write. Abandon the scope and the messages roll back with it, silently. That is the opposite
+of what a `TransactionScope` around a send is usually reaching for — with a broker outside your
+database the message is queued whether your transaction commits or aborts, and it is easy to carry
+that assumption across.
 
-`CompetingSender` sends inside a `TransactionScope` and **completes it**, because with a database
-as the broker the send is not decoupled from your transaction: `Post` opens a `SqlConnection`,
-`Enlist` defaults to `true`, and the insert into the queue table joins the ambient transaction.
-Abandon the scope and the message rolls back with it.
-
-**The experiment is worth running yourself.** Comment out `scope.Complete()` and send:
-nothing reaches `QueueData`, with no error anywhere. Then add `Enlist=False` to the connection
-string and send again with the scope still abandoned — the messages arrive, because the insert is
-no longer part of your transaction. Measured, three sends each way:
+Wrap `CompetingSender`'s loop in a scope and send three, and the rows follow the transaction:
 
 | | `Complete()` | rows in `QueueData` |
 |---|---|---|
@@ -121,11 +117,26 @@ no longer part of your transaction. Measured, three sends each way:
 
 That third row is the decoupling a broker outside your database gives you for free, bought back by
 opting out of enlistment — and losing, in exchange, any guarantee that the message and your own
-write agree. **The Outbox is the version that keeps both**, and `GreetingsSender` is where to see
-it.
+write agree.
 
-This is the argument for the Outbox rather than a defect: `DepositPost` writes to the Outbox
-inside your transaction, and `ClearOutbox` dispatches once it has committed.
+**The scope is safe here only because it guards nothing, and that is the warning.** `Post` opens
+and closes one connection at a time, so the transaction stays lightweight. Add the business write
+that would give the scope something to be atomic *between* — a second connection open at the same
+time — and .NET escalates to a distributed transaction:
+
+```text
+A. sequential connections in one scope
+   ok -- stayed a lightweight transaction, no escalation
+B. two connections open at once in one scope
+   PlatformNotSupportedException: This platform does not support distributed transactions.
+```
+
+MSDTC is Windows-only on .NET, so the pattern becomes a platform failure at the moment it starts
+meaning something.
+
+**The Outbox is the version that works**, and it is why Brighter has one: `DepositPost` writes to
+the Outbox inside your transaction, on your connection, and `ClearOutbox` dispatches once that
+transaction has committed. `GreetingsSender` is where to see it.
 
 ### Idempotence
 


### PR DESCRIPTION
Follows #4343, and it is the separate PR asked for there.

## Why the scope goes

**There is no transaction here to scope.** The `TransactionScope` in `CompetingSender` wrapped
nothing but `Post` calls — no business write, no domain state. Atomicity needs two things to be
atomic *between*, and there is one, so the scope's whole observable effect was to enlist the
messaging connection in an ambient transaction and commit it: a no-op wearing the shape of a
guarantee.

**It is also the anti-pattern the Outbox exists to replace.** `GreetingsSender`, in the same
sample, already shows `DepositPost` inside the transaction and `ClearOutbox` after it commits.
Shipping the enlisted-`Post` form next to it teaches the thing we then tell people not to do.

**And the scope is safe here only to the extent that it is pointless.** `Post` opens and closes one
connection at a time, so the transaction never escalates. Add the business write that would
*justify* the scope — two connections open at once — and it throws on any non-Windows host.
Measured on macOS, .NET 9, against SQL Server 2022 in a container:

```text
A. sequential connections in one scope
   ok -- stayed a lightweight transaction, no escalation
B. two connections open at once in one scope
   PlatformNotSupportedException: This platform does not support distributed transactions.
```

The pattern becomes a platform failure at the moment it becomes meaningful.

## What the README does instead

The lesson stays; it is reframed from a demonstration into a warning, under
*Do not wrap `Post` in a `TransactionScope`*. When the broker is your database, `Post` opens a
`SqlConnection`, `Enlist` defaults to `true`, and the insert joins your ambient transaction —
which is why you want the Outbox.

**All three measured rows are kept**, and were re-measured against this branch by wrapping the
loop in a scope locally (three sends each way):

| | `Complete()` | rows in `QueueData` |
|---|---|---|
| default connection string | no | **0** |
| default connection string | yes | **3** |
| `…;Enlist=False` | no | **3** |

## Verified, not assumed

Run against `mcr.microsoft.com/mssql/server:2022-latest`, database created from
`BrighterSqlQueue.sql`, tables provisioned by the applications themselves:

- **Sends land with no scope**: 3 `Post`s, 3 rows in `QueueData`.
- **The receivers compete**: six messages across two `CompetingReceiverConsole`, three runs —
  3 and 3, 4 and 2, 3 and 3.
- **Each `Post` commits on its own**: polling `QueueData` through the shipped profile's 250, the
  count climbs steadily (0 → 1 → 250 over about 420 ms) rather than appearing in one batch. That
  is the paragraph in *What the competing demo looks like from outside*, which previously described
  the single-commit burst the scope produced.
- **The escalation probe above**, both arms.
- All four applications in the sample build clean.

## Scope of the diff

`samples/TaskQueue/MsSqlMessagingGateway/` only — one `Program.cs` and the README. No `src/`, no
`tests/`, no new project, so no `Brighter.slnx` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0146UueHL6H3zGBGTYwz7GtL
